### PR TITLE
fix(launcher): classify first-run spawn and manifest failures (P0-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0
 deepseek
 ```
 
-On first run, `deepseek` uses the native `dsh plugin` command to create the default `tui` Profile and install this Bundle. Later runs boot the same Profile. Initial tasks, workspaces, Session resume, and custom Profiles are supported:
+`deepseek` requires DeepSeek Harness (`dsh`) on `PATH`, or `DSH_BIN` pointing at the executable (`pnpm add --global @deepseek-ai/dsh@0.1.0-rc.6`). On first run, `deepseek` uses the native `dsh plugin` command to create the default `tui` Profile and install this Bundle. Later runs boot the same Profile. Initial tasks, workspaces, Session resume, and custom Profiles are supported:
 
 ```sh
 deepseek "check this project"

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,7 +72,7 @@ pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0
 deepseek
 ```
 
-`deepseek` 首次运行会通过原生 `dsh plugin` 命令创建默认 `tui` Profile 并安装本 Bundle，以后直接启动同一 Profile。它支持初始任务、工作区、会话恢复和自定义 Profile：
+`deepseek` 需要 PATH 上的 DeepSeek Harness（`dsh`），或用 `DSH_BIN` 指向可执行文件（`pnpm add --global @deepseek-ai/dsh@0.1.0-rc.6`）。`deepseek` 首次运行会通过原生 `dsh plugin` 命令创建默认 `tui` Profile 并安装本 Bundle，以后直接启动同一 Profile。它支持初始任务、工作区、会话恢复和自定义 Profile：
 
 ```sh
 deepseek "检查这个项目"

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -9,21 +9,73 @@ import { resolveProfileDir } from "@deepseek-ai/dsh-app-boot";
 const PACKAGE_NAME = "seektty";
 const LEGACY_PACKAGE_NAME = "deepseek-tui";
 const DEFAULT_SPEC = "github:Hilbert-beinghappy/seektty";
+const DSH_INSTALL_SPEC = "@deepseek-ai/dsh@0.1.0-rc.6";
+/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
+const DSH_SPAWN_OPTIONS = {
+	stdio: "inherit",
+	windowsHide: true
+};
+/** Replaceable spawn seam used by launcher tests. */
+const internals = { spawnSync: (command, args, options) => crossSpawn.sync(command, args, options) };
+function launcherLocale(env = process.env) {
+	const candidates = [
+		env.LC_ALL,
+		env.LC_MESSAGES,
+		...env.LANGUAGE?.split(":") ?? [],
+		env.LANG
+	];
+	for (const candidate of candidates) {
+		const normalized = candidate?.trim().toLowerCase();
+		if (normalized === void 0 || normalized === "") continue;
+		if (/^en(?:[-_.@]|$)/u.test(normalized)) return "en";
+		if (/^zh(?:[-_.@]|$)/u.test(normalized)) return "zh";
+	}
+	return "zh";
+}
+function launcherText(zh, en, env = process.env) {
+	return launcherLocale(env) === "en" ? en : zh;
+}
+function missingDshMessage(command) {
+	return [
+		launcherText(`${command} 未安装或不在 PATH 中。`, `${command} is not installed or not on PATH.`),
+		launcherText(`请先安装 DeepSeek Harness：pnpm add --global ${DSH_INSTALL_SPEC}`, `Install DeepSeek Harness: pnpm add --global ${DSH_INSTALL_SPEC}`),
+		launcherText("或设置 DSH_BIN 指向 dsh 可执行文件后重试。", "Or set DSH_BIN to the dsh executable and retry.")
+	].join("\n");
+}
+function classifySpawnError(command, error) {
+	if (error.code === "ENOENT") return new Error(missingDshMessage(command));
+	return error instanceof Error ? error : new Error(String(error));
+}
+function readProfileManifest$1(path) {
+	let raw;
+	try {
+		raw = readFileSync(path, "utf8");
+	} catch (error) {
+		throw error instanceof Error ? error : new Error(String(error));
+	}
+	try {
+		return JSON.parse(raw);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error([launcherText(`无法解析 Profile manifest ${path}：${detail}`, `Cannot parse Profile manifest ${path}: ${detail}`), launcherText("删除该文件后 deepseek 会重新初始化 Profile。", "Delete that file and deepseek will re-initialize the Profile.")].join("\n"));
+	}
+}
 function launcherArgs(args) {
 	let profile = "tui";
 	const inner = [];
+	const profileRequired = launcherText("--profile 需要一个 Profile 名称", "--profile requires a Profile name");
 	for (let index = 0; index < args.length; index += 1) {
 		const argument = args[index];
 		if (argument === "--profile") {
 			const value = args[index + 1];
-			if (value === void 0 || value.trim() === "") throw new Error("--profile 需要一个 Profile 名称");
+			if (value === void 0 || value.trim() === "") throw new Error(profileRequired);
 			profile = value;
 			index += 1;
 			continue;
 		}
 		if (argument?.startsWith("--profile=") === true) {
 			const value = argument.slice(10);
-			if (value === "") throw new Error("--profile 需要一个 Profile 名称");
+			if (value === "") throw new Error(profileRequired);
 			profile = value;
 			continue;
 		}
@@ -37,20 +89,16 @@ function launcherArgs(args) {
 function hasDependency(profile, name) {
 	const manifestPath = join(resolveProfileDir(profile), "package.json");
 	if (!existsSync(manifestPath)) return false;
-	return JSON.parse(readFileSync(manifestPath, "utf8")).dependencies?.[name] !== void 0;
+	return readProfileManifest$1(manifestPath).dependencies?.[name] !== void 0;
 }
 function installed(profile) {
 	return hasDependency(profile, PACKAGE_NAME);
 }
-/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
-const DSH_SPAWN_OPTIONS = {
-	stdio: "inherit",
-	windowsHide: true
-};
 function run(command, args) {
-	const result = crossSpawn.sync(command, [...args], DSH_SPAWN_OPTIONS);
-	if (result.error !== void 0) throw result.error;
-	if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`);
+	const result = internals.spawnSync(command, [...args], DSH_SPAWN_OPTIONS);
+	if (result.error != null) throw classifySpawnError(command, result.error);
+	if (result.signal === "SIGINT" || result.signal === "SIGTERM") return 130;
+	if (result.signal !== null) throw new Error(launcherText(`${command} 被信号 ${result.signal} 终止`, `${command} was terminated by ${result.signal}`));
 	return result.status ?? 1;
 }
 function launch(args, environment = process.env, execute = run) {
@@ -99,4 +147,4 @@ if (directInvocation()) try {
 }
 
 //#endregion
-export { DSH_SPAWN_OPTIONS, installed, launch, launcherArgs, run };
+export { DSH_SPAWN_OPTIONS, installed, internals, launch, launcherArgs, run };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -11,26 +11,108 @@ import crossSpawn from 'cross-spawn'
 const PACKAGE_NAME = 'seektty'
 const LEGACY_PACKAGE_NAME = 'deepseek-tui'
 const DEFAULT_SPEC = 'github:Hilbert-beinghappy/seektty'
+const DSH_INSTALL_SPEC = '@deepseek-ai/dsh@0.1.0-rc.6'
 
 interface ProfileManifest {
   readonly dependencies?: Readonly<Record<string, string>>
 }
 
+/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
+export const DSH_SPAWN_OPTIONS = { stdio: 'inherit' as const, windowsHide: true }
+
+/** Replaceable spawn seam used by launcher tests. */
+export const internals: {
+  spawnSync: (
+    command: string,
+    args: readonly string[],
+    options: typeof DSH_SPAWN_OPTIONS,
+  ) => { error?: Error | null; signal: NodeJS.Signals | null; status: number | null }
+} = {
+  spawnSync: (command, args, options) => crossSpawn.sync(command, args, options),
+}
+
+function launcherLocale(env: NodeJS.ProcessEnv = process.env): 'zh' | 'en' {
+  const candidates = [
+    env.LC_ALL,
+    env.LC_MESSAGES,
+    ...(env.LANGUAGE?.split(':') ?? []),
+    env.LANG,
+  ]
+  for (const candidate of candidates) {
+    const normalized = candidate?.trim().toLowerCase()
+    if (normalized === undefined || normalized === '') continue
+    if (/^en(?:[-_.@]|$)/u.test(normalized)) return 'en'
+    if (/^zh(?:[-_.@]|$)/u.test(normalized)) return 'zh'
+  }
+  return 'zh'
+}
+
+function launcherText(zh: string, en: string, env: NodeJS.ProcessEnv = process.env): string {
+  return launcherLocale(env) === 'en' ? en : zh
+}
+
+function missingDshMessage(command: string): string {
+  return [
+    launcherText(
+      `${command} 未安装或不在 PATH 中。`,
+      `${command} is not installed or not on PATH.`,
+    ),
+    launcherText(
+      `请先安装 DeepSeek Harness：pnpm add --global ${DSH_INSTALL_SPEC}`,
+      `Install DeepSeek Harness: pnpm add --global ${DSH_INSTALL_SPEC}`,
+    ),
+    launcherText(
+      '或设置 DSH_BIN 指向 dsh 可执行文件后重试。',
+      'Or set DSH_BIN to the dsh executable and retry.',
+    ),
+  ].join('\n')
+}
+
+function classifySpawnError(command: string, error: NodeJS.ErrnoException): Error {
+  if (error.code === 'ENOENT') return new Error(missingDshMessage(command))
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function readProfileManifest(path: string): ProfileManifest {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(String(error))
+  }
+  try {
+    return JSON.parse(raw) as ProfileManifest
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error([
+      launcherText(
+        `无法解析 Profile manifest ${path}：${detail}`,
+        `Cannot parse Profile manifest ${path}: ${detail}`,
+      ),
+      launcherText(
+        '删除该文件后 deepseek 会重新初始化 Profile。',
+        'Delete that file and deepseek will re-initialize the Profile.',
+      ),
+    ].join('\n'))
+  }
+}
+
 export function launcherArgs(args: readonly string[]): { profile: string; inner: string[] } {
   let profile = 'tui'
   const inner: string[] = []
+  const profileRequired = launcherText('--profile 需要一个 Profile 名称', '--profile requires a Profile name')
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index]
     if (argument === '--profile') {
       const value = args[index + 1]
-      if (value === undefined || value.trim() === '') throw new Error('--profile 需要一个 Profile 名称')
+      if (value === undefined || value.trim() === '') throw new Error(profileRequired)
       profile = value
       index += 1
       continue
     }
     if (argument?.startsWith('--profile=') === true) {
       const value = argument.slice('--profile='.length)
-      if (value === '') throw new Error('--profile 需要一个 Profile 名称')
+      if (value === '') throw new Error(profileRequired)
       profile = value
       continue
     }
@@ -42,7 +124,7 @@ export function launcherArgs(args: readonly string[]): { profile: string; inner:
 function hasDependency(profile: string, name: string): boolean {
   const manifestPath = join(resolveProfileDir(profile), 'package.json')
   if (!existsSync(manifestPath)) return false
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ProfileManifest
+  const manifest = readProfileManifest(manifestPath)
   return manifest.dependencies?.[name] !== undefined
 }
 
@@ -50,13 +132,16 @@ export function installed(profile: string): boolean {
   return hasDependency(profile, PACKAGE_NAME)
 }
 
-/** Spawn options that resolve PATHEXT shims on Windows and hide extra consoles. */
-export const DSH_SPAWN_OPTIONS = { stdio: 'inherit' as const, windowsHide: true }
-
 export function run(command: string, args: readonly string[]): number {
-  const result = crossSpawn.sync(command, [...args], DSH_SPAWN_OPTIONS)
-  if (result.error !== undefined) throw result.error
-  if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`)
+  const result = internals.spawnSync(command, [...args], DSH_SPAWN_OPTIONS)
+  if (result.error != null) throw classifySpawnError(command, result.error)
+  if (result.signal === 'SIGINT' || result.signal === 'SIGTERM') return 130
+  if (result.signal !== null) {
+    throw new Error(launcherText(
+      `${command} 被信号 ${result.signal} 终止`,
+      `${command} was terminated by ${result.signal}`,
+    ))
+  }
   return result.status ?? 1
 }
 

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1,8 +1,15 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { installed, launch, launcherArgs, DSH_SPAWN_OPTIONS } from '../src/bin.ts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DSH_SPAWN_OPTIONS,
+  installed,
+  internals,
+  launch,
+  launcherArgs,
+  run,
+} from '../src/bin.ts'
 
 const temporaryHomes: string[] = []
 
@@ -23,7 +30,17 @@ function writeProfile(home: string, profile: string, dependencies: Record<string
   }))
 }
 
+const defaultSpawnSync = internals.spawnSync
+
+beforeEach(() => {
+  vi.stubEnv('LANG', 'zh_CN.UTF-8')
+  vi.stubEnv('LC_ALL', '')
+  vi.stubEnv('LC_MESSAGES', '')
+  vi.stubEnv('LANGUAGE', '')
+})
+
 afterEach(() => {
+  internals.spawnSync = defaultSpawnSync
   vi.unstubAllEnvs()
   for (const home of temporaryHomes.splice(0)) rmSync(home, { recursive: true, force: true })
 })
@@ -50,6 +67,12 @@ describe('launcher arguments', () => {
   it('rejects an empty Profile name', () => {
     expect(() => launcherArgs(['--profile'])).toThrow('--profile 需要一个 Profile 名称')
     expect(() => launcherArgs(['--profile='])).toThrow('--profile 需要一个 Profile 名称')
+  })
+
+  it('rejects an empty Profile name in English when the terminal locale is English', () => {
+    vi.stubEnv('LANG', 'en_US.UTF-8')
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8')
+    expect(() => launcherArgs(['--profile'])).toThrow('--profile requires a Profile name')
   })
 })
 
@@ -133,5 +156,37 @@ describe('Windows launcher spawn', () => {
     expect(source).toContain("from 'cross-spawn'")
     const startup = readFileSync(new URL('../src/host/startup.ts', import.meta.url), 'utf8')
     expect(startup).toContain('windowsHide: true')
+  })
+})
+
+describe('launcher run()', () => {
+  it('returns the child exit status from a real spawn', () => {
+    expect(run(process.execPath, ['-e', 'process.exit(0)'])).toBe(0)
+    expect(run(process.execPath, ['-e', 'process.exit(9)'])).toBe(9)
+  })
+
+  it('explains a missing dsh binary with install and DSH_BIN guidance', () => {
+    expect(() => run('seektty-missing-dsh-not-on-path', [])).toThrow(/未安装或不在 PATH/)
+    expect(() => run('seektty-missing-dsh-not-on-path', [])).toThrow(/DSH_BIN/)
+    expect(() => run('seektty-missing-dsh-not-on-path', [])).toThrow(/@deepseek-ai\/dsh/)
+  })
+
+  it('returns 130 silently when dsh is interrupted by SIGINT or SIGTERM', () => {
+    internals.spawnSync = () => ({ signal: 'SIGINT', status: null })
+    expect(run('dsh', [])).toBe(130)
+    internals.spawnSync = () => ({ signal: 'SIGTERM', status: null })
+    expect(run('dsh', [])).toBe(130)
+  })
+})
+
+describe('corrupt Profile manifest', () => {
+  it('names the file and how to recover', () => {
+    const home = temporaryHome()
+    const dir = join(home, 'profiles', 'tui')
+    mkdirSync(dir, { recursive: true })
+    const manifest = join(dir, 'package.json')
+    writeFileSync(manifest, '{')
+    expect(() => installed('tui')).toThrow(manifest)
+    expect(() => installed('tui')).toThrow(/删除该文件后 deepseek 会重新初始化 Profile/)
   })
 })


### PR DESCRIPTION
## Summary
- Stacks on #11. Classify `run()` failures instead of throwing raw `spawn ENOENT`.
- Missing `dsh`: bilingual install command (`pnpm add --global @deepseek-ai/dsh@0.1.0-rc.6`) and `DSH_BIN`.
- Corrupt Profile `package.json`: include the file path and tell the user to delete it so deepseek can re-initialize.
- SIGINT/SIGTERM: silent exit code 130 (no `被信号终止` error).
- Cover `run()` itself with a real Node spawn plus injected signal/ENOENT cases. Launcher strings use terminal locale (`LANG`/`LC_*`).

## Test plan
- [x] `vitest run tests/launcher.test.ts` and `tsc --noEmit`
- [x] Rebuild `lib/bin.js`
- [ ] `DSH_BIN=/nonexistent deepseek` prints install guidance
- [ ] Ctrl+C while dsh is running exits 130 with no error line


Made with [Cursor](https://cursor.com)