### PR TITLE
fix(tui): render line-level hunks instead of whole-file diffs (P0-3)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -27306,6 +27306,152 @@ var SyntaxHighlighter = class SyntaxHighlighter {
 };
 
 //#endregion
+//#region src/client/line-diff.ts
+/** Line-level unified diffs for transcript and approval views. */
+/** Default unchanged lines kept on each side of a change island. */
+const DIFF_CONTEXT_LINES = 3;
+function splitDiffLines(text) {
+	if (text === "") return [];
+	return (text.endsWith("\n") ? text.slice(0, -1) : text).split("\n");
+}
+/**
+* Myers / LCS line edits. Equal lines stay in order; inserts and deletes are
+* the minimum replacements needed to turn `previous` into `next`.
+*/
+function lineEdits(previous, next) {
+	const n = previous.length;
+	const m = next.length;
+	const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+	for (let i$1 = n - 1; i$1 >= 0; i$1 -= 1) {
+		const row = dp[i$1];
+		const below = dp[i$1 + 1];
+		if (row === void 0 || below === void 0) continue;
+		for (let j$1 = m - 1; j$1 >= 0; j$1 -= 1) row[j$1] = previous[i$1] === next[j$1] ? (below[j$1 + 1] ?? 0) + 1 : Math.max(below[j$1] ?? 0, row[j$1 + 1] ?? 0);
+	}
+	const edits = [];
+	let i = 0;
+	let j = 0;
+	while (i < n && j < m) {
+		if (previous[i] === next[j]) {
+			edits.push({
+				type: "equal",
+				line: previous[i] ?? ""
+			});
+			i += 1;
+			j += 1;
+			continue;
+		}
+		if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+			edits.push({
+				type: "delete",
+				line: previous[i] ?? ""
+			});
+			i += 1;
+		} else {
+			edits.push({
+				type: "insert",
+				line: next[j] ?? ""
+			});
+			j += 1;
+		}
+	}
+	while (i < n) {
+		edits.push({
+			type: "delete",
+			line: previous[i] ?? ""
+		});
+		i += 1;
+	}
+	while (j < m) {
+		edits.push({
+			type: "insert",
+			line: next[j] ?? ""
+		});
+		j += 1;
+	}
+	return edits;
+}
+function changeSpans(edits) {
+	const spans = [];
+	let index = 0;
+	while (index < edits.length) {
+		if (edits[index]?.type === "equal") {
+			index += 1;
+			continue;
+		}
+		const start = index;
+		while (index < edits.length && edits[index]?.type !== "equal") index += 1;
+		spans.push({
+			start,
+			end: index
+		});
+	}
+	return spans;
+}
+function lineCounts(edits, start, end) {
+	let oldCount = 0;
+	let newCount = 0;
+	for (let index = start; index < end; index += 1) {
+		const edit$1 = edits[index];
+		if (edit$1?.type === "insert") newCount += 1;
+		else if (edit$1?.type === "delete") oldCount += 1;
+		else {
+			oldCount += 1;
+			newCount += 1;
+		}
+	}
+	return {
+		oldCount,
+		newCount
+	};
+}
+function oldIndexAt(edits, editIndex) {
+	let oldIndex = 0;
+	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "insert") oldIndex += 1;
+	return oldIndex;
+}
+function newIndexAt(edits, editIndex) {
+	let newIndex = 0;
+	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "delete") newIndex += 1;
+	return newIndex;
+}
+/**
+* Unified hunks with `context` unchanged lines around each change island.
+* Isolated one-line replacements occupy 7 body lines plus a hunk header.
+*/
+function unifiedHunks(previous, next, context = DIFF_CONTEXT_LINES) {
+	const edits = lineEdits(previous, next);
+	const spans = changeSpans(edits);
+	if (spans.length === 0) return [];
+	const hunks = [];
+	for (const span of spans) {
+		const start = Math.max(0, span.start - context);
+		const end = Math.min(edits.length, span.end + context);
+		const previousHunk = hunks[hunks.length - 1];
+		if (previousHunk !== void 0 && start <= previousHunk.end) previousHunk.end = end;
+		else hunks.push({
+			start,
+			end
+		});
+	}
+	const rows = [];
+	for (const hunk of hunks) {
+		const oldStart = oldIndexAt(edits, hunk.start) + 1;
+		const newStart = newIndexAt(edits, hunk.start) + 1;
+		const { oldCount, newCount } = lineCounts(edits, hunk.start, hunk.end);
+		rows.push(`@@ -${oldCount === 0 ? oldStart - 1 : oldStart},${oldCount} +${newCount === 0 ? newStart - 1 : newStart},${newCount} @@`);
+		for (let index = hunk.start; index < hunk.end; index += 1) {
+			const edit$1 = edits[index];
+			if (edit$1 === void 0) continue;
+			if (edit$1.type === "equal") rows.push(` ${edit$1.line}`);
+			else if (edit$1.type === "delete") rows.push(`-${edit$1.line}`);
+			else rows.push(`+${edit$1.line}`);
+		}
+	}
+	return rows;
+}
+
+//#endregion
 //#region src/client/transcript.ts
 const PULSE_FRAME_MS = 160;
 function thinkingRow() {
@@ -27539,8 +27685,7 @@ function prettyArgs(argsRaw) {
 	}
 }
 function contentLines(text) {
-	if (text === "") return [];
-	return (text.endsWith("\n") ? text.slice(0, -1) : text).split("\n");
+	return splitDiffLines(text);
 }
 function diffText(value) {
 	if (!Array.isArray(value) || value.length === 0) return jsonText(value);
@@ -27556,13 +27701,12 @@ function diffText(value) {
 		rows.push(`diff -- ${path$1}`);
 		rows.push(oldText === null ? "--- /dev/null" : `--- a/${path$1}`);
 		rows.push(`+++ b/${path$1}`);
-		if (oldText !== null) for (const line of contentLines(oldText)) {
-			rows.push(`-${line}`);
-			removed += 1;
-		}
-		for (const line of contentLines(newText)) {
-			rows.push(`+${line}`);
-			added += 1;
+		const previous = oldText === null ? [] : contentLines(oldText);
+		const next = contentLines(newText);
+		for (const line of unifiedHunks(previous, next)) {
+			if (line.startsWith("+")) added += 1;
+			else if (line.startsWith("-")) removed += 1;
+			rows.push(line);
 		}
 	}
 	const visible = rows.length <= 80 ? rows : [

--- a/src/client/line-diff.ts
+++ b/src/client/line-diff.ts
@@ -1,0 +1,149 @@
+/** Line-level unified diffs for transcript and approval views. */
+
+/** Default unchanged lines kept on each side of a change island. */
+export const DIFF_CONTEXT_LINES = 3
+
+export type LineEdit =
+  | { readonly type: 'equal'; readonly line: string }
+  | { readonly type: 'delete'; readonly line: string }
+  | { readonly type: 'insert'; readonly line: string }
+
+export function splitDiffLines(text: string): string[] {
+  if (text === '') return []
+  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
+}
+
+/**
+ * Myers / LCS line edits. Equal lines stay in order; inserts and deletes are
+ * the minimum replacements needed to turn `previous` into `next`.
+ */
+export function lineEdits(previous: readonly string[], next: readonly string[]): LineEdit[] {
+  const n = previous.length
+  const m = next.length
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array<number>(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i -= 1) {
+    const row = dp[i]
+    const below = dp[i + 1]
+    if (row === undefined || below === undefined) continue
+    for (let j = m - 1; j >= 0; j -= 1) {
+      row[j] = previous[i] === next[j]
+        ? (below[j + 1] ?? 0) + 1
+        : Math.max(below[j] ?? 0, row[j + 1] ?? 0)
+    }
+  }
+  const edits: LineEdit[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (previous[i] === next[j]) {
+      edits.push({ type: 'equal', line: previous[i] ?? '' })
+      i += 1
+      j += 1
+      continue
+    }
+    if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+      edits.push({ type: 'delete', line: previous[i] ?? '' })
+      i += 1
+    } else {
+      edits.push({ type: 'insert', line: next[j] ?? '' })
+      j += 1
+    }
+  }
+  while (i < n) {
+    edits.push({ type: 'delete', line: previous[i] ?? '' })
+    i += 1
+  }
+  while (j < m) {
+    edits.push({ type: 'insert', line: next[j] ?? '' })
+    j += 1
+  }
+  return edits
+}
+
+interface ChangeSpan {
+  readonly start: number
+  readonly end: number
+}
+
+function changeSpans(edits: readonly LineEdit[]): ChangeSpan[] {
+  const spans: ChangeSpan[] = []
+  let index = 0
+  while (index < edits.length) {
+    if (edits[index]?.type === 'equal') {
+      index += 1
+      continue
+    }
+    const start = index
+    while (index < edits.length && edits[index]?.type !== 'equal') index += 1
+    spans.push({ start, end: index })
+  }
+  return spans
+}
+
+function lineCounts(edits: readonly LineEdit[], start: number, end: number): { oldCount: number; newCount: number } {
+  let oldCount = 0
+  let newCount = 0
+  for (let index = start; index < end; index += 1) {
+    const edit = edits[index]
+    if (edit?.type === 'insert') newCount += 1
+    else if (edit?.type === 'delete') oldCount += 1
+    else {
+      oldCount += 1
+      newCount += 1
+    }
+  }
+  return { oldCount, newCount }
+}
+
+function oldIndexAt(edits: readonly LineEdit[], editIndex: number): number {
+  let oldIndex = 0
+  for (let index = 0; index < editIndex; index += 1) {
+    if (edits[index]?.type !== 'insert') oldIndex += 1
+  }
+  return oldIndex
+}
+
+function newIndexAt(edits: readonly LineEdit[], editIndex: number): number {
+  let newIndex = 0
+  for (let index = 0; index < editIndex; index += 1) {
+    if (edits[index]?.type !== 'delete') newIndex += 1
+  }
+  return newIndex
+}
+
+/**
+ * Unified hunks with `context` unchanged lines around each change island.
+ * Isolated one-line replacements occupy 7 body lines plus a hunk header.
+ */
+export function unifiedHunks(
+  previous: readonly string[],
+  next: readonly string[],
+  context: number = DIFF_CONTEXT_LINES,
+): string[] {
+  const edits = lineEdits(previous, next)
+  const spans = changeSpans(edits)
+  if (spans.length === 0) return []
+  const hunks: Array<{ start: number; end: number }> = []
+  for (const span of spans) {
+    const start = Math.max(0, span.start - context)
+    const end = Math.min(edits.length, span.end + context)
+    const previousHunk = hunks[hunks.length - 1]
+    if (previousHunk !== undefined && start <= previousHunk.end) previousHunk.end = end
+    else hunks.push({ start, end })
+  }
+  const rows: string[] = []
+  for (const hunk of hunks) {
+    const oldStart = oldIndexAt(edits, hunk.start) + 1
+    const newStart = newIndexAt(edits, hunk.start) + 1
+    const { oldCount, newCount } = lineCounts(edits, hunk.start, hunk.end)
+    rows.push(`@@ -${oldCount === 0 ? oldStart - 1 : oldStart},${oldCount} +${newCount === 0 ? newStart - 1 : newStart},${newCount} @@`)
+    for (let index = hunk.start; index < hunk.end; index += 1) {
+      const edit = edits[index]
+      if (edit === undefined) continue
+      if (edit.type === 'equal') rows.push(` ${edit.line}`)
+      else if (edit.type === 'delete') rows.push(`-${edit.line}`)
+      else rows.push(`+${edit.line}`)
+    }
+  }
+  return rows
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -32,6 +32,7 @@ import type {
   WorkflowRunPhaseData,
 } from '@deepseek-ai/dsh-client-ui-workflow-run/projection'
 import { producedForClosing } from './compat/deliverables-rc6.ts'
+import { splitDiffLines, unifiedHunks } from './line-diff.ts'
 import { translateUiText, ui } from './locale.ts'
 import {
   background,
@@ -364,8 +365,7 @@ function prettyArgs(argsRaw: string): string {
 }
 
 function contentLines(text: string): string[] {
-  if (text === '') return []
-  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
+  return splitDiffLines(text)
 }
 
 function diffText(value: unknown): string {
@@ -384,15 +384,12 @@ function diffText(value: unknown): string {
     rows.push(`diff -- ${path}`)
     rows.push(oldText === null ? '--- /dev/null' : `--- a/${path}`)
     rows.push(`+++ b/${path}`)
-    if (oldText !== null) {
-      for (const line of contentLines(oldText)) {
-        rows.push(`-${line}`)
-        removed += 1
-      }
-    }
-    for (const line of contentLines(newText)) {
-      rows.push(`+${line}`)
-      added += 1
+    const previous = oldText === null ? [] : contentLines(oldText)
+    const next = contentLines(newText)
+    for (const line of unifiedHunks(previous, next)) {
+      if (line.startsWith('+')) added += 1
+      else if (line.startsWith('-')) removed += 1
+      rows.push(line)
     }
   }
   const visible = rows.length <= 80

--- a/tests/line-diff.test.ts
+++ b/tests/line-diff.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { DIFF_CONTEXT_LINES, splitDiffLines, unifiedHunks } from '../src/client/line-diff.ts'
+
+describe('line-level unified diff', () => {
+  it('keeps three isolated edits in a 200-line file within 3×7 body lines plus hunk headers', () => {
+    const previous = Array.from({ length: 200 }, (_, index) => `line ${index + 1}`)
+    const next = [...previous]
+    next[9] = 'changed 10'
+    next[49] = 'changed 50'
+    next[149] = 'changed 150'
+    const hunks = unifiedHunks(previous, next, DIFF_CONTEXT_LINES)
+    const headers = hunks.filter(line => line.startsWith('@@'))
+    const body = hunks.length - headers.length
+    expect(headers).toHaveLength(3)
+    expect(body).toBe(3 * 8)
+    expect(hunks.length).toBe(3 * 8 + headers.length)
+    expect(hunks.join('\n')).toContain('-line 10')
+    expect(hunks.join('\n')).toContain('+changed 10')
+    expect(hunks.join('\n')).not.toContain('line 1\n')
+  })
+
+  it('shows a new file as a full addition', () => {
+    const hunks = unifiedHunks([], ['alpha', 'beta'])
+    expect(hunks.some(line => line.startsWith('@@'))).toBe(true)
+    expect(hunks).toContain('+alpha')
+    expect(hunks).toContain('+beta')
+    expect(hunks.every(line => !line.startsWith('-') || line.startsWith('---') || line.startsWith('@@'))).toBe(true)
+  })
+
+  it('splits files on the last newline the same way transcript did', () => {
+    expect(splitDiffLines('old\n')).toEqual(['old'])
+    expect(splitDiffLines('a\nb\n')).toEqual(['a', 'b'])
+    expect(splitDiffLines('')).toEqual([])
+  })
+})

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -637,7 +637,7 @@ describe('conversation viewport', () => {
     vi.stubEnv('COLORTERM', 'truecolor')
     const highlighter = vi.fn((code: string, _language?: string) => code.split('\n'))
     setCodeHighlighter(highlighter)
-    const transcript = new Transcript(() => 24)
+    const transcript = new Transcript(() => 80)
     transcript.cycleToolVisibility()
     transcript.update(snapshot([
       tool(
@@ -672,6 +672,37 @@ describe('conversation viewport', () => {
     expect(highlighter.mock.calls.map(call => call[1])).toEqual(expect.arrayContaining(['typescript', 'diff']))
     expect(highlighter.mock.calls.some(call => call[0].includes('RED'))).toBe(false)
   })
+
+  it('renders a 200-line three-edit file as compact hunks instead of a whole-file rewrite', () => {
+    const previous = Array.from({ length: 200 }, (_, index) => `line ${index + 1}`).join('\n') + '\n'
+    const nextLines = Array.from({ length: 200 }, (_, index) => `line ${index + 1}`)
+    nextLines[9] = 'changed 10'
+    nextLines[49] = 'changed 50'
+    nextLines[149] = 'changed 150'
+    const transcript = new Transcript(() => 80)
+    transcript.cycleToolVisibility()
+    transcript.update(snapshot([
+      tool(
+        'diff-compact',
+        {
+          card: 'diff',
+          title: 'Edit file.ts',
+          diffs: [{ path: 'file.ts', oldText: previous, newText: `${nextLines.join('\n')}\n` }],
+        },
+        {
+          card: 'diff',
+          diffs: [{ path: 'file.ts', oldText: previous, newText: `${nextLines.join('\n')}\n` }],
+        },
+      ),
+    ]))
+    const rendered = transcript.render(100).join('\n')
+    expect(rendered).toContain('@@ -')
+    expect(rendered).toContain('+changed 10')
+    expect(rendered).not.toMatch(/-line 1(?!\d)/)
+    const diffLines = rendered.split('\n').filter(line => line.includes('file.ts') || line.includes('changed') || line.includes('@@'))
+    expect(diffLines.length).toBeLessThan(80)
+  })
+
 
   it('recolors existing history without moving the current viewport', () => {
     vi.stubEnv('NO_COLOR', undefined)


### PR DESCRIPTION
## Summary
- Replace the whole-file delete-plus-add `diffText` with a line-level LCS unified diff (3 lines of context).
- Isolated one-line replacements occupy 8 body lines plus a hunk header; a 200-line file with three edits stays compact instead of ~400 truncated lines.
- New files (`oldText === null`) still render as a full addition. `resultView.card === 'diff'` and `callView.card === 'diff'` pick this up automatically.

## Test plan
- [x] `vitest run tests/line-diff.test.ts tests/transcript.test.ts`
- [x] Rebuild `lib/index.js`
- [ ] Open a file-edit tool result: hunk headers and `+`/`-` context, not a full rewrite


Made with [Cursor](https://cursor.com)