### PR TITLE
fix(tui): default dangerous confirms onto cancel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -23276,7 +23276,7 @@ var TuiActions = class {
 		this.host.notice(`工作区已重命名为 ${updated.title}`, "success");
 	}
 	async deleteWorkspace(workspace) {
-		if (!await this.host.overlays.confirm(`移除工作区注册 ${workspace.title}？`, `${workspace.path}\n目录、用户文件和全部会话记录都会保留；会话将成为未分组。`, "移除注册")) return;
+		if (!await this.host.overlays.confirm(`移除工作区注册 ${workspace.title}？`, `${workspace.path}\n目录、用户文件和全部会话记录都会保留；会话将成为未分组。`, "移除注册", true)) return;
 		await this.capabilities.deleteWorkspace(workspace.workspaceId);
 		this.host.notice(`已移除工作区注册 ${workspace.title}`, "success");
 	}
@@ -23742,7 +23742,7 @@ var TuiActions = class {
 		if (name$1 === "" || name$1.length > 80) throw new Error("主题名称必须为 1–80 个字符");
 		if (/[\u0000-\u001F\u007F-\u009F]/u.test(name$1)) throw new Error("主题名称不能包含终端控制字符");
 		const existing = appearance.customThemes.find((theme) => theme.name.toLowerCase() === name$1.toLowerCase());
-		if (existing !== void 0) return await this.host.overlays.confirm(`覆盖主题 ${existing.name}？`, "原主题颜色会被新配置替换，其他命名主题不受影响。", "覆盖") ? {
+		if (existing !== void 0) return await this.host.overlays.confirm(`覆盖主题 ${existing.name}？`, "原主题颜色会被新配置替换，其他命名主题不受影响。", "覆盖", true) ? {
 			id: existing.id,
 			name: existing.name
 		} : void 0;
@@ -23858,7 +23858,7 @@ var TuiActions = class {
 			if (identity === void 0) return;
 			editable = editableTheme(source, identity.id, identity.name);
 		} else {
-			if (!await this.host.overlays.confirm(`编辑并覆盖主题 ${source.name}？`, "保存后会替换这个命名主题；其他主题不受影响。", "继续编辑")) return;
+			if (!await this.host.overlays.confirm(`编辑并覆盖主题 ${source.name}？`, "保存后会替换这个命名主题；其他主题不受影响。", "继续编辑", true)) return;
 			editable = editableTheme(source, source.id.slice(7), source.name);
 		}
 		const edited = await this.editThemeValue(editable);
@@ -24049,7 +24049,7 @@ var TuiActions = class {
 			theme = appearance.customThemes.find((candidate) => candidate.id === selected.id);
 		}
 		if (theme === void 0) return;
-		if (!await this.host.overlays.confirm(`删除主题 ${theme.name}？`, appearance.theme === customThemeId(theme) && appearance.codeTheme === customThemeId(theme) ? "该主题会从 Harness Settings 删除；界面切换到 DeepSeek 暗色，代码主题恢复自动匹配。" : appearance.theme === customThemeId(theme) ? "该主题会从 Harness Settings 删除，界面立即切换到 DeepSeek 暗色。" : appearance.codeTheme === customThemeId(theme) ? "该主题会从 Harness Settings 删除，代码主题恢复自动匹配。" : "该主题会从 Harness Settings 删除；当前界面和代码主题不变。", "删除")) return;
+		if (!await this.host.overlays.confirm(`删除主题 ${theme.name}？`, appearance.theme === customThemeId(theme) && appearance.codeTheme === customThemeId(theme) ? "该主题会从 Harness Settings 删除；界面切换到 DeepSeek 暗色，代码主题恢复自动匹配。" : appearance.theme === customThemeId(theme) ? "该主题会从 Harness Settings 删除，界面立即切换到 DeepSeek 暗色。" : appearance.codeTheme === customThemeId(theme) ? "该主题会从 Harness Settings 删除，代码主题恢复自动匹配。" : "该主题会从 Harness Settings 删除；当前界面和代码主题不变。", "删除", true)) return;
 		const updated = await deleteCustomTheme(bridge, document, theme.id);
 		await this.settingsChanged(updated, `主题 ${theme.name}`);
 	}
@@ -24077,7 +24077,7 @@ var TuiActions = class {
 	async selectPermission(option) {
 		if (option.current) return;
 		if (option.needsConfirmation) {
-			if (!await this.host.overlays.confirm(option.id === "danger-full-access" ? "进入完全访问？" : "切换到未知风险权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。切换后立即作用于当前会话。`, "确认切换")) return;
+			if (!await this.host.overlays.confirm(option.id === "danger-full-access" ? "进入完全访问？" : "切换到未知风险权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。切换后立即作用于当前会话。`, "确认切换", true)) return;
 		}
 		await this.capabilities.selectPermission(option.id);
 		this.host.notice(`权限已切换为${permissionLabel$1(option)}`, "success");
@@ -24372,7 +24372,7 @@ var TuiActions = class {
 		const option = options$1.find((candidate) => candidate.id === selected.id);
 		if (option === void 0 || Object.is(field.value, option.id)) return;
 		if (option.needsConfirmation) {
-			if (!await overlays.confirm(option.id === "danger-full-access" ? "新会话默认使用完全访问？" : "使用未知风险默认权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`, "确认保存")) return;
+			if (!await overlays.confirm(option.id === "danger-full-access" ? "新会话默认使用完全访问？" : "使用未知风险默认权限？", `${permissionLabel$1(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`, "确认保存", true)) return;
 		}
 		const updated = await this.capabilities.managementBridge().settings.mutate(document.namespace, [{
 			op: "set",
@@ -24538,7 +24538,7 @@ var TuiActions = class {
 			this.host.notice(`Credential ${ref} 未配置`, "info");
 			return;
 		}
-		if (!await overlays.confirm(`清除 Credential ${ref}？`, "密钥将被清除，Settings 中的引用名会保留。", "清除")) return;
+		if (!await overlays.confirm(`清除 Credential ${ref}？`, "密钥将被清除，Settings 中的引用名会保留。", "清除", true)) return;
 		await bridge.unsetCredential(ref);
 		await this.settingsChanged(document, `Credential ${ref}`, overlays);
 	}
@@ -24840,7 +24840,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			target = selected.id;
 		}
 		if (snapshot.plugins.find((candidate) => candidate.name === target) === void 0) throw new Error(`当前 Profile 未安装 ${JSON.stringify(target)}`);
-		if (!await this.host.overlays.confirm(`从 ${snapshot.profile} 移除 ${target}？`, `将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, "移除")) return;
+		if (!await this.host.overlays.confirm(`从 ${snapshot.profile} 移除 ${target}？`, `将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, "移除", true)) return;
 		await this.pluginOperation(`移除 ${target}`, await this.capabilities.managementBridge().plugins.run(["remove", target]));
 	}
 	async pluginUpdate(name$1) {
@@ -24863,7 +24863,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			target = selected.id === "__all__" ? "" : selected.id;
 		} else if (!snapshot.plugins.some((plugin) => plugin.name === target)) throw new Error(`当前 Profile 未安装 ${JSON.stringify(target)}`);
 		const args = target === "" ? ["update"] : ["update", target];
-		if (!await this.host.overlays.confirm(target === "" ? `更新 ${snapshot.profile} 全部依赖？` : `更新 ${target}？`, `将执行：pnpm ${args.join(" ")}。解析结果由 Profile lockfile 持久化。`, "更新")) return;
+		if (!await this.host.overlays.confirm(target === "" ? `更新 ${snapshot.profile} 全部依赖？` : `更新 ${target}？`, `将执行：pnpm ${args.join(" ")}。解析结果由 Profile lockfile 持久化。`, "更新", target === "")) return;
 		await this.pluginOperation(target === "" ? "更新全部插件" : `更新 ${target}`, await this.capabilities.managementBridge().plugins.run(args));
 	}
 	async pluginOperation(label, result) {
@@ -25084,7 +25084,7 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		}
 		if (source.builtIn) return;
 		if (selected.id === "remove") {
-			if (!await overlays.confirm(`移除 ${source.label}？`, "该目录将不再参与搜索；已安装插件不受影响。", "移除")) return;
+			if (!await overlays.confirm(`移除 ${source.label}？`, "该目录将不再参与搜索；已安装插件不受影响。", "移除", true)) return;
 		}
 		const next = selected.id === "remove" ? sources.filter((item) => item.id !== source.id) : sources.map((item) => item.id === source.id ? {
 			...item,
@@ -26169,6 +26169,34 @@ var PromptEditor = class extends Editor {
 
 //#endregion
 //#region src/client/overlays.ts
+function confirmChoices(confirmLabel, dangerous) {
+	const confirm = {
+		id: "confirm",
+		label: confirmLabel,
+		description: "我已理解上述影响"
+	};
+	const cancel = {
+		id: "cancel",
+		label: "取消",
+		description: "保持当前状态"
+	};
+	return dangerous ? [cancel, confirm] : [confirm, cancel];
+}
+function confirmRequest(title, detail, confirmLabel, dangerous) {
+	return {
+		title,
+		detail,
+		searchable: false,
+		choices: confirmChoices(confirmLabel, dangerous),
+		footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
+		options: {
+			width: "95%",
+			maxHeight: "90%",
+			anchor: "center",
+			margin: 1
+		}
+	};
+}
 function rowOf(choice, descriptionWidth) {
 	const state = choice.active === true ? "● " : choice.disabledReason === void 0 ? "  " : "× ";
 	const description = choice.disabledReason ?? choice.description;
@@ -26577,28 +26605,8 @@ var NavigationOverlay = class {
 			submit();
 		}));
 	}
-	async confirm(title, detail, confirmLabel = "确认") {
-		return (await this.select({
-			title,
-			detail,
-			searchable: false,
-			choices: [{
-				id: "confirm",
-				label: confirmLabel,
-				description: "我已理解上述影响"
-			}, {
-				id: "cancel",
-				label: "取消",
-				description: "保持当前状态"
-			}],
-			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
-			options: {
-				width: "95%",
-				maxHeight: "90%",
-				anchor: "center",
-				margin: 1
-			}
-		}))?.id === "confirm";
+	async confirm(title, detail, confirmLabel = "确认", dangerous = false) {
+		return (await this.select(confirmRequest(title, detail, confirmLabel, dangerous)))?.id === "confirm";
 	}
 	back() {
 		const entry = this.current();
@@ -26771,30 +26779,11 @@ var OverlayQueue = class {
 	* @param title - concise risk prompt.
 	* @param detail - complete impact description.
 	* @param confirmLabel - affirmative action label.
+	* @param dangerous - when true, Cancel is focused so a bare Enter aborts.
 	* @returns true only when the affirmative action was selected.
 	*/
-	async confirm(title, detail, confirmLabel = "确认") {
-		return (await this.select({
-			title,
-			detail,
-			searchable: false,
-			choices: [{
-				id: "confirm",
-				label: confirmLabel,
-				description: "我已理解上述影响"
-			}, {
-				id: "cancel",
-				label: "取消",
-				description: "保持当前状态"
-			}],
-			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
-			options: {
-				width: "95%",
-				maxHeight: "90%",
-				anchor: "center",
-				margin: 1
-			}
-		}))?.id === "confirm";
+	async confirm(title, detail, confirmLabel = "确认", dangerous = false) {
+		return (await this.select(confirmRequest(title, detail, confirmLabel, dangerous)))?.id === "confirm";
 	}
 	/** Settle every active/queued request before terminal teardown. */
 	dispose() {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -713,6 +713,7 @@ export class TuiActions {
       `移除工作区注册 ${workspace.title}？`,
       `${workspace.path}\n目录、用户文件和全部会话记录都会保留；会话将成为未分组。`,
       '移除注册',
+      true,
     )
     if (!confirmed) return
     await this.capabilities.deleteWorkspace(workspace.workspaceId)
@@ -1176,6 +1177,7 @@ export class TuiActions {
         `覆盖主题 ${existing.name}？`,
         '原主题颜色会被新配置替换，其他命名主题不受影响。',
         '覆盖',
+        true,
       )
       return overwrite ? { id: existing.id, name: existing.name } : undefined
     }
@@ -1289,6 +1291,7 @@ export class TuiActions {
         `编辑并覆盖主题 ${source.name}？`,
         '保存后会替换这个命名主题；其他主题不受影响。',
         '继续编辑',
+        true,
       )
       if (!overwrite) return
       editable = editableTheme(source, source.id.slice('custom:'.length), source.name)
@@ -1458,6 +1461,7 @@ export class TuiActions {
             ? '该主题会从 Harness Settings 删除，代码主题恢复自动匹配。'
             : '该主题会从 Harness Settings 删除；当前界面和代码主题不变。',
       '删除',
+      true,
     )
     if (!confirmed) return
     const updated = await deleteCustomTheme(bridge, document, theme.id)
@@ -1493,6 +1497,7 @@ export class TuiActions {
         option.id === 'danger-full-access' ? '进入完全访问？' : '切换到未知风险权限？',
         `${permissionLabel(option)}：${permissionDescription(option)}。切换后立即作用于当前会话。`,
         '确认切换',
+        true,
       )
       if (!confirmed) return
     }
@@ -1778,6 +1783,7 @@ export class TuiActions {
         option.id === 'danger-full-access' ? '新会话默认使用完全访问？' : '使用未知风险默认权限？',
         `${permissionLabel(option)}：${permissionDescription(option)}。以后创建的会话会采用该权限；现有会话不会改变。`,
         '确认保存',
+        true,
       )
       if (!confirmed) return
     }
@@ -1957,6 +1963,7 @@ export class TuiActions {
       `清除 Credential ${ref}？`,
       '密钥将被清除，Settings 中的引用名会保留。',
       '清除',
+      true,
     )
     if (!confirmed) return
     await bridge.unsetCredential(ref)
@@ -2234,6 +2241,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       `从 ${snapshot.profile} 移除 ${target}？`,
       `将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`,
       '移除',
+      true,
     )
     if (!confirmed) return
     await this.pluginOperation(`移除 ${target}`, await this.capabilities.managementBridge().plugins.run(['remove', target]))
@@ -2260,6 +2268,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       target === '' ? `更新 ${snapshot.profile} 全部依赖？` : `更新 ${target}？`,
       `将执行：pnpm ${args.join(' ')}。解析结果由 Profile lockfile 持久化。`,
       '更新',
+      target === '',
     )
     if (!confirmed) return
     await this.pluginOperation(target === '' ? '更新全部插件' : `更新 ${target}`, await this.capabilities.managementBridge().plugins.run(args))
@@ -2462,7 +2471,7 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
     }
     if (source.builtIn) return
     if (selected.id === 'remove') {
-      const confirmed = await overlays.confirm(`移除 ${source.label}？`, '该目录将不再参与搜索；已安装插件不受影响。', '移除')
+      const confirmed = await overlays.confirm(`移除 ${source.label}？`, '该目录将不再参与搜索；已安装插件不受影响。', '移除', true)
       if (!confirmed) return
     }
     const next = selected.id === 'remove'

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -65,7 +65,7 @@ export interface OverlayPrompts {
   secretInput(request: InputOverlayRequest): Promise<string | undefined>
   multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined>
   detail(request: DetailOverlayRequest): Promise<void>
-  confirm(title: string, detail: string, confirmLabel?: string): Promise<boolean>
+  confirm(title: string, detail: string, confirmLabel?: string, dangerous?: boolean): Promise<boolean>
 }
 
 /** One logical overlay session whose page stack owns all back navigation. */
@@ -104,6 +104,28 @@ interface NavigationEntry {
   readonly dismiss: () => void
   busy: boolean
   active: boolean
+}
+
+function confirmChoices(confirmLabel: string, dangerous: boolean): readonly OverlayChoice[] {
+  const confirm = { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' }
+  const cancel = { id: 'cancel', label: '取消', description: '保持当前状态' }
+  return dangerous ? [cancel, confirm] : [confirm, cancel]
+}
+
+function confirmRequest(
+  title: string,
+  detail: string,
+  confirmLabel: string,
+  dangerous: boolean,
+): SelectOverlayRequest {
+  return {
+    title,
+    detail,
+    searchable: false,
+    choices: confirmChoices(confirmLabel, dangerous),
+    footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
+    options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+  }
 }
 
 function rowOf(choice: OverlayChoice, descriptionWidth: number): SelectItem {
@@ -590,18 +612,8 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     await this.prompt<void>(submit => new ScrollableDetailOverlay(request, () => { submit() }))
   }
 
-  async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
-    const selected = await this.select({
-      title,
-      detail,
-      searchable: false,
-      choices: [
-        { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
-        { id: 'cancel', label: '取消', description: '保持当前状态' },
-      ],
-      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
-      options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
-    })
+  async confirm(title: string, detail: string, confirmLabel = '确认', dangerous = false): Promise<boolean> {
+    const selected = await this.select(confirmRequest(title, detail, confirmLabel, dangerous))
     return selected?.id === 'confirm'
   }
 
@@ -791,20 +803,11 @@ export class OverlayQueue implements OverlayPrompts {
    * @param title - concise risk prompt.
    * @param detail - complete impact description.
    * @param confirmLabel - affirmative action label.
+   * @param dangerous - when true, Cancel is focused so a bare Enter aborts.
    * @returns true only when the affirmative action was selected.
    */
-  async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
-    const selected = await this.select({
-      title,
-      detail,
-      searchable: false,
-      choices: [
-        { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
-        { id: 'cancel', label: '取消', description: '保持当前状态' },
-      ],
-      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
-      options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
-    })
+  async confirm(title: string, detail: string, confirmLabel = '确认', dangerous = false): Promise<boolean> {
+    const selected = await this.select(confirmRequest(title, detail, confirmLabel, dangerous))
     return selected?.id === 'confirm'
   }
 

--- a/tests/actions-theme.test.ts
+++ b/tests/actions-theme.test.ts
@@ -231,6 +231,7 @@ describe('/theme commands', () => {
       '编辑并覆盖主题 Ocean？',
       expect.stringContaining('替换这个命名主题'),
       '继续编辑',
+      true,
     )
     expect(select).not.toHaveBeenCalled()
     expect(state.mutate).not.toHaveBeenCalled()
@@ -245,6 +246,12 @@ describe('/theme commands', () => {
     await actions.execute('theme', 'delete Ocean')
 
     expect(confirm).toHaveBeenCalledTimes(1)
+    expect(confirm).toHaveBeenCalledWith(
+      '删除主题 Ocean？',
+      expect.stringContaining('该主题会从 Harness Settings 删除'),
+      '删除',
+      true,
+    )
     expect(state.current().value).toEqual({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
     expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({ id: 'dark' }))
   })

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -101,4 +101,28 @@ describe('overlay navigation', () => {
     await expect(session).resolves.toBeUndefined()
     expect(harness.hide).toHaveBeenCalledOnce()
   })
+
+  it('defaults a dangerous confirm onto cancel so Enter does not execute', async () => {
+    const harness = overlayHarness()
+    const confirmed = harness.overlays.confirm('删除主题？', '该主题会从 Settings 删除。', '删除', true)
+
+    const view = plain(harness.component().render(80))
+    expect(view).toMatch(/→\s+取消/u)
+    expect(view).not.toMatch(/→\s+删除/u)
+
+    harness.component().handleInput(ENTER)
+    await expect(confirmed).resolves.toBe(false)
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+
+  it('keeps low-risk confirms focused on the affirmative action', async () => {
+    const harness = overlayHarness()
+    const confirmed = harness.overlays.confirm('立即重启？', '会恢复当前会话。', '立即重启')
+
+    const view = plain(harness.component().render(80))
+    expect(view).toMatch(/→\s+立即重启/u)
+
+    harness.component().handleInput(ENTER)
+    await expect(confirmed).resolves.toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- P0-4 from `docs/DEEP_OPTIMIZATION.md`: `confirm(..., dangerous)` puts Cancel first so a bare Enter does not execute.
- Wired for theme delete/overwrite, workspace unregister, credential clear, plugin remove, full plugin update, and full-access permission.
- Low-risk confirms such as restart keep the affirmative action focused.

## Test plan
- [x] overlays-navigation default-focus assertions
- [x] theme edit/delete confirm argument assertions
- [x] full `vitest run` (98 passing)
- [ ] Manual: delete a theme and press Enter immediately — the theme should remain

Do not merge yet — remaining P0 items land on separate branches.

Made with [Cursor](https://cursor.com)