### PR TITLE
fix(tui): restore the terminal on crash and termination signals (P0-11)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -26876,6 +26876,79 @@ var OverlayQueue = class {
 };
 
 //#endregion
+//#region src/client/process-guards.ts
+/** Conventional exit status for SIGTERM (128 + 15). */
+const FATAL_SIGTERM_EXIT_CODE = 143;
+/** Conventional exit status for SIGHUP (128 + 1). */
+const FATAL_SIGHUP_EXIT_CODE = 129;
+const SHOW_CURSOR_LEAVE_PRIVATE_MODES = "\x1B[?25h\x1B[?1049l\x1B[?2004l";
+function formatFatalMessage(error, logHint) {
+	const summary = error instanceof Error ? error.message : String(error);
+	return [ui(`deepseek: 未捕获异常：${summary}`, `deepseek: uncaught exception: ${summary}`), ui(`日志目录：${logHint}`, `Log directory: ${logHint}`)].join("\n");
+}
+function fatalLogHint(env = process.env) {
+	const home = env.DSH_HOME?.trim();
+	return home === void 0 || home === "" ? "~/.dsh" : home;
+}
+function restoreCookedMode(options$1, write) {
+	try {
+		options$1.restoreStdin?.();
+	} catch {}
+	try {
+		write(SHOW_CURSOR_LEAVE_PRIVATE_MODES);
+	} catch {}
+}
+/**
+* Register one-shot SIGTERM/SIGHUP and crash handlers.
+* @returns a disposer that removes the listeners; safe to call more than once.
+*/
+function attachFatalGuards(options$1) {
+	let handling = false;
+	const restore = options$1.restoreFallback ?? ((chunk) => {
+		process.stdout.write(chunk);
+	});
+	const handle = (error, code) => {
+		if (handling) return;
+		handling = true;
+		if (error !== void 0) try {
+			options$1.writeError(formatFatalMessage(error, options$1.logHint ?? fatalLogHint()));
+		} catch {}
+		const finish = () => {
+			restoreCookedMode(options$1, restore);
+			options$1.exit(code);
+		};
+		try {
+			const pending = options$1.cleanup();
+			Promise.resolve(pending).finally(finish);
+		} catch {
+			finish();
+		}
+	};
+	const onException = (error) => {
+		handle(error, 1);
+	};
+	const onRejection = (reason) => {
+		handle(reason, 1);
+	};
+	const onTerm = () => {
+		handle(void 0, FATAL_SIGTERM_EXIT_CODE);
+	};
+	const onHup = () => {
+		handle(void 0, FATAL_SIGHUP_EXIT_CODE);
+	};
+	process.on("uncaughtException", onException);
+	process.on("unhandledRejection", onRejection);
+	process.on("SIGTERM", onTerm);
+	process.on("SIGHUP", onHup);
+	return () => {
+		process.off("uncaughtException", onException);
+		process.off("unhandledRejection", onRejection);
+		process.off("SIGTERM", onTerm);
+		process.off("SIGHUP", onHup);
+	};
+}
+
+//#endregion
 //#region src/client/syntax-highlighter.ts
 const LANGUAGE_LOADERS = {
 	typescript: () => import("@shikijs/langs/typescript"),
@@ -28509,6 +28582,7 @@ async function startTuiSurface(options$1) {
 	const client = await internals$1.startClient(options$1);
 	let stopConstructedTui = () => void 0;
 	let disposeConstructedSyntax = () => void 0;
+	let detachFatalGuards = () => void 0;
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
 		setTheme(initialTheme);
@@ -28644,6 +28718,8 @@ async function startTuiSurface(options$1) {
 			renderWhileOpen();
 		};
 		const close = (outcome) => {
+			detachFatalGuards();
+			detachFatalGuards = () => void 0;
 			if (stopping !== void 0) return stopping;
 			stopping = (async () => {
 				const failures = [];
@@ -28937,6 +29013,22 @@ async function startTuiSurface(options$1) {
 			return { consume: true };
 		});
 		terminal.setTitle("DeepSeek Harness");
+		detachFatalGuards = attachFatalGuards({
+			cleanup: () => close({
+				kind: "exit",
+				code: 1
+			}),
+			writeError: (message) => {
+				process.stderr.write(`${escapeTerminalText(message)}\n`);
+			},
+			exit: (code) => {
+				process.exit(code);
+			},
+			logHint: fatalLogHint(),
+			restoreStdin: () => {
+				if (process.stdin.isTTY === true && typeof process.stdin.setRawMode === "function") process.stdin.setRawMode(false);
+			}
+		});
 		tui.start();
 		refreshHeader(true);
 		refresh();
@@ -28963,6 +29055,7 @@ async function startTuiSurface(options$1) {
 			})
 		};
 	} catch (error) {
+		detachFatalGuards();
 		setCodeHighlighter(void 0);
 		try {
 			disposeConstructedSyntax();

--- a/src/client/process-guards.ts
+++ b/src/client/process-guards.ts
@@ -1,0 +1,85 @@
+/** One-shot process guards that restore cooked terminal mode after a crash or signal. */
+
+import { ui } from './locale.ts'
+
+/** Conventional exit status for SIGTERM (128 + 15). */
+export const FATAL_SIGTERM_EXIT_CODE = 143
+/** Conventional exit status for SIGHUP (128 + 1). */
+export const FATAL_SIGHUP_EXIT_CODE = 129
+
+const SHOW_CURSOR_LEAVE_PRIVATE_MODES = '\u001B[?25h\u001B[?1049l\u001B[?2004l'
+
+export interface FatalGuardOptions {
+  cleanup(): Promise<void>
+  writeError(message: string): void
+  exit(code: number): void
+  logHint?: string
+  restoreStdin?: () => void
+  restoreFallback?: (chunk: string) => void
+}
+
+export function formatFatalMessage(error: unknown, logHint: string): string {
+  const summary = error instanceof Error ? error.message : String(error)
+  return [
+    ui(`deepseek: 未捕获异常：${summary}`, `deepseek: uncaught exception: ${summary}`),
+    ui(`日志目录：${logHint}`, `Log directory: ${logHint}`),
+  ].join('\n')
+}
+
+export function fatalLogHint(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.DSH_HOME?.trim()
+  return home === undefined || home === '' ? '~/.dsh' : home
+}
+
+function restoreCookedMode(options: FatalGuardOptions, write: (chunk: string) => void): void {
+  try {
+    options.restoreStdin?.()
+  } catch { /* best-effort restore must not throw */ }
+  try {
+    write(SHOW_CURSOR_LEAVE_PRIVATE_MODES)
+  } catch { /* ignore a closed stdout */ }
+}
+
+/**
+ * Register one-shot SIGTERM/SIGHUP and crash handlers.
+ * @returns a disposer that removes the listeners; safe to call more than once.
+ */
+export function attachFatalGuards(options: FatalGuardOptions): () => void {
+  let handling = false
+  const restore = options.restoreFallback ?? (chunk => {
+    process.stdout.write(chunk)
+  })
+  const handle = (error: unknown | undefined, code: number): void => {
+    if (handling) return
+    handling = true
+    if (error !== undefined) {
+      try {
+        options.writeError(formatFatalMessage(error, options.logHint ?? fatalLogHint()))
+      } catch { /* diagnostics must not break restore */ }
+    }
+    const finish = (): void => {
+      restoreCookedMode(options, restore)
+      options.exit(code)
+    }
+    try {
+      const pending = options.cleanup()
+      void Promise.resolve(pending).finally(finish)
+    } catch {
+      finish()
+    }
+  }
+  const onException = (error: unknown): void => { handle(error, 1) }
+  const onRejection = (reason: unknown): void => { handle(reason, 1) }
+  const onTerm = (): void => { handle(undefined, FATAL_SIGTERM_EXIT_CODE) }
+  const onHup = (): void => { handle(undefined, FATAL_SIGHUP_EXIT_CODE) }
+  process.on('uncaughtException', onException)
+  process.on('unhandledRejection', onRejection)
+  process.on('SIGTERM', onTerm)
+  process.on('SIGHUP', onHup)
+  return () => {
+    process.off('uncaughtException', onException)
+    process.off('unhandledRejection', onRejection)
+    process.off('SIGTERM', onTerm)
+    process.off('SIGHUP', onHup)
+  }
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -28,6 +28,7 @@ import {
   ui,
 } from './locale.ts'
 import { OverlayQueue } from './overlays.ts'
+import { attachFatalGuards, fatalLogHint } from './process-guards.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
@@ -112,6 +113,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   const client = await internals.startClient(options)
   let stopConstructedTui = (): void => undefined
   let disposeConstructedSyntax = (): void => undefined
+  let detachFatalGuards = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
     setTheme(initialTheme)
@@ -278,6 +280,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     const close = (outcome: TuiSurfaceOutcome): Promise<void> => {
+      detachFatalGuards()
+      detachFatalGuards = () => undefined
       if (stopping !== undefined) return stopping
       stopping = (async () => {
         const failures: unknown[] = []
@@ -574,6 +578,19 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     })
 
     terminal.setTitle('DeepSeek Harness')
+    detachFatalGuards = attachFatalGuards({
+      cleanup: () => close({ kind: 'exit', code: 1 }),
+      writeError: (message) => {
+        process.stderr.write(`${escapeTerminalText(message)}\n`)
+      },
+      exit: (code) => { process.exit(code) },
+      logHint: fatalLogHint(),
+      restoreStdin: () => {
+        if (process.stdin.isTTY === true && typeof process.stdin.setRawMode === 'function') {
+          process.stdin.setRawMode(false)
+        }
+      },
+    })
     tui.start()
     refreshHeader(true)
     refresh()
@@ -596,6 +613,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
     return { closed, stop: () => close({ kind: 'exit', code: 0 }) }
   } catch (error) {
+    detachFatalGuards()
     setCodeHighlighter(undefined)
     try { disposeConstructedSyntax() } catch { /* preserve the setup failure */ }
     try { stopConstructedTui() } catch { /* preserve the setup failure */ }

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  attachFatalGuards,
+  FATAL_SIGHUP_EXIT_CODE,
+  FATAL_SIGTERM_EXIT_CODE,
+  formatFatalMessage,
+} from '../src/client/process-guards.ts'
+
+describe('fatal process guards', () => {
+  const detachers: Array<() => void> = []
+
+  afterEach(() => {
+    for (const detach of detachers.splice(0)) detach()
+  })
+
+  function attach(partial: {
+    cleanup: () => Promise<void>
+    writeError: (message: string) => void
+    exit: (code: number) => void
+    logHint?: string
+    restoreFallback?: (chunk: string) => void
+  }): void {
+    detachers.push(attachFatalGuards({
+      restoreFallback: () => undefined,
+      ...partial,
+    }))
+  }
+
+  it('restores the terminal once then exits on SIGTERM without an error summary', async () => {
+    const cleanup = vi.fn(async () => undefined)
+    const writeError = vi.fn()
+    const exit = vi.fn()
+    const restoreFallback = vi.fn()
+    attach({ cleanup, writeError, exit, logHint: '/tmp/dsh-home', restoreFallback })
+    process.emit('SIGTERM')
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(FATAL_SIGTERM_EXIT_CODE))
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(restoreFallback).toHaveBeenCalled()
+    expect(writeError).not.toHaveBeenCalled()
+    process.emit('SIGTERM')
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('prints a crash summary and log location on uncaughtException', async () => {
+    const cleanup = vi.fn(async () => undefined)
+    const writeError = vi.fn()
+    const exit = vi.fn()
+    attach({ cleanup, writeError, exit, logHint: '/tmp/dsh-home' })
+    process.emit('uncaughtException', new Error('boom'))
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+    expect(writeError).toHaveBeenCalledTimes(1)
+    const message = String(writeError.mock.calls[0]?.[0])
+    expect(message).toContain('boom')
+    expect(message).toContain('/tmp/dsh-home')
+  })
+
+  it('uses the same cleanup path for SIGHUP', async () => {
+    const cleanup = vi.fn(async () => undefined)
+    const writeError = vi.fn()
+    const exit = vi.fn()
+    attach({ cleanup, writeError, exit })
+    process.emit('SIGHUP')
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(FATAL_SIGHUP_EXIT_CODE))
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the crash summary to an error line plus the log directory', () => {
+    const message = formatFatalMessage(new Error('broken pipe'), '~/.dsh')
+    expect(message.split('\n')).toHaveLength(2)
+    expect(message).toMatch(/broken pipe/)
+    expect(message).toContain('~/.dsh')
+  })
+})
+
+describe('surface fatal-guard wiring', () => {
+  it('registers the shared guards before the TUI takes over the terminal', () => {
+    const source = readFileSync(new URL('../src/client/surface.ts', import.meta.url), 'utf8')
+    expect(source).toContain('attachFatalGuards')
+    expect(source).toContain('detachFatalGuards')
+  })
+})


### PR DESCRIPTION
## Summary
- Register one-shot `uncaughtException` / `unhandledRejection` / `SIGTERM` / `SIGHUP` guards before the TUI takes over the TTY.
- Cleanup is the existing `close()` path (pi-tui `stop()` plus drain), then a fallback cooked-mode restore (`setRawMode(false)`, show cursor, leave private modes).
- Crashes print a two-line summary (exception + `DSH_HOME` / `~/.dsh`). Signals restore and exit 143/129 without treating the stop as an error.
- Guards detach on a normal close so Ctrl+C exit stays a single cleanup.

## Test plan
- [x] `vitest run tests/process-guards.test.ts` and full suite
- [x] Rebuild `lib/index.js`
- [ ] Send SIGTERM to a running TUI: shell echo returns
- [ ] Inject an uncaught exception: terminal restored and summary visible


Made with [Cursor](https://cursor.com)