### PR TITLE
fix(launcher): wait in deepseek for /restart instead of orphaning dsh (P0-9)

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { i as APP_HANDOFF_ENV, n as consumeLauncherRestart, o as writeAppHandoff, t as LAUNCHER_RESTART_EXIT_CODE } from "./launcher-restart-DG_Iw5tr.js";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import crossSpawn from "cross-spawn";
 import { resolveProfileDir } from "@deepseek-ai/dsh-app-boot";
@@ -94,41 +95,127 @@ function hasDependency(profile, name) {
 function installed(profile) {
 	return hasDependency(profile, PACKAGE_NAME);
 }
-function run(command, args) {
-	const result = internals.spawnSync(command, [...args], DSH_SPAWN_OPTIONS);
+function run(command, args, env = process.env) {
+	const result = internals.spawnSync(command, [...args], {
+		...DSH_SPAWN_OPTIONS,
+		env
+	});
 	if (result.error != null) throw classifySpawnError(command, result.error);
 	if (result.signal === "SIGINT" || result.signal === "SIGTERM") return 130;
 	if (result.signal !== null) throw new Error(launcherText(`${command} 被信号 ${result.signal} 终止`, `${command} was terminated by ${result.signal}`));
 	return result.status ?? 1;
 }
-function launch(args, environment = process.env, execute = run) {
-	const { profile, inner } = launcherArgs(args);
+function forwardedCwd(inner) {
+	for (let index = 0; index < inner.length; index += 1) {
+		const argument = inner[index];
+		if (argument === "--cwd") {
+			const value = inner[index + 1];
+			if (value !== void 0 && value.trim() !== "") return resolve(value);
+		}
+		if (argument?.startsWith("--cwd=") === true) {
+			const value = argument.slice(6);
+			if (value !== "") return resolve(value);
+		}
+	}
+	return resolve(process.cwd());
+}
+function forwardedResume(inner) {
+	for (let index = 0; index < inner.length; index += 1) {
+		const argument = inner[index];
+		if (argument === "--resume") {
+			const value = inner[index + 1];
+			if (value !== void 0 && !value.startsWith("-") && value.trim() !== "") return value;
+			return;
+		}
+		if (argument?.startsWith("--resume=") === true) {
+			const value = argument.slice(9);
+			if (value !== "") return value;
+		}
+	}
+}
+function launch(args, environment = process.env, execute = run, hooks = {}) {
+	let { profile, inner } = launcherArgs(args);
 	const dsh = environment.DSH_BIN?.trim() || "dsh";
-	if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
+	const spec = environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC;
+	const pid = hooks.pid ?? process.pid;
+	const consumeRestart = hooks.consumeRestart ?? consumeLauncherRestart;
+	const writeFallbackHandoff = hooks.writeFallbackHandoff ?? ((payload) => writeAppHandoff("seektty-v1", payload));
+	consumeLauncherRestart(pid);
+	let previous;
+	let fallingBack = false;
+	const childEnv = {
+		...process.env,
+		...environment
+	};
+	const recover = (failedProfile, reason) => {
+		if (previous === void 0 || fallingBack) return false;
+		fallingBack = true;
+		const notice = launcherText(`无法启动 Profile ${failedProfile}，已回退到 ${previous.profile}：${reason}`, `Could not start Profile ${failedProfile}; fell back to ${previous.profile}: ${reason}`);
+		process.stderr.write(`deepseek: ${notice}\n`);
+		profile = previous.profile;
+		inner = previous.inner;
+		const resume = forwardedResume(inner);
+		try {
+			childEnv[APP_HANDOFF_ENV] = writeFallbackHandoff({
+				profile,
+				cwd: forwardedCwd(inner),
+				attachmentPaths: [],
+				notice,
+				...resume === void 0 ? {} : { resume }
+			});
+		} catch {}
+		return true;
+	};
+	while (true) try {
+		if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
+			const status$1 = execute(dsh, [
+				"plugin",
+				"--profile",
+				profile,
+				"remove",
+				LEGACY_PACKAGE_NAME
+			], childEnv);
+			if (status$1 !== 0) {
+				if (recover(profile, `exit ${status$1}`)) continue;
+				return status$1;
+			}
+		}
+		if (!installed(profile)) {
+			const status$1 = execute(dsh, [
+				"plugin",
+				"--profile",
+				profile,
+				"add",
+				spec
+			], childEnv);
+			if (status$1 !== 0) {
+				if (recover(profile, `exit ${status$1}`)) continue;
+				return status$1;
+			}
+		}
 		const status = execute(dsh, [
-			"plugin",
 			"--profile",
 			profile,
-			"remove",
-			LEGACY_PACKAGE_NAME
-		]);
-		if (status !== 0) return status;
-	}
-	if (!installed(profile)) {
-		const status = execute(dsh, [
-			"plugin",
-			"--profile",
+			...inner
+		], childEnv);
+		if (status === 130) return status;
+		if (status !== LAUNCHER_RESTART_EXIT_CODE) return status;
+		const ticket = consumeRestart(pid);
+		if (ticket === void 0) return status;
+		previous = {
 			profile,
-			"add",
-			environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC
-		]);
-		if (status !== 0) return status;
+			inner
+		};
+		fallingBack = false;
+		profile = ticket.profile;
+		inner = [...ticket.args];
+		if (ticket.handoffPath === void 0) delete childEnv[APP_HANDOFF_ENV];
+		else childEnv[APP_HANDOFF_ENV] = ticket.handoffPath;
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		if (recover(profile, reason)) continue;
+		throw error;
 	}
-	return execute(dsh, [
-		"--profile",
-		profile,
-		...inner
-	]);
 }
 function directInvocation() {
 	const entry = process.argv[1];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DoJiciCf.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DHbdGfF_.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
+import "./launcher-restart-DG_Iw5tr.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { spawn } from "child_process";
@@ -29341,7 +29342,7 @@ async function run(ctx) {
 		});
 	} catch (error) {
 		internals.stderr.write(`deepseek: ${translateUiText(`重启失败：${error instanceof Error ? error.message : String(error)}`)}\n`);
-		process.exitCode = 1;
+		exit(1);
 	}
 }
 /**

--- a/lib/launcher-restart-DG_Iw5tr.js
+++ b/lib/launcher-restart-DG_Iw5tr.js
@@ -1,0 +1,135 @@
+import { lstatSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+//#region src/host/app-handoff.ts
+/** Inherited environment key carrying one single-use handoff path. */
+const APP_HANDOFF_ENV = "DSH_APP_HANDOFF_FILE";
+/** Maximum serialized handoff bytes; payloads carry references, never file bytes. */
+const APP_HANDOFF_MAX_BYTES = 256 * 1024;
+const PREFIX$1 = "deepseek-handoff-";
+function allowedPath$1(path) {
+	const absolute = resolve(path);
+	return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX$1);
+}
+/**
+* Persist one opaque app payload for a child process. The file is exclusive,
+* owner-only where the platform exposes POSIX modes, and never logged.
+* @param channel - app protocol identifier.
+* @param payload - JSON-compatible references and draft metadata.
+* @returns absolute handoff path for {@link APP_HANDOFF_ENV}.
+*/
+function writeAppHandoff(channel, payload) {
+	if (channel.trim() === "") throw new Error("app handoff channel cannot be blank");
+	const body = JSON.stringify({
+		version: 1,
+		channel,
+		payload
+	});
+	if (Buffer.byteLength(body) > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff payload exceeds size limit");
+	const path = join(tmpdir(), `${PREFIX$1}${randomUUID()}.json`);
+	writeFileSync(path, body, {
+		encoding: "utf8",
+		flag: "wx",
+		mode: 384
+	});
+	return path;
+}
+/**
+* Consume and delete this process's handoff when its channel matches.
+* Invalid paths, permissions, envelopes, or channels fail loud after the
+* environment value is cleared; a missing value means ordinary startup.
+* @param channel - expected app protocol identifier.
+* @returns parsed opaque payload, or undefined when no handoff was supplied.
+*/
+function consumeAppHandoff(channel) {
+	const path = process.env[APP_HANDOFF_ENV];
+	delete process.env.DSH_APP_HANDOFF_FILE;
+	if (path === void 0) return void 0;
+	if (!allowedPath$1(path)) throw new Error("app handoff path is outside the launcher temp boundary");
+	try {
+		const stat = lstatSync(path);
+		if (!stat.isFile()) throw new Error("app handoff path is not a regular file");
+		if (stat.size > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff file exceeds size limit");
+		if (process.platform !== "win32" && (stat.mode & 63) !== 0) throw new Error("app handoff file permissions are not owner-only");
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		if (parsed === null || parsed.version !== 1 || parsed.channel !== channel || !("payload" in parsed)) throw new Error(`app handoff does not match channel ${JSON.stringify(channel)}`);
+		return parsed.payload;
+	} finally {
+		try {
+			unlinkSync(path);
+		} catch {}
+	}
+}
+
+//#endregion
+//#region src/launcher-restart.ts
+/** Exit status that tells the product launcher to spawn dsh again. */
+const LAUNCHER_RESTART_EXIT_CODE = 75;
+const PREFIX = "deepseek-restart-";
+function launcherRestartPath(launcherPid) {
+	return join(tmpdir(), `${PREFIX}${launcherPid}.json`);
+}
+function allowedPath(path) {
+	const absolute = resolve(path);
+	return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX);
+}
+/**
+* Record the next dsh invocation for the waiting `deepseek` parent.
+* @param launcherPid - parent pid of this dsh process (`process.ppid`).
+* @param request - Profile, forwarded args, and optional handoff path.
+* @returns absolute ticket path.
+*/
+function writeLauncherRestart(launcherPid, request) {
+	if (!Number.isInteger(launcherPid) || launcherPid <= 0) throw new Error("launcher restart pid is invalid");
+	if (request.profile.trim() === "") throw new Error("launcher restart Profile cannot be blank");
+	const body = JSON.stringify({
+		version: 1,
+		profile: request.profile,
+		args: [...request.args],
+		...request.handoffPath === void 0 ? {} : { handoffPath: request.handoffPath }
+	});
+	const path = launcherRestartPath(launcherPid);
+	try {
+		unlinkSync(path);
+	} catch {}
+	writeFileSync(path, body, {
+		encoding: "utf8",
+		flag: "wx",
+		mode: 384
+	});
+	return path;
+}
+/**
+* Consume and delete this launcher process's restart ticket.
+* @param launcherPid - pid of the waiting `deepseek` process.
+* @returns the next invocation, or undefined when dsh did not request a restart.
+*/
+function consumeLauncherRestart(launcherPid) {
+	const path = launcherRestartPath(launcherPid);
+	if (!allowedPath(path)) throw new Error("launcher restart path is outside the temp boundary");
+	try {
+		const stat = lstatSync(path);
+		if (!stat.isFile()) throw new Error("launcher restart path is not a regular file");
+		if (process.platform !== "win32" && (stat.mode & 63) !== 0) throw new Error("launcher restart file permissions are not owner-only");
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		if (parsed === null || parsed.version !== 1 || typeof parsed.profile !== "string" || parsed.profile.trim() === "" || !Array.isArray(parsed.args) || !parsed.args.every((argument) => typeof argument === "string")) throw new Error("launcher restart ticket is invalid");
+		if (parsed.handoffPath !== void 0 && typeof parsed.handoffPath !== "string") throw new Error("launcher restart handoff path is invalid");
+		return {
+			profile: parsed.profile,
+			args: parsed.args,
+			...parsed.handoffPath === void 0 ? {} : { handoffPath: parsed.handoffPath }
+		};
+	} catch (error) {
+		if (error.code === "ENOENT") return void 0;
+		throw error;
+	} finally {
+		try {
+			unlinkSync(path);
+		} catch {}
+	}
+}
+
+//#endregion
+export { consumeAppHandoff as a, APP_HANDOFF_ENV as i, consumeLauncherRestart as n, writeAppHandoff as o, writeLauncherRestart as r, LAUNCHER_RESTART_EXIT_CODE as t };

--- a/lib/startup-DHbdGfF_.js
+++ b/lib/startup-DHbdGfF_.js
@@ -1,13 +1,11 @@
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { a as consumeAppHandoff, o as writeAppHandoff, r as writeLauncherRestart, t as LAUNCHER_RESTART_EXIT_CODE } from "./launcher-restart-DG_Iw5tr.js";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { LOCALE_IDS, LOCALE_PREFERENCE_FIELD, LOCALE_SETTINGS_NAMESPACE } from "@deepseek-ai/dsh-client-locale";
 import { entryListSchema } from "@deepseek-ai/cordis-plugin-include";
 import { load } from "js-yaml";
-import { spawn } from "node:child_process";
 import { Command } from "commander";
 import { parseCmdline } from "@deepseek-ai/dsh-cmdline";
-import { randomUUID } from "node:crypto";
 import crossSpawn from "cross-spawn";
 import { DEFAULT_PROFILE_BUNDLES, PROFILES_DIR, PROFILE_PATCH_FILENAME, PROFILE_TEMPLATES, initProfile, readProfileManifest, resolveBundleDir, resolveProfileDir, writeProfileManifest } from "@deepseek-ai/dsh-app-boot";
 
@@ -1269,67 +1267,6 @@ async function saveLanguage(settings, document, selection, env = process.env) {
 }
 
 //#endregion
-//#region src/host/app-handoff.ts
-/** Inherited environment key carrying one single-use handoff path. */
-const APP_HANDOFF_ENV = "DSH_APP_HANDOFF_FILE";
-/** Maximum serialized handoff bytes; payloads carry references, never file bytes. */
-const APP_HANDOFF_MAX_BYTES = 256 * 1024;
-const PREFIX = "deepseek-handoff-";
-function allowedPath(path) {
-	const absolute = resolve(path);
-	return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX);
-}
-/**
-* Persist one opaque app payload for a child process. The file is exclusive,
-* owner-only where the platform exposes POSIX modes, and never logged.
-* @param channel - app protocol identifier.
-* @param payload - JSON-compatible references and draft metadata.
-* @returns absolute handoff path for {@link APP_HANDOFF_ENV}.
-*/
-function writeAppHandoff(channel, payload) {
-	if (channel.trim() === "") throw new Error("app handoff channel cannot be blank");
-	const body = JSON.stringify({
-		version: 1,
-		channel,
-		payload
-	});
-	if (Buffer.byteLength(body) > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff payload exceeds size limit");
-	const path = join(tmpdir(), `${PREFIX}${randomUUID()}.json`);
-	writeFileSync(path, body, {
-		encoding: "utf8",
-		flag: "wx",
-		mode: 384
-	});
-	return path;
-}
-/**
-* Consume and delete this process's handoff when its channel matches.
-* Invalid paths, permissions, envelopes, or channels fail loud after the
-* environment value is cleared; a missing value means ordinary startup.
-* @param channel - expected app protocol identifier.
-* @returns parsed opaque payload, or undefined when no handoff was supplied.
-*/
-function consumeAppHandoff(channel) {
-	const path = process.env[APP_HANDOFF_ENV];
-	delete process.env.DSH_APP_HANDOFF_FILE;
-	if (path === void 0) return void 0;
-	if (!allowedPath(path)) throw new Error("app handoff path is outside the launcher temp boundary");
-	try {
-		const stat = lstatSync(path);
-		if (!stat.isFile()) throw new Error("app handoff path is not a regular file");
-		if (stat.size > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff file exceeds size limit");
-		if (process.platform !== "win32" && (stat.mode & 63) !== 0) throw new Error("app handoff file permissions are not owner-only");
-		const parsed = JSON.parse(readFileSync(path, "utf8"));
-		if (parsed === null || parsed.version !== 1 || parsed.channel !== channel || !("payload" in parsed)) throw new Error(`app handoff does not match channel ${JSON.stringify(channel)}`);
-		return parsed.payload;
-	} finally {
-		try {
-			unlinkSync(path);
-		} catch {}
-	}
-}
-
-//#endregion
 //#region src/host/profile-plugin-manager.ts
 const NAME = "dsh";
 const MAX_CAPTURE_BYTES = 1024 * 1024;
@@ -1848,26 +1785,12 @@ function dshInstallAnchor() {
 }
 function restartProvider(ctx) {
 	return async (request) => {
-		const entry = process.argv[1];
-		if (entry === void 0) throw new Error(ui("无法定位 dsh 启动文件", "Cannot locate the dsh entry file"));
 		const handoffPath = request.handoff === void 0 ? void 0 : writeAppHandoff(request.handoff.channel, request.handoff.payload);
-		const child = spawn(process.execPath, [
-			realpathSync(entry),
-			"--profile",
-			request.profile,
-			...request.args
-		], {
-			stdio: "inherit",
-			windowsHide: true,
-			env: {
-				...process.env,
-				...handoffPath === void 0 ? {} : { [APP_HANDOFF_ENV]: handoffPath }
-			}
-		});
 		try {
-			await new Promise((resolveSpawn, reject) => {
-				child.once("spawn", resolveSpawn);
-				child.once("error", reject);
+			writeLauncherRestart(process.ppid, {
+				profile: request.profile,
+				args: request.args,
+				...handoffPath === void 0 ? {} : { handoffPath }
 			});
 		} catch (error) {
 			if (handoffPath !== void 0) try {
@@ -1875,7 +1798,7 @@ function restartProvider(ctx) {
 			} catch {}
 			throw error;
 		}
-		ctx.get("appExit")?.(0);
+		ctx.get("appExit")?.(LAUNCHER_RESTART_EXIT_CODE);
 	};
 }
 function tuiCommand() {

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,4 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DoJiciCf.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DHbdGfF_.js";
+import "./launcher-restart-DG_Iw5tr.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,10 +3,16 @@
 /** Product launcher that provisions and boots the native dsh Profile. */
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { resolveProfileDir } from '@deepseek-ai/dsh-app-boot'
 import crossSpawn from 'cross-spawn'
+import { APP_HANDOFF_ENV, writeAppHandoff } from './host/app-handoff.ts'
+import {
+  consumeLauncherRestart,
+  LAUNCHER_RESTART_EXIT_CODE,
+  type LauncherRestartRequest,
+} from './launcher-restart.ts'
 
 const PACKAGE_NAME = 'seektty'
 const LEGACY_PACKAGE_NAME = 'deepseek-tui'
@@ -25,7 +31,7 @@ export const internals: {
   spawnSync: (
     command: string,
     args: readonly string[],
-    options: typeof DSH_SPAWN_OPTIONS,
+    options: typeof DSH_SPAWN_OPTIONS & { env?: NodeJS.ProcessEnv },
   ) => { error?: Error | null; signal: NodeJS.Signals | null; status: number | null }
 } = {
   spawnSync: (command, args, options) => crossSpawn.sync(command, args, options),
@@ -132,8 +138,12 @@ export function installed(profile: string): boolean {
   return hasDependency(profile, PACKAGE_NAME)
 }
 
-export function run(command: string, args: readonly string[]): number {
-  const result = internals.spawnSync(command, [...args], DSH_SPAWN_OPTIONS)
+export function run(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const result = internals.spawnSync(command, [...args], { ...DSH_SPAWN_OPTIONS, env })
   if (result.error != null) throw classifySpawnError(command, result.error)
   if (result.signal === 'SIGINT' || result.signal === 'SIGTERM') return 130
   if (result.signal !== null) {
@@ -145,23 +155,117 @@ export function run(command: string, args: readonly string[]): number {
   return result.status ?? 1
 }
 
+function forwardedCwd(inner: readonly string[]): string {
+  for (let index = 0; index < inner.length; index += 1) {
+    const argument = inner[index]
+    if (argument === '--cwd') {
+      const value = inner[index + 1]
+      if (value !== undefined && value.trim() !== '') return resolve(value)
+    }
+    if (argument?.startsWith('--cwd=') === true) {
+      const value = argument.slice('--cwd='.length)
+      if (value !== '') return resolve(value)
+    }
+  }
+  return resolve(process.cwd())
+}
+
+function forwardedResume(inner: readonly string[]): string | undefined {
+  for (let index = 0; index < inner.length; index += 1) {
+    const argument = inner[index]
+    if (argument === '--resume') {
+      const value = inner[index + 1]
+      if (value !== undefined && !value.startsWith('-') && value.trim() !== '') return value
+      return undefined
+    }
+    if (argument?.startsWith('--resume=') === true) {
+      const value = argument.slice('--resume='.length)
+      if (value !== '') return value
+    }
+  }
+  return undefined
+}
+
+/** Test seams for the outer-wait restart loop. */
+export interface LaunchHooks {
+  readonly pid?: number
+  consumeRestart?(pid: number): LauncherRestartRequest | undefined
+  writeFallbackHandoff?(payload: unknown): string
+}
+
 export function launch(
   args: readonly string[],
   environment: NodeJS.ProcessEnv = process.env,
-  execute: (command: string, args: readonly string[]) => number = run,
+  execute: (command: string, args: readonly string[], env?: NodeJS.ProcessEnv) => number = run,
+  hooks: LaunchHooks = {},
 ): number {
-  const { profile, inner } = launcherArgs(args)
+  let { profile, inner } = launcherArgs(args)
   const dsh = environment.DSH_BIN?.trim() || 'dsh'
-  if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
-    const status = execute(dsh, ['plugin', '--profile', profile, 'remove', LEGACY_PACKAGE_NAME])
-    if (status !== 0) return status
+  const spec = environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC
+  const pid = hooks.pid ?? process.pid
+  const consumeRestart = hooks.consumeRestart ?? consumeLauncherRestart
+  const writeFallbackHandoff = hooks.writeFallbackHandoff ?? ((payload: unknown) => writeAppHandoff('seektty-v1', payload))
+  consumeLauncherRestart(pid)
+  let previous: { profile: string; inner: string[] } | undefined
+  let fallingBack = false
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, ...environment }
+
+  const recover = (failedProfile: string, reason: string): boolean => {
+    if (previous === undefined || fallingBack) return false
+    fallingBack = true
+    const notice = launcherText(
+      `无法启动 Profile ${failedProfile}，已回退到 ${previous.profile}：${reason}`,
+      `Could not start Profile ${failedProfile}; fell back to ${previous.profile}: ${reason}`,
+    )
+    process.stderr.write(`deepseek: ${notice}\n`)
+    profile = previous.profile
+    inner = previous.inner
+    const resume = forwardedResume(inner)
+    try {
+      childEnv[APP_HANDOFF_ENV] = writeFallbackHandoff({
+        profile,
+        cwd: forwardedCwd(inner),
+        attachmentPaths: [],
+        notice,
+        ...(resume === undefined ? {} : { resume }),
+      })
+    } catch { /* stderr already carried the reason */ }
+    return true
   }
-  if (!installed(profile)) {
-    const spec = environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC
-    const status = execute(dsh, ['plugin', '--profile', profile, 'add', spec])
-    if (status !== 0) return status
+
+  while (true) {
+    try {
+      if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
+        const status = execute(dsh, ['plugin', '--profile', profile, 'remove', LEGACY_PACKAGE_NAME], childEnv)
+        if (status !== 0) {
+          if (recover(profile, `exit ${status}`)) continue
+          return status
+        }
+      }
+      if (!installed(profile)) {
+        const status = execute(dsh, ['plugin', '--profile', profile, 'add', spec], childEnv)
+        if (status !== 0) {
+          if (recover(profile, `exit ${status}`)) continue
+          return status
+        }
+      }
+      const status = execute(dsh, ['--profile', profile, ...inner], childEnv)
+      if (status === 130) return status
+      if (status !== LAUNCHER_RESTART_EXIT_CODE) return status
+      const ticket = consumeRestart(pid)
+      if (ticket === undefined) return status
+      previous = { profile, inner }
+      fallingBack = false
+      profile = ticket.profile
+      inner = [...ticket.args]
+      if (ticket.handoffPath === undefined) delete childEnv[APP_HANDOFF_ENV]
+      else childEnv[APP_HANDOFF_ENV] = ticket.handoffPath
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      if (recover(profile, reason)) continue
+      throw error
+    }
   }
-  return execute(dsh, ['--profile', profile, ...inner])
 }
 
 function directInvocation(): boolean {

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -85,7 +85,7 @@ async function run(ctx: Context): Promise<void> {
     })
   } catch (error) {
     internals.stderr.write(`deepseek: ${translateUiText(`重启失败：${error instanceof Error ? error.message : String(error)}`)}\n`)
-    process.exitCode = 1
+    exit(1)
   }
 }
 

--- a/src/host/startup.ts
+++ b/src/host/startup.ts
@@ -1,14 +1,14 @@
 /** TUI command-line provider for the `deepseek` product entry. */
 
-import { spawn } from 'node:child_process'
 import { realpathSync, unlinkSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { Command } from 'commander'
 import type { Context } from '@deepseek-ai/cordis'
 import { parseCmdline } from '@deepseek-ai/dsh-cmdline'
 import { localeFromEnvironment, setUiLocale, ui } from '../client/locale.ts'
-import { APP_HANDOFF_ENV, consumeAppHandoff, writeAppHandoff } from './app-handoff.ts'
+import { consumeAppHandoff, writeAppHandoff } from './app-handoff.ts'
 import { ProfilePluginManager } from './profile-plugin-manager.ts'
+import { LAUNCHER_RESTART_EXIT_CODE, writeLauncherRestart } from '../launcher-restart.ts'
 
 /** Stable Cordis plugin name. */
 export const name = 'tui-startup'
@@ -97,34 +97,22 @@ function dshInstallAnchor(): string {
 
 function restartProvider(ctx: Context): AppRestart {
   return async (request) => {
-    const entry = process.argv[1]
-    if (entry === undefined) throw new Error(ui(
-      '无法定位 dsh 启动文件',
-      'Cannot locate the dsh entry file',
-    ))
     const handoffPath = request.handoff === undefined
       ? undefined
       : writeAppHandoff(request.handoff.channel, request.handoff.payload)
-    const child = spawn(process.execPath, [realpathSync(entry), '--profile', request.profile, ...request.args], {
-      stdio: 'inherit',
-      windowsHide: true,
-      env: {
-        ...process.env,
-        ...(handoffPath === undefined ? {} : { [APP_HANDOFF_ENV]: handoffPath }),
-      },
-    })
     try {
-      await new Promise<void>((resolveSpawn, reject) => {
-        child.once('spawn', resolveSpawn)
-        child.once('error', reject)
+      writeLauncherRestart(process.ppid, {
+        profile: request.profile,
+        args: request.args,
+        ...(handoffPath === undefined ? {} : { handoffPath }),
       })
     } catch (error) {
       if (handoffPath !== undefined) {
-        try { unlinkSync(handoffPath) } catch { /* failed spawn retains no usable handoff owner */ }
+        try { unlinkSync(handoffPath) } catch { /* failed ticket retains no usable handoff owner */ }
       }
       throw error
     }
-    ctx.get('appExit')?.(0)
+    ctx.get('appExit')?.(LAUNCHER_RESTART_EXIT_CODE)
   }
 }
 

--- a/src/launcher-restart.ts
+++ b/src/launcher-restart.ts
@@ -1,0 +1,88 @@
+/** Single-use restart tickets so the outer `deepseek` launcher respawns dsh. */
+
+import { lstatSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+
+/** Exit status that tells the product launcher to spawn dsh again. */
+export const LAUNCHER_RESTART_EXIT_CODE = 75
+const PREFIX = 'deepseek-restart-'
+
+/** Profile and arguments for the next dsh process owned by the launcher. */
+export interface LauncherRestartRequest {
+  readonly profile: string
+  readonly args: readonly string[]
+  readonly handoffPath?: string
+}
+
+interface LauncherRestartEnvelope {
+  readonly version: 1
+  readonly profile: string
+  readonly args: readonly string[]
+  readonly handoffPath?: string
+}
+
+export function launcherRestartPath(launcherPid: number): string {
+  return join(tmpdir(), `${PREFIX}${launcherPid}.json`)
+}
+
+function allowedPath(path: string): boolean {
+  const absolute = resolve(path)
+  return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX)
+}
+
+/**
+ * Record the next dsh invocation for the waiting `deepseek` parent.
+ * @param launcherPid - parent pid of this dsh process (`process.ppid`).
+ * @param request - Profile, forwarded args, and optional handoff path.
+ * @returns absolute ticket path.
+ */
+export function writeLauncherRestart(launcherPid: number, request: LauncherRestartRequest): string {
+  if (!Number.isInteger(launcherPid) || launcherPid <= 0) throw new Error('launcher restart pid is invalid')
+  if (request.profile.trim() === '') throw new Error('launcher restart Profile cannot be blank')
+  const body = JSON.stringify({
+    version: 1,
+    profile: request.profile,
+    args: [...request.args],
+    ...(request.handoffPath === undefined ? {} : { handoffPath: request.handoffPath }),
+  } satisfies LauncherRestartEnvelope)
+  const path = launcherRestartPath(launcherPid)
+  try { unlinkSync(path) } catch { /* replace a stale ticket from a previous interrupted restart */ }
+  writeFileSync(path, body, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+  return path
+}
+
+/**
+ * Consume and delete this launcher process's restart ticket.
+ * @param launcherPid - pid of the waiting `deepseek` process.
+ * @returns the next invocation, or undefined when dsh did not request a restart.
+ */
+export function consumeLauncherRestart(launcherPid: number): LauncherRestartRequest | undefined {
+  const path = launcherRestartPath(launcherPid)
+  if (!allowedPath(path)) throw new Error('launcher restart path is outside the temp boundary')
+  try {
+    const stat = lstatSync(path)
+    if (!stat.isFile()) throw new Error('launcher restart path is not a regular file')
+    if (process.platform !== 'win32' && (stat.mode & 0o077) !== 0) {
+      throw new Error('launcher restart file permissions are not owner-only')
+    }
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<LauncherRestartEnvelope> | null
+    if (parsed === null || parsed.version !== 1 || typeof parsed.profile !== 'string' || parsed.profile.trim() === ''
+      || !Array.isArray(parsed.args) || !parsed.args.every(argument => typeof argument === 'string')) {
+      throw new Error('launcher restart ticket is invalid')
+    }
+    if (parsed.handoffPath !== undefined && typeof parsed.handoffPath !== 'string') {
+      throw new Error('launcher restart handoff path is invalid')
+    }
+    return {
+      profile: parsed.profile,
+      args: parsed.args,
+      ...(parsed.handoffPath === undefined ? {} : { handoffPath: parsed.handoffPath }),
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  } finally {
+    try { unlinkSync(path) } catch { /* single-use cleanup is best effort after a read failure */ }
+  }
+}

--- a/tests/launcher-restart.test.ts
+++ b/tests/launcher-restart.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  consumeLauncherRestart,
+  launcherRestartPath,
+  writeLauncherRestart,
+} from '../src/launcher-restart.ts'
+
+const pid = 8_675_309
+
+describe('launcher restart ticket', () => {
+  it('round-trips an exclusive owner-only ticket and deletes it on consume', () => {
+    const path = writeLauncherRestart(pid, {
+      profile: 'team',
+      args: ['--cwd', '/workspace'],
+      handoffPath: '/tmp/deepseek-handoff-test.json',
+    })
+    expect(path).toBe(launcherRestartPath(pid))
+    expect(existsSync(path)).toBe(true)
+    if (process.platform !== 'win32') {
+      expect(readFileSync(path).length).toBeGreaterThan(0)
+    }
+    expect(consumeLauncherRestart(pid)).toEqual({
+      profile: 'team',
+      args: ['--cwd', '/workspace'],
+      handoffPath: '/tmp/deepseek-handoff-test.json',
+    })
+    expect(existsSync(path)).toBe(false)
+    expect(consumeLauncherRestart(pid)).toBeUndefined()
+  })
+
+  it('replaces a stale ticket so a second restart is not blocked', () => {
+    writeFileSync(launcherRestartPath(pid), '{', { encoding: 'utf8' })
+    writeLauncherRestart(pid, { profile: 'tui', args: [] })
+    expect(consumeLauncherRestart(pid)).toEqual({ profile: 'tui', args: [] })
+  })
+
+  it('keeps tickets inside the process temp directory', () => {
+    expect(launcherRestartPath(pid).startsWith(tmpdir())).toBe(true)
+    expect(launcherRestartPath(pid)).toContain('deepseek-restart-')
+  })
+})
+
+describe('outer-wait restart contract', () => {
+  it('does not spawn a replacement dsh from the inner process', () => {
+    const startup = readFileSync(new URL('../src/host/startup.ts', import.meta.url), 'utf8')
+    expect(startup).not.toContain("from 'node:child_process'")
+    expect(startup).not.toContain('child.once')
+    expect(startup).toContain('writeLauncherRestart')
+    expect(startup).toContain('LAUNCHER_RESTART_EXIT_CODE')
+    const host = readFileSync(new URL('../src/host/index.ts', import.meta.url), 'utf8')
+    expect(host).toMatch(/exit\(1\)/)
+    expect(host).not.toMatch(/process\.exitCode = 1/)
+  })
+})

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -10,6 +10,7 @@ import {
   launcherArgs,
   run,
 } from '../src/bin.ts'
+import { LAUNCHER_RESTART_EXIT_CODE } from '../src/launcher-restart.ts'
 
 const temporaryHomes: string[] = []
 
@@ -154,8 +155,6 @@ describe('Windows launcher spawn', () => {
     expect(DSH_SPAWN_OPTIONS).toMatchObject({ stdio: 'inherit', windowsHide: true })
     const source = readFileSync(new URL('../src/bin.ts', import.meta.url), 'utf8')
     expect(source).toContain("from 'cross-spawn'")
-    const startup = readFileSync(new URL('../src/host/startup.ts', import.meta.url), 'utf8')
-    expect(startup).toContain('windowsHide: true')
   })
 })
 
@@ -188,5 +187,71 @@ describe('corrupt Profile manifest', () => {
     writeFileSync(manifest, '{')
     expect(() => installed('tui')).toThrow(manifest)
     expect(() => installed('tui')).toThrow(/删除该文件后 deepseek 会重新初始化 Profile/)
+  })
+})
+
+describe('outer-wait launcher restart', () => {
+  it('respawns dsh from the waiting launcher after a restart exit', () => {
+    const home = temporaryHome()
+    writeProfile(home, 'tui', { seektty: '0.1.0' })
+    const calls: string[][] = []
+    const execute = (_command: string, args: readonly string[]): number => {
+      calls.push([...args])
+      if (args[0] === '--profile' && calls.filter(call => call[0] === '--profile').length === 1) {
+        return LAUNCHER_RESTART_EXIT_CODE
+      }
+      return 0
+    }
+
+    expect(launch([], { DSH_BIN: '/stock/dsh' }, execute, {
+      pid: 4242,
+      consumeRestart: () => ({ profile: 'tui', args: ['--cwd', '/workspace'] }),
+    })).toBe(0)
+    expect(calls).toEqual([
+      ['--profile', 'tui'],
+      ['--profile', 'tui', '--cwd', '/workspace'],
+    ])
+  })
+
+  it('re-runs installed() self-heal and falls back when the new Profile cannot boot', () => {
+    const home = temporaryHome()
+    writeProfile(home, 'tui', { seektty: '0.1.0' })
+    const calls: string[][] = []
+    const notices: unknown[] = []
+    const execute = (_command: string, args: readonly string[]): number => {
+      calls.push([...args])
+      if (args[0] === '--profile' && args[1] === 'tui' && calls.length === 1) return LAUNCHER_RESTART_EXIT_CODE
+      if (args[0] === 'plugin' && args[3] === 'add') return 17
+      return 0
+    }
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      expect(launch([], { DSH_BIN: '/stock/dsh' }, execute, {
+        pid: 4242,
+        consumeRestart: () => ({ profile: 'broken', args: ['--cwd', '/workspace'] }),
+        writeFallbackHandoff: (payload) => {
+          notices.push(payload)
+          return '/tmp/deepseek-handoff-fallback.json'
+        },
+      })).toBe(0)
+      expect(calls[0]).toEqual(['--profile', 'tui'])
+      expect(calls[1]?.slice(0, 4)).toEqual(['plugin', '--profile', 'broken', 'add'])
+      expect(calls.at(-1)).toEqual(['--profile', 'tui'])
+      expect(notices).toHaveLength(1)
+      expect(String((notices[0] as { notice: string }).notice)).toMatch(/broken/)
+      expect(String((notices[0] as { notice: string }).notice)).toMatch(/tui/)
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+
+  it('does not treat Ctrl+C as a restart', () => {
+    const home = temporaryHome()
+    writeProfile(home, 'tui', { seektty: '0.1.0' })
+    const execute = (): number => 130
+    expect(launch([], { DSH_BIN: '/stock/dsh' }, execute, {
+      pid: 4242,
+      consumeRestart: () => ({ profile: 'tui', args: [] }),
+    })).toBe(130)
   })
 })


### PR DESCRIPTION
## Summary
- Stacks on #12 (P0-7) and #11 (P0-10). `/restart` no longer spawns a replacement `dsh` from the inner process.
- Inner process writes `deepseek-restart-<ppid>.json` and exits **75**. The outer `deepseek` launcher stays in the TTY, respawns `dsh`, and re-runs `installed()` self-heal.
- If the new Profile cannot be provisioned, fall back to the previous Profile and attach a startup notice via the existing handoff file.
- Restart failure in `host/index.ts` now calls `appExit(1)` so the process does not become a zombie.

## Test plan
- [x] `vitest run` (109 tests) and `tsc --noEmit`
- [x] Rebuild `lib/` including the new launcher-restart chunk
- [ ] `/restart` keeps `deepseek → dsh` parent/child; shell prompt does not return
- [ ] Switch to a Profile without seektty: launcher runs `dsh plugin add`, or falls back with a notice
- [ ] Ctrl+C during dsh still exits 130 and does not restart


Made with [Cursor](https://cursor.com)