### PR TITLE
fix(launcher): spawn dsh through cross-spawn on Windows (P0-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Models, Providers, Agent Presets, permissions, Host commands, tools, Settings, S
 
 ## Install the bare command
 
-The repository is public and can be installed directly from GitHub without private-repository authentication. SeekTTY supports macOS, Linux, and Windows.
+The repository is public and can be installed directly from GitHub without private-repository authentication. SeekTTY supports macOS, Linux, and Windows. On Windows, install with `pnpm add --global` as shown below so PATHEXT-aware shims (`dsh.cmd`) can be resolved; there is no `install.sh` path.
 
 ```sh
 pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0

--- a/README.zh.md
+++ b/README.zh.md
@@ -65,7 +65,7 @@ Markdown 围栏会直接渲染成连续代码色块。助手代码、Shell 指�
 
 ## 安装并使用裸命令
 
-仓库公开，可直接从 GitHub 安装，无需配置私有仓库访问权限。SeekTTY 支持 macOS、Linux 和 Windows。
+仓库公开，可直接从 GitHub 安装，无需配置私有仓库访问权限。SeekTTY 支持 macOS、Linux 和 Windows。Windows 请用下方的 `pnpm add --global` 安装，以便解析 PATHEXT 的 `dsh.cmd` shim；没有 `install.sh` 这条路径。
 
 ```sh
 pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
+import crossSpawn from "cross-spawn";
 import { resolveProfileDir } from "@deepseek-ai/dsh-app-boot";
 
 //#region src/bin.ts
@@ -42,8 +42,13 @@ function hasDependency(profile, name) {
 function installed(profile) {
 	return hasDependency(profile, PACKAGE_NAME);
 }
+/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
+const DSH_SPAWN_OPTIONS = {
+	stdio: "inherit",
+	windowsHide: true
+};
 function run(command, args) {
-	const result = spawnSync(command, [...args], { stdio: "inherit" });
+	const result = crossSpawn.sync(command, [...args], DSH_SPAWN_OPTIONS);
 	if (result.error !== void 0) throw result.error;
 	if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`);
 	return result.status ?? 1;
@@ -94,4 +99,4 @@ if (directInvocation()) try {
 }
 
 //#endregion
-export { installed, launch, launcherArgs, run };
+export { DSH_SPAWN_OPTIONS, installed, launch, launcherArgs, run };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-fAI-vm30.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DoJiciCf.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/lib/startup-DoJiciCf.js
+++ b/lib/startup-DoJiciCf.js
@@ -1858,6 +1858,7 @@ function restartProvider(ctx) {
 			...request.args
 		], {
 			stdio: "inherit",
+			windowsHide: true,
 			env: {
 				...process.env,
 				...handoffPath === void 0 ? {} : { [APP_HANDOFF_ENV]: handoffPath }

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-fAI-vm30.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DoJiciCf.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,10 +3,10 @@
 /** Product launcher that provisions and boots the native dsh Profile. */
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { resolveProfileDir } from '@deepseek-ai/dsh-app-boot'
+import crossSpawn from 'cross-spawn'
 
 const PACKAGE_NAME = 'seektty'
 const LEGACY_PACKAGE_NAME = 'deepseek-tui'
@@ -50,8 +50,11 @@ export function installed(profile: string): boolean {
   return hasDependency(profile, PACKAGE_NAME)
 }
 
+/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
+export const DSH_SPAWN_OPTIONS = { stdio: 'inherit' as const, windowsHide: true }
+
 export function run(command: string, args: readonly string[]): number {
-  const result = spawnSync(command, [...args], { stdio: 'inherit' })
+  const result = crossSpawn.sync(command, [...args], DSH_SPAWN_OPTIONS)
   if (result.error !== undefined) throw result.error
   if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`)
   return result.status ?? 1

--- a/src/host/startup.ts
+++ b/src/host/startup.ts
@@ -107,6 +107,7 @@ function restartProvider(ctx: Context): AppRestart {
       : writeAppHandoff(request.handoff.channel, request.handoff.payload)
     const child = spawn(process.execPath, [realpathSync(entry), '--profile', request.profile, ...request.args], {
       stdio: 'inherit',
+      windowsHide: true,
       env: {
         ...process.env,
         ...(handoffPath === undefined ? {} : { [APP_HANDOFF_ENV]: handoffPath }),

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { installed, launch, launcherArgs } from '../src/bin.ts'
+import { installed, launch, launcherArgs, DSH_SPAWN_OPTIONS } from '../src/bin.ts'
 
 const temporaryHomes: string[] = []
 
@@ -123,5 +123,15 @@ describe('launcher provisioning', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0]?.slice(0, 4)).toEqual(['plugin', '--profile', 'tui', 'add'])
     expect(calls[0]?.[4]).toBe('/legacy-plugin.tgz')
+  })
+})
+
+describe('Windows launcher spawn', () => {
+  it('hides the console window and uses the PATHEXT-aware sync spawn', () => {
+    expect(DSH_SPAWN_OPTIONS).toMatchObject({ stdio: 'inherit', windowsHide: true })
+    const source = readFileSync(new URL('../src/bin.ts', import.meta.url), 'utf8')
+    expect(source).toContain("from 'cross-spawn'")
+    const startup = readFileSync(new URL('../src/host/startup.ts', import.meta.url), 'utf8')
+    expect(startup).toContain('windowsHide: true')
   })
 })


### PR DESCRIPTION
## Summary
- Switch the product launcher from Node `spawnSync` to `cross-spawn.sync` so Windows can resolve PATHEXT shims such as `dsh.cmd`.
- Pass `windowsHide: true` on both the launcher spawn and the in-process restart spawn to avoid extra console windows.
- Document that Windows installs via `pnpm add --global`; there is no `install.sh` path.

## Test plan
- [x] `vitest run tests/launcher.test.ts` and `tsc --noEmit`
- [x] Rebuild `lib/` and include hashed startup chunk
- [ ] Windows: `deepseek` cold start, `/restart`, Ctrl+C exit (manual / later CI)


Made with [Cursor](https://cursor.com)