### PR TITLE
fix(ci): gate PRs on check and a rebuilt lib tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main, 'codex/**']
+  pull_request:
+
+jobs:
+  check:
+    name: pnpm run check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck, test, build, and pack dry-run
+        run: pnpm run check
+
+      - name: Keep committed lib/ in sync with source
+        run: |
+          git diff --exit-code lib/
+          test -z "$(git status --porcelain -- lib/)"

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, globSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { entryListSchema } from '@deepseek-ai/cordis-plugin-include'
 import { load } from 'js-yaml'
@@ -70,5 +71,30 @@ describe('out-of-tree Bundle contract', () => {
     expect(candidate.diagnostics).toEqual([
       '安装包声明脚本：build、typecheck、test、test:stock、check',
     ])
+  })
+
+  it('gates pull requests on pnpm run check and a rebuilt lib/ tree', () => {
+    const workflow = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8')
+    expect(workflow).toContain('pnpm run check')
+    expect(workflow).toContain('git diff --exit-code lib/')
+  })
+
+  it('tracks every packaged path so GitHub ref installs cannot omit files', () => {
+    const tracked = new Set(
+      execFileSync('git', ['ls-files', '-z'], { cwd: root }).toString().split('\0').filter(Boolean),
+    )
+    const patterns = [
+      ...(manifest.files as string[]),
+      ...Object.values(manifest.bin as Record<string, string>),
+    ]
+    for (const pattern of patterns) {
+      const matches = pattern.includes('*')
+        ? globSync(pattern, { cwd: root })
+        : existsSync(resolve(root, pattern)) ? [pattern] : []
+      expect(matches, pattern).not.toEqual([])
+      for (const file of matches) {
+        expect(tracked.has(file.replaceAll('\\', '/').replace(/^\.\//u, '')), file).toBe(true)
+      }
+    }
   })
 })


### PR DESCRIPTION
## Summary
- P0-12 from `docs/DEEP_OPTIMIZATION.md`: PR CI now runs `pnpm run check` and fails if `lib/` drifted from source.
- Contract tests require every `package.json` `files`/`bin` path to be git-tracked, so GitHub-ref installs cannot omit unpublished files.
- Does not add the broken `seektty-demo` entry from the dirty working tree.

## Test plan
- [x] package-contract CI and pack-path tests
- [x] full `vitest run` (98 passing)
- [ ] Confirm the new workflow runs on this PR

Do not merge yet — remaining P0 items land on separate branches.