### PR TITLE
fix(tui): restore idle Ctrl+C drafts from editor history

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-fAI-vm30.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-dlYTZRHm.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -26876,6 +26876,25 @@ var OverlayQueue = class {
 };
 
 //#endregion
+//#region src/client/composer-draft.ts
+/** Idle composer draft recovery used by the Ctrl+C clear path. */
+const IDLE_DRAFT_CLEARED_NOTICE = "已清空草稿，按 ↑ 可找回";
+const IDLE_ATTACHMENTS_CLEARED_NOTICE = "已清空输入草稿";
+/**
+* Preserve composer text in editor history, then clear the draft and attachments.
+* @param editor - focused prompt editor.
+* @param clearAttachments - pending image attachment sink.
+* @returns the notice shown after a successful idle clear.
+*/
+function clearIdleComposerDraft(editor, clearAttachments) {
+	const text = editor.getText();
+	if (text !== "") editor.addToHistory(text);
+	editor.setText("");
+	clearAttachments();
+	return text !== "" ? IDLE_DRAFT_CLEARED_NOTICE : IDLE_ATTACHMENTS_CLEARED_NOTICE;
+}
+
+//#endregion
 //#region src/client/syntax-highlighter.ts
 const LANGUAGE_LOADERS = {
 	typescript: () => import("@shikijs/langs/typescript"),
@@ -28919,9 +28938,9 @@ async function startTuiSurface(options$1) {
 				return { consume: true };
 			}
 			if (editor.getText() !== "" || capabilities.draftAttachments().length > 0) {
-				editor.setText("");
-				capabilities.clearAttachments();
-				setNotice("已清空输入草稿", "info");
+				setNotice(clearIdleComposerDraft(editor, () => {
+					capabilities.clearAttachments();
+				}), "info");
 				return { consume: true };
 			}
 			const now = Date.now();

--- a/lib/startup-dlYTZRHm.js
+++ b/lib/startup-dlYTZRHm.js
@@ -97,6 +97,7 @@ const ENGLISH_TEXT = new Map([
 	["输入消息，/ 打开命令", "Enter a message; / opens commands"],
 	["再按一次 Ctrl+C 退出", "Press Ctrl+C again to exit"],
 	["已清空输入草稿", "Draft cleared"],
+	["已清空草稿，按 ↑ 可找回", "Draft cleared; press ↑ to restore"],
 	["已返回输入区", "Returned to the composer"],
 	["对话浏览 · Tab/Escape 返回输入", "Transcript navigation · Tab/Escape returns to the composer"],
 	["没有可跳转的用户轮次", "No user turn to jump to"],

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-fAI-vm30.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-dlYTZRHm.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/composer-draft.ts
+++ b/src/client/composer-draft.ts
@@ -1,0 +1,26 @@
+/** Idle composer draft recovery used by the Ctrl+C clear path. */
+
+export const IDLE_DRAFT_CLEARED_NOTICE = '已清空草稿，按 ↑ 可找回'
+
+interface ComposerDraftEditor {
+  getText(): string
+  addToHistory(text: string): void
+  setText(text: string): void
+}
+
+/**
+ * Preserve composer text in editor history, then clear the draft and attachments.
+ * @param editor - focused prompt editor.
+ * @param clearAttachments - pending image attachment sink.
+ * @returns the notice shown after a successful idle clear.
+ */
+export function clearIdleComposerDraft(
+  editor: ComposerDraftEditor,
+  clearAttachments: () => void,
+): string {
+  const text = editor.getText()
+  if (text !== '') editor.addToHistory(text)
+  editor.setText('')
+  clearAttachments()
+  return IDLE_DRAFT_CLEARED_NOTICE
+}

--- a/src/client/composer-draft.ts
+++ b/src/client/composer-draft.ts
@@ -1,6 +1,7 @@
 /** Idle composer draft recovery used by the Ctrl+C clear path. */
 
 export const IDLE_DRAFT_CLEARED_NOTICE = '已清空草稿，按 ↑ 可找回'
+export const IDLE_ATTACHMENTS_CLEARED_NOTICE = '已清空输入草稿'
 
 interface ComposerDraftEditor {
   getText(): string
@@ -22,5 +23,5 @@ export function clearIdleComposerDraft(
   if (text !== '') editor.addToHistory(text)
   editor.setText('')
   clearAttachments()
-  return IDLE_DRAFT_CLEARED_NOTICE
+  return text !== '' ? IDLE_DRAFT_CLEARED_NOTICE : IDLE_ATTACHMENTS_CLEARED_NOTICE
 }

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -102,6 +102,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['输入消息，/ 打开命令', 'Enter a message; / opens commands'],
   ['再按一次 Ctrl+C 退出', 'Press Ctrl+C again to exit'],
   ['已清空输入草稿', 'Draft cleared'],
+  ['已清空草稿，按 ↑ 可找回', 'Draft cleared; press ↑ to restore'],
   ['已返回输入区', 'Returned to the composer'],
   ['对话浏览 · Tab/Escape 返回输入', 'Transcript navigation · Tab/Escape returns to the composer'],
   ['没有可跳转的用户轮次', 'No user turn to jump to'],

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -28,6 +28,7 @@ import {
   ui,
 } from './locale.ts'
 import { OverlayQueue } from './overlays.ts'
+import { clearIdleComposerDraft } from './composer-draft.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
@@ -558,9 +559,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         return { consume: true }
       }
       if (editor.getText() !== '' || capabilities.draftAttachments().length > 0) {
-        editor.setText('')
-        capabilities.clearAttachments()
-        setNotice('已清空输入草稿', 'info')
+        setNotice(clearIdleComposerDraft(editor, () => { capabilities.clearAttachments() }), 'info')
         return { consume: true }
       }
       const now = Date.now()

--- a/tests/surface-draft.test.ts
+++ b/tests/surface-draft.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Key, matchesKey, type TUI } from '@mariozechner/pi-tui'
+import { PromptEditor } from '../src/client/chrome.ts'
+import { clearIdleComposerDraft } from '../src/client/composer-draft.ts'
+
+const UP = '\u001B[A'
+
+function editor(): PromptEditor {
+  return new PromptEditor({
+    terminal: { rows: 24 },
+    requestRender: vi.fn(),
+  } as unknown as TUI)
+}
+
+describe('idle Ctrl+C draft recovery', () => {
+  it('stashes multiline composer text so Up restores the original draft', () => {
+    const composer = editor()
+    const draft = '第一行提示\n请保留这段还没发出去的内容'
+    composer.setText(draft)
+    composer.render(80)
+
+    const notice = clearIdleComposerDraft(composer, () => undefined)
+    expect(notice).toBe('已清空草稿，按 ↑ 可找回')
+    expect(composer.getText()).toBe('')
+
+    composer.handleInput(UP)
+    expect(composer.getText()).toBe(draft)
+  })
+
+  it('clears pending attachments even when the composer text is already empty', () => {
+    const composer = editor()
+    const clearAttachments = vi.fn()
+
+    const notice = clearIdleComposerDraft(composer, clearAttachments)
+
+    expect(notice).toBe('已清空草稿，按 ↑ 可找回')
+    expect(clearAttachments).toHaveBeenCalledOnce()
+    expect(composer.getText()).toBe('')
+  })
+
+  it('matches the terminal Ctrl+C chord used by the idle composer path', () => {
+    expect(matchesKey('\u0003', Key.ctrl('c'))).toBe(true)
+  })
+})

--- a/tests/surface-draft.test.ts
+++ b/tests/surface-draft.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { Key, matchesKey, type TUI } from '@mariozechner/pi-tui'
+import { readFileSync } from 'node:fs'
+import type { TUI } from '@mariozechner/pi-tui'
 import { PromptEditor } from '../src/client/chrome.ts'
 import { clearIdleComposerDraft } from '../src/client/composer-draft.ts'
 
@@ -33,12 +34,13 @@ describe('idle Ctrl+C draft recovery', () => {
 
     const notice = clearIdleComposerDraft(composer, clearAttachments)
 
-    expect(notice).toBe('已清空草稿，按 ↑ 可找回')
+    expect(notice).toBe('已清空输入草稿')
     expect(clearAttachments).toHaveBeenCalledOnce()
     expect(composer.getText()).toBe('')
   })
 
-  it('matches the terminal Ctrl+C chord used by the idle composer path', () => {
-    expect(matchesKey('\u0003', Key.ctrl('c'))).toBe(true)
+  it('wires idle Ctrl+C through the draft helper', () => {
+    const surface = readFileSync(new URL('../src/client/surface.ts', import.meta.url), 'utf8')
+    expect(surface).toContain('clearIdleComposerDraft(editor')
   })
 })


### PR DESCRIPTION
## Summary
- P0-1 from `docs/DEEP_OPTIMIZATION.md`: idle Ctrl+C now stashes the composer draft in editor history before clearing it.
- Notice is `已清空草稿，按 ↑ 可找回`; Up restores the original multiline text.
- Adds a PromptEditor regression covering multiline restore and attachment-only clears.

## Test plan
- [x] `vitest run tests/surface-draft.test.ts`
- [x] full `vitest run` (99 passing)
- [ ] Manual: type a multiline prompt, Ctrl+C, press ↑, confirm the draft returns

Do not merge yet — remaining P0 items will land on separate branches.

Made with [Cursor](https://cursor.com)