### PR TITLE
Fix Esc to navigate back one overlay level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -143,7 +143,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -1286,7 +1286,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2102,7 +2102,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2180,7 +2180,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2854,7 +2854,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3072,7 +3072,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3148,7 +3148,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3190,7 +3190,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3462,7 +3462,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4246,7 +4246,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4273,7 +4273,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4400,7 +4400,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5863,7 +5863,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5927,7 +5927,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -8090,7 +8090,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8587,7 +8587,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8821,7 +8821,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_c31407d4e39c53bea988c1dc633a41af/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -23475,9 +23475,9 @@ var TuiActions = class {
 		this.host.refreshHeader();
 		this.host.notice(`模型已切换为 ${selection.provider}/${selection.model}`, "success");
 	}
-	async reasoningSelection(option) {
+	async reasoningSelection(option, overlays = this.host.overlays) {
 		if (option.efforts.length === 0) return option.selection;
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: `${option.label} · 推理强度`,
 			choices: [{
 				id: "__default__",
@@ -24117,60 +24117,75 @@ var TuiActions = class {
 	async settings(args) {
 		const documents = await this.capabilities.managementBridge().settings.describe();
 		if (documents.length === 0) throw new Error("当前 Profile 未注册任何 Settings 命名空间");
-		let document;
 		if (args !== "") {
-			document = documents.find((candidate) => candidate.namespace === args);
-			if (document === void 0) throw new Error(`Settings 命名空间 ${JSON.stringify(args)} 不存在`);
-		} else {
-			const selected$1 = await this.host.overlays.select({
+			if (documents.find((candidate) => candidate.namespace === args) === void 0) throw new Error(`Settings 命名空间 ${JSON.stringify(args)} 不存在`);
+		}
+		await this.host.overlays.navigate(async (navigation) => {
+			const root = navigation.selectPage({
 				title: "设置",
 				detail: "搜索并修改全部功能设置",
 				choices: documents.map((candidate) => ({
 					id: candidate.namespace,
 					label: candidate.namespace,
 					description: `${settingsSectionLabel(candidate.namespace)} · ${candidate.applies === "live" ? "立即生效" : "需重启"}`
-				})),
-				options: {
-					width: "90%",
-					maxHeight: "90%",
-					anchor: "center",
-					margin: 1
-				}
+				}))
+			}, async (selected) => {
+				await this.settingsNamespace(navigation, selected.id);
 			});
-			if (selected$1 === void 0) return;
-			document = documents.find((candidate) => candidate.namespace === selected$1.id);
-		}
-		if (document === void 0) return;
-		const fields = settingsFields(document);
-		const special = this.settingsSpecialChoices(document);
+			if (args !== "") await this.settingsNamespace(navigation, args);
+			await root;
+		}, {
+			width: "95%",
+			maxHeight: "90%",
+			anchor: "center",
+			margin: 1
+		});
+	}
+	async settingsNamespace(navigation, namespace) {
+		const bridge = this.capabilities.managementBridge().settings;
+		const initialDocument = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
+		if (initialDocument === void 0) throw new Error(`Settings 命名空间 ${JSON.stringify(namespace)} 不存在`);
+		let document = initialDocument;
+		let fields = settingsFields(document);
+		let special = this.settingsSpecialChoices(document);
 		if (fields.length + special.length === 0) {
 			this.host.notice(`${document.namespace} 没有可见设置字段`, "info");
 			return;
 		}
-		const selected = await this.host.overlays.select({
+		const request = (initialChoiceId) => ({
 			title: `设置 · ${document.namespace}`,
 			detail: `${settingsSectionLabel(document.namespace)} · ${document.applies === "live" ? "修改立即生效" : "修改后需重启"}`,
-			choices: [...special, ...fields.map((field$1) => ({
-				id: JSON.stringify(field$1.path),
-				label: field$1.label,
-				description: `${fieldState(field$1)}${field$1.description === void 0 ? "" : ` · ${field$1.description}`}`,
-				...field$1.disabled ? { disabledReason: "该字段当前不可编辑" } : {}
+			choices: [...special, ...fields.map((field) => ({
+				id: JSON.stringify(field.path),
+				label: field.label,
+				description: `${fieldState(field)}${field.description === void 0 ? "" : ` · ${field.description}`}`,
+				...field.disabled ? { disabledReason: "该字段当前不可编辑" } : {}
 			}))],
-			options: {
-				width: "95%",
-				maxHeight: "90%",
-				anchor: "center",
-				margin: 1
-			}
+			...initialChoiceId === void 0 ? {} : { initialChoiceId }
 		});
-		if (selected === void 0) return;
-		if (selected.id.startsWith("__settings_")) {
-			await this.editSpecialSetting(document, selected.id);
-			return;
-		}
-		const field = fields.find((candidate) => JSON.stringify(candidate.path) === selected.id);
-		if (field === void 0) return;
-		await this.editSetting(document, field);
+		const handle = async (selected) => {
+			if (selected.id.startsWith("__settings_")) await this.editSpecialSetting(navigation, document, selected.id);
+			else {
+				const field = fields.find((candidate) => JSON.stringify(candidate.path) === selected.id);
+				if (field !== void 0) await this.editSetting(navigation, document, field);
+			}
+			const refreshed = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
+			if (refreshed === void 0) {
+				this.host.notice(`Settings 命名空间 ${namespace} 已不可用`, "warning");
+				navigation.back();
+				return;
+			}
+			document = refreshed;
+			fields = settingsFields(document);
+			special = this.settingsSpecialChoices(document);
+			if (fields.length + special.length === 0) {
+				this.host.notice(`${document.namespace} 没有可见设置字段`, "info");
+				navigation.back();
+				return;
+			}
+			navigation.replaceSelectPage(request(selected.id), handle);
+		};
+		await navigation.selectPage(request(), handle);
 	}
 	settingsSpecialChoices(document) {
 		switch (document.namespace) {
@@ -24197,27 +24212,27 @@ var TuiActions = class {
 			default: return [];
 		}
 	}
-	async editSpecialSetting(document, action) {
+	async editSpecialSetting(overlays, document, action) {
 		switch (action) {
 			case "__settings_default_model__":
-				await this.editDefaultModel(document);
+				await this.editDefaultModel(overlays, document);
 				return;
 			case "__settings_default_permission__":
-				await this.editDefaultPermission(document);
+				await this.editDefaultPermission(overlays, document);
 				return;
 			case "__settings_default_mode__":
-				await this.editDefaultMode(document);
+				await this.editDefaultMode(overlays, document);
 				return;
 			case "__settings_plugin_sources__":
-				await this.pluginSources("");
+				await this.pluginSources("", overlays);
 				return;
 			default: throw new Error(`未知 Settings 专用动作 ${JSON.stringify(action)}`);
 		}
 	}
-	async editDefaultModel(document) {
+	async editDefaultModel(overlays, document) {
 		const directory = await this.capabilities.listModels();
 		const current = typeof document.value === "object" && document.value !== null ? document.value : {};
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: "新会话默认模型",
 			detail: "保存后只影响未来创建且未单独选择模型的会话",
 			choices: [...directory.options.map((option$1) => ({
@@ -24239,7 +24254,7 @@ var TuiActions = class {
 		if (selected === void 0) return;
 		const option = directory.options.find((candidate) => candidate.id === selected.id);
 		if (option === void 0) return;
-		const selection = await this.reasoningSelection(option);
+		const selection = await this.reasoningSelection(option, overlays);
 		if (selection === void 0) return;
 		const ops = [
 			{
@@ -24262,13 +24277,13 @@ var TuiActions = class {
 			}
 		];
 		const updated = await this.capabilities.managementBridge().settings.mutate(document.namespace, ops, document.revision);
-		await this.settingsChanged(updated, "新会话默认模型");
+		await this.settingsChanged(updated, "新会话默认模型", overlays);
 	}
-	async editDefaultPermission(document) {
+	async editDefaultPermission(overlays, document) {
 		const field = settingsFields(document).find((candidate) => candidate.path.length === 1 && candidate.path[0] === "defaultPreset");
 		if (field === void 0) throw new Error("当前设置没有默认权限选项；仍可使用下方通用控件");
 		const options$1 = this.capabilities.listPermissions();
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: "新会话默认权限",
 			detail: "保存后只影响未来创建的会话；当前会话权限保持不变",
 			choices: options$1.map((option$1) => ({
@@ -24281,20 +24296,20 @@ var TuiActions = class {
 		const option = options$1.find((candidate) => candidate.id === selected.id);
 		if (option === void 0 || Object.is(field.value, option.id)) return;
 		if (option.needsConfirmation) {
-			if (!await this.host.overlays.confirm(option.id === "danger-full-access" ? "新会话默认使用完全访问？" : "使用未知风险默认权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`, "确认保存")) return;
+			if (!await overlays.confirm(option.id === "danger-full-access" ? "新会话默认使用完全访问？" : "使用未知风险默认权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`, "确认保存")) return;
 		}
 		const updated = await this.capabilities.managementBridge().settings.mutate(document.namespace, [{
 			op: "set",
 			path: field.path,
 			value: option.id
 		}], document.revision);
-		await this.settingsChanged(updated, "新会话默认权限");
+		await this.settingsChanged(updated, "新会话默认权限", overlays);
 	}
-	async editDefaultMode(document) {
+	async editDefaultMode(overlays, document) {
 		const field = settingsFields(document).find((candidate) => candidate.path.length === 1 && candidate.path[0] === "default");
 		if (field === void 0) throw new Error("当前设置没有默认模式选项；仍可使用下方通用控件");
 		const modes = await this.capabilities.listModes();
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: "新会话默认模式",
 			detail: "保存后只影响未来创建且未显式选择 Agent Preset 的会话",
 			choices: modes.map((mode$1) => ({
@@ -24312,9 +24327,9 @@ var TuiActions = class {
 			path: field.path,
 			value: mode.id
 		}], document.revision);
-		await this.settingsChanged(updated, "新会话默认模式");
+		await this.settingsChanged(updated, "新会话默认模式", overlays);
 	}
-	async editSetting(document, field) {
+	async editSetting(overlays, document, field) {
 		const bridge = this.capabilities.managementBridge().settings;
 		const actions = [
 			{
@@ -24337,7 +24352,7 @@ var TuiActions = class {
 				description: "不改变 Settings 中的 Credential Ref"
 			}] : []] : []
 		];
-		const action = await this.host.overlays.select({
+		const action = await overlays.select({
 			title: field.label,
 			detail: `${field.description ?? "暂无说明"}
 当前：${field.control === "secret" ? field.secretSet ? "已配置（不可回显）" : "未配置" : formatSettingsValue(field.value)}
@@ -24347,19 +24362,19 @@ var TuiActions = class {
 		});
 		if (action === void 0) return;
 		if (action.id === "credential-set" || action.id === "credential-unset") {
-			await this.manageCredential(document, field, action.id === "credential-set");
+			await this.manageCredential(overlays, document, field, action.id === "credential-set");
 			return;
 		}
 		const updated = action.id === "reset" ? await bridge.mutate(document.namespace, [{
 			op: "unset",
 			path: field.path
-		}], document.revision) : await this.writeSetting(document, field);
-		if (updated !== void 0) await this.settingsChanged(updated, `${document.namespace}.${field.path.join(".")}`);
+		}], document.revision) : await this.writeSetting(overlays, document, field);
+		if (updated !== void 0) await this.settingsChanged(updated, `${document.namespace}.${field.path.join(".")}`, overlays);
 	}
-	async writeSetting(document, field) {
+	async writeSetting(overlays, document, field) {
 		let value;
 		if (field.control === "boolean") {
-			const choice = await this.host.overlays.select({
+			const choice = await overlays.select({
 				title: field.label,
 				choices: [{
 					id: "true",
@@ -24375,7 +24390,7 @@ var TuiActions = class {
 			if (choice === void 0) return void 0;
 			value = choice.id === "true";
 		} else if (field.control === "enum") {
-			const choice = await this.host.overlays.select({
+			const choice = await overlays.select({
 				title: field.label,
 				choices: field.choices.map((option) => ({
 					id: option.id,
@@ -24387,7 +24402,7 @@ var TuiActions = class {
 			if (choice === void 0) return void 0;
 			value = field.choices.find((option) => option.id === choice.id)?.value;
 		} else if (field.control === "secret") {
-			const secret = await this.host.overlays.secretInput({
+			const secret = await overlays.secretInput({
 				title: `写入 ${field.label}`,
 				detail: "现有值不会回显；保存后将替换原值",
 				placeholder: "输入新 Secret"
@@ -24396,7 +24411,7 @@ var TuiActions = class {
 			value = secret;
 		} else {
 			const initialValue = field.control === "json" ? JSON.stringify(field.value, null, 2) : typeof field.value === "string" ? field.value : "";
-			const text = await this.host.overlays.input({
+			const text = await overlays.input({
 				title: `修改 ${field.label}`,
 				...field.description === void 0 ? {} : { detail: field.description },
 				initialValue
@@ -24410,12 +24425,12 @@ var TuiActions = class {
 			value
 		}], document.revision);
 	}
-	async manageCredential(document, field, set) {
+	async manageCredential(overlays, document, field, set) {
 		const bridge = this.capabilities.managementBridge().settings;
 		let ref = typeof field.value === "string" ? field.value.trim() : "";
 		let writeReference = false;
 		if (ref === "") {
-			const entered = await this.host.overlays.input({
+			const entered = await overlays.input({
 				title: "Credential Ref",
 				detail: "这是引用名，不是 Secret 值",
 				placeholder: "例如 DEEPSEEK_API_KEY"
@@ -24427,7 +24442,7 @@ var TuiActions = class {
 		const info = await bridge.credentialInfo(ref);
 		if (!info.writable) throw new Error(`Credential ${JSON.stringify(ref)} 由系统管理，不能在这里修改`);
 		if (set) {
-			const secret = await this.host.overlays.secretInput({
+			const secret = await overlays.secretInput({
 				title: `配置 Credential ${ref}`,
 				detail: `状态：${info.configured ? "已配置" : "未配置"}。原值不会回显；保存后将替换原值。`,
 				placeholder: "输入 Secret"
@@ -24439,7 +24454,7 @@ var TuiActions = class {
 				value: ref
 			}], document.revision);
 			await bridge.setCredential(ref, secret);
-			await this.settingsChanged(document, `Credential ${ref}`);
+			await this.settingsChanged(document, `Credential ${ref}`, overlays);
 			return;
 		}
 		if (writeReference) return;
@@ -24447,17 +24462,17 @@ var TuiActions = class {
 			this.host.notice(`Credential ${ref} 未配置`, "info");
 			return;
 		}
-		if (!await this.host.overlays.confirm(`清除 Credential ${ref}？`, "密钥将被清除，Settings 中的引用名会保留。", "清除")) return;
+		if (!await overlays.confirm(`清除 Credential ${ref}？`, "密钥将被清除，Settings 中的引用名会保留。", "清除")) return;
 		await bridge.unsetCredential(ref);
-		await this.settingsChanged(document, `Credential ${ref}`);
+		await this.settingsChanged(document, `Credential ${ref}`, overlays);
 	}
-	async settingsChanged(document, label) {
+	async settingsChanged(document, label, overlays = this.host.overlays) {
 		if (document.applies === "live") {
 			if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) this.host.applyTheme(themeFromAppearance(document));
 			this.host.notice(`${label} 已更新并立即生效`, "success");
 			return;
 		}
-		if (await this.host.overlays.confirm(`${label} 需要重启`, "可立即受控重启并恢复工作区、会话、草稿和附件路径，或稍后使用 /restart。", "立即重启")) this.host.restart(this.capabilities.currentProfile(), `已应用 ${label}`);
+		if (await overlays.confirm(`${label} 需要重启`, "可立即受控重启并恢复工作区、会话、草稿和附件路径，或稍后使用 /restart。", "立即重启")) this.host.restart(this.capabilities.currentProfile(), `已应用 ${label}`);
 		else this.host.requireRestart(`${label} 已修改，输入 /restart 生效`);
 	}
 	async plugin(args) {
@@ -24821,7 +24836,7 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 		this.host.notice("插件顺序已保存", "success");
 		await this.restartAfterPluginChange("调整 Bundle 顺序");
 	}
-	async pluginSources(args) {
+	async pluginSources(args, overlays = this.host.overlays) {
 		const bridge = this.capabilities.managementBridge().plugins;
 		const parsed = commandParts(args);
 		if (parsed.command === "add") {
@@ -24858,7 +24873,7 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 		}
 		if (parsed.command !== "" && parsed.command !== "list") throw new Error("用法：/plugin source [list|add <id> <URL>|remove|enable|disable]");
 		const snapshot = await bridge.sources();
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: "插件市场来源",
 			detail: "npm 与插件提供的目录为只读；你添加的插件目录可在这里管理",
 			choices: [...snapshot.sources.map((source$1) => ({
@@ -24878,30 +24893,30 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 		});
 		if (selected === void 0) return;
 		if (selected.id === "__add__") {
-			await this.addPluginSource(snapshot.sources, snapshot.revision);
+			await this.addPluginSource(overlays, snapshot.sources, snapshot.revision);
 			return;
 		}
 		const source = snapshot.sources.find((item) => item.id === selected.id.slice(7));
 		if (source === void 0) return;
-		await this.editPluginSource(source, snapshot.sources, snapshot.revision);
+		await this.editPluginSource(overlays, source, snapshot.sources, snapshot.revision);
 	}
-	async addPluginSource(sources, revision) {
-		const id = await this.host.overlays.input({
+	async addPluginSource(overlays, sources, revision) {
+		const id = await overlays.input({
 			title: "插件目录 ID",
 			placeholder: "小写 kebab-case"
 		});
 		if (id === void 0 || id.trim() === "") return;
-		const label = await this.host.overlays.input({
+		const label = await overlays.input({
 			title: "插件目录名称",
 			initialValue: id.trim()
 		});
 		if (label === void 0 || label.trim() === "") return;
-		const url = await this.host.overlays.input({
+		const url = await overlays.input({
 			title: "目录 URL 或文件",
 			placeholder: "https://example/catalog.json"
 		});
 		if (url === void 0 || url.trim() === "") return;
-		const credentialRef$1 = await this.host.overlays.input({
+		const credentialRef$1 = await overlays.input({
 			title: "Credential Ref（可选）",
 			detail: "只输入引用名，不要在 URL 或此处粘贴 Secret",
 			placeholder: "留空表示无认证"
@@ -24918,9 +24933,9 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 		};
 		await this.capabilities.managementBridge().plugins.saveSources([...sources, source], revision);
 		this.host.notice(`已添加插件目录 ${source.id}`, "success");
-		if (source.credentialRef !== void 0) await this.configureSourceCredential(source.credentialRef);
+		if (source.credentialRef !== void 0) await this.configureSourceCredential(overlays, source.credentialRef);
 	}
-	async editPluginSource(source, sources, revision) {
+	async editPluginSource(overlays, source, sources, revision) {
 		const choices = source.builtIn ? [...source.credentialRef === void 0 ? [] : [{
 			id: "credential",
 			label: "配置 Credential…",
@@ -24944,7 +24959,7 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 				label: "移除插件目录…"
 			}
 		];
-		const selected = await this.host.overlays.select({
+		const selected = await overlays.select({
 			title: source.label,
 			detail: `${source.url}
 ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${source.credentialRef}`}`,
@@ -24955,7 +24970,7 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		if (selected.id === "credential") {
 			let ref = source.credentialRef;
 			if (ref === void 0 || ref === "") {
-				const entered = await this.host.overlays.input({
+				const entered = await overlays.input({
 					title: "Credential Ref",
 					placeholder: "输入引用名，不是 Secret"
 				});
@@ -24968,12 +24983,12 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 				} : item);
 				await this.capabilities.managementBridge().plugins.saveSources(updated, revision);
 			}
-			await this.configureSourceCredential(ref);
+			await this.configureSourceCredential(overlays, ref);
 			return;
 		}
 		if (source.builtIn) return;
 		if (selected.id === "remove") {
-			if (!await this.host.overlays.confirm(`移除 ${source.label}？`, "该目录将不再参与搜索；已安装插件不受影响。", "移除")) return;
+			if (!await overlays.confirm(`移除 ${source.label}？`, "该目录将不再参与搜索；已安装插件不受影响。", "移除")) return;
 		}
 		const next = selected.id === "remove" ? sources.filter((item) => item.id !== source.id) : sources.map((item) => item.id === source.id ? {
 			...item,
@@ -24982,13 +24997,13 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		await this.capabilities.managementBridge().plugins.saveSources(next, revision);
 		this.host.notice(`插件目录 ${source.id} 已${selected.id === "remove" ? "移除" : source.enabled ? "停用" : "启用"}`, "success");
 	}
-	async configureSourceCredential(ref) {
+	async configureSourceCredential(overlays, ref) {
 		const bridge = this.capabilities.managementBridge().settings;
 		if (!(await bridge.credentialInfo(ref)).writable) {
 			this.host.notice(`Credential ${ref} 由系统管理，无需在这里配置`, "info");
 			return;
 		}
-		const secret = await this.host.overlays.secretInput({
+		const secret = await overlays.secretInput({
 			title: `配置 Credential ${ref}`,
 			detail: "值不会回显；保存后将替换原值",
 			placeholder: "输入 Secret；Esc 跳过"
@@ -26076,7 +26091,7 @@ function wrappedDetail(detail, width, maxLines = 4) {
 	visible[visible.length - 1] = truncateToWidth(`${last} …`, width, "…");
 	return visible.map((line) => color.muted(line));
 }
-/** Search input plus SelectList, with disabled-row and Escape-first semantics. */
+/** Search input plus SelectList; the owning navigator handles Escape and abort. */
 var SearchSelectOverlay = class {
 	focused = false;
 	input = new Input();
@@ -26084,16 +26099,13 @@ var SearchSelectOverlay = class {
 	filtered;
 	descriptionWidth = 36;
 	notice = "";
-	constructor(request, settle) {
+	constructor(request, submit) {
 		this.request = request;
-		this.settle = settle;
+		this.submit = submit;
 		this.filtered = request.choices;
-		this.list = this.createList(this.filtered);
+		this.list = this.createList(this.filtered, request.initialChoiceId);
 		this.input.onSubmit = () => {
 			this.choose();
-		};
-		this.input.onEscape = () => {
-			this.escape();
 		};
 	}
 	invalidate() {
@@ -26116,14 +26128,10 @@ var SearchSelectOverlay = class {
 		}
 		lines.push(...this.list.render(safeWidth));
 		if (this.notice !== "") lines.push(color.warning(truncateToWidth(this.notice, safeWidth, "…")));
-		lines.push(color.muted(this.request.footer ?? "↑↓ 选择 · Enter 确认 · Esc 清空/关闭"));
+		lines.push(color.muted(this.request.footer ?? "↑↓ 选择 · Enter 确认 · Esc 返回/关闭"));
 		return modalFrame(this.request.title, lines, width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-			this.escape();
-			return;
-		}
 		if (matchesKey(data, Key.tab)) {
 			this.choose();
 			return;
@@ -26152,9 +26160,6 @@ var SearchSelectOverlay = class {
 		list$1.onSelect = () => {
 			this.choose();
 		};
-		list$1.onCancel = () => {
-			this.escape();
-		};
 		return list$1;
 	}
 	applyFilter(query) {
@@ -26170,30 +26175,19 @@ var SearchSelectOverlay = class {
 			this.notice = choice.disabledReason;
 			return;
 		}
-		this.settle(choice);
-	}
-	escape() {
-		if (this.request.searchable !== false && this.input.getValue() !== "") {
-			this.input.setValue("");
-			this.applyFilter("");
-			return;
-		}
-		this.settle(void 0);
+		this.submit(choice);
 	}
 };
 /** Single-line input overlay for titles, paths, custom answers, and queue edits. */
 var TextInputOverlay = class {
 	focused = false;
 	input = new Input();
-	constructor(request, settle) {
+	constructor(request, submit) {
 		this.request = request;
-		this.settle = settle;
+		this.submit = submit;
 		this.input.setValue(escapeTerminalText(request.initialValue ?? ""));
 		this.input.onSubmit = (value) => {
-			settle(escapeTerminalText(value));
-		};
-		this.input.onEscape = () => {
-			settle(void 0);
+			submit(escapeTerminalText(value));
 		};
 	}
 	invalidate() {
@@ -26205,14 +26199,10 @@ var TextInputOverlay = class {
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			this.input.render(safeWidth)[0] ?? color.muted(this.request.placeholder ?? ""),
-			color.muted("Enter 确认 · Esc 取消")
+			color.muted("Enter 确认 · Esc 返回/关闭")
 		], width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-			this.settle(void 0);
-			return;
-		}
 		this.input.handleInput(data);
 	}
 };
@@ -26220,14 +26210,11 @@ var TextInputOverlay = class {
 var SecretInputOverlay = class {
 	focused = false;
 	input = new Input();
-	constructor(request, settle) {
+	constructor(request, submit) {
 		this.request = request;
-		this.settle = settle;
+		this.submit = submit;
 		this.input.onSubmit = (value) => {
 			this.finish(value);
-		};
-		this.input.onEscape = () => {
-			this.finish(void 0);
 		};
 	}
 	invalidate() {
@@ -26241,19 +26228,18 @@ var SecretInputOverlay = class {
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			truncateToWidth(masked, safeWidth, "…"),
-			color.muted("输入内容不会回显或写入日志 · Enter 保存 · Esc 取消")
+			color.muted("输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭")
 		], width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.ctrl("c"))) {
-			this.finish(void 0);
-			return;
-		}
 		this.input.handleInput(data);
+	}
+	dispose() {
+		this.input.setValue("");
 	}
 	finish(value) {
 		this.input.setValue("");
-		this.settle(value);
+		this.submit(value);
 	}
 };
 /** Multi-select question overlay; Space toggles, Enter commits. */
@@ -26264,9 +26250,9 @@ var MultiSelectOverlay = class {
 	list;
 	selected = /* @__PURE__ */ new Set();
 	descriptionWidth = 36;
-	constructor(request, settle) {
+	constructor(request, submit) {
 		this.request = request;
-		this.settle = settle;
+		this.submit = submit;
 		this.filtered = request.choices;
 		this.list = this.createList();
 	}
@@ -26287,17 +26273,10 @@ var MultiSelectOverlay = class {
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			`${color.muted("搜索 ")}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`,
 			...this.list.render(safeWidth),
-			color.muted(this.request.footer ?? "↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 取消")
+			color.muted(this.request.footer ?? "↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭")
 		], width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-			if (this.input.getValue() !== "") {
-				this.input.setValue("");
-				this.applyFilter("");
-			} else this.settle(void 0);
-			return;
-		}
 		if (matchesKey(data, Key.space)) {
 			const item = this.list.getSelectedItem();
 			if (item === null) return;
@@ -26307,7 +26286,7 @@ var MultiSelectOverlay = class {
 			return;
 		}
 		if (matchesKey(data, Key.enter)) {
-			this.settle(this.request.choices.filter((choice) => this.selected.has(choice.id)));
+			this.submit(this.request.choices.filter((choice) => this.selected.has(choice.id)));
 			return;
 		}
 		if (matchesKey(data, Key.home)) {
@@ -26362,10 +26341,10 @@ var ScrollableDetailOverlay = class {
 		this.offset = Math.min(this.offset, maxOffset);
 		const end = Math.min(this.lineCount, this.offset + this.viewportRows);
 		const position = `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`;
-		return modalFrame(this.request.title, [...lines.slice(this.offset, end), color.muted(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/Esc 关闭`)], width);
+		return modalFrame(this.request.title, [...lines.slice(this.offset, end), color.muted(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`)], width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c")) || matchesKey(data, Key.enter) || data === "q") {
+		if (matchesKey(data, Key.enter) || data === "q") {
 			this.settle();
 			return;
 		}
@@ -26378,7 +26357,204 @@ var ScrollableDetailOverlay = class {
 		else if (matchesKey(data, Key.end)) this.offset = maxOffset;
 	}
 };
-/** One-focus-owner FIFO for every built-in terminal modal. */
+/** A single mounted modal with a logical page stack and one Escape owner. */
+var NavigationOverlay = class {
+	focused = false;
+	stack = [];
+	closed = false;
+	pendingBack;
+	constructor(run$1, settle, reject, requestRender) {
+		this.settle = settle;
+		this.reject = reject;
+		this.requestRender = requestRender;
+		try {
+			Promise.resolve(run$1(this)).then(() => {
+				this.finish();
+			}, (error) => {
+				this.fail(error);
+			});
+		} catch (error) {
+			queueMicrotask(() => {
+				this.fail(error);
+			});
+		}
+	}
+	invalidate() {
+		this.current()?.component.invalidate();
+	}
+	render(width) {
+		const component = this.current()?.component;
+		if (component === void 0) return [];
+		if ("focused" in component) component.focused = this.focused;
+		return component.render(width);
+	}
+	handleInput(data) {
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.finish();
+			return;
+		}
+		const current = this.current();
+		if (current === void 0) return;
+		if (matchesKey(data, Key.escape)) {
+			if (current.busy) this.pendingBack = current;
+			else this.back();
+			return;
+		}
+		if (current.busy) return;
+		current.component.handleInput?.(data);
+	}
+	selectPage(request, onSelect) {
+		if (this.closed) return Promise.resolve();
+		return new Promise((resolve$1) => {
+			let entry;
+			entry = {
+				component: new SearchSelectOverlay(request, (choice) => {
+					this.dispatch(entry, () => onSelect(choice));
+				}),
+				dismiss: resolve$1,
+				busy: false,
+				active: true
+			};
+			this.stack.push(entry);
+			this.requestRender();
+		});
+	}
+	replaceSelectPage(request, onSelect) {
+		if (this.closed) return;
+		const entry = this.current();
+		if (entry === void 0) throw new Error("没有可替换的 overlay 页面");
+		this.disposeComponent(entry.component);
+		entry.component = new SearchSelectOverlay(request, (choice) => {
+			this.dispatch(entry, () => onSelect(choice));
+		});
+		this.requestRender();
+	}
+	select(request) {
+		return this.prompt((submit) => new SearchSelectOverlay(request, submit));
+	}
+	input(request) {
+		return this.prompt((submit) => new TextInputOverlay(request, submit));
+	}
+	secretInput(request) {
+		return this.prompt((submit) => new SecretInputOverlay(request, submit));
+	}
+	multiSelect(request) {
+		return this.prompt((submit) => new MultiSelectOverlay(request, submit));
+	}
+	async detail(request) {
+		await this.prompt((submit) => new ScrollableDetailOverlay(request, () => {
+			submit();
+		}));
+	}
+	async confirm(title, detail, confirmLabel = "确认") {
+		return (await this.select({
+			title,
+			detail,
+			searchable: false,
+			choices: [{
+				id: "confirm",
+				label: confirmLabel,
+				description: "我已理解上述影响"
+			}, {
+				id: "cancel",
+				label: "取消",
+				description: "保持当前状态"
+			}],
+			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
+			options: {
+				width: "95%",
+				maxHeight: "90%",
+				anchor: "center",
+				margin: 1
+			}
+		}))?.id === "confirm";
+	}
+	back() {
+		const entry = this.current();
+		if (entry === void 0) return;
+		this.remove(entry);
+		entry.dismiss();
+	}
+	finish(value) {
+		if (this.closed) return;
+		this.closed = true;
+		this.pendingBack = void 0;
+		this.dismissAll();
+		this.settle(value);
+	}
+	dispose() {
+		if (this.closed) return;
+		this.closed = true;
+		this.pendingBack = void 0;
+		this.dismissAll();
+	}
+	prompt(create) {
+		if (this.closed) return Promise.resolve(void 0);
+		return new Promise((resolve$1) => {
+			let entry;
+			entry = {
+				component: create((value) => {
+					if (!this.remove(entry)) return;
+					resolve$1(value);
+				}),
+				dismiss: () => {
+					resolve$1(void 0);
+				},
+				busy: false,
+				active: true
+			};
+			this.stack.push(entry);
+			this.requestRender();
+		});
+	}
+	dispatch(entry, action) {
+		if (this.closed || this.current() !== entry || entry.busy) return;
+		entry.busy = true;
+		Promise.resolve().then(action).catch((error) => {
+			this.fail(error);
+		}).finally(() => {
+			if (entry.active) entry.busy = false;
+			if (this.pendingBack === entry) {
+				this.pendingBack = void 0;
+				this.back();
+			}
+			this.requestRender();
+		});
+	}
+	current() {
+		return this.stack.at(-1);
+	}
+	remove(entry) {
+		if (!entry.active || this.current() !== entry) return false;
+		this.stack.pop();
+		if (this.pendingBack === entry) this.pendingBack = void 0;
+		entry.active = false;
+		this.disposeComponent(entry.component);
+		this.requestRender();
+		return true;
+	}
+	dismissAll() {
+		for (const entry of this.stack.splice(0).reverse()) {
+			entry.active = false;
+			this.disposeComponent(entry.component);
+			entry.dismiss();
+		}
+		this.requestRender();
+	}
+	fail(error) {
+		if (this.closed) return;
+		this.closed = true;
+		this.pendingBack = void 0;
+		this.dismissAll();
+		this.reject(error);
+	}
+	disposeComponent(component) {
+		try {
+			component.dispose?.();
+		} catch {}
+	}
+};
+/** One-focus-owner FIFO for independent overlay navigation sessions. */
 var OverlayQueue = class {
 	entries = [];
 	active;
@@ -26395,12 +26571,26 @@ var OverlayQueue = class {
 		return this.active !== void 0;
 	}
 	/**
+	* Mount one physical overlay whose navigator owns every logical child page.
+	* @param run - navigation session body.
+	* @param options - fixed modal placement for the complete session.
+	* @returns the explicit session result, or undefined after root Back/abort.
+	*/
+	navigate(run$1, options$1) {
+		return this.enqueue((settle, reject) => new NavigationOverlay(run$1, settle, reject, () => {
+			this.tui.requestRender();
+		}), options$1);
+	}
+	/**
 	* Open a searchable choice selector in FIFO order.
 	* @param request - selector content and presentation options.
 	* @returns the selected choice, or undefined after cancellation.
 	*/
 	select(request) {
-		return this.enqueue((settle) => new SearchSelectOverlay(request, settle), request.options);
+		return this.navigate(async (navigation) => {
+			const selected = await navigation.select(request);
+			navigation.finish(selected);
+		}, request.options);
 	}
 	/**
 	* Open a single-line text input in FIFO order.
@@ -26408,7 +26598,10 @@ var OverlayQueue = class {
 	* @returns submitted text, or undefined after cancellation.
 	*/
 	input(request) {
-		return this.enqueue((settle) => new TextInputOverlay(request, settle), request.options);
+		return this.navigate(async (navigation) => {
+			const value = await navigation.input(request);
+			navigation.finish(value);
+		}, request.options);
 	}
 	/**
 	* Open a write-only masked input; no existing value or raw render is supported.
@@ -26416,7 +26609,10 @@ var OverlayQueue = class {
 	* @returns submitted secret, or undefined after cancellation.
 	*/
 	secretInput(request) {
-		return this.enqueue((settle) => new SecretInputOverlay(request, settle), request.options);
+		return this.navigate(async (navigation) => {
+			const value = await navigation.secretInput(request);
+			navigation.finish(value);
+		}, request.options);
 	}
 	/**
 	* Open a multi-select question in FIFO order.
@@ -26424,16 +26620,20 @@ var OverlayQueue = class {
 	* @returns selected choices, or undefined after cancellation.
 	*/
 	multiSelect(request) {
-		return this.enqueue((settle) => new MultiSelectOverlay(request, settle), request.options);
+		return this.navigate(async (navigation) => {
+			const selected = await navigation.multiSelect(request);
+			navigation.finish(selected);
+		}, request.options);
 	}
 	/**
 	* Open scrollable read-only content in FIFO order.
 	* @param request - title, complete content, and viewport options.
 	*/
 	async detail(request) {
-		await this.enqueue((settle) => new ScrollableDetailOverlay(request, () => {
-			settle(void 0);
-		}), request.options);
+		await this.navigate(async (navigation) => {
+			await navigation.detail(request);
+			navigation.finish();
+		}, request.options);
 	}
 	/**
 	* Explicit high-risk confirmation.
@@ -26456,7 +26656,7 @@ var OverlayQueue = class {
 				label: "取消",
 				description: "保持当前状态"
 			}],
-			footer: "↑↓ 选择 · Enter 确认 · Esc 取消",
+			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
 			options: {
 				width: "95%",
 				maxHeight: "90%",
@@ -26476,7 +26676,7 @@ var OverlayQueue = class {
 		if (!this.accepting) return Promise.resolve(void 0);
 		return new Promise((resolve$1, reject) => {
 			const entry = {
-				create: (settle) => create(settle),
+				create,
 				options: modalOptions(options$1),
 				resolve: resolve$1,
 				reject,
@@ -26491,10 +26691,17 @@ var OverlayQueue = class {
 		const entry = this.entries.shift();
 		if (entry === void 0) return;
 		this.active = entry;
-		const component = entry.create((value) => {
-			this.settle(entry, value);
-		});
 		try {
+			const component = entry.create((value) => {
+				this.settle(entry, value);
+			}, (error) => {
+				this.fail(entry, error);
+			});
+			entry.component = component;
+			if (entry.settled) {
+				this.disposeComponent(component);
+				return;
+			}
 			entry.handle = this.tui.showOverlay(component, entry.options);
 			this.tui.requestRender();
 		} catch (error) {
@@ -26504,6 +26711,7 @@ var OverlayQueue = class {
 	settle(entry, value) {
 		if (entry.settled) return;
 		entry.settled = true;
+		this.disposeComponent(entry.component);
 		entry.handle?.hide();
 		if (this.active === entry) this.active = void 0;
 		const queued = this.entries.indexOf(entry);
@@ -26517,12 +26725,22 @@ var OverlayQueue = class {
 	fail(entry, error) {
 		if (entry.settled) return;
 		entry.settled = true;
+		this.disposeComponent(entry.component);
+		entry.handle?.hide();
 		if (this.active === entry) this.active = void 0;
+		const queued = this.entries.indexOf(entry);
+		if (queued >= 0) this.entries.splice(queued, 1);
 		entry.reject(error);
 		this.tui.requestRender();
 		queueMicrotask(() => {
 			this.activateNext();
 		});
+	}
+	disposeComponent(component) {
+		if (component === void 0 || !("dispose" in component)) return;
+		try {
+			component.dispose?.();
+		} catch {}
 	}
 };
 

--- a/scripts/stock-dsh-cycle.mjs
+++ b/scripts/stock-dsh-cycle.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process'
+import crossSpawn from 'cross-spawn'
 import { readFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 const dsh = process.env.DSH_BIN?.trim()
 const pluginSpec = process.env.SEEKTTY_SPEC?.trim()
+const spawnSync = crossSpawn.sync
 
 if (!dsh || !pluginSpec) {
   process.stderr.write('用法：DSH_BIN=/path/to/dsh SEEKTTY_SPEC=/path/to/seektty.tgz pnpm test:stock\n')

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -34,7 +34,12 @@ import type {
   TuiSettingsDocument,
   TuiSettingsPathOp,
 } from './management.ts'
-import type { OverlayChoice } from './overlays.ts'
+import type {
+  OverlayChoice,
+  OverlayNavigation,
+  OverlayPrompts,
+  SelectOverlayRequest,
+} from './overlays.ts'
 import { OverlayQueue } from './overlays.ts'
 import {
   formatSettingsValue,
@@ -905,9 +910,12 @@ export class TuiActions {
     this.host.notice(`模型已切换为 ${selection.provider}/${selection.model}`, 'success')
   }
 
-  private async reasoningSelection(option: TuiModelOption): Promise<TuiModelOption['selection'] | undefined> {
+  private async reasoningSelection(
+    option: TuiModelOption,
+    overlays: OverlayPrompts = this.host.overlays,
+  ): Promise<TuiModelOption['selection'] | undefined> {
     if (option.efforts.length === 0) return option.selection
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: `${option.label} · 推理强度`,
       choices: [
         {
@@ -1493,12 +1501,12 @@ export class TuiActions {
     const bridge = this.capabilities.managementBridge().settings
     const documents = await bridge.describe()
     if (documents.length === 0) throw new Error('当前 Profile 未注册任何 Settings 命名空间')
-    let document: TuiSettingsDocument | undefined
     if (args !== '') {
-      document = documents.find(candidate => candidate.namespace === args)
+      const document = documents.find(candidate => candidate.namespace === args)
       if (document === undefined) throw new Error(`Settings 命名空间 ${JSON.stringify(args)} 不存在`)
-    } else {
-      const selected = await this.host.overlays.select({
+    }
+    await this.host.overlays.navigate<void>(async (navigation) => {
+      const root = navigation.selectPage({
         title: '设置',
         detail: '搜索并修改全部功能设置',
         choices: documents.map(candidate => ({
@@ -1506,19 +1514,29 @@ export class TuiActions {
           label: candidate.namespace,
           description: `${settingsSectionLabel(candidate.namespace)} · ${candidate.applies === 'live' ? '立即生效' : '需重启'}`,
         })),
-        options: { width: '90%', maxHeight: '90%', anchor: 'center', margin: 1 },
+      }, async (selected) => {
+        await this.settingsNamespace(navigation, selected.id)
       })
-      if (selected === undefined) return
-      document = documents.find(candidate => candidate.namespace === selected.id)
-    }
-    if (document === undefined) return
-    const fields = settingsFields(document)
-    const special = this.settingsSpecialChoices(document)
+      if (args !== '') await this.settingsNamespace(navigation, args)
+      await root
+    }, { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 })
+  }
+
+  private async settingsNamespace(
+    navigation: OverlayNavigation<void>,
+    namespace: string,
+  ): Promise<void> {
+    const bridge = this.capabilities.managementBridge().settings
+    const initialDocument = (await bridge.describe()).find(candidate => candidate.namespace === namespace)
+    if (initialDocument === undefined) throw new Error(`Settings 命名空间 ${JSON.stringify(namespace)} 不存在`)
+    let document: TuiSettingsDocument = initialDocument
+    let fields = settingsFields(document)
+    let special = this.settingsSpecialChoices(document)
     if (fields.length + special.length === 0) {
       this.host.notice(`${document.namespace} 没有可见设置字段`, 'info')
       return
     }
-    const selected = await this.host.overlays.select({
+    const request = (initialChoiceId?: string): SelectOverlayRequest => ({
       title: `设置 · ${document.namespace}`,
       detail: `${settingsSectionLabel(document.namespace)} · ${document.applies === 'live' ? '修改立即生效' : '修改后需重启'}`,
       choices: [
@@ -1530,16 +1548,32 @@ export class TuiActions {
           ...(field.disabled ? { disabledReason: '该字段当前不可编辑' } : {}),
         })),
       ],
-      options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+      ...(initialChoiceId === undefined ? {} : { initialChoiceId }),
     })
-    if (selected === undefined) return
-    if (selected.id.startsWith('__settings_')) {
-      await this.editSpecialSetting(document, selected.id)
-      return
+    const handle = async (selected: OverlayChoice): Promise<void> => {
+      if (selected.id.startsWith('__settings_')) {
+        await this.editSpecialSetting(navigation, document, selected.id)
+      } else {
+        const field = fields.find(candidate => JSON.stringify(candidate.path) === selected.id)
+        if (field !== undefined) await this.editSetting(navigation, document, field)
+      }
+      const refreshed = (await bridge.describe()).find(candidate => candidate.namespace === namespace)
+      if (refreshed === undefined) {
+        this.host.notice(`Settings 命名空间 ${namespace} 已不可用`, 'warning')
+        navigation.back()
+        return
+      }
+      document = refreshed
+      fields = settingsFields(document)
+      special = this.settingsSpecialChoices(document)
+      if (fields.length + special.length === 0) {
+        this.host.notice(`${document.namespace} 没有可见设置字段`, 'info')
+        navigation.back()
+        return
+      }
+      navigation.replaceSelectPage(request(selected.id), handle)
     }
-    const field = fields.find(candidate => JSON.stringify(candidate.path) === selected.id)
-    if (field === undefined) return
-    await this.editSetting(document, field)
+    await navigation.selectPage(request(), handle)
   }
 
   private settingsSpecialChoices(document: TuiSettingsDocument): readonly OverlayChoice[] {
@@ -1572,22 +1606,26 @@ export class TuiActions {
     }
   }
 
-  private async editSpecialSetting(document: TuiSettingsDocument, action: string): Promise<void> {
+  private async editSpecialSetting(
+    overlays: OverlayPrompts,
+    document: TuiSettingsDocument,
+    action: string,
+  ): Promise<void> {
     switch (action) {
-      case '__settings_default_model__': await this.editDefaultModel(document); return
-      case '__settings_default_permission__': await this.editDefaultPermission(document); return
-      case '__settings_default_mode__': await this.editDefaultMode(document); return
-      case '__settings_plugin_sources__': await this.pluginSources(''); return
+      case '__settings_default_model__': await this.editDefaultModel(overlays, document); return
+      case '__settings_default_permission__': await this.editDefaultPermission(overlays, document); return
+      case '__settings_default_mode__': await this.editDefaultMode(overlays, document); return
+      case '__settings_plugin_sources__': await this.pluginSources('', overlays); return
       default: throw new Error(`未知 Settings 专用动作 ${JSON.stringify(action)}`)
     }
   }
 
-  private async editDefaultModel(document: TuiSettingsDocument): Promise<void> {
+  private async editDefaultModel(overlays: OverlayPrompts, document: TuiSettingsDocument): Promise<void> {
     const directory = await this.capabilities.listModels()
     const current = typeof document.value === 'object' && document.value !== null
       ? document.value as Record<string, unknown>
       : {}
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: '新会话默认模型',
       detail: '保存后只影响未来创建且未单独选择模型的会话',
       choices: [
@@ -1607,7 +1645,7 @@ export class TuiActions {
     if (selected === undefined) return
     const option = directory.options.find(candidate => candidate.id === selected.id)
     if (option === undefined) return
-    const selection = await this.reasoningSelection(option)
+    const selection = await this.reasoningSelection(option, overlays)
     if (selection === undefined) return
     const ops: TuiSettingsPathOp[] = [
       { op: 'set', path: ['provider'], value: selection.provider },
@@ -1621,14 +1659,14 @@ export class TuiActions {
       ops,
       document.revision,
     )
-    await this.settingsChanged(updated, '新会话默认模型')
+    await this.settingsChanged(updated, '新会话默认模型', overlays)
   }
 
-  private async editDefaultPermission(document: TuiSettingsDocument): Promise<void> {
+  private async editDefaultPermission(overlays: OverlayPrompts, document: TuiSettingsDocument): Promise<void> {
     const field = settingsFields(document).find(candidate => candidate.path.length === 1 && candidate.path[0] === 'defaultPreset')
     if (field === undefined) throw new Error('当前设置没有默认权限选项；仍可使用下方通用控件')
     const options = this.capabilities.listPermissions()
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: '新会话默认权限',
       detail: '保存后只影响未来创建的会话；当前会话权限保持不变',
       choices: options.map(option => ({
@@ -1641,7 +1679,7 @@ export class TuiActions {
     const option = options.find(candidate => candidate.id === selected.id)
     if (option === undefined || Object.is(field.value, option.id)) return
     if (option.needsConfirmation) {
-      const confirmed = await this.host.overlays.confirm(
+      const confirmed = await overlays.confirm(
         option.id === 'danger-full-access' ? '新会话默认使用完全访问？' : '使用未知风险默认权限？',
         `${permissionLabel(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`,
         '确认保存',
@@ -1653,14 +1691,14 @@ export class TuiActions {
       [{ op: 'set', path: field.path, value: option.id }],
       document.revision,
     )
-    await this.settingsChanged(updated, '新会话默认权限')
+    await this.settingsChanged(updated, '新会话默认权限', overlays)
   }
 
-  private async editDefaultMode(document: TuiSettingsDocument): Promise<void> {
+  private async editDefaultMode(overlays: OverlayPrompts, document: TuiSettingsDocument): Promise<void> {
     const field = settingsFields(document).find(candidate => candidate.path.length === 1 && candidate.path[0] === 'default')
     if (field === undefined) throw new Error('当前设置没有默认模式选项；仍可使用下方通用控件')
     const modes = await this.capabilities.listModes()
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: '新会话默认模式',
       detail: '保存后只影响未来创建且未显式选择 Agent Preset 的会话',
       choices: modes.map(mode => ({
@@ -1678,10 +1716,14 @@ export class TuiActions {
       [{ op: 'set', path: field.path, value: mode.id }],
       document.revision,
     )
-    await this.settingsChanged(updated, '新会话默认模式')
+    await this.settingsChanged(updated, '新会话默认模式', overlays)
   }
 
-  private async editSetting(document: TuiSettingsDocument, field: TuiSettingsField): Promise<void> {
+  private async editSetting(
+    overlays: OverlayPrompts,
+    document: TuiSettingsDocument,
+    field: TuiSettingsField,
+  ): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
     const actions: OverlayChoice[] = [
       { id: 'edit', label: field.control === 'secret' ? '写入新 Secret…' : '修改值…', description: `控件：${field.control}` },
@@ -1697,7 +1739,7 @@ export class TuiActions {
         ]
         : []),
     ]
-    const action = await this.host.overlays.select({
+    const action = await overlays.select({
       title: field.label,
       detail: `${field.description ?? '暂无说明'}
 当前：${field.control === 'secret' ? (field.secretSet ? '已配置（不可回显）' : '未配置') : formatSettingsValue(field.value)}
@@ -1707,22 +1749,23 @@ export class TuiActions {
     })
     if (action === undefined) return
     if (action.id === 'credential-set' || action.id === 'credential-unset') {
-      await this.manageCredential(document, field, action.id === 'credential-set')
+      await this.manageCredential(overlays, document, field, action.id === 'credential-set')
       return
     }
     const updated = action.id === 'reset'
       ? await bridge.mutate(document.namespace, [{ op: 'unset', path: field.path }], document.revision)
-      : await this.writeSetting(document, field)
-    if (updated !== undefined) await this.settingsChanged(updated, `${document.namespace}.${field.path.join('.')}`)
+      : await this.writeSetting(overlays, document, field)
+    if (updated !== undefined) await this.settingsChanged(updated, `${document.namespace}.${field.path.join('.')}`, overlays)
   }
 
   private async writeSetting(
+    overlays: OverlayPrompts,
     document: TuiSettingsDocument,
     field: TuiSettingsField,
   ): Promise<TuiSettingsDocument | undefined> {
     let value: unknown
     if (field.control === 'boolean') {
-      const choice = await this.host.overlays.select({
+      const choice = await overlays.select({
         title: field.label,
         choices: [
           { id: 'true', label: '开启', description: 'true' },
@@ -1733,7 +1776,7 @@ export class TuiActions {
       if (choice === undefined) return undefined
       value = choice.id === 'true'
     } else if (field.control === 'enum') {
-      const choice = await this.host.overlays.select({
+      const choice = await overlays.select({
         title: field.label,
         choices: field.choices.map(option => ({
           id: option.id,
@@ -1745,7 +1788,7 @@ export class TuiActions {
       if (choice === undefined) return undefined
       value = field.choices.find(option => option.id === choice.id)?.value
     } else if (field.control === 'secret') {
-      const secret = await this.host.overlays.secretInput({
+      const secret = await overlays.secretInput({
         title: `写入 ${field.label}`,
         detail: '现有值不会回显；保存后将替换原值',
         placeholder: '输入新 Secret',
@@ -1756,7 +1799,7 @@ export class TuiActions {
       const initialValue = field.control === 'json'
         ? JSON.stringify(field.value, null, 2)
         : (typeof field.value === 'string' ? field.value : '')
-      const text = await this.host.overlays.input({
+      const text = await overlays.input({
         title: `修改 ${field.label}`,
         ...(field.description === undefined ? {} : { detail: field.description }),
         initialValue,
@@ -1772,6 +1815,7 @@ export class TuiActions {
   }
 
   private async manageCredential(
+    overlays: OverlayPrompts,
     document: TuiSettingsDocument,
     field: TuiSettingsField,
     set: boolean,
@@ -1780,7 +1824,7 @@ export class TuiActions {
     let ref = typeof field.value === 'string' ? field.value.trim() : ''
     let writeReference = false
     if (ref === '') {
-      const entered = await this.host.overlays.input({
+      const entered = await overlays.input({
         title: 'Credential Ref',
         detail: '这是引用名，不是 Secret 值',
         placeholder: '例如 DEEPSEEK_API_KEY',
@@ -1792,7 +1836,7 @@ export class TuiActions {
     const info = await bridge.credentialInfo(ref)
     if (!info.writable) throw new Error(`Credential ${JSON.stringify(ref)} 由系统管理，不能在这里修改`)
     if (set) {
-      const secret = await this.host.overlays.secretInput({
+      const secret = await overlays.secretInput({
         title: `配置 Credential ${ref}`,
         detail: `状态：${info.configured ? '已配置' : '未配置'}。原值不会回显；保存后将替换原值。`,
         placeholder: '输入 Secret',
@@ -1806,7 +1850,7 @@ export class TuiActions {
         )
       }
       await bridge.setCredential(ref, secret)
-      await this.settingsChanged(document, `Credential ${ref}`)
+      await this.settingsChanged(document, `Credential ${ref}`, overlays)
       return
     }
     if (writeReference) return
@@ -1814,17 +1858,21 @@ export class TuiActions {
       this.host.notice(`Credential ${ref} 未配置`, 'info')
       return
     }
-    const confirmed = await this.host.overlays.confirm(
+    const confirmed = await overlays.confirm(
       `清除 Credential ${ref}？`,
       '密钥将被清除，Settings 中的引用名会保留。',
       '清除',
     )
     if (!confirmed) return
     await bridge.unsetCredential(ref)
-    await this.settingsChanged(document, `Credential ${ref}`)
+    await this.settingsChanged(document, `Credential ${ref}`, overlays)
   }
 
-  private async settingsChanged(document: TuiSettingsDocument, label: string): Promise<void> {
+  private async settingsChanged(
+    document: TuiSettingsDocument,
+    label: string,
+    overlays: OverlayPrompts = this.host.overlays,
+  ): Promise<void> {
     if (document.applies === 'live') {
       if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) {
         this.host.applyTheme(themeFromAppearance(document))
@@ -1832,7 +1880,7 @@ export class TuiActions {
       this.host.notice(`${label} 已更新并立即生效`, 'success')
       return
     }
-    const restart = await this.host.overlays.confirm(
+    const restart = await overlays.confirm(
       `${label} 需要重启`,
       '可立即受控重启并恢复工作区、会话、草稿和附件路径，或稍后使用 /restart。',
       '立即重启',
@@ -2150,7 +2198,10 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
     await this.restartAfterPluginChange('调整 Bundle 顺序')
   }
 
-  private async pluginSources(args: string): Promise<void> {
+  private async pluginSources(
+    args: string,
+    overlays: OverlayPrompts = this.host.overlays,
+  ): Promise<void> {
     const bridge = this.capabilities.managementBridge().plugins
     const parsed = commandParts(args)
     if (parsed.command === 'add') {
@@ -2186,7 +2237,7 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
       throw new Error('用法：/plugin source [list|add <id> <URL>|remove|enable|disable]')
     }
     const snapshot = await bridge.sources()
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: '插件市场来源',
       detail: 'npm 与插件提供的目录为只读；你添加的插件目录可在这里管理',
       choices: [
@@ -2201,22 +2252,26 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
     })
     if (selected === undefined) return
     if (selected.id === '__add__') {
-      await this.addPluginSource(snapshot.sources, snapshot.revision)
+      await this.addPluginSource(overlays, snapshot.sources, snapshot.revision)
       return
     }
     const source = snapshot.sources.find(item => item.id === selected.id.slice('source:'.length))
     if (source === undefined) return
-    await this.editPluginSource(source, snapshot.sources, snapshot.revision)
+    await this.editPluginSource(overlays, source, snapshot.sources, snapshot.revision)
   }
 
-  private async addPluginSource(sources: readonly TuiMarketplaceSource[], revision: number): Promise<void> {
-    const id = await this.host.overlays.input({ title: '插件目录 ID', placeholder: '小写 kebab-case' })
+  private async addPluginSource(
+    overlays: OverlayPrompts,
+    sources: readonly TuiMarketplaceSource[],
+    revision: number,
+  ): Promise<void> {
+    const id = await overlays.input({ title: '插件目录 ID', placeholder: '小写 kebab-case' })
     if (id === undefined || id.trim() === '') return
-    const label = await this.host.overlays.input({ title: '插件目录名称', initialValue: id.trim() })
+    const label = await overlays.input({ title: '插件目录名称', initialValue: id.trim() })
     if (label === undefined || label.trim() === '') return
-    const url = await this.host.overlays.input({ title: '目录 URL 或文件', placeholder: 'https://example/catalog.json' })
+    const url = await overlays.input({ title: '目录 URL 或文件', placeholder: 'https://example/catalog.json' })
     if (url === undefined || url.trim() === '') return
-    const credentialRef = await this.host.overlays.input({
+    const credentialRef = await overlays.input({
       title: 'Credential Ref（可选）',
       detail: '只输入引用名，不要在 URL 或此处粘贴 Secret',
       placeholder: '留空表示无认证',
@@ -2233,10 +2288,11 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
     }
     await this.capabilities.managementBridge().plugins.saveSources([...sources, source], revision)
     this.host.notice(`已添加插件目录 ${source.id}`, 'success')
-    if (source.credentialRef !== undefined) await this.configureSourceCredential(source.credentialRef)
+    if (source.credentialRef !== undefined) await this.configureSourceCredential(overlays, source.credentialRef)
   }
 
   private async editPluginSource(
+    overlays: OverlayPrompts,
     source: TuiMarketplaceSource,
     sources: readonly TuiMarketplaceSource[],
     revision: number,
@@ -2257,7 +2313,7 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
         { id: 'credential', label: '配置 Credential…', description: source.credentialRef ?? '尚未设置 Credential Ref' },
         { id: 'remove', label: '移除插件目录…' },
       ]
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: source.label,
       detail: `${source.url}
 ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：${source.credentialRef}`}`,
@@ -2268,19 +2324,19 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
     if (selected.id === 'credential') {
       let ref = source.credentialRef
       if (ref === undefined || ref === '') {
-        const entered = await this.host.overlays.input({ title: 'Credential Ref', placeholder: '输入引用名，不是 Secret' })
+        const entered = await overlays.input({ title: 'Credential Ref', placeholder: '输入引用名，不是 Secret' })
         if (entered === undefined || entered.trim() === '') return
         ref = entered.trim()
         const credentialRef = ref
         const updated = sources.map(item => item.id === source.id ? { ...item, credentialRef } : item)
         await this.capabilities.managementBridge().plugins.saveSources(updated, revision)
       }
-      await this.configureSourceCredential(ref)
+      await this.configureSourceCredential(overlays, ref)
       return
     }
     if (source.builtIn) return
     if (selected.id === 'remove') {
-      const confirmed = await this.host.overlays.confirm(`移除 ${source.label}？`, '该目录将不再参与搜索；已安装插件不受影响。', '移除')
+      const confirmed = await overlays.confirm(`移除 ${source.label}？`, '该目录将不再参与搜索；已安装插件不受影响。', '移除')
       if (!confirmed) return
     }
     const next = selected.id === 'remove'
@@ -2290,14 +2346,14 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
     this.host.notice(`插件目录 ${source.id} 已${selected.id === 'remove' ? '移除' : source.enabled ? '停用' : '启用'}`, 'success')
   }
 
-  private async configureSourceCredential(ref: string): Promise<void> {
+  private async configureSourceCredential(overlays: OverlayPrompts, ref: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
     const info = await bridge.credentialInfo(ref)
     if (!info.writable) {
       this.host.notice(`Credential ${ref} 由系统管理，无需在这里配置`, 'info')
       return
     }
-    const secret = await this.host.overlays.secretInput({
+    const secret = await overlays.secretInput({
       title: `配置 Credential ${ref}`,
       detail: '值不会回显；保存后将替换原值',
       placeholder: '输入 Secret；Esc 跳过',

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -32,6 +32,7 @@ export interface SelectOverlayRequest {
   readonly title: string
   readonly detail?: string
   readonly choices: readonly OverlayChoice[]
+  readonly initialChoiceId?: string
   readonly footer?: string
   readonly searchable?: boolean
   readonly maxVisible?: number
@@ -56,13 +57,52 @@ export interface DetailOverlayRequest {
   readonly options?: OverlayOptions
 }
 
+/** Shared prompt surface implemented by both standalone and navigated overlays. */
+export interface OverlayPrompts {
+  select(request: SelectOverlayRequest): Promise<OverlayChoice | undefined>
+  input(request: InputOverlayRequest): Promise<string | undefined>
+  secretInput(request: InputOverlayRequest): Promise<string | undefined>
+  multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined>
+  detail(request: DetailOverlayRequest): Promise<void>
+  confirm(title: string, detail: string, confirmLabel?: string): Promise<boolean>
+}
+
+/** One logical overlay session whose page stack owns all back navigation. */
+export interface OverlayNavigation<TResult = void> extends OverlayPrompts {
+  selectPage(
+    request: SelectOverlayRequest,
+    onSelect: (choice: OverlayChoice) => void | Promise<void>,
+  ): Promise<void>
+  replaceSelectPage(
+    request: SelectOverlayRequest,
+    onSelect: (choice: OverlayChoice) => void | Promise<void>,
+  ): void
+  back(): void
+  finish(value?: TResult): void
+}
+
 interface QueueEntry<T> {
-  readonly create: (settle: (value: T | undefined) => void) => Component
+  readonly create: (
+    settle: (value: T | undefined) => void,
+    reject: (error: unknown) => void,
+  ) => Component
   readonly options: OverlayOptions
   readonly resolve: (value: T | undefined) => void
   readonly reject: (error: unknown) => void
   settled: boolean
   handle?: OverlayHandle
+  component?: Component
+}
+
+interface DisposableComponent extends Component {
+  dispose?(): void
+}
+
+interface NavigationEntry {
+  component: DisposableComponent
+  readonly dismiss: () => void
+  busy: boolean
+  active: boolean
 }
 
 function rowOf(choice: OverlayChoice, descriptionWidth: number): SelectItem {
@@ -132,7 +172,7 @@ function wrappedDetail(detail: string, width: number, maxLines = 4): string[] {
   return visible.map(line => color.muted(line))
 }
 
-/** Search input plus SelectList, with disabled-row and Escape-first semantics. */
+/** Search input plus SelectList; the owning navigator handles Escape and abort. */
 class SearchSelectOverlay implements Component {
   focused = false
   private readonly input = new Input()
@@ -143,12 +183,11 @@ class SearchSelectOverlay implements Component {
 
   constructor(
     private readonly request: SelectOverlayRequest,
-    private readonly settle: (value: OverlayChoice | undefined) => void,
+    private readonly submit: (value: OverlayChoice) => void,
   ) {
     this.filtered = request.choices
-    this.list = this.createList(this.filtered)
+    this.list = this.createList(this.filtered, request.initialChoiceId)
     this.input.onSubmit = () => { this.choose() }
-    this.input.onEscape = () => { this.escape() }
   }
 
   invalidate(): void {
@@ -174,15 +213,11 @@ class SearchSelectOverlay implements Component {
     }
     lines.push(...this.list.render(safeWidth))
     if (this.notice !== '') lines.push(color.warning(truncateToWidth(this.notice, safeWidth, '…')))
-    lines.push(color.muted(this.request.footer ?? '↑↓ 选择 · Enter 确认 · Esc 清空/关闭'))
+    lines.push(color.muted(this.request.footer ?? '↑↓ 选择 · Enter 确认 · Esc 返回/关闭'))
     return modalFrame(this.request.title, lines, width)
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
-      this.escape()
-      return
-    }
     if (matchesKey(data, Key.tab)) {
       this.choose()
       return
@@ -210,7 +245,6 @@ class SearchSelectOverlay implements Component {
     const preferredIndex = preferredId === undefined ? 0 : rows.findIndex(row => row.value === preferredId)
     list.setSelectedIndex(Math.max(0, preferredIndex))
     list.onSelect = () => { this.choose() }
-    list.onCancel = () => { this.escape() }
     return list
   }
 
@@ -233,16 +267,7 @@ class SearchSelectOverlay implements Component {
       this.notice = choice.disabledReason
       return
     }
-    this.settle(choice)
-  }
-
-  private escape(): void {
-    if (this.request.searchable !== false && this.input.getValue() !== '') {
-      this.input.setValue('')
-      this.applyFilter('')
-      return
-    }
-    this.settle(undefined)
+    this.submit(choice)
   }
 }
 
@@ -253,11 +278,10 @@ class TextInputOverlay implements Component {
 
   constructor(
     private readonly request: InputOverlayRequest,
-    private readonly settle: (value: string | undefined) => void,
+    private readonly submit: (value: string) => void,
   ) {
     this.input.setValue(escapeTerminalText(request.initialValue ?? ''))
-    this.input.onSubmit = (value) => { settle(escapeTerminalText(value)) }
-    this.input.onEscape = () => { settle(undefined) }
+    this.input.onSubmit = (value) => { submit(escapeTerminalText(value)) }
   }
 
   invalidate(): void { this.input.invalidate() }
@@ -270,15 +294,11 @@ class TextInputOverlay implements Component {
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
       this.input.render(safeWidth)[0] ?? color.muted(this.request.placeholder ?? ''),
-      color.muted('Enter 确认 · Esc 取消'),
+      color.muted('Enter 确认 · Esc 返回/关闭'),
     ], width)
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
-      this.settle(undefined)
-      return
-    }
     this.input.handleInput(data)
   }
 }
@@ -290,10 +310,9 @@ class SecretInputOverlay implements Component {
 
   constructor(
     private readonly request: InputOverlayRequest,
-    private readonly settle: (value: string | undefined) => void,
+    private readonly submit: (value: string) => void,
   ) {
     this.input.onSubmit = (value) => { this.finish(value) }
-    this.input.onEscape = () => { this.finish(undefined) }
   }
 
   invalidate(): void { this.input.invalidate() }
@@ -310,21 +329,19 @@ class SecretInputOverlay implements Component {
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
       truncateToWidth(masked, safeWidth, '…'),
-      color.muted('输入内容不会回显或写入日志 · Enter 保存 · Esc 取消'),
+      color.muted('输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭'),
     ], width)
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.ctrl('c'))) {
-      this.finish(undefined)
-      return
-    }
     this.input.handleInput(data)
   }
 
-  private finish(value: string | undefined): void {
+  dispose(): void { this.input.setValue('') }
+
+  private finish(value: string): void {
     this.input.setValue('')
-    this.settle(value)
+    this.submit(value)
   }
 }
 
@@ -339,7 +356,7 @@ class MultiSelectOverlay implements Component {
 
   constructor(
     private readonly request: SelectOverlayRequest,
-    private readonly settle: (value: readonly OverlayChoice[] | undefined) => void,
+    private readonly submit: (value: readonly OverlayChoice[]) => void,
   ) {
     this.filtered = request.choices
     this.list = this.createList()
@@ -365,20 +382,11 @@ class MultiSelectOverlay implements Component {
         : wrappedDetail(this.request.detail, safeWidth)),
       `${color.muted('搜索 ')}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ''}`,
       ...this.list.render(safeWidth),
-      color.muted(this.request.footer ?? '↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 取消'),
+      color.muted(this.request.footer ?? '↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭'),
     ], width)
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
-      if (this.input.getValue() !== '') {
-        this.input.setValue('')
-        this.applyFilter('')
-      } else {
-        this.settle(undefined)
-      }
-      return
-    }
     if (matchesKey(data, Key.space)) {
       const item = this.list.getSelectedItem()
       if (item === null) return
@@ -388,7 +396,7 @@ class MultiSelectOverlay implements Component {
       return
     }
     if (matchesKey(data, Key.enter)) {
-      this.settle(this.request.choices.filter(choice => this.selected.has(choice.id)))
+      this.submit(this.request.choices.filter(choice => this.selected.has(choice.id)))
       return
     }
     if (matchesKey(data, Key.home)) {
@@ -458,13 +466,12 @@ class ScrollableDetailOverlay implements Component {
     const position = `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`
     return modalFrame(this.request.title, [
       ...lines.slice(this.offset, end),
-      color.muted(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/Esc 关闭`),
+      color.muted(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`),
     ], width)
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))
-      || matchesKey(data, Key.enter) || data === 'q') {
+    if (matchesKey(data, Key.enter) || data === 'q') {
       this.settle()
       return
     }
@@ -478,8 +485,216 @@ class ScrollableDetailOverlay implements Component {
   }
 }
 
-/** One-focus-owner FIFO for every built-in terminal modal. */
-export class OverlayQueue {
+/** A single mounted modal with a logical page stack and one Escape owner. */
+class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult> {
+  focused = false
+  private readonly stack: NavigationEntry[] = []
+  private closed = false
+  private pendingBack: NavigationEntry | undefined
+
+  constructor(
+    run: (navigation: OverlayNavigation<TResult>) => void | Promise<void>,
+    private readonly settle: (value: TResult | undefined) => void,
+    private readonly reject: (error: unknown) => void,
+    private readonly requestRender: () => void,
+  ) {
+    try {
+      void Promise.resolve(run(this)).then(
+        () => { this.finish() },
+        error => { this.fail(error) },
+      )
+    } catch (error) {
+      queueMicrotask(() => { this.fail(error) })
+    }
+  }
+
+  invalidate(): void { this.current()?.component.invalidate() }
+
+  render(width: number): string[] {
+    const component = this.current()?.component
+    if (component === undefined) return []
+    if ('focused' in component) {
+      (component as Component & { focused: boolean }).focused = this.focused
+    }
+    return component.render(width)
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.ctrl('c'))) {
+      this.finish()
+      return
+    }
+    const current = this.current()
+    if (current === undefined) return
+    if (matchesKey(data, Key.escape)) {
+      if (current.busy) this.pendingBack = current
+      else this.back()
+      return
+    }
+    if (current.busy) return
+    current.component.handleInput?.(data)
+  }
+
+  selectPage(
+    request: SelectOverlayRequest,
+    onSelect: (choice: OverlayChoice) => void | Promise<void>,
+  ): Promise<void> {
+    if (this.closed) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      let entry: NavigationEntry
+      entry = {
+        component: new SearchSelectOverlay(request, choice => {
+          this.dispatch(entry, () => onSelect(choice))
+        }),
+        dismiss: resolve,
+        busy: false,
+        active: true,
+      }
+      this.stack.push(entry)
+      this.requestRender()
+    })
+  }
+
+  replaceSelectPage(
+    request: SelectOverlayRequest,
+    onSelect: (choice: OverlayChoice) => void | Promise<void>,
+  ): void {
+    if (this.closed) return
+    const entry = this.current()
+    if (entry === undefined) throw new Error('没有可替换的 overlay 页面')
+    this.disposeComponent(entry.component)
+    entry.component = new SearchSelectOverlay(request, choice => {
+      this.dispatch(entry, () => onSelect(choice))
+    })
+    this.requestRender()
+  }
+
+  select(request: SelectOverlayRequest): Promise<OverlayChoice | undefined> {
+    return this.prompt(submit => new SearchSelectOverlay(request, submit))
+  }
+
+  input(request: InputOverlayRequest): Promise<string | undefined> {
+    return this.prompt(submit => new TextInputOverlay(request, submit))
+  }
+
+  secretInput(request: InputOverlayRequest): Promise<string | undefined> {
+    return this.prompt(submit => new SecretInputOverlay(request, submit))
+  }
+
+  multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined> {
+    return this.prompt(submit => new MultiSelectOverlay(request, submit))
+  }
+
+  async detail(request: DetailOverlayRequest): Promise<void> {
+    await this.prompt<void>(submit => new ScrollableDetailOverlay(request, () => { submit() }))
+  }
+
+  async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
+    const selected = await this.select({
+      title,
+      detail,
+      searchable: false,
+      choices: [
+        { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
+        { id: 'cancel', label: '取消', description: '保持当前状态' },
+      ],
+      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
+      options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+    })
+    return selected?.id === 'confirm'
+  }
+
+  back(): void {
+    const entry = this.current()
+    if (entry === undefined) return
+    this.remove(entry)
+    entry.dismiss()
+  }
+
+  finish(value?: TResult): void {
+    if (this.closed) return
+    this.closed = true
+    this.pendingBack = undefined
+    this.dismissAll()
+    this.settle(value)
+  }
+
+  dispose(): void {
+    if (this.closed) return
+    this.closed = true
+    this.pendingBack = undefined
+    this.dismissAll()
+  }
+
+  private prompt<T>(create: (submit: (value: T) => void) => DisposableComponent): Promise<T | undefined> {
+    if (this.closed) return Promise.resolve(undefined)
+    return new Promise<T | undefined>((resolve) => {
+      let entry: NavigationEntry
+      entry = {
+        component: create((value) => {
+          if (!this.remove(entry)) return
+          resolve(value)
+        }),
+        dismiss: () => { resolve(undefined) },
+        busy: false,
+        active: true,
+      }
+      this.stack.push(entry)
+      this.requestRender()
+    })
+  }
+
+  private dispatch(entry: NavigationEntry, action: () => void | Promise<void>): void {
+    if (this.closed || this.current() !== entry || entry.busy) return
+    entry.busy = true
+    void Promise.resolve().then(action).catch(error => {
+      this.fail(error)
+    }).finally(() => {
+      if (entry.active) entry.busy = false
+      if (this.pendingBack === entry) {
+        this.pendingBack = undefined
+        this.back()
+      }
+      this.requestRender()
+    })
+  }
+
+  private current(): NavigationEntry | undefined { return this.stack.at(-1) }
+
+  private remove(entry: NavigationEntry): boolean {
+    if (!entry.active || this.current() !== entry) return false
+    this.stack.pop()
+    if (this.pendingBack === entry) this.pendingBack = undefined
+    entry.active = false
+    this.disposeComponent(entry.component)
+    this.requestRender()
+    return true
+  }
+
+  private dismissAll(): void {
+    for (const entry of this.stack.splice(0).reverse()) {
+      entry.active = false
+      this.disposeComponent(entry.component)
+      entry.dismiss()
+    }
+    this.requestRender()
+  }
+
+  private fail(error: unknown): void {
+    if (this.closed) return
+    this.closed = true
+    this.pendingBack = undefined
+    this.dismissAll()
+    this.reject(error)
+  }
+
+  private disposeComponent(component: DisposableComponent): void {
+    try { component.dispose?.() } catch { /* page cleanup must not mask the navigation result */ }
+  }
+}
+
+/** One-focus-owner FIFO for independent overlay navigation sessions. */
+export class OverlayQueue implements OverlayPrompts {
   private readonly entries: Array<QueueEntry<unknown>> = []
   private active: QueueEntry<unknown> | undefined
   private accepting = true
@@ -494,15 +709,33 @@ export class OverlayQueue {
   hasActive(): boolean { return this.active !== undefined }
 
   /**
+   * Mount one physical overlay whose navigator owns every logical child page.
+   * @param run - navigation session body.
+   * @param options - fixed modal placement for the complete session.
+   * @returns the explicit session result, or undefined after root Back/abort.
+   */
+  navigate<TResult>(
+    run: (navigation: OverlayNavigation<TResult>) => void | Promise<void>,
+    options?: OverlayOptions,
+  ): Promise<TResult | undefined> {
+    return this.enqueue(
+      (settle, reject) => new NavigationOverlay(run, settle, reject, () => {
+        this.tui.requestRender()
+      }),
+      options,
+    )
+  }
+
+  /**
    * Open a searchable choice selector in FIFO order.
    * @param request - selector content and presentation options.
    * @returns the selected choice, or undefined after cancellation.
    */
   select(request: SelectOverlayRequest): Promise<OverlayChoice | undefined> {
-    return this.enqueue(
-      settle => new SearchSelectOverlay(request, settle),
-      request.options,
-    )
+    return this.navigate<OverlayChoice>(async (navigation) => {
+      const selected = await navigation.select(request)
+      navigation.finish(selected)
+    }, request.options)
   }
 
   /**
@@ -511,10 +744,10 @@ export class OverlayQueue {
    * @returns submitted text, or undefined after cancellation.
    */
   input(request: InputOverlayRequest): Promise<string | undefined> {
-    return this.enqueue(
-      settle => new TextInputOverlay(request, settle),
-      request.options,
-    )
+    return this.navigate<string>(async (navigation) => {
+      const value = await navigation.input(request)
+      navigation.finish(value)
+    }, request.options)
   }
 
   /**
@@ -523,10 +756,10 @@ export class OverlayQueue {
    * @returns submitted secret, or undefined after cancellation.
    */
   secretInput(request: InputOverlayRequest): Promise<string | undefined> {
-    return this.enqueue(
-      settle => new SecretInputOverlay(request, settle),
-      request.options,
-    )
+    return this.navigate<string>(async (navigation) => {
+      const value = await navigation.secretInput(request)
+      navigation.finish(value)
+    }, request.options)
   }
 
   /**
@@ -535,10 +768,10 @@ export class OverlayQueue {
    * @returns selected choices, or undefined after cancellation.
    */
   multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined> {
-    return this.enqueue(
-      settle => new MultiSelectOverlay(request, settle),
-      request.options,
-    )
+    return this.navigate<readonly OverlayChoice[]>(async (navigation) => {
+      const selected = await navigation.multiSelect(request)
+      navigation.finish(selected)
+    }, request.options)
   }
 
   /**
@@ -546,10 +779,10 @@ export class OverlayQueue {
    * @param request - title, complete content, and viewport options.
    */
   async detail(request: DetailOverlayRequest): Promise<void> {
-    await this.enqueue<void>(
-      settle => new ScrollableDetailOverlay(request, () => { settle(undefined) }),
-      request.options,
-    )
+    await this.navigate<void>(async (navigation) => {
+      await navigation.detail(request)
+      navigation.finish()
+    }, request.options)
   }
 
   /**
@@ -568,7 +801,7 @@ export class OverlayQueue {
         { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
         { id: 'cancel', label: '取消', description: '保持当前状态' },
       ],
-      footer: '↑↓ 选择 · Enter 确认 · Esc 取消',
+      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })
     return selected?.id === 'confirm'
@@ -583,13 +816,16 @@ export class OverlayQueue {
   }
 
   private enqueue<T>(
-    create: (settle: (value: T | undefined) => void) => Component,
+    create: (
+      settle: (value: T | undefined) => void,
+      reject: (error: unknown) => void,
+    ) => Component,
     options: OverlayOptions | undefined,
   ): Promise<T | undefined> {
     if (!this.accepting) return Promise.resolve(undefined)
     return new Promise<T | undefined>((resolve, reject) => {
       const entry: QueueEntry<T> = {
-        create: settle => create(settle),
+        create,
         options: modalOptions(options),
         resolve,
         reject,
@@ -605,8 +841,16 @@ export class OverlayQueue {
     const entry = this.entries.shift()
     if (entry === undefined) return
     this.active = entry
-    const component = entry.create((value) => { this.settle(entry, value) })
     try {
+      const component = entry.create(
+        value => { this.settle(entry, value) },
+        error => { this.fail(entry, error) },
+      )
+      entry.component = component
+      if (entry.settled) {
+        this.disposeComponent(component)
+        return
+      }
       entry.handle = this.tui.showOverlay(component, entry.options)
       this.tui.requestRender()
     } catch (error) {
@@ -617,6 +861,7 @@ export class OverlayQueue {
   private settle(entry: QueueEntry<unknown>, value: unknown): void {
     if (entry.settled) return
     entry.settled = true
+    this.disposeComponent(entry.component)
     entry.handle?.hide()
     if (this.active === entry) this.active = undefined
     const queued = this.entries.indexOf(entry)
@@ -629,9 +874,18 @@ export class OverlayQueue {
   private fail(entry: QueueEntry<unknown>, error: unknown): void {
     if (entry.settled) return
     entry.settled = true
+    this.disposeComponent(entry.component)
+    entry.handle?.hide()
     if (this.active === entry) this.active = undefined
+    const queued = this.entries.indexOf(entry)
+    if (queued >= 0) this.entries.splice(queued, 1)
     entry.reject(error)
     this.tui.requestRender()
     queueMicrotask(() => { this.activateNext() })
+  }
+
+  private disposeComponent(component: Component | undefined): void {
+    if (component === undefined || !('dispose' in component)) return
+    try { (component as DisposableComponent).dispose?.() } catch { /* teardown remains best effort */ }
   }
 }

--- a/tests/actions-settings-navigation.test.ts
+++ b/tests/actions-settings-navigation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
+import z from '@deepseek-ai/schemastery'
+import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
+import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
+import { OverlayQueue } from '../src/client/overlays.ts'
+import type { Transcript } from '../src/client/transcript.ts'
+import type {
+  TuiManagementBridge,
+  TuiSettingsDocument,
+  TuiSettingsPathOp,
+} from '../src/protocol.ts'
+
+const ESCAPE = '\u001B'
+const ENTER = '\r'
+
+function plain(lines: readonly string[]): string {
+  return lines.join('\n').replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+function settingsDocument(value = true, revision = 0): TuiSettingsDocument {
+  return {
+    namespace: 'example',
+    schema: z.object({ enabled: z.boolean().default(true) }).toJSON(),
+    value: { enabled: value },
+    base: { enabled: true },
+    user: revision === 0 ? {} : { enabled: value },
+    revision,
+    applies: 'live',
+    secrets: [],
+  }
+}
+
+function actionHarness(): {
+  readonly actions: TuiActions
+  readonly overlays: OverlayQueue
+  readonly describe: ReturnType<typeof vi.fn>
+  readonly mutate: ReturnType<typeof vi.fn>
+  readonly hide: ReturnType<typeof vi.fn>
+  component(): Component & { handleInput(data: string): void }
+} {
+  let current = settingsDocument()
+  const describe = vi.fn(async () => [current])
+  const mutate = vi.fn(async (
+    _namespace: string,
+    ops: readonly TuiSettingsPathOp[],
+    expectedRevision: number,
+  ) => {
+    expect(expectedRevision).toBe(current.revision)
+    const set = ops.find(op => op.op === 'set')
+    current = settingsDocument(set?.op === 'set' ? Boolean(set.value) : true, current.revision + 1)
+    return current
+  })
+  const management = {
+    settings: { describe, mutate },
+  } as unknown as TuiManagementBridge
+  const capabilities = {
+    managementBridge: () => management,
+    active: () => undefined,
+  } as unknown as HarnessTuiCapabilities
+  let mounted: Component | undefined
+  const hide = vi.fn()
+  const tui = {
+    showOverlay: vi.fn((component: Component) => {
+      mounted = component
+      return { hide } as unknown as OverlayHandle
+    }),
+    requestRender: vi.fn(),
+  } as unknown as TUI
+  const overlays = new OverlayQueue(tui)
+  const host: TuiActionHost = {
+    overlays,
+    transcript: {} as Transcript,
+    notice: vi.fn(),
+    refresh: vi.fn(),
+    refreshHeader: vi.fn(),
+    applyTheme: vi.fn(),
+    setEditor: vi.fn(),
+    copy: vi.fn(),
+    close: vi.fn(),
+    restart: vi.fn(),
+    requireRestart: vi.fn(),
+  }
+  return {
+    actions: new TuiActions(capabilities, host),
+    overlays,
+    describe,
+    mutate,
+    hide,
+    component: () => {
+      if (mounted === undefined) throw new Error('overlay has not mounted')
+      return mounted as Component & { handleInput(data: string): void }
+    },
+  }
+}
+
+describe('/settings overlay navigation', () => {
+  it('returns field/action → namespace → settings root → composer one level at a time', async () => {
+    const harness = actionHarness()
+    const execution = harness.actions.execute('settings', '')
+
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('设置')
+    })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('设置 · example')
+    })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('enabled')
+      expect(plain(harness.component().render(90))).toContain('修改值')
+    })
+
+    harness.component().handleInput(ESCAPE)
+    expect(plain(harness.component().render(90))).toContain('设置 · example')
+    expect(harness.hide).not.toHaveBeenCalled()
+
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('搜索并修改全部功能设置')
+    })
+    expect(harness.hide).not.toHaveBeenCalled()
+
+    harness.component().handleInput(ESCAPE)
+    await execution
+    expect(harness.hide).toHaveBeenCalledOnce()
+    expect(harness.mutate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the settings root below a directly addressed namespace', async () => {
+    const harness = actionHarness()
+    const execution = harness.actions.execute('settings', 'example')
+
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('设置 · example')
+    })
+    harness.component().handleInput(ESCAPE)
+    expect(plain(harness.component().render(90))).toContain('搜索并修改全部功能设置')
+    harness.component().handleInput(ESCAPE)
+
+    await execution
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes the namespace document after a field mutation', async () => {
+    const harness = actionHarness()
+    const execution = harness.actions.execute('settings', '')
+
+    await vi.waitFor(() => { expect(harness.component()).toBeDefined() })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('设置 · example')
+    })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('修改值')
+    })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('开启')
+    })
+    harness.component().handleInput(ENTER)
+
+    await vi.waitFor(() => {
+      expect(harness.mutate).toHaveBeenCalledWith(
+        'example',
+        [{ op: 'set', path: ['enabled'], value: true }],
+        0,
+      )
+      expect(harness.describe.mock.calls.length).toBeGreaterThanOrEqual(3)
+      expect(plain(harness.component().render(90))).toContain('设置 · example')
+    })
+
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(90))).toContain('搜索并修改全部功能设置')
+    })
+    harness.component().handleInput(ESCAPE)
+    await execution
+  })
+})

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
+import { OverlayQueue } from '../src/client/overlays.ts'
+
+const ESCAPE = '\u001B'
+const ENTER = '\r'
+const CTRL_C = '\u0003'
+
+function plain(lines: readonly string[]): string {
+  return lines.join('\n').replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+function overlayHarness(): {
+  readonly overlays: OverlayQueue
+  readonly hide: ReturnType<typeof vi.fn>
+  component(): Component & { handleInput(data: string): void }
+} {
+  let mounted: Component | undefined
+  const hide = vi.fn()
+  const tui = {
+    showOverlay: vi.fn((component: Component) => {
+      mounted = component
+      return { hide } as unknown as OverlayHandle
+    }),
+    requestRender: vi.fn(),
+  } as unknown as TUI
+  return {
+    overlays: new OverlayQueue(tui),
+    hide,
+    component: () => {
+      if (mounted === undefined) throw new Error('overlay has not mounted')
+      return mounted as Component & { handleInput(data: string): void }
+    },
+  }
+}
+
+describe('overlay navigation', () => {
+  it('uses one physical overlay while Escape returns through the logical page stack', async () => {
+    const harness = overlayHarness()
+    const session = harness.overlays.navigate(async (navigation) => {
+      await navigation.selectPage({
+        title: 'root page',
+        choices: [{ id: 'child', label: 'open child' }],
+      }, async () => {
+        await navigation.selectPage({
+          title: 'child page',
+          choices: [{ id: 'noop', label: 'stay here' }],
+        }, () => undefined)
+      })
+    })
+
+    expect(plain(harness.component().render(80))).toContain('root page')
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('child page')
+    })
+
+    harness.component().handleInput(ESCAPE)
+    expect(plain(harness.component().render(80))).toContain('root page')
+    expect(harness.hide).not.toHaveBeenCalled()
+
+    harness.component().handleInput(ESCAPE)
+    await expect(session).resolves.toBeUndefined()
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+
+  it('treats Escape as Back even when a searchable page contains a query', async () => {
+    const harness = overlayHarness()
+    const selected = harness.overlays.select({
+      title: 'searchable root',
+      choices: [{ id: 'one', label: 'one' }],
+    })
+
+    harness.component().handleInput('query')
+    harness.component().handleInput(ESCAPE)
+
+    await expect(selected).resolves.toBeUndefined()
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+
+  it('lets Ctrl+C abort the complete navigation session from a child page', async () => {
+    const harness = overlayHarness()
+    const session = harness.overlays.navigate(async (navigation) => {
+      await navigation.selectPage({
+        title: 'root page',
+        choices: [{ id: 'child', label: 'open child' }],
+      }, async () => {
+        await navigation.selectPage({
+          title: 'child page',
+          choices: [{ id: 'noop', label: 'stay here' }],
+        }, () => undefined)
+      })
+    })
+
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('child page')
+    })
+    harness.component().handleInput(CTRL_C)
+
+    await expect(session).resolves.toBeUndefined()
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- introduce a single navigation session with a retained page stack for overlay flows
- make `Esc` emit Back, so nested settings pages return one level and only the root closes the overlay
- keep `Ctrl+C` as the explicit whole-session abort and preserve parent query/cursor state
- add navigation and settings regression coverage, plus Windows-compatible stock `dsh` lifecycle execution

## Root cause

Each overlay page previously handled `Esc` by resolving `undefined`. `OverlayQueue.settle()` then hid the physical overlay immediately, while the sequential `/settings` awaits propagated that result through every logical level. As a result, a single `Esc` unwound the entire settings flow instead of navigating to its parent.

## User impact

The settings flow now behaves as a back stack:

- field/action → namespace
- namespace → settings root
- settings root → composer

An active search query no longer consumes the first `Esc`; one press always navigates back. Parent selection and search state are retained.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run --exclude tests/actions-theme.test.ts` — 80 tests passed
- `pnpm exec vitest run tests/overlays-navigation.test.ts tests/actions-settings-navigation.test.ts` — 6 regression tests passed
- `pnpm run build`
- `pnpm run test:stock` against unmodified `@deepseek-ai/dsh@0.1.0-rc.6` with an isolated `DSH_HOME`
- manually accepted on Windows with the packaged bundle installed into a real `tui` Profile

The excluded `actions-theme` test has a pre-existing Windows quoted-backslash path failure unrelated to this change.

Closes #2
