### PR TITLE
fix(tui): confirm before discarding a question batch on Escape

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-fAI-vm30.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-Bjh9Au4u.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -25773,9 +25773,13 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 	}
 	async question(wait) {
 		const answers = [];
-		for (const [index, question] of wait.payload.questions.entries()) {
+		const questions = wait.payload.questions;
+		let index = 0;
+		while (index < questions.length) {
+			const question = questions[index];
+			if (question === void 0) break;
 			const planReview = question.intent?.kind === "plan-review" ? question.intent : void 0;
-			const title = `${planReview === void 0 ? question.header ?? "问题" : "计划审查"} · ${index + 1}/${wait.payload.questions.length}`;
+			const title = `${planReview === void 0 ? question.header ?? "问题" : "计划审查"} · ${index + 1}/${questions.length}`;
 			const presentation = (option) => {
 				if (planReview === void 0) return option;
 				return option.label === planReview.approve ? {
@@ -25785,6 +25789,9 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 					label: "继续规划",
 					description: "返回并修改计划"
 				};
+			};
+			const escapeAction = async () => {
+				return this.confirmQuestionEscape(index, questions.length, answers.length);
 			};
 			if (question.multiSelect === true) {
 				const picked$1 = await this.host.overlays.multiSelect({
@@ -25806,14 +25813,26 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 					}
 				});
 				if (picked$1 === void 0) {
-					this.host.transcript.followLatest();
-					await this.capabilities.cancelQuestion(wait);
-					return;
+					const decision = await escapeAction();
+					if (decision === "cancel") {
+						this.host.transcript.followLatest();
+						await this.capabilities.cancelQuestion(wait);
+						return;
+					}
+					if (decision === "skip") {
+						answers.push({
+							id: question.id,
+							selected: []
+						});
+						index += 1;
+					}
+					continue;
 				}
 				answers.push({
 					id: question.id,
 					selected: picked$1.map((option) => option.id)
 				});
+				index += 1;
 				continue;
 			}
 			const choices = [...(question.options ?? []).map((option) => {
@@ -25844,9 +25863,20 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 				}
 			});
 			if (picked === void 0) {
-				this.host.transcript.followLatest();
-				await this.capabilities.cancelQuestion(wait);
-				return;
+				const decision = await escapeAction();
+				if (decision === "cancel") {
+					this.host.transcript.followLatest();
+					await this.capabilities.cancelQuestion(wait);
+					return;
+				}
+				if (decision === "skip") {
+					answers.push({
+						id: question.id,
+						selected: []
+					});
+					index += 1;
+				}
+				continue;
 			}
 			if (picked.id === "__custom__") {
 				const custom = await this.host.overlays.input({
@@ -25860,9 +25890,20 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 					}
 				});
 				if (custom === void 0) {
-					this.host.transcript.followLatest();
-					await this.capabilities.cancelQuestion(wait);
-					return;
+					const decision = await escapeAction();
+					if (decision === "cancel") {
+						this.host.transcript.followLatest();
+						await this.capabilities.cancelQuestion(wait);
+						return;
+					}
+					if (decision === "skip") {
+						answers.push({
+							id: question.id,
+							selected: []
+						});
+						index += 1;
+					}
+					continue;
 				}
 				answers.push({
 					id: question.id,
@@ -25877,9 +25918,44 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 				id: question.id,
 				selected: [picked.id.slice(7)]
 			});
+			index += 1;
 		}
 		this.host.transcript.followLatest();
 		await this.capabilities.answerQuestion(wait, { answers });
+	}
+	async confirmQuestionEscape(index, total, answered) {
+		const selected = await this.host.overlays.select({
+			title: "取消这批问题？",
+			detail: `已回答 ${String(answered)}/${String(total)} · 当前第 ${String(index + 1)} 题`,
+			searchable: false,
+			choices: [
+				{
+					id: "continue",
+					label: "继续作答",
+					description: "回到当前问题"
+				},
+				{
+					id: "skip",
+					label: "仅跳过本题",
+					description: "提交空选择并进入下一题"
+				},
+				{
+					id: "cancel",
+					label: "取消全部",
+					description: "已答内容作废"
+				}
+			],
+			footer: "Enter 确认 · Esc 继续作答",
+			options: {
+				width: "95%",
+				maxHeight: "90%",
+				anchor: "bottom-center",
+				margin: 1
+			}
+		});
+		if (selected?.id === "skip") return "skip";
+		if (selected?.id === "cancel") return "cancel";
+		return "continue";
 	}
 };
 /**

--- a/lib/startup-Bjh9Au4u.js
+++ b/lib/startup-Bjh9Au4u.js
@@ -224,6 +224,14 @@ const ENGLISH_TEXT = new Map([
 	["批准计划", "Approve plan"],
 	["继续规划", "Continue planning"],
 	["跳过", "Skip"],
+	["取消这批问题？", "Cancel this question batch?"],
+	["继续作答", "Keep answering"],
+	["回到当前问题", "Return to the current question"],
+	["仅跳过本题", "Skip only this question"],
+	["提交空选择并进入下一题", "Submit an empty choice and continue"],
+	["取消全部", "Cancel all"],
+	["已答内容作废", "Discard answers already given"],
+	["Enter 确认 · Esc 继续作答", "Enter confirms · Esc keeps answering"],
 	["拒绝", "Deny"],
 	["仅本次允许", "Allow once"],
 	["正在思考…", "Thinking…"],
@@ -662,6 +670,10 @@ const ENGLISH_PATTERNS = [
 	{
 		pattern: /^(.+) · 立即生效$/u,
 		replace: (value) => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately`
+	},
+	{
+		pattern: /^已回答 (\d+)\/(\d+) · 当前第 (\d+) 题$/u,
+		replace: (answered, total, current) => `Answered ${answered}/${total} · currently question ${current}`
 	},
 	{
 		pattern: /^(.+) · 需重启$/u,

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-fAI-vm30.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-Bjh9Au4u.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3075,9 +3075,13 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
 
   private async question(wait: PendingWait<'question'>): Promise<void> {
     const answers: QuestionResponsePayload['answer']['answers'] = []
-    for (const [index, question] of wait.payload.questions.entries()) {
+    const questions = wait.payload.questions
+    let index = 0
+    while (index < questions.length) {
+      const question = questions[index]
+      if (question === undefined) break
       const planReview = question.intent?.kind === 'plan-review' ? question.intent : undefined
-      const title = `${planReview === undefined ? question.header ?? '问题' : '计划审查'} · ${index + 1}/${wait.payload.questions.length}`
+      const title = `${planReview === undefined ? question.header ?? '问题' : '计划审查'} · ${index + 1}/${questions.length}`
       const presentation = (option: NonNullable<typeof question.options>[number]): {
         readonly label: string
         readonly description?: string
@@ -3086,6 +3090,9 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
         return option.label === planReview.approve
           ? { label: '批准计划', description: '按此计划继续' }
           : { label: '继续规划', description: '返回并修改计划' }
+      }
+      const escapeAction = async (): Promise<'cancel' | 'skip' | 'continue'> => {
+        return this.confirmQuestionEscape(index, questions.length, answers.length)
       }
       if (question.multiSelect === true) {
         const picked = await this.host.overlays.multiSelect({
@@ -3102,11 +3109,20 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
           options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
         })
         if (picked === undefined) {
-          this.host.transcript.followLatest()
-          await this.capabilities.cancelQuestion(wait)
-          return
+          const decision = await escapeAction()
+          if (decision === 'cancel') {
+            this.host.transcript.followLatest()
+            await this.capabilities.cancelQuestion(wait)
+            return
+          }
+          if (decision === 'skip') {
+            answers.push({ id: question.id, selected: [] })
+            index += 1
+          }
+          continue
         }
         answers.push({ id: question.id, selected: picked.map(option => option.id) })
+        index += 1
         continue
       }
       const choices: OverlayChoice[] = [
@@ -3133,9 +3149,17 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
         options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
       })
       if (picked === undefined) {
-        this.host.transcript.followLatest()
-        await this.capabilities.cancelQuestion(wait)
-        return
+        const decision = await escapeAction()
+        if (decision === 'cancel') {
+          this.host.transcript.followLatest()
+          await this.capabilities.cancelQuestion(wait)
+          return
+        }
+        if (decision === 'skip') {
+          answers.push({ id: question.id, selected: [] })
+          index += 1
+        }
+        continue
       }
       if (picked.id === '__custom__') {
         const custom = await this.host.overlays.input({
@@ -3144,9 +3168,17 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
           options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
         })
         if (custom === undefined) {
-          this.host.transcript.followLatest()
-          await this.capabilities.cancelQuestion(wait)
-          return
+          const decision = await escapeAction()
+          if (decision === 'cancel') {
+            this.host.transcript.followLatest()
+            await this.capabilities.cancelQuestion(wait)
+            return
+          }
+          if (decision === 'skip') {
+            answers.push({ id: question.id, selected: [] })
+            index += 1
+          }
+          continue
         }
         answers.push({ id: question.id, selected: [], custom })
       } else if (picked.id === '__skip__') {
@@ -3154,9 +3186,32 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
       } else {
         answers.push({ id: question.id, selected: [picked.id.slice('option:'.length)] })
       }
+      index += 1
     }
     this.host.transcript.followLatest()
     await this.capabilities.answerQuestion(wait, { answers })
+  }
+
+  private async confirmQuestionEscape(
+    index: number,
+    total: number,
+    answered: number,
+  ): Promise<'cancel' | 'skip' | 'continue'> {
+    const selected = await this.host.overlays.select({
+      title: '取消这批问题？',
+      detail: `已回答 ${String(answered)}/${String(total)} · 当前第 ${String(index + 1)} 题`,
+      searchable: false,
+      choices: [
+        { id: 'continue', label: '继续作答', description: '回到当前问题' },
+        { id: 'skip', label: '仅跳过本题', description: '提交空选择并进入下一题' },
+        { id: 'cancel', label: '取消全部', description: '已答内容作废' },
+      ],
+      footer: 'Enter 确认 · Esc 继续作答',
+      options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
+    })
+    if (selected?.id === 'skip') return 'skip'
+    if (selected?.id === 'cancel') return 'cancel'
+    return 'continue'
   }
 }
 

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -229,6 +229,14 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['批准计划', 'Approve plan'],
   ['继续规划', 'Continue planning'],
   ['跳过', 'Skip'],
+  ['取消这批问题？', 'Cancel this question batch?'],
+  ['继续作答', 'Keep answering'],
+  ['回到当前问题', 'Return to the current question'],
+  ['仅跳过本题', 'Skip only this question'],
+  ['提交空选择并进入下一题', 'Submit an empty choice and continue'],
+  ['取消全部', 'Cancel all'],
+  ['已答内容作废', 'Discard answers already given'],
+  ['Enter 确认 · Esc 继续作答', 'Enter confirms · Esc keeps answering'],
   ['拒绝', 'Deny'],
   ['仅本次允许', 'Allow once'],
   ['正在思考…', 'Thinking…'],
@@ -668,7 +676,7 @@ const ENGLISH_PATTERNS: readonly {
   readonly pattern: RegExp
   readonly replace: (...groups: string[]) => string
 }[] = [
-  { pattern: /^(.+) · 立即生效$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
+  { pattern: /^已回答 (\d+)\/(\d+) · 当前第 (\d+) 题$/u, replace: (answered, total, current) => `Answered ${answered}/${total} · currently question ${current}` },
   { pattern: /^(.+) · 需重启$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · restart required` },
   { pattern: /^设置 · (.+)$/u, replace: value => `Settings · ${value}` },
   { pattern: /^设置 (.+) 已更新并立即生效$/u, replace: value => `${value} was updated and is now active` },

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -676,6 +676,7 @@ const ENGLISH_PATTERNS: readonly {
   readonly pattern: RegExp
   readonly replace: (...groups: string[]) => string
 }[] = [
+  { pattern: /^(.+) · 立即生效$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
   { pattern: /^已回答 (\d+)\/(\d+) · 当前第 (\d+) 题$/u, replace: (answered, total, current) => `Answered ${answered}/${total} · currently question ${current}` },
   { pattern: /^(.+) · 需重启$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · restart required` },
   { pattern: /^设置 · (.+)$/u, replace: value => `Settings · ${value}` },

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -32,6 +32,46 @@ function host(overlays: Partial<OverlayQueue>, transcript: Partial<Transcript>):
   }
 }
 
+function questionBatch(count: number): PendingWait<'question'> {
+  return {
+    key: 'question:batch',
+    kind: 'question',
+    sessionId: 'session' as SessionId,
+    payload: {
+      questions: Array.from({ length: count }, (_, index) => ({
+        id: `q${String(index + 1)}`,
+        header: '问题',
+        question: `第 ${String(index + 1)} 题`,
+        options: [{ label: `选项${String(index + 1)}` }],
+        multiSelect: false,
+      })),
+    },
+  } as unknown as PendingWait<'question'>
+}
+
+function pendingActions(
+  wait: PendingWait<'question'>,
+  overlays: Partial<OverlayQueue>,
+): {
+  readonly actions: TuiActions
+  readonly answerQuestion: ReturnType<typeof vi.fn>
+  readonly cancelQuestion: ReturnType<typeof vi.fn>
+} {
+  const snapshot = { pending: [wait] } as unknown as ConversationSnapshot
+  const answerQuestion = vi.fn(async () => undefined)
+  const cancelQuestion = vi.fn(async () => undefined)
+  const active = {
+    session: { getSnapshot: () => snapshot },
+  } as unknown as TuiActiveSession
+  const capabilities = {
+    active: () => active,
+    answerQuestion,
+    cancelQuestion,
+  } as unknown as HarnessTuiCapabilities
+  const actions = new TuiActions(capabilities, host(overlays, { followLatest: vi.fn() }))
+  return { actions, answerQuestion, cancelQuestion }
+}
+
 describe('pending interaction continuation', () => {
   it('returns to the latest transcript before submitting a selected answer', async () => {
     const question = {
@@ -73,6 +113,58 @@ describe('pending interaction continuation', () => {
       .toBeLessThan(answerQuestion.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY)
     expect(answerQuestion).toHaveBeenCalledWith(question, {
       answers: [{ id: 'which_pkg', selected: ['visualtex-src 根目录 (Recommended)'] }],
+    })
+  })
+
+  it('asks before discarding a batch when Escape is pressed mid-question', async () => {
+    const wait = questionBatch(3)
+    const seenTitles: string[] = []
+    const select = vi.fn(async (request: { title: string; detail?: string }) => {
+      seenTitles.push(request.title)
+      if (request.title.includes('1/3')) return { id: 'option:选项1', label: '选项1' }
+      if (request.title.includes('2/3')) return { id: 'option:选项2', label: '选项2' }
+      if (request.title.includes('取消')) {
+        expect(request.detail).toContain('2/3')
+        return { id: 'continue', label: '继续作答' }
+      }
+      const thirdShows = seenTitles.filter(title => title.includes('3/3')).length
+      if (thirdShows === 1) return undefined
+      return { id: 'option:选项3', label: '选项3' }
+    })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+
+    actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
+    await vi.waitFor(() => { expect(answerQuestion).toHaveBeenCalledOnce() })
+
+    expect(cancelQuestion).not.toHaveBeenCalled()
+    expect(seenTitles.some(title => title.includes('取消'))).toBe(true)
+    expect(answerQuestion).toHaveBeenCalledWith(wait, {
+      answers: [
+        { id: 'q1', selected: ['选项1'] },
+        { id: 'q2', selected: ['选项2'] },
+        { id: 'q3', selected: ['选项3'] },
+      ],
+    })
+  })
+
+  it('can skip only the current question after Escape', async () => {
+    const wait = questionBatch(2)
+    const select = vi.fn(async (request: { title: string }) => {
+      if (request.title.includes('1/2')) return undefined
+      if (request.title.includes('取消')) return { id: 'skip', label: '仅跳过本题' }
+      return { id: 'option:选项2', label: '选项2' }
+    })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+
+    actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
+    await vi.waitFor(() => { expect(answerQuestion).toHaveBeenCalledOnce() })
+
+    expect(cancelQuestion).not.toHaveBeenCalled()
+    expect(answerQuestion).toHaveBeenCalledWith(wait, {
+      answers: [
+        { id: 'q1', selected: [] },
+        { id: 'q2', selected: ['选项2'] },
+      ],
     })
   })
 })

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -167,4 +167,20 @@ describe('pending interaction continuation', () => {
       ],
     })
   })
+
+  it('cancels the whole batch when Escape is confirmed', async () => {
+    const wait = questionBatch(2)
+    const select = vi.fn(async (request: { title: string }) => {
+      if (request.title.includes('1/2')) return { id: 'option:选项1', label: '选项1' }
+      if (request.title.includes('2/2')) return undefined
+      return { id: 'cancel', label: '取消全部' }
+    })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+
+    actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
+    await vi.waitFor(() => { expect(cancelQuestion).toHaveBeenCalledOnce() })
+
+    expect(cancelQuestion).toHaveBeenCalledWith(wait)
+    expect(answerQuestion).not.toHaveBeenCalled()
+  })
 })

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -97,6 +97,8 @@ describe('terminal locale preference', () => {
     expect(ui('设置', 'Settings')).toBe('Settings')
     expect(translateUiText('命令面板')).toBe('Command palette')
     expect(translateUiText('队列 3')).toBe('Queue 3')
+    expect(translateUiText('插件 · 立即生效')).toBe('插件 · applies immediately')
+    expect(translateUiText('已回答 2/3 · 当前第 3 题')).toBe('Answered 2/3 · currently question 3')
     expect(translateUiText('provider-authored 中文说明')).toBe('provider-authored 中文说明')
   })
 


### PR DESCRIPTION
## Summary
- P0-8 from `docs/DEEP_OPTIMIZATION.md`: Escape during a multi-question prompt no longer cancels the whole batch.
- Secondary overlay offers 继续作答 / 仅跳过本题 / 取消全部, and shows `已回答 n/N` progress.
- Esc on that overlay returns to the current question.

## Test plan
- [x] Batch of 3: answer two, Esc, continue, answer the third
- [x] Esc then skip only the current question
- [x] full `vitest run` (98 passing)
- [ ] Manual: three-question batch, Esc on the third, choose 继续作答

Do not merge yet — remaining P0 items land on separate branches.