### PR TITLE
fix(tui): shadow colliding Host commands instead of failing the catalog

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-fAI-vm30.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-CEo8NZIs.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -19549,6 +19549,60 @@ const HOST_COMMAND_FUNCTIONS = new Map([
 	["compact", "压缩当前会话上下文"]
 ]);
 const HOST_COMMAND_ARGUMENT_HINTS = new Map([["permission", "[权限]"], ["feedback", "[内容]"]]);
+/**
+* Merge TUI builtins with Host commands and Skills, shadowing colliding Host names.
+* @param hostCommands - Host-registered slash commands for the current Session.
+* @param skills - user-invocable Skills from the same Session.
+* @returns the surviving catalog plus Host shadow diagnostics.
+*/
+function mergeCommandCatalog(hostCommands, skills) {
+	const local = new Map(TUI_COMMANDS.map((command) => [command.name, command]));
+	const catalog = [...TUI_COMMANDS];
+	const names = new Set(TUI_COMMANDS.map((command) => command.name));
+	const shadows = [];
+	for (const command of hostCommands) {
+		if (local.has(command.name)) {
+			shadows.push(command.name);
+			continue;
+		}
+		names.add(command.name);
+		catalog.push({
+			name: command.name,
+			description: HOST_COMMAND_FUNCTIONS.get(command.name) ?? shortFunctionDescription(command.description, "执行命令"),
+			...command.input === void 0 ? {} : { argumentHint: HOST_COMMAND_ARGUMENT_HINTS.get(command.name) ?? command.input.hint },
+			source: HOST_COMMAND_DECORATORS.has(command.name) ? "Host + TUI" : "Host",
+			behavior: HOST_COMMAND_DECORATORS.has(command.name) ? "local" : "host"
+		});
+	}
+	for (const skill of skills) {
+		if (names.has(skill.name)) continue;
+		names.add(skill.name);
+		catalog.push({
+			name: skill.name,
+			description: shortFunctionDescription(skill.description, "按名称执行对应能力"),
+			source: "Skill",
+			behavior: "skill"
+		});
+	}
+	return {
+		catalog,
+		shadows,
+		diagnostics: commandShadowMessages(shadows)
+	};
+}
+/**
+* Doctor copy for Host commands skipped because they collide with TUI builtins.
+* @param shadowsBySession - Host names shadowed per Session.
+* @param sessionId - Session whose catalog was last merged, if any.
+* @returns warning lines for /doctor, or none when the Session has no shadows.
+*/
+function commandShadowDiagnostics(shadowsBySession, sessionId) {
+	if (sessionId === void 0) return [];
+	return commandShadowMessages(shadowsBySession.get(sessionId) ?? []);
+}
+function commandShadowMessages(names) {
+	return names.map((name$1) => `命令 /${name$1} 被 TUI 内置命令遮蔽`);
+}
 function shortFunctionDescription(description, fallback) {
 	const normalized = description.replace(/\s+/gu, " ").trim();
 	if (!/\p{Script=Han}/u.test(normalized)) return fallback;
@@ -19895,6 +19949,7 @@ function workspaceFor(sessionId, path$1, workspaces) {
 */
 var HarnessTuiCapabilities = class {
 	commandCatalogs = /* @__PURE__ */ new Map();
+	commandShadows = /* @__PURE__ */ new Map();
 	modelCatalogs = /* @__PURE__ */ new Map();
 	modelLoads = /* @__PURE__ */ new Map();
 	attachments = [];
@@ -19912,10 +19967,10 @@ var HarnessTuiCapabilities = class {
 		this.initialWorkspacePath = initialWorkspacePath;
 		this.management = management;
 		ctx.remote.$on("commands/change", () => {
-			this.commandCatalogs.clear();
+			this.forgetCommandCatalogs();
 		});
 		ctx.remote.$on("agent-preset/selected", (sessionId) => {
-			this.commandCatalogs.delete(sessionId);
+			this.forgetCommandCatalogs(sessionId);
 			this.invalidateModels();
 		});
 		ctx.remote.$on("llm/adapters-updated", () => {
@@ -19925,7 +19980,7 @@ var HarnessTuiCapabilities = class {
 			this.invalidateModels();
 		});
 		ctx.on("connection/reset", () => {
-			this.commandCatalogs.clear();
+			this.forgetCommandCatalogs();
 			this.invalidateModels();
 		});
 	}
@@ -20041,7 +20096,7 @@ var HarnessTuiCapabilities = class {
 		if (sessionId === void 0) return Promise.resolve(TUI_COMMANDS);
 		const existing = this.commandCatalogs.get(sessionId);
 		const request = existing ?? this.readCommandCatalog(sessionId).catch((error) => {
-			this.commandCatalogs.delete(sessionId);
+			this.forgetCommandCatalogs(sessionId);
 			throw error;
 		});
 		if (existing === void 0) this.commandCatalogs.set(sessionId, request);
@@ -20053,8 +20108,23 @@ var HarnessTuiCapabilities = class {
 	}
 	/** Invalidate the current command/Skill snapshot and repull on next use. */
 	invalidateCommandCatalog() {
-		const id = this.active()?.sessionId;
-		if (id !== void 0) this.commandCatalogs.delete(id);
+		this.forgetCommandCatalogs(this.active()?.sessionId);
+	}
+	/**
+	* Host commands skipped because they collide with TUI builtins.
+	* @returns doctor-ready shadow records for the active Session.
+	*/
+	commandDiagnostics() {
+		return commandShadowDiagnostics(this.commandShadows, this.active()?.sessionId);
+	}
+	forgetCommandCatalogs(sessionId) {
+		if (sessionId === void 0) {
+			this.commandCatalogs.clear();
+			this.commandShadows.clear();
+			return;
+		}
+		this.commandCatalogs.delete(sessionId);
+		this.commandShadows.delete(sessionId);
 	}
 	/**
 	* List every Host Agent Preset without a client-side enum.
@@ -20113,7 +20183,7 @@ var HarnessTuiCapabilities = class {
 		if (!response.result.ok) throw new Error(`切换模式失败：${response.result.error.message}`);
 		this.ctx.sessions.noteAgentPreset(target.sessionId, response.result.value.agentPreset);
 		this.ctx.sessions.open(target.sessionId);
-		this.commandCatalogs.delete(target.sessionId);
+		this.forgetCommandCatalogs(target.sessionId);
 		return target.sessionId;
 	}
 	/**
@@ -20810,32 +20880,10 @@ var HarnessTuiCapabilities = class {
 		}) : this.ctx.remote.commands.list(sessionId), isSubagent ? Promise.resolve(void 0) : this.api.skills.list({ sessionId })]);
 		if (!hostResult.ok) throw new Error(`读取 Host 命令失败：${hostResult.error.message}`);
 		if (skillResponse !== void 0 && !skillResponse.result.ok) throw new Error(`读取 Skill 失败：${skillResponse.result.error.message}`);
-		const local = new Map(TUI_COMMANDS.map((command) => [command.name, command]));
-		const merged = [...TUI_COMMANDS];
-		const names = new Set(TUI_COMMANDS.map((command) => command.name));
-		for (const command of hostResult.value) {
-			if (local.get(command.name) !== void 0) throw new Error(`命令冲突：TUI 与 Host 都注册了 /${command.name}`);
-			names.add(command.name);
-			merged.push({
-				name: command.name,
-				description: HOST_COMMAND_FUNCTIONS.get(command.name) ?? shortFunctionDescription(command.description, "执行命令"),
-				...command.input === void 0 ? {} : { argumentHint: HOST_COMMAND_ARGUMENT_HINTS.get(command.name) ?? command.input.hint },
-				source: HOST_COMMAND_DECORATORS.has(command.name) ? "Host + TUI" : "Host",
-				behavior: HOST_COMMAND_DECORATORS.has(command.name) ? "local" : "host"
-			});
-		}
 		const skills = skillResponse?.result.ok === true ? skillResponse.result.value.skills : [];
-		for (const skill of skills) {
-			if (names.has(skill.name)) continue;
-			names.add(skill.name);
-			merged.push({
-				name: skill.name,
-				description: shortFunctionDescription(skill.description, "按名称执行对应能力"),
-				source: "Skill",
-				behavior: "skill"
-			});
-		}
-		return merged;
+		const merged = mergeCommandCatalog(hostResult.value, skills);
+		this.commandShadows.set(sessionId, merged.shadows);
+		return merged.catalog;
 	}
 };
 /**
@@ -25112,10 +25160,18 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		const [report, status, inventory] = await Promise.all([
 			this.capabilities.managementBridge().plugins.doctor(),
 			this.capabilities.headerFacts(true),
-			this.capabilities.pluginInventory()
+			this.capabilities.pluginInventory(),
+			this.capabilities.commandCatalog().catch(() => void 0)
 		]);
+		const commandDiagnostics = this.capabilities.commandDiagnostics();
 		const errors = report.diagnostics.filter((item) => item.level === "error").length;
-		const warnings = report.diagnostics.filter((item) => item.level === "warning").length;
+		const warnings = report.diagnostics.filter((item) => item.level === "warning").length + commandDiagnostics.length;
+		const commandShadows = commandDiagnostics.map((message, index) => ({
+			id: `command:${index}`,
+			label: `! ${translateUiText(message)}`,
+			description: "warning",
+			message
+		}));
 		const failedInstances = inventory.filter((item) => item.fiberPhase === "failed");
 		const enabledInstances = inventory.filter((item) => item.enabled).length;
 		const selected = await this.host.overlays.select({
@@ -25127,6 +25183,11 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 					label: `Runtime · ${status.running ? "运行中" : "空闲"}`,
 					description: `${status.workspace} · ${status.model} · ${status.permission}`
 				},
+				...commandShadows.map(({ id, label, description }) => ({
+					id,
+					label,
+					description
+				})),
 				...report.diagnostics.map((item, index) => ({
 					id: `plugin:${index}`,
 					label: `${item.level === "error" ? "✕" : item.level === "warning" ? "!" : "✓"} ${translateUiText(item.message)}`,
@@ -25175,6 +25236,22 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 					`Permission: ${status.permission}`,
 					`Status: ${status.running ? "running" : "idle"}`
 				].join("\n")),
+				options: {
+					width: "95%",
+					maxHeight: "90%",
+					anchor: "center",
+					margin: 1
+				}
+			});
+			return;
+		}
+		if (selected.id.startsWith("command:")) {
+			const index = Number(selected.id.slice(8));
+			const shadow = Number.isInteger(index) ? commandShadows[index] : void 0;
+			if (shadow === void 0) return;
+			await this.host.overlays.detail({
+				title: "诊断详情 · 警告",
+				content: translateUiText(shadow.message),
 				options: {
 					width: "95%",
 					maxHeight: "90%",

--- a/lib/startup-CEo8NZIs.js
+++ b/lib/startup-CEo8NZIs.js
@@ -664,6 +664,10 @@ const ENGLISH_PATTERNS = [
 		replace: (value) => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately`
 	},
 	{
+		pattern: /^命令 \/(.+) 被 TUI 内置命令遮蔽$/u,
+		replace: (name$1) => `Command /${name$1} is shadowed by a TUI builtin`
+	},
+	{
 		pattern: /^(.+) · 需重启$/u,
 		replace: (value) => `${ENGLISH_TEXT.get(value) ?? value} · restart required`
 	},

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-fAI-vm30.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-CEo8NZIs.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -2494,9 +2494,18 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
       this.capabilities.managementBridge().plugins.doctor(),
       this.capabilities.headerFacts(true),
       this.capabilities.pluginInventory(),
+      this.capabilities.commandCatalog().catch(() => undefined),
     ])
+    const commandDiagnostics = this.capabilities.commandDiagnostics()
     const errors = report.diagnostics.filter(item => item.level === 'error').length
     const warnings = report.diagnostics.filter(item => item.level === 'warning').length
+      + commandDiagnostics.length
+    const commandShadows = commandDiagnostics.map((message, index) => ({
+      id: `command:${index}`,
+      label: `! ${translateUiText(message)}`,
+      description: 'warning',
+      message,
+    }))
     const failedInstances = inventory.filter(item => item.fiberPhase === 'failed')
     const enabledInstances = inventory.filter(item => item.enabled).length
     const selected = await this.host.overlays.select({
@@ -2511,6 +2520,7 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
           label: `Runtime · ${status.running ? '运行中' : '空闲'}`,
           description: `${status.workspace} · ${status.model} · ${status.permission}`,
         },
+        ...commandShadows.map(({ id, label, description }) => ({ id, label, description })),
         ...report.diagnostics.map((item, index) => ({
           id: `plugin:${index}`,
           label: `${item.level === 'error' ? '✕' : item.level === 'warning' ? '!' : '✓'} ${translateUiText(item.message)}`,
@@ -2557,6 +2567,17 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
             `Status: ${status.running ? 'running' : 'idle'}`,
           ].join('\n'),
         ),
+        options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+      })
+      return
+    }
+    if (selected.id.startsWith('command:')) {
+      const index = Number(selected.id.slice('command:'.length))
+      const shadow = Number.isInteger(index) ? commandShadows[index] : undefined
+      if (shadow === undefined) return
+      await this.host.overlays.detail({
+        title: '诊断详情 · 警告',
+        content: translateUiText(shadow.message),
         options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
       })
       return

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -194,6 +194,60 @@ const HOST_COMMAND_ARGUMENT_HINTS = new Map<string, string>([
   ['feedback', '[内容]'],
 ])
 
+export interface MergedCommandCatalog {
+  readonly catalog: readonly TuiCommandCandidate[]
+  readonly shadows: readonly string[]
+  readonly diagnostics: readonly string[]
+}
+
+/**
+ * Merge TUI builtins with Host commands and Skills, shadowing colliding Host names.
+ * @param hostCommands - Host-registered slash commands for the current Session.
+ * @param skills - user-invocable Skills from the same Session.
+ * @returns the surviving catalog plus Host shadow diagnostics.
+ */
+export function mergeCommandCatalog(
+  hostCommands: readonly HostCommandDescriptor[],
+  skills: readonly Pick<SkillEntry, 'name' | 'description'>[],
+): MergedCommandCatalog {
+  const local = new Map(TUI_COMMANDS.map(command => [command.name, command]))
+  const catalog = [...TUI_COMMANDS]
+  const names = new Set(TUI_COMMANDS.map(command => command.name))
+  const shadows: string[] = []
+  for (const command of hostCommands) {
+    if (local.has(command.name)) {
+      shadows.push(command.name)
+      continue
+    }
+    names.add(command.name)
+    catalog.push({
+      name: command.name,
+      description: HOST_COMMAND_FUNCTIONS.get(command.name)
+        ?? shortFunctionDescription(command.description, '执行命令'),
+      ...(command.input === undefined
+        ? {}
+        : { argumentHint: HOST_COMMAND_ARGUMENT_HINTS.get(command.name) ?? command.input.hint }),
+      source: HOST_COMMAND_DECORATORS.has(command.name) ? 'Host + TUI' : 'Host',
+      behavior: HOST_COMMAND_DECORATORS.has(command.name) ? 'local' : 'host',
+    })
+  }
+  for (const skill of skills) {
+    if (names.has(skill.name)) continue
+    names.add(skill.name)
+    catalog.push({
+      name: skill.name,
+      description: shortFunctionDescription(skill.description, '按名称执行对应能力'),
+      source: 'Skill',
+      behavior: 'skill',
+    })
+  }
+  return {
+    catalog,
+    shadows,
+    diagnostics: shadows.map(name => `命令 /${name} 被 TUI 内置命令遮蔽`),
+  }
+}
+
 function shortFunctionDescription(description: string, fallback: string): string {
   const normalized = description.replace(/\s+/gu, ' ').trim()
   if (!/\p{Script=Han}/u.test(normalized)) return fallback
@@ -390,6 +444,7 @@ function workspaceFor(
  */
 export class HarnessTuiCapabilities {
   private readonly commandCatalogs = new Map<SessionId, Promise<readonly TuiCommandCandidate[]>>()
+  private readonly commandShadows: string[] = []
   private readonly modelCatalogs = new Map<SessionId, SessionModels>()
   private readonly modelLoads = new Map<SessionId, Promise<SessionModels>>()
   private readonly attachments: TuiDraftAttachment[] = []
@@ -560,6 +615,14 @@ export class HarnessTuiCapabilities {
   invalidateCommandCatalog(): void {
     const id = this.active()?.sessionId
     if (id !== undefined) this.commandCatalogs.delete(id)
+  }
+
+  /**
+   * Host commands skipped because they collide with TUI builtins.
+   * @returns doctor-ready shadow records for the last successful catalog merge.
+   */
+  commandDiagnostics(): readonly string[] {
+    return this.commandShadows.map(name => `命令 /${name} 被 TUI 内置命令遮蔽`)
   }
 
   /**
@@ -1447,40 +1510,12 @@ export class HarnessTuiCapabilities {
     if (skillResponse !== undefined && !skillResponse.result.ok) {
       throw new Error(`读取 Skill 失败：${skillResponse.result.error.message}`)
     }
-    const local = new Map(TUI_COMMANDS.map(command => [command.name, command]))
-    const merged = [...TUI_COMMANDS]
-    const names = new Set(TUI_COMMANDS.map(command => command.name))
-    for (const command of hostResult.value as readonly HostCommandDescriptor[]) {
-      const localCommand = local.get(command.name)
-      if (localCommand !== undefined) {
-        throw new Error(`命令冲突：TUI 与 Host 都注册了 /${command.name}`)
-      }
-      names.add(command.name)
-      merged.push({
-        name: command.name,
-        description: HOST_COMMAND_FUNCTIONS.get(command.name)
-          ?? shortFunctionDescription(command.description, '执行命令'),
-        ...(command.input === undefined
-          ? {}
-          : { argumentHint: HOST_COMMAND_ARGUMENT_HINTS.get(command.name) ?? command.input.hint }),
-        source: HOST_COMMAND_DECORATORS.has(command.name) ? 'Host + TUI' : 'Host',
-        behavior: HOST_COMMAND_DECORATORS.has(command.name) ? 'local' : 'host',
-      })
-    }
     const skills: readonly SkillEntry[] = skillResponse?.result.ok === true
       ? skillResponse.result.value.skills
       : []
-    for (const skill of skills) {
-      if (names.has(skill.name)) continue
-      names.add(skill.name)
-      merged.push({
-        name: skill.name,
-        description: shortFunctionDescription(skill.description, '按名称执行对应能力'),
-        source: 'Skill',
-        behavior: 'skill',
-      })
-    }
-    return merged
+    const merged = mergeCommandCatalog(hostResult.value as readonly HostCommandDescriptor[], skills)
+    this.commandShadows.splice(0, this.commandShadows.length, ...merged.shadows)
+    return merged.catalog
   }
 }
 

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -244,8 +244,26 @@ export function mergeCommandCatalog(
   return {
     catalog,
     shadows,
-    diagnostics: shadows.map(name => `命令 /${name} 被 TUI 内置命令遮蔽`),
+    diagnostics: commandShadowMessages(shadows),
   }
+}
+
+/**
+ * Doctor copy for Host commands skipped because they collide with TUI builtins.
+ * @param shadowsBySession - Host names shadowed per Session.
+ * @param sessionId - Session whose catalog was last merged, if any.
+ * @returns warning lines for /doctor, or none when the Session has no shadows.
+ */
+export function commandShadowDiagnostics(
+  shadowsBySession: ReadonlyMap<string, readonly string[]>,
+  sessionId: string | undefined,
+): readonly string[] {
+  if (sessionId === undefined) return []
+  return commandShadowMessages(shadowsBySession.get(sessionId) ?? [])
+}
+
+function commandShadowMessages(names: readonly string[]): readonly string[] {
+  return names.map(name => `命令 /${name} 被 TUI 内置命令遮蔽`)
 }
 
 function shortFunctionDescription(description: string, fallback: string): string {
@@ -444,7 +462,7 @@ function workspaceFor(
  */
 export class HarnessTuiCapabilities {
   private readonly commandCatalogs = new Map<SessionId, Promise<readonly TuiCommandCandidate[]>>()
-  private readonly commandShadows: string[] = []
+  private readonly commandShadows = new Map<SessionId, readonly string[]>()
   private readonly modelCatalogs = new Map<SessionId, SessionModels>()
   private readonly modelLoads = new Map<SessionId, Promise<SessionModels>>()
   private readonly attachments: TuiDraftAttachment[] = []
@@ -463,15 +481,15 @@ export class HarnessTuiCapabilities {
     private readonly initialWorkspacePath: string,
     private readonly management?: TuiManagementBridge,
   ) {
-    ctx.remote.$on('commands/change', () => { this.commandCatalogs.clear() })
+    ctx.remote.$on('commands/change', () => { this.forgetCommandCatalogs() })
     ctx.remote.$on('agent-preset/selected', (sessionId: SessionId) => {
-      this.commandCatalogs.delete(sessionId)
+      this.forgetCommandCatalogs(sessionId)
       this.invalidateModels()
     })
     ctx.remote.$on('llm/adapters-updated', () => { this.invalidateModels() })
     ctx.remote.$on('settings/document-updated', () => { this.invalidateModels() })
     ctx.on('connection/reset', () => {
-      this.commandCatalogs.clear()
+      this.forgetCommandCatalogs()
       this.invalidateModels()
     })
   }
@@ -600,7 +618,7 @@ export class HarnessTuiCapabilities {
     const existing = this.commandCatalogs.get(sessionId)
     const request = existing ?? this.readCommandCatalog(sessionId)
       .catch((error: unknown) => {
-        this.commandCatalogs.delete(sessionId)
+        this.forgetCommandCatalogs(sessionId)
         throw error
       })
     if (existing === undefined) this.commandCatalogs.set(sessionId, request)
@@ -613,16 +631,25 @@ export class HarnessTuiCapabilities {
 
   /** Invalidate the current command/Skill snapshot and repull on next use. */
   invalidateCommandCatalog(): void {
-    const id = this.active()?.sessionId
-    if (id !== undefined) this.commandCatalogs.delete(id)
+    this.forgetCommandCatalogs(this.active()?.sessionId)
   }
 
   /**
    * Host commands skipped because they collide with TUI builtins.
-   * @returns doctor-ready shadow records for the last successful catalog merge.
+   * @returns doctor-ready shadow records for the active Session.
    */
   commandDiagnostics(): readonly string[] {
-    return this.commandShadows.map(name => `命令 /${name} 被 TUI 内置命令遮蔽`)
+    return commandShadowDiagnostics(this.commandShadows, this.active()?.sessionId)
+  }
+
+  private forgetCommandCatalogs(sessionId?: SessionId): void {
+    if (sessionId === undefined) {
+      this.commandCatalogs.clear()
+      this.commandShadows.clear()
+      return
+    }
+    this.commandCatalogs.delete(sessionId)
+    this.commandShadows.delete(sessionId)
   }
 
   /**
@@ -685,7 +712,7 @@ export class HarnessTuiCapabilities {
     if (!response.result.ok) throw new Error(`切换模式失败：${response.result.error.message}`)
     this.ctx.sessions.noteAgentPreset(target.sessionId, response.result.value.agentPreset)
     this.ctx.sessions.open(target.sessionId)
-    this.commandCatalogs.delete(target.sessionId)
+    this.forgetCommandCatalogs(target.sessionId)
     return target.sessionId
   }
 
@@ -1514,7 +1541,7 @@ export class HarnessTuiCapabilities {
       ? skillResponse.result.value.skills
       : []
     const merged = mergeCommandCatalog(hostResult.value as readonly HostCommandDescriptor[], skills)
-    this.commandShadows.splice(0, this.commandShadows.length, ...merged.shadows)
+    this.commandShadows.set(sessionId, merged.shadows)
     return merged.catalog
   }
 }

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -668,6 +668,7 @@ const ENGLISH_PATTERNS: readonly {
   readonly pattern: RegExp
   readonly replace: (...groups: string[]) => string
 }[] = [
+  { pattern: /^(.+) · 立即生效$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
   { pattern: /^命令 \/(.+) 被 TUI 内置命令遮蔽$/u, replace: name => `Command /${name} is shadowed by a TUI builtin` },
   { pattern: /^(.+) · 需重启$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · restart required` },
   { pattern: /^设置 · (.+)$/u, replace: value => `Settings · ${value}` },

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -668,7 +668,7 @@ const ENGLISH_PATTERNS: readonly {
   readonly pattern: RegExp
   readonly replace: (...groups: string[]) => string
 }[] = [
-  { pattern: /^(.+) · 立即生效$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
+  { pattern: /^命令 \/(.+) 被 TUI 内置命令遮蔽$/u, replace: name => `Command /${name} is shadowed by a TUI builtin` },
   { pattern: /^(.+) · 需重启$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · restart required` },
   { pattern: /^设置 · (.+)$/u, replace: value => `Settings · ${value}` },
   { pattern: /^设置 (.+) 已更新并立即生效$/u, replace: value => `${value} was updated and is now active` },

--- a/tests/command-catalog.test.ts
+++ b/tests/command-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  commandShadowDiagnostics,
   mergeCommandCatalog,
   TUI_COMMANDS,
 } from '../src/client/capabilities.ts'
@@ -30,5 +31,20 @@ describe('command catalog merge', () => {
     expect(result.catalog.some(command => command.name === 'help' && command.source === 'Skill')).toBe(false)
     expect(result.catalog.some(command => command.name === 'unique-skill')).toBe(true)
     expect(result.shadows).toEqual([])
+  })
+
+  it('reports Host shadows only for the active session', () => {
+    const shadows = new Map<string, readonly string[]>([
+      ['session-a', ['new']],
+      ['session-b', ['status']],
+    ])
+    expect(commandShadowDiagnostics(shadows, 'session-a')).toEqual([
+      '命令 /new 被 TUI 内置命令遮蔽',
+    ])
+    expect(commandShadowDiagnostics(shadows, 'session-b')).toEqual([
+      '命令 /status 被 TUI 内置命令遮蔽',
+    ])
+    expect(commandShadowDiagnostics(shadows, undefined)).toEqual([])
+    expect(commandShadowDiagnostics(shadows, 'missing')).toEqual([])
   })
 })

--- a/tests/command-catalog.test.ts
+++ b/tests/command-catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergeCommandCatalog,
+  TUI_COMMANDS,
+} from '../src/client/capabilities.ts'
+
+describe('command catalog merge', () => {
+  it('keeps the catalog when a Host command collides with a TUI builtin', () => {
+    const result = mergeCommandCatalog([
+      { name: 'new', description: 'Host 侧新建' },
+      { name: 'plan', description: '开启或关闭计划模式。' },
+    ], [])
+
+    expect(result.catalog.map(command => command.name)).toEqual([
+      ...TUI_COMMANDS.map(command => command.name),
+      'plan',
+    ])
+    expect(result.shadows).toEqual(['new'])
+    expect(result.diagnostics).toEqual([
+      '命令 /new 被 TUI 内置命令遮蔽',
+    ])
+  })
+
+  it('still skips colliding Skills and does not record them as Host shadows', () => {
+    const result = mergeCommandCatalog([], [
+      { name: 'help', description: 'Skill 帮助' },
+      { name: 'unique-skill', description: '按名称执行对应能力。' },
+    ])
+
+    expect(result.catalog.some(command => command.name === 'help' && command.source === 'Skill')).toBe(false)
+    expect(result.catalog.some(command => command.name === 'unique-skill')).toBe(true)
+    expect(result.shadows).toEqual([])
+  })
+})

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -97,6 +97,8 @@ describe('terminal locale preference', () => {
     expect(ui('设置', 'Settings')).toBe('Settings')
     expect(translateUiText('命令面板')).toBe('Command palette')
     expect(translateUiText('队列 3')).toBe('Queue 3')
+    expect(translateUiText('插件 · 立即生效')).toBe('插件 · applies immediately')
+    expect(translateUiText('命令 /new 被 TUI 内置命令遮蔽')).toBe('Command /new is shadowed by a TUI builtin')
     expect(translateUiText('provider-authored 中文说明')).toBe('provider-authored 中文说明')
   })
 


### PR DESCRIPTION
## Summary
- P0-6 from `docs/DEEP_OPTIMIZATION.md`: Host commands that collide with TUI builtins are skipped instead of throwing.
- `/doctor` lists `命令 /xxx 被 TUI 内置命令遮蔽`.
- Slash completion, the command palette, and dispatch keep the rest of the catalog.

## Test plan
- [x] merge with `/new` Host collision still returns every other command
- [x] colliding Skills stay skipped without Host shadow records
- [x] full `vitest run` (98 passing)
- [ ] Manual: install a bundle that registers `/status` and confirm `/` still completes

Do not merge yet — remaining P0 items land on separate branches.