### PR TITLE
fix(tui): show the pending tool command and diff in approval overlays (P0-2)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,9 +35,9 @@ import { mkdir, open, readFile, realpath, stat, unlink } from "node:fs/promises"
 import { fileURLToPath } from "node:url";
 import { LOCALE_SETTINGS_NAMESPACE } from "@deepseek-ai/dsh-client-locale";
 import { getPath, hasPath, rehydrateSchema } from "@deepseek-ai/dsh-client-schema-form";
-import { parse, printParseErrorCode } from "jsonc-parser";
 import { createHighlighterCore } from "@shikijs/core";
 import { createJavaScriptRegexEngine, defaultJavaScriptRegexConstructor } from "@shikijs/engine-javascript";
+import { parse, printParseErrorCode } from "jsonc-parser";
 import z$1 from "@deepseek-ai/schemastery";
 import { credentialRef } from "@deepseek-ai/dsh-credentials";
 import { SettingsConflictError, settingsNamespace } from "@deepseek-ai/dsh-settings";
@@ -22196,6 +22196,1754 @@ function settingsSectionLabel(namespace) {
 }
 
 //#endregion
+//#region src/client/line-diff.ts
+/** Line-level unified diffs for transcript and approval views. */
+/** Default unchanged lines kept on each side of a change island. */
+const DIFF_CONTEXT_LINES = 3;
+function splitDiffLines(text) {
+	if (text === "") return [];
+	return (text.endsWith("\n") ? text.slice(0, -1) : text).split("\n");
+}
+/**
+* Myers / LCS line edits. Equal lines stay in order; inserts and deletes are
+* the minimum replacements needed to turn `previous` into `next`.
+*/
+function lineEdits(previous, next) {
+	const n = previous.length;
+	const m = next.length;
+	const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+	for (let i$1 = n - 1; i$1 >= 0; i$1 -= 1) {
+		const row = dp[i$1];
+		const below = dp[i$1 + 1];
+		if (row === void 0 || below === void 0) continue;
+		for (let j$1 = m - 1; j$1 >= 0; j$1 -= 1) row[j$1] = previous[i$1] === next[j$1] ? (below[j$1 + 1] ?? 0) + 1 : Math.max(below[j$1] ?? 0, row[j$1 + 1] ?? 0);
+	}
+	const edits = [];
+	let i = 0;
+	let j = 0;
+	while (i < n && j < m) {
+		if (previous[i] === next[j]) {
+			edits.push({
+				type: "equal",
+				line: previous[i] ?? ""
+			});
+			i += 1;
+			j += 1;
+			continue;
+		}
+		if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+			edits.push({
+				type: "delete",
+				line: previous[i] ?? ""
+			});
+			i += 1;
+		} else {
+			edits.push({
+				type: "insert",
+				line: next[j] ?? ""
+			});
+			j += 1;
+		}
+	}
+	while (i < n) {
+		edits.push({
+			type: "delete",
+			line: previous[i] ?? ""
+		});
+		i += 1;
+	}
+	while (j < m) {
+		edits.push({
+			type: "insert",
+			line: next[j] ?? ""
+		});
+		j += 1;
+	}
+	return edits;
+}
+function changeSpans(edits) {
+	const spans = [];
+	let index = 0;
+	while (index < edits.length) {
+		if (edits[index]?.type === "equal") {
+			index += 1;
+			continue;
+		}
+		const start = index;
+		while (index < edits.length && edits[index]?.type !== "equal") index += 1;
+		spans.push({
+			start,
+			end: index
+		});
+	}
+	return spans;
+}
+function lineCounts(edits, start, end) {
+	let oldCount = 0;
+	let newCount = 0;
+	for (let index = start; index < end; index += 1) {
+		const edit$1 = edits[index];
+		if (edit$1?.type === "insert") newCount += 1;
+		else if (edit$1?.type === "delete") oldCount += 1;
+		else {
+			oldCount += 1;
+			newCount += 1;
+		}
+	}
+	return {
+		oldCount,
+		newCount
+	};
+}
+function oldIndexAt(edits, editIndex) {
+	let oldIndex = 0;
+	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "insert") oldIndex += 1;
+	return oldIndex;
+}
+function newIndexAt(edits, editIndex) {
+	let newIndex = 0;
+	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "delete") newIndex += 1;
+	return newIndex;
+}
+/**
+* Unified hunks with `context` unchanged lines around each change island.
+* Isolated one-line replacements occupy 7 body lines plus a hunk header.
+*/
+function unifiedHunks(previous, next, context = DIFF_CONTEXT_LINES) {
+	const edits = lineEdits(previous, next);
+	const spans = changeSpans(edits);
+	if (spans.length === 0) return [];
+	const hunks = [];
+	for (const span of spans) {
+		const start = Math.max(0, span.start - context);
+		const end = Math.min(edits.length, span.end + context);
+		const previousHunk = hunks[hunks.length - 1];
+		if (previousHunk !== void 0 && start <= previousHunk.end) previousHunk.end = end;
+		else hunks.push({
+			start,
+			end
+		});
+	}
+	const rows = [];
+	for (const hunk of hunks) {
+		const oldStart = oldIndexAt(edits, hunk.start) + 1;
+		const newStart = newIndexAt(edits, hunk.start) + 1;
+		const { oldCount, newCount } = lineCounts(edits, hunk.start, hunk.end);
+		rows.push(`@@ -${oldCount === 0 ? oldStart - 1 : oldStart},${oldCount} +${newCount === 0 ? newStart - 1 : newStart},${newCount} @@`);
+		for (let index = hunk.start; index < hunk.end; index += 1) {
+			const edit$1 = edits[index];
+			if (edit$1 === void 0) continue;
+			if (edit$1.type === "equal") rows.push(` ${edit$1.line}`);
+			else if (edit$1.type === "delete") rows.push(`-${edit$1.line}`);
+			else rows.push(`+${edit$1.line}`);
+		}
+	}
+	return rows;
+}
+
+//#endregion
+//#region src/client/syntax-highlighter.ts
+const LANGUAGE_LOADERS = {
+	typescript: () => import("@shikijs/langs/typescript"),
+	javascript: () => import("@shikijs/langs/javascript"),
+	tsx: () => import("@shikijs/langs/tsx"),
+	jsx: () => import("@shikijs/langs/jsx"),
+	bash: () => import("@shikijs/langs/bash"),
+	json: () => import("@shikijs/langs/json"),
+	jsonc: () => import("@shikijs/langs/jsonc"),
+	python: () => import("@shikijs/langs/python"),
+	ruby: () => import("@shikijs/langs/ruby"),
+	go: () => import("@shikijs/langs/go"),
+	rust: () => import("@shikijs/langs/rust"),
+	java: () => import("@shikijs/langs/java"),
+	c: () => import("@shikijs/langs/c"),
+	cpp: () => import("@shikijs/langs/cpp"),
+	csharp: () => import("@shikijs/langs/csharp"),
+	kotlin: () => import("@shikijs/langs/kotlin"),
+	swift: () => import("@shikijs/langs/swift"),
+	php: () => import("@shikijs/langs/php"),
+	yaml: () => import("@shikijs/langs/yaml"),
+	toml: () => import("@shikijs/langs/toml"),
+	ini: () => import("@shikijs/langs/ini"),
+	markdown: () => import("@shikijs/langs/markdown"),
+	mdx: () => import("@shikijs/langs/mdx"),
+	html: () => import("@shikijs/langs/html"),
+	css: () => import("@shikijs/langs/css"),
+	scss: () => import("@shikijs/langs/scss"),
+	less: () => import("@shikijs/langs/less"),
+	sql: () => import("@shikijs/langs/sql"),
+	xml: () => import("@shikijs/langs/xml"),
+	lua: () => import("@shikijs/langs/lua"),
+	diff: () => import("@shikijs/langs/diff")
+};
+const LANGUAGE_ALIASES = {
+	ts: "typescript",
+	mts: "typescript",
+	cts: "typescript",
+	typescript: "typescript",
+	js: "javascript",
+	mjs: "javascript",
+	cjs: "javascript",
+	javascript: "javascript",
+	tsx: "tsx",
+	jsx: "jsx",
+	sh: "bash",
+	shell: "bash",
+	shellscript: "bash",
+	zsh: "bash",
+	bash: "bash",
+	json: "json",
+	json5: "jsonc",
+	jsonc: "jsonc",
+	py: "python",
+	python: "python",
+	rb: "ruby",
+	ruby: "ruby",
+	golang: "go",
+	go: "go",
+	rs: "rust",
+	rust: "rust",
+	java: "java",
+	c: "c",
+	h: "c",
+	cpp: "cpp",
+	"c++": "cpp",
+	cc: "cpp",
+	hpp: "cpp",
+	cs: "csharp",
+	csharp: "csharp",
+	kt: "kotlin",
+	kotlin: "kotlin",
+	swift: "swift",
+	php: "php",
+	yml: "yaml",
+	yaml: "yaml",
+	toml: "toml",
+	ini: "ini",
+	properties: "ini",
+	md: "markdown",
+	markdown: "markdown",
+	mdx: "mdx",
+	html: "html",
+	htm: "html",
+	css: "css",
+	scss: "scss",
+	less: "less",
+	sql: "sql",
+	xml: "xml",
+	svg: "xml",
+	lua: "lua",
+	diff: "diff",
+	patch: "diff"
+};
+const EXTENSION_LANGUAGES = {
+	ts: "typescript",
+	mts: "typescript",
+	cts: "typescript",
+	js: "javascript",
+	mjs: "javascript",
+	cjs: "javascript",
+	tsx: "tsx",
+	jsx: "jsx",
+	sh: "bash",
+	bash: "bash",
+	zsh: "bash",
+	json: "json",
+	jsonc: "jsonc",
+	py: "python",
+	rb: "ruby",
+	go: "go",
+	rs: "rust",
+	java: "java",
+	c: "c",
+	h: "c",
+	cc: "cpp",
+	cpp: "cpp",
+	cxx: "cpp",
+	hpp: "cpp",
+	cs: "csharp",
+	kt: "kotlin",
+	kts: "kotlin",
+	swift: "swift",
+	php: "php",
+	yml: "yaml",
+	yaml: "yaml",
+	toml: "toml",
+	ini: "ini",
+	md: "markdown",
+	mdx: "mdx",
+	html: "html",
+	htm: "html",
+	css: "css",
+	scss: "scss",
+	less: "less",
+	sql: "sql",
+	xml: "xml",
+	svg: "xml",
+	lua: "lua",
+	diff: "diff",
+	patch: "diff"
+};
+const COMMON_LANGUAGES = [
+	"typescript",
+	"javascript",
+	"tsx",
+	"jsx",
+	"bash",
+	"json",
+	"jsonc",
+	"markdown",
+	"diff"
+];
+const COMMON_WARMUPS = [
+	{
+		language: "typescript",
+		code: "const answer: number = 42"
+	},
+	{
+		language: "bash",
+		code: "printf '%s\\n' \"$HOME\""
+	},
+	{
+		language: "json",
+		code: "{\"ready\":true}"
+	},
+	{
+		language: "markdown",
+		code: "# ready"
+	},
+	{
+		language: "diff",
+		code: "@@ -1 +1 @@\n-old\n+new"
+	}
+];
+const MAX_HIGHLIGHT_CHARS = 1e5;
+const MAX_HIGHLIGHT_LINE_CHARS = 2e4;
+const MAX_CACHE_ENTRIES = 512;
+const ROLE_SCOPES$1 = {
+	comment: ["comment"],
+	keyword: [
+		"keyword",
+		"storage.type",
+		"storage.modifier"
+	],
+	string: ["string"],
+	number: ["constant.numeric"],
+	constant: ["constant", "variable.language"],
+	function: [
+		"entity.name.function",
+		"support.function",
+		"meta.function-call"
+	],
+	type: [
+		"entity.name.type",
+		"entity.name.class",
+		"support.type",
+		"support.class"
+	],
+	variable: ["variable.other", "variable.language"],
+	property: ["variable.other.property", "support.variable.property"],
+	parameter: ["variable.parameter"],
+	operator: ["keyword.operator"],
+	punctuation: ["punctuation"],
+	tag: ["entity.name.tag"],
+	attribute: ["entity.other.attribute-name"],
+	regexp: ["string.regexp"]
+};
+const DIFF_SCOPES = {
+	inserted: ["markup.inserted", "punctuation.definition.inserted"],
+	deleted: ["markup.deleted", "punctuation.definition.deleted"],
+	header: ["meta.diff.header", "meta.diff.range"]
+};
+function languageOf(value) {
+	if (value === void 0) return void 0;
+	return LANGUAGE_ALIASES[value.trim().toLowerCase().split(/[\s,{]/u, 1)[0] ?? ""];
+}
+/**
+* Infer a supported syntax grammar from a path and optional explicit language.
+* @param path - file path or display name.
+* @param explicit - Harness-provided language id.
+* @returns canonical language or undefined for plain text.
+*/
+function syntaxLanguageForPath(path$1, explicit) {
+	const requested = languageOf(explicit);
+	if (requested !== void 0) return requested;
+	const filename = path$1.toLowerCase().split(/[\\/]/u).at(-1) ?? "";
+	if (filename === "dockerfile") return "bash";
+	if (filename === "makefile") return void 0;
+	return EXTENSION_LANGUAGES[filename.includes(".") ? filename.split(".").at(-1) ?? "" : ""];
+}
+function themeHash(theme) {
+	const value = JSON.stringify([
+		theme.syntaxTone,
+		theme.colors,
+		theme.syntax,
+		theme.tokenColors
+	]);
+	let hash = 2166136261;
+	for (const character of value) {
+		hash ^= character.codePointAt(0) ?? 0;
+		hash = Math.imul(hash, 16777619);
+	}
+	return `seektty-${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+function themeRegistration(theme, name$1) {
+	const settings = [
+		{ settings: {
+			foreground: theme.syntax.foreground,
+			background: theme.syntax.background
+		} },
+		...Object.entries(ROLE_SCOPES$1).map(([role, scope]) => ({
+			scope: [...scope],
+			settings: { foreground: theme.syntax[role] }
+		})),
+		{
+			scope: [...DIFF_SCOPES.inserted],
+			settings: { foreground: theme.colors.success }
+		},
+		{
+			scope: [...DIFF_SCOPES.deleted],
+			settings: { foreground: theme.colors.danger }
+		},
+		{
+			scope: [...DIFF_SCOPES.header],
+			settings: { foreground: theme.colors.accent }
+		},
+		...theme.tokenColors.map((rule) => ({
+			scope: [...rule.scope],
+			settings: {
+				...rule.foreground === void 0 ? {} : { foreground: rule.foreground },
+				...rule.background === void 0 ? {} : { background: rule.background },
+				...rule.fontStyle === void 0 ? {} : { fontStyle: rule.fontStyle.join(" ") }
+			}
+		}))
+	];
+	return {
+		name: name$1,
+		displayName: theme.name,
+		type: theme.syntaxTone,
+		fg: theme.syntax.foreground,
+		bg: theme.syntax.background,
+		settings,
+		colors: {
+			"editor.foreground": theme.syntax.foreground,
+			"editor.background": theme.syntax.background
+		}
+	};
+}
+function safeTokenColor(value, fallback) {
+	if (value === void 0) return fallback;
+	try {
+		return normalizeThemeColor(value);
+	} catch {
+		return fallback;
+	}
+}
+function renderToken(token, theme) {
+	const fontStyle = token.fontStyle ?? 0;
+	return styleTerminalText(token.content, {
+		foreground: safeTokenColor(token.color, theme.syntax.foreground),
+		background: safeTokenColor(token.bgColor, theme.syntax.background),
+		italic: (fontStyle & 1) !== 0,
+		bold: (fontStyle & 2) !== 0,
+		underline: (fontStyle & 4) !== 0,
+		strikethrough: (fontStyle & 8) !== 0
+	});
+}
+function plainLines(code, theme) {
+	return code.split("\n").map((line) => styleTerminalText(line, {
+		foreground: theme.syntax.foreground,
+		background: theme.syntax.background
+	}));
+}
+function highlightable(code) {
+	return code.length <= MAX_HIGHLIGHT_CHARS && code.split("\n").every((line) => line.length <= MAX_HIGHLIGHT_LINE_CHARS);
+}
+/** Synchronous render face backed by asynchronously loaded Shiki grammars. */
+var SyntaxHighlighter = class SyntaxHighlighter {
+	loaded = /* @__PURE__ */ new Set();
+	loading = /* @__PURE__ */ new Map();
+	failed = /* @__PURE__ */ new Set();
+	themes = /* @__PURE__ */ new Set();
+	cache = /* @__PURE__ */ new Map();
+	themeName = "";
+	disposed = false;
+	constructor(highlighter, theme, invalidate) {
+		this.highlighter = highlighter;
+		this.theme = theme;
+		this.invalidate = invalidate;
+	}
+	/**
+	* Prepare the JavaScript-regex engine and common Harness grammars.
+	* @param theme - initial resolved theme.
+	* @param invalidate - called after a lazy grammar becomes usable.
+	* @returns ready syntax renderer.
+	*/
+	static async create(theme, invalidate) {
+		const highlighter = await createHighlighterCore({
+			engine: createJavaScriptRegexEngine({
+				forgiving: true,
+				regexConstructor: (pattern) => defaultJavaScriptRegexConstructor(pattern, { lazyCompileLength: Number.POSITIVE_INFINITY })
+			}),
+			langs: COMMON_LANGUAGES.map((language) => LANGUAGE_LOADERS[language]),
+			themes: [],
+			warnings: false
+		});
+		const service = new SyntaxHighlighter(highlighter, theme, invalidate);
+		for (const language of COMMON_LANGUAGES) service.loaded.add(language);
+		service.setTheme(theme);
+		for (const sample of COMMON_WARMUPS) highlighter.codeToTokens(sample.code, {
+			lang: sample.language,
+			theme: service.themeName,
+			tokenizeTimeLimit: 0
+		});
+		return service;
+	}
+	/**
+	* Replace the active token theme and invalidate bounded render caches.
+	* @param theme - complete current theme.
+	*/
+	setTheme(theme) {
+		if (this.disposed) return;
+		this.theme = theme;
+		this.themeName = themeHash(theme);
+		if (!this.themes.has(this.themeName)) {
+			this.highlighter.loadThemeSync(themeRegistration(theme, this.themeName));
+			this.themes.add(this.themeName);
+		}
+		this.cache.clear();
+	}
+	/**
+	* Highlight one code block synchronously, loading uncommon grammars in the background.
+	* @param code - raw code block.
+	* @param language - Markdown or tool-provided language id.
+	* @returns ANSI-styled lines or a safe plain fallback.
+	*/
+	highlight(code, language) {
+		if (this.disposed || !highlightable(code) || terminalColorLevel() === 0) return plainLines(code, this.theme);
+		const canonical = languageOf(language);
+		if (canonical === void 0) return plainLines(code, this.theme);
+		if (!this.loaded.has(canonical)) {
+			this.load(canonical);
+			return plainLines(code, this.theme);
+		}
+		const key = `${this.themeName}:${String(terminalColorLevel())}:${canonical}:${code}`;
+		const cached = this.cache.get(key);
+		if (cached !== void 0) {
+			this.cache.delete(key);
+			this.cache.set(key, cached);
+			return [...cached];
+		}
+		let lines;
+		try {
+			lines = this.highlighter.codeToTokens(code, {
+				lang: canonical,
+				theme: this.themeName,
+				tokenizeTimeLimit: 0
+			}).tokens.map((line) => line.map((token) => renderToken(token, this.theme)).join(""));
+		} catch {
+			this.failed.add(canonical);
+			return plainLines(code, this.theme);
+		}
+		this.cache.set(key, lines);
+		if (this.cache.size > MAX_CACHE_ENTRIES) this.cache.delete(this.cache.keys().next().value);
+		return [...lines];
+	}
+	/** Release Shiki registries and ignore pending lazy-load invalidations. */
+	dispose() {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.cache.clear();
+		this.highlighter.dispose();
+	}
+	load(language) {
+		if (this.loading.has(language) || this.failed.has(language) || this.disposed) return;
+		const task = this.highlighter.loadLanguage(LANGUAGE_LOADERS[language]).then(() => {
+			if (this.disposed) return;
+			this.loaded.add(language);
+			this.invalidate();
+		}).catch(() => {
+			this.failed.add(language);
+		}).finally(() => {
+			this.loading.delete(language);
+		});
+		this.loading.set(language, task);
+	}
+};
+
+//#endregion
+//#region src/client/transcript.ts
+const PULSE_FRAME_MS = 160;
+function thinkingRow() {
+	return {
+		format: "plain",
+		text: ui("正在思考…", "Thinking…"),
+		pulse: "thinking"
+	};
+}
+var PulsingRow = class {
+	constructor(text, mode, frame, liveDurationSince) {
+		this.text = text;
+		this.mode = mode;
+		this.frame = frame;
+		this.liveDurationSince = liveDurationSince;
+	}
+	render(width) {
+		const marker = color.pulse("◆", this.frame());
+		const liveDuration = this.liveDurationSince === void 0 ? "" : ` · ${durationText(Math.max(0, Date.now() - this.liveDurationSince))}`;
+		const safeText = escapeTerminalText(`${this.text}${liveDuration}`);
+		return new Text(this.mode === "thinking" ? `${marker} ${color.muted(safeText)}` : safeText.replace("◆", marker), 0, 0).render(width);
+	}
+	invalidate() {}
+};
+var CodeRow = class {
+	constructor(row) {
+		this.row = row;
+	}
+	render(width) {
+		const safeWidth = Math.max(1, width);
+		const requestedPrefix = escapeTerminalText(this.row.prefix ?? "");
+		const prefix = visibleWidth(requestedPrefix) < safeWidth ? requestedPrefix : "";
+		const prefixWidth = visibleWidth(prefix);
+		const numbers = this.row.lineNumbers;
+		const highest = numbers?.reduce((value, number) => Math.max(value, number), 0) ?? 0;
+		const numberWidth = numbers !== void 0 && safeWidth - prefixWidth >= 8 ? String(highest).length + 2 : 0;
+		const codeWidth = Math.max(1, safeWidth - prefixWidth - numberWidth);
+		const highlighted = highlightCodeLines(this.row.text, this.row.language);
+		const rows = [];
+		if (this.row.caption !== void 0) rows.push(...new Text(`${color.muted(prefix)}${color.muted(escapeTerminalText(this.row.caption))}`, 0, 0).render(safeWidth));
+		for (const [index, sourceLine] of highlighted.entries()) {
+			const wrapped = wrapTextWithAnsi(sourceLine, codeWidth);
+			const parts = wrapped.length === 0 ? [""] : wrapped;
+			for (const [partIndex, part] of parts.entries()) {
+				const number = numbers?.[index];
+				const gutter$1 = numberWidth === 0 ? "" : color.muted(partIndex === 0 && number !== void 0 ? `${String(number).padStart(numberWidth - 1)} ` : " ".repeat(numberWidth));
+				const padded$1 = `${part}${" ".repeat(Math.max(0, codeWidth - visibleWidth(part)))}`;
+				const connector = prefix === "" ? "" : this.row.caption === void 0 && index === 0 && partIndex === 0 ? color.muted(prefix) : " ".repeat(prefixWidth);
+				rows.push(`${connector}${gutter$1}${background.code(padded$1)}`);
+			}
+		}
+		return rows;
+	}
+	invalidate() {}
+};
+function imageAttachment(value) {
+	if (typeof value !== "object" || value === null) return void 0;
+	const row = value;
+	return typeof row.attachmentId === "string" && typeof row.mediaType === "string" && typeof row.bytes === "number" && typeof row.width === "number" && typeof row.height === "number" ? value : void 0;
+}
+function imageRow(attachment) {
+	return {
+		format: "image",
+		key: String(attachment.attachmentId),
+		attachment
+	};
+}
+function imageLabel(attachment) {
+	const name$1 = attachment.name ?? String(attachment.attachmentId);
+	return ui(`[图片 · ${name$1} · ${attachment.width}×${attachment.height} · ${attachment.mediaType} · ${attachment.bytes} 字节]`, `[Image · ${name$1} · ${attachment.width}×${attachment.height} · ${attachment.mediaType} · ${attachment.bytes} bytes]`);
+}
+function jsonText(value) {
+	if (value === void 0 || typeof value === "function" || typeof value === "symbol") return String(value);
+	try {
+		const rendered = JSON.stringify(value, null, 2);
+		return rendered.length > 8e3 ? `${rendered.slice(0, 8e3)}\n${ui("…（终端显示已截断）", "… (terminal display truncated)")}` : rendered;
+	} catch {
+		return typeof value === "bigint" ? value.toString() : ui("[内容无法序列化]", "[content cannot be serialized]");
+	}
+}
+function contentBlockText(block$1) {
+	if (typeof block$1 !== "object" || block$1 === null) return String(block$1);
+	const value = block$1;
+	if (value.type === "text" || value.type === "reasoning") return typeof value.text === "string" ? value.text : `[${value.type}]`;
+	if (value.type === "image") return ui("[图片附件]", "[image attachment]");
+	if (value.type === "tool-result") return ui("[工具结果]", "[tool result]");
+	return `[${typeof value.type === "string" ? value.type : ui("内容", "content")}]`;
+}
+function permissionCommandText(node) {
+	if (node.name !== "permission" || node.outcome?.kind !== "success") return void 0;
+	const preset = /^preset\s+(\S+)/u.exec(node.outcome.text ?? "")?.[1] ?? node.args?.trim();
+	if (preset === void 0 || preset === "") return color.success(ui("权限已切换", "Permission changed"));
+	const label = preset === "read-only" ? ui("只读", "Read only") : preset === "workspace-write" ? ui("工作区", "Workspace") : preset === "danger-full-access" ? ui("完全访问", "Full access") : preset;
+	return color.success(ui(`权限已切换为${label}`, `Permission changed to ${label}`));
+}
+function planCommandText(node) {
+	if (node.name !== "plan") return void 0;
+	if (node.outcome === null) return color.warning(ui("正在切换计划模式", "Switching plan mode"));
+	if (node.outcome.kind !== "success") return color.danger(ui(`计划模式切换失败${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`, `Failed to switch plan mode${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`));
+	const text = node.outcome.text ?? "";
+	if (node.args?.trim() === "off") {
+		if (text.includes("entry cancelled")) return color.success(ui("已取消进入计划模式", "Plan-mode entry cancelled"));
+		if (text.includes("already inactive")) return color.muted(ui("计划模式未开启", "Plan mode is not active"));
+		if (text.startsWith("Leaving ")) return color.success(ui("计划模式将在下一步关闭", "Plan mode will stop on the next step"));
+		return color.success(ui("计划模式已关闭", "Plan mode disabled"));
+	}
+	return color.success(text.startsWith("Entering ") ? ui("计划模式将在下一步开启", "Plan mode will start on the next step") : ui("计划模式已开启", "Plan mode enabled"));
+}
+function goalCommandText(node) {
+	if (node.name !== "goal") return void 0;
+	if (node.outcome === null) return color.warning(ui("正在处理目标", "Processing goal"));
+	const args = node.args?.trim() ?? "";
+	const action = args.toLowerCase();
+	if (node.outcome.kind !== "success") {
+		if (node.outcome.text?.startsWith("A goal is already ") === true) return color.danger(ui("已有进行中的目标；可编辑或清除后重新创建", "A goal is already active; edit or clear it before creating another"));
+		if (action === "edit") return color.danger(ui("请提供新的目标内容", "Provide the new goal text"));
+		if (node.outcome.text?.startsWith("No goal is currently set") === true) return color.danger(ui("当前没有目标", "No active goal"));
+		return color.danger(ui("当前状态不能执行此目标操作", "This goal action is not valid in the current state"));
+	}
+	if (action === "clear") return color.success(node.outcome.text === "No goal to clear." ? ui("当前没有目标", "No active goal") : ui("目标已清除", "Goal cleared"));
+	if (action === "pause") return color.success(ui("目标已暂停", "Goal paused"));
+	if (action === "resume") return color.success(ui("目标已继续", "Goal resumed"));
+	if (action.startsWith("edit ")) return color.success(ui(`目标已更新：${args.slice(5).trim()}`, `Goal updated: ${args.slice(5).trim()}`));
+	if (args !== "") return color.success(ui(`目标已创建：${args}`, `Goal created: ${args}`));
+	if (node.outcome.text?.startsWith("No goal is currently set.") === true) return color.muted(ui("当前没有目标", "No active goal"));
+	const objective = /^Objective: (.*)$/mu.exec(node.outcome.text ?? "")?.[1];
+	const phase = /^Status: (\S+)$/mu.exec(node.outcome.text ?? "")?.[1];
+	const blocker = /^Blocker: (.*)$/mu.exec(node.outcome.text ?? "")?.[1];
+	const phaseLabel = phase === "active" ? ui("进行中", "In progress") : phase === "paused" ? ui("已暂停", "Paused") : phase === "blocked" ? ui("受阻", "Blocked") : phase === "complete" ? ui("已完成", "Completed") : void 0;
+	return [
+		objective === void 0 ? ui("当前目标", "Current goal") : ui(`目标：${objective}`, `Goal: ${objective}`),
+		...phaseLabel === void 0 ? [] : [ui(`状态：${phaseLabel}`, `Status: ${phaseLabel}`)],
+		...blocker === void 0 ? [] : [ui(`阻塞原因：${blocker}`, `Blocked by: ${blocker}`)]
+	].join("\n");
+}
+function contentText(content) {
+	return content.map(contentBlockText).join("\n").trim();
+}
+function contentRows(content) {
+	return content.flatMap((block$1) => {
+		if (typeof block$1 !== "object" || block$1 === null) return [{
+			format: "plain",
+			text: String(block$1)
+		}];
+		const value = block$1;
+		if (value.type === "text" && typeof value.text === "string") return value.text === "" ? [] : [{
+			format: "markdown",
+			text: value.text
+		}];
+		if (value.type === "image") {
+			const attachment = imageAttachment(value.attachment);
+			return attachment === void 0 ? [{
+				format: "plain",
+				text: color.warning(ui("[图片附件元数据无效]", "[invalid image attachment metadata]"))
+			}] : [imageRow(attachment)];
+		}
+		return [{
+			format: "plain",
+			text: contentBlockText(block$1)
+		}];
+	});
+}
+function userContentRows(content, steering = false) {
+	const rows = contentRows(content).map((row) => row.format === "markdown" ? {
+		...row,
+		format: "plain"
+	} : row);
+	const prefix = steering ? `${color.brand(">")} ${color.muted(ui("引导", "Steering"))} ` : `${color.brand(">")} `;
+	const first = rows[0];
+	if (first === void 0) return [{
+		format: "plain",
+		text: prefix.trimEnd(),
+		userTurn: true
+	}];
+	if (first.format === "image") return [{
+		format: "plain",
+		text: prefix.trimEnd(),
+		userTurn: true
+	}, ...rows];
+	return [{
+		...first,
+		text: `${prefix}${first.text}`,
+		userTurn: true
+	}, ...rows.slice(1)];
+}
+function assistantBlockText(block$1, preferences) {
+	switch (block$1.kind) {
+		case "text": return block$1.text;
+		case "reasoning": return preferences.reasoning ? color.muted(`${ui("思考", "Reasoning")}\n${block$1.text}`) : "";
+		case "image": return color.muted(ui("[图片附件]", "[image attachment]"));
+		case "tool-call":
+			if (preferences.tools === "hidden") return "";
+			return color.accent(`◆ ${block$1.name}${preferences.tools === "expanded" ? `\n${prettyArgs(block$1.argsRaw)}` : ""}`);
+		case "other": return color.muted(ui("模型扩展内容 · /trajectory 查看详情", "Extended model content · use /trajectory for details"));
+	}
+}
+function assistantBlockRows(block$1, preferences) {
+	switch (block$1.kind) {
+		case "text": return block$1.text === "" ? [] : [{
+			format: "markdown",
+			text: block$1.text
+		}];
+		case "reasoning":
+			if (!preferences.reasoning || block$1.text === "") return [];
+			return [{
+				format: "markdown",
+				text: `> **${ui("思考", "Reasoning")}**\n>\n${block$1.text.split("\n").map((line) => `> ${line}`).join("\n")}`
+			}];
+		case "image": return [imageRow(block$1.attachment)];
+		case "tool-call":
+			if (preferences.tools === "hidden") return [];
+			return [{
+				format: "plain",
+				text: color.accent(`◆ ${block$1.name}`)
+			}, ...preferences.tools === "expanded" ? [{
+				format: "code",
+				text: prettyArgs(block$1.argsRaw),
+				language: "json"
+			}] : []];
+		case "other": return [{
+			format: "plain",
+			text: color.muted(ui("模型扩展内容 · /trajectory 查看详情", "Extended model content · use /trajectory for details"))
+		}];
+	}
+}
+function prettyArgs(argsRaw) {
+	try {
+		return jsonText(JSON.parse(argsRaw));
+	} catch {
+		return argsRaw;
+	}
+}
+function contentLines(text) {
+	return splitDiffLines(text);
+}
+function diffText(value) {
+	if (!Array.isArray(value) || value.length === 0) return jsonText(value);
+	const rows = [];
+	const paths = /* @__PURE__ */ new Set();
+	let added = 0;
+	let removed = 0;
+	for (const item of value) {
+		if (typeof item !== "object" || item === null) return jsonText(value);
+		const { path: path$1, oldText, newText } = item;
+		if (typeof path$1 !== "string" || oldText !== null && typeof oldText !== "string" || typeof newText !== "string") return jsonText(value);
+		paths.add(path$1);
+		rows.push(`diff -- ${path$1}`);
+		rows.push(oldText === null ? "--- /dev/null" : `--- a/${path$1}`);
+		rows.push(`+++ b/${path$1}`);
+		const previous = oldText === null ? [] : contentLines(oldText);
+		const next = contentLines(newText);
+		for (const line of unifiedHunks(previous, next)) {
+			if (line.startsWith("+")) added += 1;
+			else if (line.startsWith("-")) removed += 1;
+			rows.push(line);
+		}
+	}
+	const visible = rows.length <= 80 ? rows : [
+		...rows.slice(0, 40),
+		ui(`@@ … 省略 ${rows.length - 80} 行 … @@`, `@@ … ${rows.length - 80} lines omitted … @@`),
+		...rows.slice(-40)
+	];
+	visible.push(ui(`# +${added} -${removed} · ${paths.size} 个文件`, `# +${added} -${removed} · ${paths.size} file(s)`));
+	return visible.join("\n");
+}
+const PRODUCT_TOOL_TITLES = {
+	ask_user_question: ["向用户提问", "Ask user"],
+	create_goal: ["创建目标", "Create goal"],
+	exit_plan_mode: ["计划审查", "Plan review"],
+	get_goal: ["查看目标", "View goal"],
+	job_kill: ["停止后台任务", "Stop background job"],
+	job_list: ["查看后台任务", "View background jobs"],
+	job_output: ["读取后台任务", "Read background job"],
+	subagent: ["子 Agent", "Subagent"],
+	todo_write: ["更新任务清单", "Update task list"],
+	update_goal: ["更新目标", "Update goal"],
+	workflow: ["工作流", "Workflow"]
+};
+function toolTitle(node) {
+	const name$1 = "kind" in node ? node.call?.name : node.name;
+	const productTitle = name$1 === void 0 ? void 0 : PRODUCT_TOOL_TITLES[name$1];
+	if (productTitle !== void 0) return ui(productTitle[0], productTitle[1]);
+	const callView = node.callView;
+	if (callView?.card === "terminal") {
+		const description = callView.description?.trim();
+		return description === void 0 || description === "" ? ui("执行 Shell 指令", "Run shell command") : description;
+	}
+	if ("kind" in node) return node.resultView?.title ?? node.callView?.title ?? node.call?.name ?? node.callId;
+	return node.callView?.title ?? node.name;
+}
+function settledToolFailed(node) {
+	if (node.isError) return true;
+	const result = node.resultView;
+	return result?.card === "terminal" && (result.exitCode !== void 0 && result.exitCode !== 0 || result.signal !== void 0);
+}
+function contentDetails(content) {
+	return content.flatMap((block$1) => {
+		if (typeof block$1 !== "object" || block$1 === null) return [{
+			kind: "plain",
+			text: String(block$1)
+		}];
+		const value = block$1;
+		if ((value.type === "text" || value.type === "reasoning") && typeof value.text === "string") return value.text === "" ? [] : [{
+			kind: "markdown",
+			text: value.text
+		}];
+		return [{
+			kind: "plain",
+			text: contentBlockText(block$1)
+		}];
+	});
+}
+function invocationCode(name$1, value) {
+	return {
+		kind: "code",
+		text: `${name$1}(${typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length === 0 ? "" : jsonText(value)})`,
+		language: "typescript"
+	};
+}
+function toolInvocationDetail(name$1, argsRaw) {
+	try {
+		return invocationCode(name$1, JSON.parse(argsRaw));
+	} catch {
+		return {
+			kind: "code",
+			text: `${name$1}(${argsRaw})`,
+			language: "typescript"
+		};
+	}
+}
+function fallbackInvocationDetail(value) {
+	return invocationCode("tool", value);
+}
+function terminalCommandDetail(value) {
+	if (typeof value !== "object" || value === null) return void 0;
+	const view = value;
+	if (view.card !== "terminal" || typeof view.title !== "string" || view.title === "") return void 0;
+	return {
+		kind: "code",
+		text: `$ ${view.title}`,
+		language: "bash"
+	};
+}
+function readInvocationFallback(node) {
+	const result = node.resultView;
+	if (result?.card === "read") return invocationCode("read", { file_path: String(result.path) });
+	const call = node.callView;
+	if (call?.card !== "generic" || call.kind !== "read") return void 0;
+	const location$1 = (Array.isArray(call.locations) ? call.locations : []).find((candidate) => typeof candidate === "object" && candidate !== null && "path" in candidate && typeof candidate.path === "string" && candidate.path !== "");
+	return location$1 === void 0 ? void 0 : invocationCode("read", { file_path: location$1.path });
+}
+function settledInvocationDetails(node) {
+	const call = node.callView;
+	const details = [];
+	if (call?.card === "terminal") {
+		const command = terminalCommandDetail(call);
+		if (command !== void 0) details.push(command);
+	} else if (call?.card === "diff") details.push({
+		kind: "code",
+		text: diffText(call.diffs),
+		language: "diff"
+	});
+	else if (node.call !== null) details.push(toolInvocationDetail(node.call.name, node.call.argsRaw));
+	else if (call?.card === "generic" && call.rawInput !== void 0) details.push(fallbackInvocationDetail(call.rawInput));
+	const readFallback = details.length === 0 ? readInvocationFallback(node) : void 0;
+	if (readFallback !== void 0) details.push(readFallback);
+	return details;
+}
+function viewDetails(node) {
+	const result = node.resultView;
+	const details = settledInvocationDetails(node);
+	if (result?.card === "terminal") {
+		if (result.output !== void 0) details.push({
+			kind: "plain",
+			text: result.output
+		});
+		if (result.exitCode !== void 0) details.push({
+			kind: "plain",
+			text: ui(`退出码 ${result.exitCode}`, `Exit code ${result.exitCode}`)
+		});
+		if (result.signal !== void 0) details.push({
+			kind: "plain",
+			text: ui(`信号 ${result.signal}`, `Signal ${result.signal}`)
+		});
+	} else if (result?.card === "diff") details.push({
+		kind: "code",
+		text: diffText(result.diffs),
+		language: "diff"
+	});
+	else if (result?.card === "generic" && result.content !== void 0) details.push(...contentDetails(result.content));
+	else if (result?.card === "read") {
+		const lines = result.lines;
+		const path$1 = String(result.path);
+		const language = syntaxLanguageForPath(path$1, typeof result.lang === "string" ? result.lang : void 0);
+		const first = lines[0]?.number ?? Number(result.offset);
+		const last = lines.at(-1)?.number ?? first;
+		details.push({
+			kind: "code",
+			text: lines.map((line) => line.text).join("\n"),
+			...language === void 0 ? {} : { language },
+			caption: `${path$1} · ${String(first)}–${String(last)} / ${String(result.totalLines)}`,
+			lineNumbers: lines.map((line) => line.number)
+		});
+	} else if (result?.card === "search" && result.shape === "matches") {
+		const files = result.files;
+		for (const file of files) {
+			const language = syntaxLanguageForPath(file.path);
+			details.push({
+				kind: "code",
+				text: file.matches.map((match) => match.line).join("\n"),
+				...language === void 0 ? {} : { language },
+				caption: file.path,
+				lineNumbers: file.matches.map((match) => match.lineNumber)
+			});
+		}
+		if (result.truncated) details.push({
+			kind: "plain",
+			text: ui(`只显示部分结果 · 共 ${String(result.total)} 项`, `Partial results · ${String(result.total)} item(s) total`)
+		});
+	} else if (result?.card === "search") {
+		details.push({
+			kind: "plain",
+			text: result.paths.join("\n")
+		});
+		if (result.truncated) details.push({
+			kind: "plain",
+			text: ui(`只显示部分结果 · 共 ${String(result.total)} 项`, `Partial results · ${String(result.total)} item(s) total`)
+		});
+	} else if (result?.card === "web" && result.kind === "search") {
+		if (result.answer !== void 0) details.push({
+			kind: "markdown",
+			text: result.answer
+		});
+		const sources = result.sources;
+		details.push(...sources.map((source) => ({
+			kind: "plain",
+			text: `${source.title ?? source.url}\n${source.url}${source.snippet === void 0 ? "" : `\n${source.snippet}`}`
+		})));
+		if (result.truncated) details.push({
+			kind: "plain",
+			text: ui("来源列表已截断", "Source list truncated")
+		});
+	} else if (result?.card === "web") {
+		details.push({
+			kind: "plain",
+			text: `${result.statusCode} · ${result.url}${result.truncated ? ui(" · 内容已截断", " · content truncated") : ""}`
+		});
+		details.push(...contentDetails(node.content));
+	} else if (result?.card === "generic") details.push(...contentDetails(node.content));
+	else details.push(...contentDetails(node.content));
+	if (node.meta !== void 0) details.push({
+		kind: "code",
+		text: jsonText(node.meta),
+		language: "json",
+		caption: ui("元数据", "Metadata")
+	});
+	return details.filter((value) => value.text !== "");
+}
+function runningViewDetails(node) {
+	const view = node.callView;
+	if (view?.card === "terminal") {
+		const command = terminalCommandDetail(view);
+		return command === void 0 ? [] : [command];
+	}
+	if (view?.card === "diff") return [{
+		kind: "code",
+		text: diffText(view.diffs),
+		language: "diff"
+	}];
+	return [toolInvocationDetail(node.name, node.argsRaw)];
+}
+/** Flatten the same tool preview the transcript uses so approval overlays are not blind. */
+function toolApprovalPreview(call) {
+	if (call === void 0) return "";
+	return runningViewDetails(call).map((detail) => detail.text).filter((text) => text !== "").join("\n");
+}
+function detailRow(detail, depth) {
+	if (detail.kind === "plain") return {
+		format: "plain",
+		text: detail.text
+	};
+	if (detail.kind === "markdown") return {
+		format: "markdown",
+		text: detail.text
+	};
+	return {
+		format: "code",
+		text: detail.text,
+		...detail.language === void 0 ? {} : { language: detail.language },
+		...detail.caption === void 0 ? {} : { caption: detail.caption },
+		...detail.lineNumbers === void 0 ? {} : { lineNumbers: detail.lineNumbers },
+		prefix: `${"  ".repeat(depth + 1)}⎿  `
+	};
+}
+function toolBlockRows(block$1, preferences, depth) {
+	const prefix = depth === 0 ? "◆ " : `${"  ".repeat(depth)}↳ `;
+	if ("kind" in block$1) {
+		const duration = block$1.callTime === null ? "" : ` · ${toolDurationText(Math.max(0, block$1.time - block$1.callTime))}`;
+		const failed = settledToolFailed(block$1);
+		const details$1 = preferences.tools === "expanded" ? viewDetails(block$1) : settledInvocationDetails(block$1);
+		return [
+			{
+				format: "plain",
+				text: `${prefix}${color.accent(toolTitle(block$1))}${failed ? ` · ${color.danger(ui("失败", "Failed"))}` : ""}${duration}`
+			},
+			...details$1.map((detail) => detailRow(detail, depth)),
+			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
+		];
+	}
+	const details = runningViewDetails(block$1);
+	return [
+		{
+			format: "plain",
+			text: `${prefix}${color.accent(toolTitle(block$1))}`,
+			pulse: "marker",
+			liveDurationSince: block$1.time
+		},
+		...details.map((detail) => detailRow(detail, depth)),
+		...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
+	];
+}
+function toolBlockText(block$1, preferences, depth) {
+	return toolBlockRows(block$1, preferences, depth).map((row) => row.format === "image" ? imageLabel(row.attachment) : row.text).join("\n");
+}
+function nodeText(node, preferences) {
+	switch (node.kind) {
+		case "user": return `${color.brand(">")} ${contentText(node.content)}`;
+		case "steering": return `${color.brand(">")} ${color.muted(ui("引导", "Steering"))} ${contentText(node.content)}`;
+		case "context": return `${color.muted(`${node.provenance.role === "recall" ? ui("召回", "Recall") : ui("上下文", "Context")}${node.provenance.label === null ? "" : ` · ${node.provenance.label}`}${node.form === null ? ui(" · 未知格式", " · unknown format") : ` · ${node.form}`}`)}\n${contentText(node.content)}`;
+		case "assistant": return `${node.blocks.map((block$1) => assistantBlockText(block$1, preferences)).filter(Boolean).join("\n")}${node.interrupted === true ? color.warning(ui("\n已停止", "\nStopped")) : ""}`;
+		case "command": return permissionCommandText(node) ?? planCommandText(node) ?? goalCommandText(node) ?? (node.outcome === null ? color.warning(ui(`命令 /${node.name ?? "unknown"}${node.args ?? ""} · 执行中`, `Command /${node.name ?? "unknown"}${node.args ?? ""} · running`)) : `${node.outcome.kind === "success" ? color.success(ui("命令完成", "Command completed")) : color.danger(ui("命令失败", "Command failed"))} /${node.name ?? "unknown"}${node.args ?? ""}${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`);
+		case "tool-result": return preferences.tools === "hidden" ? "" : toolBlockText(node, preferences, 0);
+		case "compaction": return color.muted(ui(`上下文已压缩${node.shadowedItemCount === null ? "" : ` · ${node.shadowedItemCount} 项`}${node.shadowedTokenCount === null ? "" : ` · 约 ${node.shadowedTokenCount} Token`}${node.summary === null ? "" : `\n${node.summary}`}`, `Context compacted${node.shadowedItemCount === null ? "" : ` · ${node.shadowedItemCount} item(s)`}${node.shadowedTokenCount === null ? "" : ` · about ${node.shadowedTokenCount} tokens`}${node.summary === null ? "" : `\n${node.summary}`}`));
+		case "model-retry": return color.warning(ui(`模型请求${node.retryState === "scheduled" ? "等待重试" : node.retryState === "started" ? "正在重试" : "重试已取消"} · ${node.provider} · 第 ${node.retry} 次${node.mode === "normal" ? `/${node.maxRetries}` : ""} · ${node.delayMs} ms`, `Model request ${node.retryState === "scheduled" ? "waiting to retry" : node.retryState === "started" ? "retrying" : "retry cancelled"} · ${node.provider} · attempt ${node.retry}${node.mode === "normal" ? `/${node.maxRetries}` : ""} · ${node.delayMs} ms`));
+		case "turn-error": return color.danger(ui(`本轮执行失败${node.code === void 0 ? "" : ` [${node.code}]`}\n${node.message}`, `Turn failed${node.code === void 0 ? "" : ` [${node.code}]`}\n${node.message}`));
+		case "turn-max-tokens": return color.warning(ui("本轮已达到最大 Token 数", "This turn reached the token limit"));
+		case "unknown": return color.muted(ui(`未知事件 ${node.type} · /trajectory 查看详情`, `Unknown event ${node.type} · use /trajectory for details`));
+		default: return color.muted(ui("未知会话事件 · /trajectory 查看详情", "Unknown session event · use /trajectory for details"));
+	}
+}
+function textProperty(value) {
+	if (typeof value !== "object" || value === null || !("text" in value)) return void 0;
+	return typeof value.text === "string" ? value.text : void 0;
+}
+const CONVERSATION_KINDS = new Set([
+	"user",
+	"assistant",
+	"steering",
+	"context",
+	"model-retry",
+	"turn-error",
+	"turn-max-tokens",
+	"tool-result",
+	"command",
+	"compaction",
+	"unknown"
+]);
+function isConversationNode(value) {
+	return typeof value === "object" && value !== null && "kind" in value && typeof value.kind === "string" && CONVERSATION_KINDS.has(value.kind);
+}
+function workflowStatusLabel(status) {
+	switch (status) {
+		case "running": return ui("运行中", "Running");
+		case "completed": return ui("已完成", "Completed");
+		case "failed": return ui("失败", "Failed");
+		case "cancelled": return ui("已取消", "Cancelled");
+		case "interrupted": return ui("已中断", "Interrupted");
+		default: return escapeTerminalText(status);
+	}
+}
+function workflowStatusText(status) {
+	const label = workflowStatusLabel(status);
+	switch (status) {
+		case "completed": return color.success(label);
+		case "failed": return color.danger(label);
+		case "cancelled":
+		case "interrupted": return color.warning(label);
+		case "running": return color.accent(label);
+		default: return color.muted(label);
+	}
+}
+function workflowMemberLabel(member) {
+	const safe = escapeTerminalText(member.label.trim());
+	if (safe === "") return ui(`成员 ${member.seq}`, `Member ${member.seq}`);
+	const generated = /^agent-([a-z0-9]+)$/iu.exec(safe);
+	return generated === null ? safe : `Agent ${generated[1] ?? String(member.seq)}`;
+}
+function workflowText(value) {
+	if (typeof value !== "object" || value === null) return void 0;
+	const workflow = value;
+	if (typeof workflow.name !== "string" || typeof workflow.status !== "string" || !Array.isArray(workflow.phases)) return;
+	const rows = workflow.phases.flatMap((phase) => {
+		const phaseLabel = phase.phase === null ? void 0 : escapeTerminalText(phase.phase.trim()) || ui("未命名阶段", "Unnamed phase");
+		const members = phase.members.map((member) => `    ${workflowStatusText(member.status)} · ${workflowMemberLabel(member)}`);
+		return phaseLabel === void 0 ? members.map((row) => row.slice(2)) : [`  ${color.muted(phaseLabel)}`, ...members];
+	});
+	const name$1 = escapeTerminalText(workflow.name);
+	return `${color.accent(ui(`工作流 · ${name$1}`, `Workflow · ${name$1}`))} · ${workflowStatusText(workflow.status)}${rows.length === 0 ? "" : `\n${rows.join("\n")}`}`;
+}
+function deliverablesText(node, data) {
+	if (!isConversationNode(data) || data.kind !== "assistant") return "";
+	const location$1 = node.location;
+	if (location$1.kind !== "turn" && location$1.kind !== "step") return "";
+	const produced = producedForClosing(location$1.turn.data.get("deliverables"), data.seq);
+	return produced.length === 0 ? "" : `\n${color.success(ui(`生成文件 · ${produced.join(" · ")}`, `Produced files · ${produced.join(" · ")}`))}`;
+}
+function grouped(rows) {
+	return rows.map((row, index) => index === 0 ? {
+		...row,
+		gapBefore: true
+	} : row);
+}
+function nonnegativeNumber(value) {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : void 0;
+}
+function durationText(milliseconds) {
+	const seconds = milliseconds / 1e3;
+	if (seconds < 60) return `${String(Math.round(seconds * 10) / 10)}s`;
+	const whole = Math.round(seconds);
+	return `${String(Math.floor(whole / 60))}m${String(whole % 60)}s`;
+}
+function toolDurationText(milliseconds) {
+	if (milliseconds <= 0) return "<1ms";
+	if (milliseconds < 1e3) return `${String(Math.round(milliseconds))}ms`;
+	return durationText(milliseconds);
+}
+function tokenText(value) {
+	const scaled = (number) => number >= 100 ? String(Math.round(number)) : String(Math.round(number * 10) / 10);
+	if (value < 1e3) return String(Math.round(value));
+	if (value < 1e6) return `${scaled(value / 1e3)}K`;
+	return `${scaled(value / 1e6)}M`;
+}
+function recordOf(value) {
+	return typeof value === "object" && value !== null ? value : void 0;
+}
+/** Render Grok-style groups from the engine-owned completed-Turn footer. */
+function turnTailText(data) {
+	const value = recordOf(data);
+	if (value === void 0) return "";
+	const statistics = recordOf(value.statistics);
+	const usage = recordOf(value.usage);
+	const groups = [];
+	const steps = nonnegativeNumber(statistics?.steps);
+	if (steps !== void 0 && steps > 0) groups.push(ui(`1 轮 · ${tokenText(steps)} 步`, `1 turn · ${tokenText(steps)} steps`));
+	const llmMs = nonnegativeNumber(statistics?.llmMs);
+	const toolMs = nonnegativeNumber(statistics?.toolMs);
+	const durations = [...llmMs === void 0 || llmMs === 0 ? [] : [`LLM ${durationText(llmMs)}`], ...toolMs === void 0 || toolMs === 0 ? [] : [ui(`工具调用 ${durationText(toolMs)}`, `Tools ${durationText(toolMs)}`)]];
+	if (durations.length > 0) groups.push(durations.join(" · "));
+	const ttftMs = nonnegativeNumber(statistics?.ttftMs);
+	const ttftSteps = nonnegativeNumber(statistics?.ttftSteps);
+	const decodeMs = nonnegativeNumber(statistics?.decodeMs);
+	const decodeTokens = nonnegativeNumber(statistics?.decodeTokens);
+	const performance$1 = [...ttftMs === void 0 || ttftSteps === void 0 || ttftSteps === 0 ? [] : [ui(`首 token 平均 ${durationText(ttftMs / ttftSteps)}`, `Average first token ${durationText(ttftMs / ttftSteps)}`)], ...decodeMs === void 0 || decodeTokens === void 0 || decodeMs === 0 ? [] : [`${String(Math.round(decodeTokens / (decodeMs / 1e3) * 10) / 10)} tok/s`]];
+	if (performance$1.length > 0) groups.push(performance$1.join(" · "));
+	const uncached = nonnegativeNumber(usage?.uncachedInputTokens);
+	const cacheRead = nonnegativeNumber(usage?.cacheReadTokens);
+	const cacheWrite = nonnegativeNumber(usage?.cacheWriteTokens);
+	const output = nonnegativeNumber(usage?.outputTokens);
+	if (uncached !== void 0 && cacheRead !== void 0 && cacheWrite !== void 0 && output !== void 0) {
+		const input = uncached + cacheRead + cacheWrite;
+		if (input > 0) groups.push(ui(`缓存命中 ${String(Math.round(cacheRead / input * 100))}%`, `Cache hit ${String(Math.round(cacheRead / input * 100))}%`));
+		if (input > 0 || output > 0) groups.push(ui(`输入 ${tokenText(input)} tok · 输出 ${tokenText(output)} tok`, `Input ${tokenText(input)} tok · output ${tokenText(output)} tok`));
+	}
+	if (groups.length > 0) return color.muted(groups.join("  |  "));
+	const legacy = [...nonnegativeNumber(value.ttftMs) === void 0 ? [] : [ui(`首 token ${durationText(nonnegativeNumber(value.ttftMs) ?? 0)}`, `First token ${durationText(nonnegativeNumber(value.ttftMs) ?? 0)}`)], ...nonnegativeNumber(value.tokensPerSecond) === void 0 ? [] : [`${String(Math.round((nonnegativeNumber(value.tokensPerSecond) ?? 0) * 10) / 10)} tok/s`]];
+	return legacy.length === 0 ? "" : color.muted(legacy.join(" · "));
+}
+function assistantStepData(data) {
+	if (typeof data !== "object" || data === null) return void 0;
+	const value = data;
+	return (value.status === "running" || value.status === "settled" || value.status === "interrupted") && Array.isArray(value.blocks) ? value : void 0;
+}
+function assistantStepRows(data, preferences) {
+	const step = assistantStepData(data);
+	if (step === void 0) return [];
+	const content = step.blocks.flatMap((block$1) => block$1.kind === "tool-call" ? [] : assistantBlockRows(block$1, preferences));
+	const hasFoldedReasoning = !preferences.reasoning && step.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "");
+	const hasAnswer = step.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "");
+	if (content.length === 0 && step.status === "settled" && !hasFoldedReasoning) return [];
+	const rows = [];
+	if (!hasAnswer && step.status === "running" && (hasFoldedReasoning || content.length === 0)) rows.push(thinkingRow());
+	rows.push(...content);
+	if (step.status === "interrupted") rows.push({
+		format: "plain",
+		text: color.warning(ui("已停止", "Stopped"))
+	});
+	return grouped(rows);
+}
+function toolChatData(data) {
+	if (typeof data !== "object" || data === null || !("root" in data)) return void 0;
+	const root = data.root;
+	if (typeof root !== "object" || root === null || !("callId" in root) || typeof root.callId !== "string" || !("subCalls" in root) || !Array.isArray(root.subCalls)) return void 0;
+	return data;
+}
+function compactContextRows(node) {
+	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "kind" in node.source && node.source.kind === "plugin" && "plugin" in node.source && node.source.plugin === "plan-mode") return [];
+	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "kind" in node.source && node.source.kind === "plugin" && "plugin" in node.source && node.source.plugin === "tool-jobs") return grouped([{
+		format: "plain",
+		text: color.muted(ui("◆ 后台任务已结束", "◆ Background job finished"))
+	}]);
+	if (node.provenance.role === "recall") {
+		const source = node.provenance.label === null ? "" : ` · ${node.provenance.label}`;
+		return grouped([{
+			format: "plain",
+			text: color.muted(ui(`跨会话召回${source} · /trajectory 查看`, `Cross-session recall${source} · view with /trajectory`))
+		}]);
+	}
+	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "summary" in node.source && typeof node.source.summary === "string") return grouped([{
+		format: "plain",
+		text: color.muted(node.source.summary)
+	}]);
+	return [];
+}
+function subagentUserRows(node) {
+	if (typeof node.source !== "object" || node.source === null || !("kind" in node.source)) return void 0;
+	if (node.source.kind === "subagent-settled") return grouped([{
+		format: "plain",
+		text: color.muted(ui("◆ 子 Agent 已结束", "◆ Subagent finished")),
+		userTurn: true
+	}]);
+	if (node.source.kind !== "subagent-report") return void 0;
+	return grouped([{
+		format: "plain",
+		text: `${color.brand(">")} ${color.muted(ui("子 Agent 报告", "Subagent report"))}`,
+		userTurn: true
+	}, ...contentRows(node.content.slice(1))]);
+}
+function manualCompactionRows(data, preferences) {
+	if (typeof data !== "object" || data === null || !("command" in data)) return [];
+	const value = data;
+	const rows = [];
+	if (isConversationNode(value.command)) {
+		const command = nodeText(value.command, preferences);
+		if (command !== "") rows.push({
+			format: "plain",
+			text: command
+		});
+	}
+	if (isConversationNode(value.compaction)) {
+		const compaction = nodeText(value.compaction, preferences);
+		if (compaction !== "") rows.push({
+			format: "plain",
+			text: compaction
+		});
+	}
+	return grouped(rows);
+}
+function retryRows(data, preferences) {
+	if (typeof data !== "object" || data === null || !("current" in data)) return [];
+	const retry = data.current;
+	if (!isConversationNode(retry)) return [];
+	const rendered = nodeText(retry, preferences);
+	return rendered === "" ? [] : grouped([{
+		format: "plain",
+		text: rendered
+	}]);
+}
+function chatNodeRows(node, preferences) {
+	if (node.kind === "assistant-step") return assistantStepRows(node.data, preferences);
+	if (node.kind === "tool-call") {
+		if (preferences.tools === "hidden") return [];
+		const data = toolChatData(node.data);
+		return data === void 0 ? [] : grouped(toolBlockRows(data.root, preferences, 0));
+	}
+	if (node.kind === "manual-compaction") return manualCompactionRows(node.data, preferences);
+	if (node.kind === "model-retry") return retryRows(node.data, preferences);
+	if (isConversationNode(node.data)) {
+		if (node.data.kind === "user" || node.data.kind === "steering" || node.data.kind === "context") {
+			if (node.data.kind === "context") return compactContextRows(node.data);
+			if (node.data.kind === "user") {
+				const subagent = subagentUserRows(node.data);
+				if (subagent !== void 0) return subagent;
+			}
+			return grouped(userContentRows(node.data.content, node.data.kind === "steering"));
+		}
+		if (node.data.kind === "assistant") {
+			const rows = [...node.data.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences))];
+			if (node.data.interrupted === true) rows.push({
+				format: "plain",
+				text: color.warning(ui("已停止", "Stopped"))
+			});
+			const deliverables = deliverablesText(node, node.data);
+			if (deliverables !== "") rows.push({
+				format: "plain",
+				text: deliverables.trimStart()
+			});
+			return grouped(rows);
+		}
+		const text = nodeText(node.data, preferences);
+		return text === "" ? [] : grouped([{
+			format: "plain",
+			text
+		}]);
+	}
+	const commandInputText = node.kind === "command-input" ? textProperty(node.data) : void 0;
+	if (commandInputText !== void 0) return grouped([{
+		format: "plain",
+		text: `${color.brand(">")} ${commandInputText}`,
+		userTurn: true
+	}]);
+	if (node.kind === "workflow-run") {
+		const rendered = workflowText(node.data);
+		if (rendered !== void 0) return grouped([{
+			format: "plain",
+			text: rendered
+		}]);
+	}
+	if (node.kind === "turn-tail") {
+		const rendered = turnTailText(node.data);
+		return rendered === "" ? [] : [{
+			format: "plain",
+			text: rendered
+		}];
+	}
+	return grouped([{
+		format: "plain",
+		text: color.muted(ui(`扩展节点 ${node.kind} · /trajectory 查看详情`, `Extended node ${node.kind} · use /trajectory for details`))
+	}]);
+}
+/** Mutable pi-tui component backed only by the official conversation snapshot. */
+var Transcript = class {
+	components = [new Text("", 0, 0)];
+	rows = [];
+	imageComponents = /* @__PURE__ */ new Map();
+	pendingImages = /* @__PURE__ */ new Set();
+	imageGeneration = 0;
+	imageLoader;
+	snapshot;
+	emptyMessage = "在下方输入消息，或用 /help 查看命令。";
+	sessionId;
+	toolVisibility = "collapsed";
+	reasoningVisible = false;
+	emptyState = true;
+	hasMore = false;
+	loadingOlder = false;
+	scrollOffset = 0;
+	renderedLineCount = 0;
+	turnAnchors = [];
+	turnCursor;
+	pulseFrame = 0;
+	pulseTimer;
+	focused = false;
+	/**
+	* @param viewportRows - current terminal-dependent transcript height.
+	* @param requestRender - schedule a TUI frame after local presentation state changes.
+	* @param requestOlder - ask Harness for the preceding durable history page.
+	*/
+	constructor(viewportRows = () => Number.POSITIVE_INFINITY, requestRender = () => void 0, requestOlder = () => void 0) {
+		this.viewportRows = viewportRows;
+		this.requestRender = requestRender;
+		this.requestOlder = requestOlder;
+	}
+	/**
+	* Cycle folded → expanded → hidden without mutating the Harness log.
+	* @returns the newly active tool visibility.
+	*/
+	cycleToolVisibility() {
+		this.toolVisibility = this.toolVisibility === "collapsed" ? "expanded" : this.toolVisibility === "expanded" ? "hidden" : "collapsed";
+		return this.toolVisibility;
+	}
+	/**
+	* Toggle reasoning presentation without changing model request parameters.
+	* @returns whether reasoning is now visible.
+	*/
+	toggleReasoning() {
+		this.reasoningVisible = !this.reasoningVisible;
+		return this.reasoningVisible;
+	}
+	/** Follow new transcript output after the user submits from a historical viewport. */
+	followLatest() {
+		this.turnCursor = void 0;
+		this.scrollOffset = 0;
+		this.requestRender();
+	}
+	/**
+	* Report whether the transcript is showing non-durable empty-session guidance.
+	* @returns true while the conversation has no visible durable content.
+	*/
+	isEmptyState() {
+		return this.emptyState;
+	}
+	/**
+	* Replace the transcript with non-durable empty-selection guidance.
+	* @param message - guidance rendered when no Session is active.
+	*/
+	empty(message = "在下方输入消息，或用 /help 查看命令。") {
+		this.imageGeneration += 1;
+		this.imageLoader = void 0;
+		this.snapshot = void 0;
+		this.emptyMessage = message;
+		this.sessionId = void 0;
+		this.pendingImages.clear();
+		this.imageComponents.clear();
+		this.emptyState = true;
+		this.hasMore = false;
+		this.loadingOlder = false;
+		this.replace([{
+			format: "plain",
+			text: color.muted(translateUiText(message))
+		}]);
+	}
+	/**
+	* Replace the rendered snapshot after a Harness observable notification.
+	* @param snapshot - authoritative Session conversation projection.
+	* @param imageLoader - authenticated reader for references in this Session.
+	*/
+	update(snapshot, imageLoader) {
+		this.snapshot = snapshot;
+		const sessionId = String(snapshot.sessionId);
+		if (sessionId !== this.sessionId) {
+			this.imageGeneration += 1;
+			this.pendingImages.clear();
+			this.imageComponents.clear();
+			this.sessionId = sessionId;
+		}
+		this.imageLoader = imageLoader;
+		this.hasMore = snapshot.hasMore;
+		this.loadingOlder = snapshot.loadingOlder;
+		const preferences = {
+			tools: this.toolVisibility,
+			reasoning: this.reasoningVisible
+		};
+		const visibleNodes = snapshot.chat.order.flatMap((key) => {
+			const node = snapshot.chat.nodes.get(key);
+			return node === void 0 || node.visibility !== "visible" ? [] : [node];
+		});
+		const rows = visibleNodes.flatMap((node) => chatNodeRows(node, preferences));
+		if (snapshot.partial !== null && !visibleNodes.some((node) => node.kind === "assistant-step")) {
+			const partialRows = snapshot.partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences));
+			rows.push(...grouped([...partialRows.length === 0 ? [thinkingRow()] : [], ...partialRows]));
+		}
+		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0))));
+		this.emptyState = rows.length === 0;
+		if (this.emptyState) rows.push({
+			format: "plain",
+			text: `${color.brand("deepseek")}\n${color.muted(ui("探索未至之境", "Explore beyond the known"))}\n${color.muted(ui("直接描述你想完成的事", "Describe what you want to accomplish"))}`
+		});
+		this.replace(rows);
+	}
+	/**
+	* Rebuild colorized rows after a live theme or lazy grammar change.
+	* The current viewport and durable turn cursor remain unchanged.
+	*/
+	refreshPresentation() {
+		const scrollOffset = this.scrollOffset;
+		const turnCursor = this.turnCursor;
+		const snapshot = this.snapshot;
+		if (snapshot === void 0) this.replace([{
+			format: "plain",
+			text: color.muted(translateUiText(this.emptyMessage))
+		}]);
+		else this.update(snapshot, this.imageLoader);
+		this.scrollOffset = scrollOffset;
+		this.turnCursor = turnCursor;
+		this.requestRender();
+	}
+	invalidate() {
+		for (const component of this.components) component.invalidate();
+	}
+	/** Stop pending attachment presentation updates during terminal teardown. */
+	dispose() {
+		this.stopPulseAnimation();
+		this.imageGeneration += 1;
+		this.imageLoader = void 0;
+		this.pendingImages.clear();
+		this.imageComponents.clear();
+	}
+	render(width) {
+		const inset = width >= 12 ? 2 : 0;
+		const contentWidth = Math.max(1, width - inset * 2);
+		const withInset = (values) => values.map((line) => line === "" ? "" : `${" ".repeat(inset)}${line}`);
+		const olderMarker = (count) => {
+			if (this.loadingOlder) return color.muted(ui("↑ 正在加载更早内容…", "↑ Loading older content…"));
+			const hint = this.focused ? "PgUp/Home" : ui("滚轮上翻", "Scroll up");
+			return color.muted(count === 0 ? ui(`↑ 还有更早内容 · ${hint}`, `↑ Older content available · ${hint}`) : ui(`↑ ${String(count)} 行更早内容 · ${hint}`, `↑ ${String(count)} older line(s) · ${hint}`));
+		};
+		const lines = [];
+		const anchors = [];
+		for (const [index, component] of this.components.entries()) {
+			if (lines.length > 0 && this.rows[index]?.gapBefore === true) lines.push("");
+			if (this.rows[index]?.userTurn === true) anchors.push(lines.length);
+			const row = this.rows[index];
+			const rendered = component.render(contentWidth);
+			const escaped = row?.format === "image" ? rendered : rendered.map(escapeTerminalText);
+			lines.push(...escaped);
+		}
+		if (this.emptyState) for (const [index, line] of lines.entries()) {
+			if (line === "") continue;
+			const content = line.trimEnd();
+			lines[index] = `${" ".repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`;
+		}
+		this.renderedLineCount = lines.length;
+		this.turnAnchors = anchors;
+		const rows = Math.max(1, Math.floor(this.viewportRows()));
+		if (!Number.isFinite(rows)) {
+			this.scrollOffset = 0;
+			return withInset(lines);
+		}
+		if (lines.length <= rows) {
+			this.scrollOffset = 0;
+			const remaining = rows - lines.length;
+			if (!this.emptyState && this.hasMore) {
+				if (remaining === 0) {
+					const visible$1 = [...lines];
+					visible$1[0] = olderMarker(0);
+					return withInset(visible$1);
+				}
+				return withInset([
+					...Array.from({ length: remaining - 1 }, () => ""),
+					olderMarker(0),
+					...lines
+				]);
+			}
+			const before = this.emptyState ? Math.floor(remaining / 2) : remaining;
+			return withInset([
+				...Array.from({ length: before }, () => ""),
+				...lines,
+				...Array.from({ length: remaining - before }, () => "")
+			]);
+		}
+		const maxOffset = Math.max(0, lines.length - rows);
+		this.scrollOffset = Math.min(this.scrollOffset, maxOffset);
+		const end = lines.length - this.scrollOffset;
+		const start = Math.max(0, end - rows);
+		if (this.scrollOffset === 0 && start > 0) {
+			const alignedStart = this.turnAnchors.find((anchor) => anchor >= start && end - anchor <= rows - 1);
+			if (alignedStart !== void 0) {
+				const latestTurnRows = lines.slice(alignedStart, end);
+				return withInset([
+					...Array.from({ length: rows - latestTurnRows.length - 1 }, () => ""),
+					olderMarker(alignedStart),
+					...latestTurnRows
+				]);
+			}
+		}
+		const visible = lines.slice(start, end);
+		if (start > 0 && visible.length > 0) visible[0] = olderMarker(start);
+		else if (this.hasMore && visible.length > 0) visible[0] = olderMarker(0);
+		if (end < lines.length && visible.length > 0) {
+			const hint = this.focused ? "PgDn/End" : ui("滚轮下翻", "Scroll down");
+			visible[visible.length - 1] = color.muted(ui(`↓ ${String(lines.length - end)} 行更新内容 · ${hint}`, `↓ ${String(lines.length - end)} newer line(s) · ${hint}`));
+		}
+		return withInset(visible);
+	}
+	handleInput(data) {
+		this.turnCursor = void 0;
+		const rows = Math.max(1, Math.floor(this.viewportRows()));
+		const maxOffset = Math.max(0, this.renderedLineCount - rows);
+		if (matchesKey(data, Key.up)) this.scrollBy(1);
+		else if (matchesKey(data, Key.down)) this.scrollBy(-1);
+		else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1));
+		else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
+		else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
+		else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset);
+	}
+	/**
+	* Move the conversation viewport while leaving the composer focus unchanged.
+	* @param lines - positive for older content, negative for newer content.
+	* @returns whether the viewport moved.
+	*/
+	scrollBy(lines) {
+		this.turnCursor = void 0;
+		const delta = Math.trunc(lines);
+		if (!Number.isFinite(delta) || delta === 0) return false;
+		const rows = Math.max(1, Math.floor(this.viewportRows()));
+		const maxOffset = Math.max(0, this.renderedLineCount - rows);
+		const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + delta));
+		if (nextOffset === this.scrollOffset) {
+			if (delta > 0 && this.scrollOffset === maxOffset && this.hasMore && !this.loadingOlder) this.requestOlder();
+			return false;
+		}
+		this.scrollOffset = nextOffset;
+		this.requestRender();
+		return true;
+	}
+	/**
+	* Move the viewport to an adjacent durable user-turn anchor.
+	* @param offset - negative for an older turn, positive for a newer turn.
+	* @returns whether an adjacent turn exists and was selected.
+	*/
+	navigateTurn(offset) {
+		if (offset === 0 || this.turnAnchors.length === 0) return false;
+		const rows = Math.max(1, Math.floor(this.viewportRows()));
+		const viewportTop = Math.max(0, this.renderedLineCount - this.scrollOffset - rows);
+		const viewportEnd = Math.min(this.renderedLineCount, viewportTop + rows);
+		const index = this.turnCursor === void 0 ? offset < 0 ? this.turnAnchors.findLastIndex((candidate) => candidate < viewportEnd) : this.turnAnchors.findIndex((candidate) => candidate > viewportTop) : this.turnCursor + Math.sign(offset);
+		const anchor = this.turnAnchors[index];
+		if (anchor === void 0) return false;
+		this.turnCursor = index;
+		this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows));
+		this.requestRender();
+		return true;
+	}
+	replace(rows) {
+		this.rows = rows;
+		this.turnCursor = void 0;
+		this.components = rows.map((row) => this.component(row));
+		this.syncPulseAnimation(rows.some((row) => row.liveDurationSince !== void 0 || row.pulse !== void 0 && terminalColorLevel() !== 0));
+	}
+	component(row) {
+		if (row.format === "markdown") return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme);
+		if (row.format === "plain") return row.pulse === void 0 ? new Text(escapeTerminalText(row.text), 0, 0) : new PulsingRow(row.text, row.pulse, () => this.pulseFrame, row.liveDurationSince);
+		if (row.format === "code") return new CodeRow(row);
+		const cacheKey = `${this.sessionId ?? "none"}:${row.key}`;
+		const cached = this.imageComponents.get(cacheKey);
+		if (cached !== void 0) return cached;
+		const fallback = new Text(color.muted(imageLabel(row.attachment)), 0, 0);
+		const loader = this.imageLoader;
+		if (loader === void 0 || this.pendingImages.has(cacheKey)) return fallback;
+		this.pendingImages.add(cacheKey);
+		const generation = this.imageGeneration;
+		loader(row.attachment).then((payload) => {
+			if (generation !== this.imageGeneration) return;
+			const attachment = payload.attachment;
+			this.imageComponents.set(cacheKey, new Image(payload.data, attachment.mediaType, { fallbackColor: (value) => color.muted(value) }, {
+				maxWidthCells: 60,
+				maxHeightCells: 20,
+				filename: escapeTerminalText(attachment.name ?? String(attachment.attachmentId))
+			}, {
+				widthPx: attachment.width,
+				heightPx: attachment.height
+			}));
+		}, (error) => {
+			if (generation !== this.imageGeneration) return;
+			const message = error instanceof Error ? error.message : String(error);
+			this.imageComponents.set(cacheKey, new Text(color.danger(ui(`${imageLabel(row.attachment)} · 读取失败：${message}`, `${imageLabel(row.attachment)} · failed to load: ${message}`)), 0, 0));
+		}).finally(() => {
+			if (generation !== this.imageGeneration) return;
+			this.pendingImages.delete(cacheKey);
+			this.components = this.rows.map((current) => this.component(current));
+			this.requestRender();
+		});
+		return fallback;
+	}
+	syncPulseAnimation(active) {
+		if (!active) {
+			this.stopPulseAnimation();
+			return;
+		}
+		if (this.pulseTimer !== void 0) return;
+		this.pulseFrame = 0;
+		this.pulseTimer = setInterval(() => {
+			this.pulseFrame = this.pulseFrame === Number.MAX_SAFE_INTEGER ? 0 : this.pulseFrame + 1;
+			this.requestRender();
+		}, PULSE_FRAME_MS);
+		this.pulseTimer.unref();
+	}
+	stopPulseAnimation() {
+		if (this.pulseTimer !== void 0) clearInterval(this.pulseTimer);
+		this.pulseTimer = void 0;
+		this.pulseFrame = 0;
+	}
+};
+
+//#endregion
+//#region src/client/approval-preview.ts
+/** Approval overlay copy: visible command/diff plus a full-parameter subpage when truncated. */
+const APPROVAL_DETAIL_MAX_LINES = 16;
+const APPROVAL_DETAIL_MAX_CHARS = 1200;
+function composeApprovalDetail(options$1) {
+	const fallback = `调用 ${options$1.callId ?? options$1.approvalId ?? "unknown"}`;
+	const parts = [options$1.reason?.trim(), options$1.preview.trim()].filter((part) => part !== void 0 && part !== "");
+	const full = parts.length === 0 ? fallback : parts.join("\n\n");
+	const lines = full.split("\n");
+	if (lines.length <= APPROVAL_DETAIL_MAX_LINES && full.length <= APPROVAL_DETAIL_MAX_CHARS) return { detail: full };
+	return {
+		detail: `${lines.slice(0, APPROVAL_DETAIL_MAX_LINES).join("\n")}\n…`,
+		full
+	};
+}
+
+//#endregion
 //#region src/client/appearance.ts
 /**
 * Find the appearance descriptor registered by the Host bridge.
@@ -22498,7 +24246,7 @@ function textMateRules(value, background$1) {
 		}];
 	});
 }
-const ROLE_SCOPES$1 = {
+const ROLE_SCOPES = {
 	comment: ["comment"],
 	keyword: [
 		"keyword",
@@ -22571,7 +24319,7 @@ function semanticColor(semantic, candidates, background$1, fallback) {
 	return selected;
 }
 function syntaxColors(value, background$1, foreground, rules, fallback) {
-	const entries = Object.entries(ROLE_SCOPES$1).map(([role, candidates]) => {
+	const entries = Object.entries(ROLE_SCOPES).map(([role, candidates]) => {
 		const key = role;
 		const textMate = scopedColor(rules, candidates, fallback[key]);
 		return [key, semanticColor(value.semanticTokenColors, SEMANTIC_TYPES[key], background$1, textMate)];
@@ -25747,29 +27495,60 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		else await this.question(wait);
 	}
 	async approval(wait) {
-		const selected = await this.host.overlays.select({
-			title: `工具审批 · ${wait.payload.toolName}`,
-			detail: wait.payload.reason ?? `调用 ${wait.payload.callId ?? wait.payload.approvalId}`,
-			searchable: false,
-			choices: [{
-				id: "allow",
-				label: "仅本次允许",
-				description: "只允许这一次工具调用"
-			}, {
-				id: "reject",
-				label: "拒绝",
-				description: "本次工具调用不会执行"
-			}],
-			footer: "Enter 确认 · Esc 安全拒绝",
-			options: {
-				width: "95%",
-				maxHeight: "90%",
-				anchor: "bottom-center",
-				margin: 1
-			}
+		const call = (this.capabilities.active()?.session.getSnapshot())?.runningCalls?.find((candidate) => candidate.callId === wait.payload.callId);
+		const composed = composeApprovalDetail({
+			...wait.payload.reason === void 0 ? {} : { reason: wait.payload.reason },
+			...wait.payload.callId === void 0 ? {} : { callId: String(wait.payload.callId) },
+			approvalId: String(wait.payload.approvalId),
+			preview: toolApprovalPreview(call)
 		});
-		this.host.transcript.followLatest();
-		await this.capabilities.answerApproval(wait, selected?.id === "allow" ? "allowed-once" : "rejected");
+		while (true) {
+			const selected = await this.host.overlays.select({
+				title: `工具审批 · ${wait.payload.toolName}`,
+				detail: composed.detail,
+				searchable: false,
+				choices: [
+					{
+						id: "allow",
+						label: "仅本次允许",
+						description: "只允许这一次工具调用"
+					},
+					{
+						id: "reject",
+						label: "拒绝",
+						description: "本次工具调用不会执行"
+					},
+					...composed.full === void 0 ? [] : [{
+						id: "inspect",
+						label: ui("查看完整参数", "View full arguments"),
+						description: ui("打开只读子页，不批准也不拒绝", "Open a read-only page; does not approve or reject")
+					}]
+				],
+				footer: "Enter 确认 · Esc 安全拒绝",
+				options: {
+					width: "95%",
+					maxHeight: "90%",
+					anchor: "bottom-center",
+					margin: 1
+				}
+			});
+			if (selected?.id === "inspect" && composed.full !== void 0) {
+				await this.host.overlays.detail({
+					title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
+					content: composed.full,
+					options: {
+						width: "95%",
+						maxHeight: "90%",
+						anchor: "center",
+						margin: 1
+					}
+				});
+				continue;
+			}
+			this.host.transcript.followLatest();
+			await this.capabilities.answerApproval(wait, selected?.id === "allow" ? "allowed-once" : "rejected");
+			return;
+		}
 	}
 	async question(wait) {
 		const answers = [];
@@ -26872,1732 +28651,6 @@ var OverlayQueue = class {
 		try {
 			component.dispose?.();
 		} catch {}
-	}
-};
-
-//#endregion
-//#region src/client/syntax-highlighter.ts
-const LANGUAGE_LOADERS = {
-	typescript: () => import("@shikijs/langs/typescript"),
-	javascript: () => import("@shikijs/langs/javascript"),
-	tsx: () => import("@shikijs/langs/tsx"),
-	jsx: () => import("@shikijs/langs/jsx"),
-	bash: () => import("@shikijs/langs/bash"),
-	json: () => import("@shikijs/langs/json"),
-	jsonc: () => import("@shikijs/langs/jsonc"),
-	python: () => import("@shikijs/langs/python"),
-	ruby: () => import("@shikijs/langs/ruby"),
-	go: () => import("@shikijs/langs/go"),
-	rust: () => import("@shikijs/langs/rust"),
-	java: () => import("@shikijs/langs/java"),
-	c: () => import("@shikijs/langs/c"),
-	cpp: () => import("@shikijs/langs/cpp"),
-	csharp: () => import("@shikijs/langs/csharp"),
-	kotlin: () => import("@shikijs/langs/kotlin"),
-	swift: () => import("@shikijs/langs/swift"),
-	php: () => import("@shikijs/langs/php"),
-	yaml: () => import("@shikijs/langs/yaml"),
-	toml: () => import("@shikijs/langs/toml"),
-	ini: () => import("@shikijs/langs/ini"),
-	markdown: () => import("@shikijs/langs/markdown"),
-	mdx: () => import("@shikijs/langs/mdx"),
-	html: () => import("@shikijs/langs/html"),
-	css: () => import("@shikijs/langs/css"),
-	scss: () => import("@shikijs/langs/scss"),
-	less: () => import("@shikijs/langs/less"),
-	sql: () => import("@shikijs/langs/sql"),
-	xml: () => import("@shikijs/langs/xml"),
-	lua: () => import("@shikijs/langs/lua"),
-	diff: () => import("@shikijs/langs/diff")
-};
-const LANGUAGE_ALIASES = {
-	ts: "typescript",
-	mts: "typescript",
-	cts: "typescript",
-	typescript: "typescript",
-	js: "javascript",
-	mjs: "javascript",
-	cjs: "javascript",
-	javascript: "javascript",
-	tsx: "tsx",
-	jsx: "jsx",
-	sh: "bash",
-	shell: "bash",
-	shellscript: "bash",
-	zsh: "bash",
-	bash: "bash",
-	json: "json",
-	json5: "jsonc",
-	jsonc: "jsonc",
-	py: "python",
-	python: "python",
-	rb: "ruby",
-	ruby: "ruby",
-	golang: "go",
-	go: "go",
-	rs: "rust",
-	rust: "rust",
-	java: "java",
-	c: "c",
-	h: "c",
-	cpp: "cpp",
-	"c++": "cpp",
-	cc: "cpp",
-	hpp: "cpp",
-	cs: "csharp",
-	csharp: "csharp",
-	kt: "kotlin",
-	kotlin: "kotlin",
-	swift: "swift",
-	php: "php",
-	yml: "yaml",
-	yaml: "yaml",
-	toml: "toml",
-	ini: "ini",
-	properties: "ini",
-	md: "markdown",
-	markdown: "markdown",
-	mdx: "mdx",
-	html: "html",
-	htm: "html",
-	css: "css",
-	scss: "scss",
-	less: "less",
-	sql: "sql",
-	xml: "xml",
-	svg: "xml",
-	lua: "lua",
-	diff: "diff",
-	patch: "diff"
-};
-const EXTENSION_LANGUAGES = {
-	ts: "typescript",
-	mts: "typescript",
-	cts: "typescript",
-	js: "javascript",
-	mjs: "javascript",
-	cjs: "javascript",
-	tsx: "tsx",
-	jsx: "jsx",
-	sh: "bash",
-	bash: "bash",
-	zsh: "bash",
-	json: "json",
-	jsonc: "jsonc",
-	py: "python",
-	rb: "ruby",
-	go: "go",
-	rs: "rust",
-	java: "java",
-	c: "c",
-	h: "c",
-	cc: "cpp",
-	cpp: "cpp",
-	cxx: "cpp",
-	hpp: "cpp",
-	cs: "csharp",
-	kt: "kotlin",
-	kts: "kotlin",
-	swift: "swift",
-	php: "php",
-	yml: "yaml",
-	yaml: "yaml",
-	toml: "toml",
-	ini: "ini",
-	md: "markdown",
-	mdx: "mdx",
-	html: "html",
-	htm: "html",
-	css: "css",
-	scss: "scss",
-	less: "less",
-	sql: "sql",
-	xml: "xml",
-	svg: "xml",
-	lua: "lua",
-	diff: "diff",
-	patch: "diff"
-};
-const COMMON_LANGUAGES = [
-	"typescript",
-	"javascript",
-	"tsx",
-	"jsx",
-	"bash",
-	"json",
-	"jsonc",
-	"markdown",
-	"diff"
-];
-const COMMON_WARMUPS = [
-	{
-		language: "typescript",
-		code: "const answer: number = 42"
-	},
-	{
-		language: "bash",
-		code: "printf '%s\\n' \"$HOME\""
-	},
-	{
-		language: "json",
-		code: "{\"ready\":true}"
-	},
-	{
-		language: "markdown",
-		code: "# ready"
-	},
-	{
-		language: "diff",
-		code: "@@ -1 +1 @@\n-old\n+new"
-	}
-];
-const MAX_HIGHLIGHT_CHARS = 1e5;
-const MAX_HIGHLIGHT_LINE_CHARS = 2e4;
-const MAX_CACHE_ENTRIES = 512;
-const ROLE_SCOPES = {
-	comment: ["comment"],
-	keyword: [
-		"keyword",
-		"storage.type",
-		"storage.modifier"
-	],
-	string: ["string"],
-	number: ["constant.numeric"],
-	constant: ["constant", "variable.language"],
-	function: [
-		"entity.name.function",
-		"support.function",
-		"meta.function-call"
-	],
-	type: [
-		"entity.name.type",
-		"entity.name.class",
-		"support.type",
-		"support.class"
-	],
-	variable: ["variable.other", "variable.language"],
-	property: ["variable.other.property", "support.variable.property"],
-	parameter: ["variable.parameter"],
-	operator: ["keyword.operator"],
-	punctuation: ["punctuation"],
-	tag: ["entity.name.tag"],
-	attribute: ["entity.other.attribute-name"],
-	regexp: ["string.regexp"]
-};
-const DIFF_SCOPES = {
-	inserted: ["markup.inserted", "punctuation.definition.inserted"],
-	deleted: ["markup.deleted", "punctuation.definition.deleted"],
-	header: ["meta.diff.header", "meta.diff.range"]
-};
-function languageOf(value) {
-	if (value === void 0) return void 0;
-	return LANGUAGE_ALIASES[value.trim().toLowerCase().split(/[\s,{]/u, 1)[0] ?? ""];
-}
-/**
-* Infer a supported syntax grammar from a path and optional explicit language.
-* @param path - file path or display name.
-* @param explicit - Harness-provided language id.
-* @returns canonical language or undefined for plain text.
-*/
-function syntaxLanguageForPath(path$1, explicit) {
-	const requested = languageOf(explicit);
-	if (requested !== void 0) return requested;
-	const filename = path$1.toLowerCase().split(/[\\/]/u).at(-1) ?? "";
-	if (filename === "dockerfile") return "bash";
-	if (filename === "makefile") return void 0;
-	return EXTENSION_LANGUAGES[filename.includes(".") ? filename.split(".").at(-1) ?? "" : ""];
-}
-function themeHash(theme) {
-	const value = JSON.stringify([
-		theme.syntaxTone,
-		theme.colors,
-		theme.syntax,
-		theme.tokenColors
-	]);
-	let hash = 2166136261;
-	for (const character of value) {
-		hash ^= character.codePointAt(0) ?? 0;
-		hash = Math.imul(hash, 16777619);
-	}
-	return `seektty-${(hash >>> 0).toString(16).padStart(8, "0")}`;
-}
-function themeRegistration(theme, name$1) {
-	const settings = [
-		{ settings: {
-			foreground: theme.syntax.foreground,
-			background: theme.syntax.background
-		} },
-		...Object.entries(ROLE_SCOPES).map(([role, scope]) => ({
-			scope: [...scope],
-			settings: { foreground: theme.syntax[role] }
-		})),
-		{
-			scope: [...DIFF_SCOPES.inserted],
-			settings: { foreground: theme.colors.success }
-		},
-		{
-			scope: [...DIFF_SCOPES.deleted],
-			settings: { foreground: theme.colors.danger }
-		},
-		{
-			scope: [...DIFF_SCOPES.header],
-			settings: { foreground: theme.colors.accent }
-		},
-		...theme.tokenColors.map((rule) => ({
-			scope: [...rule.scope],
-			settings: {
-				...rule.foreground === void 0 ? {} : { foreground: rule.foreground },
-				...rule.background === void 0 ? {} : { background: rule.background },
-				...rule.fontStyle === void 0 ? {} : { fontStyle: rule.fontStyle.join(" ") }
-			}
-		}))
-	];
-	return {
-		name: name$1,
-		displayName: theme.name,
-		type: theme.syntaxTone,
-		fg: theme.syntax.foreground,
-		bg: theme.syntax.background,
-		settings,
-		colors: {
-			"editor.foreground": theme.syntax.foreground,
-			"editor.background": theme.syntax.background
-		}
-	};
-}
-function safeTokenColor(value, fallback) {
-	if (value === void 0) return fallback;
-	try {
-		return normalizeThemeColor(value);
-	} catch {
-		return fallback;
-	}
-}
-function renderToken(token, theme) {
-	const fontStyle = token.fontStyle ?? 0;
-	return styleTerminalText(token.content, {
-		foreground: safeTokenColor(token.color, theme.syntax.foreground),
-		background: safeTokenColor(token.bgColor, theme.syntax.background),
-		italic: (fontStyle & 1) !== 0,
-		bold: (fontStyle & 2) !== 0,
-		underline: (fontStyle & 4) !== 0,
-		strikethrough: (fontStyle & 8) !== 0
-	});
-}
-function plainLines(code, theme) {
-	return code.split("\n").map((line) => styleTerminalText(line, {
-		foreground: theme.syntax.foreground,
-		background: theme.syntax.background
-	}));
-}
-function highlightable(code) {
-	return code.length <= MAX_HIGHLIGHT_CHARS && code.split("\n").every((line) => line.length <= MAX_HIGHLIGHT_LINE_CHARS);
-}
-/** Synchronous render face backed by asynchronously loaded Shiki grammars. */
-var SyntaxHighlighter = class SyntaxHighlighter {
-	loaded = /* @__PURE__ */ new Set();
-	loading = /* @__PURE__ */ new Map();
-	failed = /* @__PURE__ */ new Set();
-	themes = /* @__PURE__ */ new Set();
-	cache = /* @__PURE__ */ new Map();
-	themeName = "";
-	disposed = false;
-	constructor(highlighter, theme, invalidate) {
-		this.highlighter = highlighter;
-		this.theme = theme;
-		this.invalidate = invalidate;
-	}
-	/**
-	* Prepare the JavaScript-regex engine and common Harness grammars.
-	* @param theme - initial resolved theme.
-	* @param invalidate - called after a lazy grammar becomes usable.
-	* @returns ready syntax renderer.
-	*/
-	static async create(theme, invalidate) {
-		const highlighter = await createHighlighterCore({
-			engine: createJavaScriptRegexEngine({
-				forgiving: true,
-				regexConstructor: (pattern) => defaultJavaScriptRegexConstructor(pattern, { lazyCompileLength: Number.POSITIVE_INFINITY })
-			}),
-			langs: COMMON_LANGUAGES.map((language) => LANGUAGE_LOADERS[language]),
-			themes: [],
-			warnings: false
-		});
-		const service = new SyntaxHighlighter(highlighter, theme, invalidate);
-		for (const language of COMMON_LANGUAGES) service.loaded.add(language);
-		service.setTheme(theme);
-		for (const sample of COMMON_WARMUPS) highlighter.codeToTokens(sample.code, {
-			lang: sample.language,
-			theme: service.themeName,
-			tokenizeTimeLimit: 0
-		});
-		return service;
-	}
-	/**
-	* Replace the active token theme and invalidate bounded render caches.
-	* @param theme - complete current theme.
-	*/
-	setTheme(theme) {
-		if (this.disposed) return;
-		this.theme = theme;
-		this.themeName = themeHash(theme);
-		if (!this.themes.has(this.themeName)) {
-			this.highlighter.loadThemeSync(themeRegistration(theme, this.themeName));
-			this.themes.add(this.themeName);
-		}
-		this.cache.clear();
-	}
-	/**
-	* Highlight one code block synchronously, loading uncommon grammars in the background.
-	* @param code - raw code block.
-	* @param language - Markdown or tool-provided language id.
-	* @returns ANSI-styled lines or a safe plain fallback.
-	*/
-	highlight(code, language) {
-		if (this.disposed || !highlightable(code) || terminalColorLevel() === 0) return plainLines(code, this.theme);
-		const canonical = languageOf(language);
-		if (canonical === void 0) return plainLines(code, this.theme);
-		if (!this.loaded.has(canonical)) {
-			this.load(canonical);
-			return plainLines(code, this.theme);
-		}
-		const key = `${this.themeName}:${String(terminalColorLevel())}:${canonical}:${code}`;
-		const cached = this.cache.get(key);
-		if (cached !== void 0) {
-			this.cache.delete(key);
-			this.cache.set(key, cached);
-			return [...cached];
-		}
-		let lines;
-		try {
-			lines = this.highlighter.codeToTokens(code, {
-				lang: canonical,
-				theme: this.themeName,
-				tokenizeTimeLimit: 0
-			}).tokens.map((line) => line.map((token) => renderToken(token, this.theme)).join(""));
-		} catch {
-			this.failed.add(canonical);
-			return plainLines(code, this.theme);
-		}
-		this.cache.set(key, lines);
-		if (this.cache.size > MAX_CACHE_ENTRIES) this.cache.delete(this.cache.keys().next().value);
-		return [...lines];
-	}
-	/** Release Shiki registries and ignore pending lazy-load invalidations. */
-	dispose() {
-		if (this.disposed) return;
-		this.disposed = true;
-		this.cache.clear();
-		this.highlighter.dispose();
-	}
-	load(language) {
-		if (this.loading.has(language) || this.failed.has(language) || this.disposed) return;
-		const task = this.highlighter.loadLanguage(LANGUAGE_LOADERS[language]).then(() => {
-			if (this.disposed) return;
-			this.loaded.add(language);
-			this.invalidate();
-		}).catch(() => {
-			this.failed.add(language);
-		}).finally(() => {
-			this.loading.delete(language);
-		});
-		this.loading.set(language, task);
-	}
-};
-
-//#endregion
-//#region src/client/line-diff.ts
-/** Line-level unified diffs for transcript and approval views. */
-/** Default unchanged lines kept on each side of a change island. */
-const DIFF_CONTEXT_LINES = 3;
-function splitDiffLines(text) {
-	if (text === "") return [];
-	return (text.endsWith("\n") ? text.slice(0, -1) : text).split("\n");
-}
-/**
-* Myers / LCS line edits. Equal lines stay in order; inserts and deletes are
-* the minimum replacements needed to turn `previous` into `next`.
-*/
-function lineEdits(previous, next) {
-	const n = previous.length;
-	const m = next.length;
-	const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
-	for (let i$1 = n - 1; i$1 >= 0; i$1 -= 1) {
-		const row = dp[i$1];
-		const below = dp[i$1 + 1];
-		if (row === void 0 || below === void 0) continue;
-		for (let j$1 = m - 1; j$1 >= 0; j$1 -= 1) row[j$1] = previous[i$1] === next[j$1] ? (below[j$1 + 1] ?? 0) + 1 : Math.max(below[j$1] ?? 0, row[j$1 + 1] ?? 0);
-	}
-	const edits = [];
-	let i = 0;
-	let j = 0;
-	while (i < n && j < m) {
-		if (previous[i] === next[j]) {
-			edits.push({
-				type: "equal",
-				line: previous[i] ?? ""
-			});
-			i += 1;
-			j += 1;
-			continue;
-		}
-		if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
-			edits.push({
-				type: "delete",
-				line: previous[i] ?? ""
-			});
-			i += 1;
-		} else {
-			edits.push({
-				type: "insert",
-				line: next[j] ?? ""
-			});
-			j += 1;
-		}
-	}
-	while (i < n) {
-		edits.push({
-			type: "delete",
-			line: previous[i] ?? ""
-		});
-		i += 1;
-	}
-	while (j < m) {
-		edits.push({
-			type: "insert",
-			line: next[j] ?? ""
-		});
-		j += 1;
-	}
-	return edits;
-}
-function changeSpans(edits) {
-	const spans = [];
-	let index = 0;
-	while (index < edits.length) {
-		if (edits[index]?.type === "equal") {
-			index += 1;
-			continue;
-		}
-		const start = index;
-		while (index < edits.length && edits[index]?.type !== "equal") index += 1;
-		spans.push({
-			start,
-			end: index
-		});
-	}
-	return spans;
-}
-function lineCounts(edits, start, end) {
-	let oldCount = 0;
-	let newCount = 0;
-	for (let index = start; index < end; index += 1) {
-		const edit$1 = edits[index];
-		if (edit$1?.type === "insert") newCount += 1;
-		else if (edit$1?.type === "delete") oldCount += 1;
-		else {
-			oldCount += 1;
-			newCount += 1;
-		}
-	}
-	return {
-		oldCount,
-		newCount
-	};
-}
-function oldIndexAt(edits, editIndex) {
-	let oldIndex = 0;
-	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "insert") oldIndex += 1;
-	return oldIndex;
-}
-function newIndexAt(edits, editIndex) {
-	let newIndex = 0;
-	for (let index = 0; index < editIndex; index += 1) if (edits[index]?.type !== "delete") newIndex += 1;
-	return newIndex;
-}
-/**
-* Unified hunks with `context` unchanged lines around each change island.
-* Isolated one-line replacements occupy 7 body lines plus a hunk header.
-*/
-function unifiedHunks(previous, next, context = DIFF_CONTEXT_LINES) {
-	const edits = lineEdits(previous, next);
-	const spans = changeSpans(edits);
-	if (spans.length === 0) return [];
-	const hunks = [];
-	for (const span of spans) {
-		const start = Math.max(0, span.start - context);
-		const end = Math.min(edits.length, span.end + context);
-		const previousHunk = hunks[hunks.length - 1];
-		if (previousHunk !== void 0 && start <= previousHunk.end) previousHunk.end = end;
-		else hunks.push({
-			start,
-			end
-		});
-	}
-	const rows = [];
-	for (const hunk of hunks) {
-		const oldStart = oldIndexAt(edits, hunk.start) + 1;
-		const newStart = newIndexAt(edits, hunk.start) + 1;
-		const { oldCount, newCount } = lineCounts(edits, hunk.start, hunk.end);
-		rows.push(`@@ -${oldCount === 0 ? oldStart - 1 : oldStart},${oldCount} +${newCount === 0 ? newStart - 1 : newStart},${newCount} @@`);
-		for (let index = hunk.start; index < hunk.end; index += 1) {
-			const edit$1 = edits[index];
-			if (edit$1 === void 0) continue;
-			if (edit$1.type === "equal") rows.push(` ${edit$1.line}`);
-			else if (edit$1.type === "delete") rows.push(`-${edit$1.line}`);
-			else rows.push(`+${edit$1.line}`);
-		}
-	}
-	return rows;
-}
-
-//#endregion
-//#region src/client/transcript.ts
-const PULSE_FRAME_MS = 160;
-function thinkingRow() {
-	return {
-		format: "plain",
-		text: ui("正在思考…", "Thinking…"),
-		pulse: "thinking"
-	};
-}
-var PulsingRow = class {
-	constructor(text, mode, frame, liveDurationSince) {
-		this.text = text;
-		this.mode = mode;
-		this.frame = frame;
-		this.liveDurationSince = liveDurationSince;
-	}
-	render(width) {
-		const marker = color.pulse("◆", this.frame());
-		const liveDuration = this.liveDurationSince === void 0 ? "" : ` · ${durationText(Math.max(0, Date.now() - this.liveDurationSince))}`;
-		const safeText = escapeTerminalText(`${this.text}${liveDuration}`);
-		return new Text(this.mode === "thinking" ? `${marker} ${color.muted(safeText)}` : safeText.replace("◆", marker), 0, 0).render(width);
-	}
-	invalidate() {}
-};
-var CodeRow = class {
-	constructor(row) {
-		this.row = row;
-	}
-	render(width) {
-		const safeWidth = Math.max(1, width);
-		const requestedPrefix = escapeTerminalText(this.row.prefix ?? "");
-		const prefix = visibleWidth(requestedPrefix) < safeWidth ? requestedPrefix : "";
-		const prefixWidth = visibleWidth(prefix);
-		const numbers = this.row.lineNumbers;
-		const highest = numbers?.reduce((value, number) => Math.max(value, number), 0) ?? 0;
-		const numberWidth = numbers !== void 0 && safeWidth - prefixWidth >= 8 ? String(highest).length + 2 : 0;
-		const codeWidth = Math.max(1, safeWidth - prefixWidth - numberWidth);
-		const highlighted = highlightCodeLines(this.row.text, this.row.language);
-		const rows = [];
-		if (this.row.caption !== void 0) rows.push(...new Text(`${color.muted(prefix)}${color.muted(escapeTerminalText(this.row.caption))}`, 0, 0).render(safeWidth));
-		for (const [index, sourceLine] of highlighted.entries()) {
-			const wrapped = wrapTextWithAnsi(sourceLine, codeWidth);
-			const parts = wrapped.length === 0 ? [""] : wrapped;
-			for (const [partIndex, part] of parts.entries()) {
-				const number = numbers?.[index];
-				const gutter$1 = numberWidth === 0 ? "" : color.muted(partIndex === 0 && number !== void 0 ? `${String(number).padStart(numberWidth - 1)} ` : " ".repeat(numberWidth));
-				const padded$1 = `${part}${" ".repeat(Math.max(0, codeWidth - visibleWidth(part)))}`;
-				const connector = prefix === "" ? "" : this.row.caption === void 0 && index === 0 && partIndex === 0 ? color.muted(prefix) : " ".repeat(prefixWidth);
-				rows.push(`${connector}${gutter$1}${background.code(padded$1)}`);
-			}
-		}
-		return rows;
-	}
-	invalidate() {}
-};
-function imageAttachment(value) {
-	if (typeof value !== "object" || value === null) return void 0;
-	const row = value;
-	return typeof row.attachmentId === "string" && typeof row.mediaType === "string" && typeof row.bytes === "number" && typeof row.width === "number" && typeof row.height === "number" ? value : void 0;
-}
-function imageRow(attachment) {
-	return {
-		format: "image",
-		key: String(attachment.attachmentId),
-		attachment
-	};
-}
-function imageLabel(attachment) {
-	const name$1 = attachment.name ?? String(attachment.attachmentId);
-	return ui(`[图片 · ${name$1} · ${attachment.width}×${attachment.height} · ${attachment.mediaType} · ${attachment.bytes} 字节]`, `[Image · ${name$1} · ${attachment.width}×${attachment.height} · ${attachment.mediaType} · ${attachment.bytes} bytes]`);
-}
-function jsonText(value) {
-	if (value === void 0 || typeof value === "function" || typeof value === "symbol") return String(value);
-	try {
-		const rendered = JSON.stringify(value, null, 2);
-		return rendered.length > 8e3 ? `${rendered.slice(0, 8e3)}\n${ui("…（终端显示已截断）", "… (terminal display truncated)")}` : rendered;
-	} catch {
-		return typeof value === "bigint" ? value.toString() : ui("[内容无法序列化]", "[content cannot be serialized]");
-	}
-}
-function contentBlockText(block$1) {
-	if (typeof block$1 !== "object" || block$1 === null) return String(block$1);
-	const value = block$1;
-	if (value.type === "text" || value.type === "reasoning") return typeof value.text === "string" ? value.text : `[${value.type}]`;
-	if (value.type === "image") return ui("[图片附件]", "[image attachment]");
-	if (value.type === "tool-result") return ui("[工具结果]", "[tool result]");
-	return `[${typeof value.type === "string" ? value.type : ui("内容", "content")}]`;
-}
-function permissionCommandText(node) {
-	if (node.name !== "permission" || node.outcome?.kind !== "success") return void 0;
-	const preset = /^preset\s+(\S+)/u.exec(node.outcome.text ?? "")?.[1] ?? node.args?.trim();
-	if (preset === void 0 || preset === "") return color.success(ui("权限已切换", "Permission changed"));
-	const label = preset === "read-only" ? ui("只读", "Read only") : preset === "workspace-write" ? ui("工作区", "Workspace") : preset === "danger-full-access" ? ui("完全访问", "Full access") : preset;
-	return color.success(ui(`权限已切换为${label}`, `Permission changed to ${label}`));
-}
-function planCommandText(node) {
-	if (node.name !== "plan") return void 0;
-	if (node.outcome === null) return color.warning(ui("正在切换计划模式", "Switching plan mode"));
-	if (node.outcome.kind !== "success") return color.danger(ui(`计划模式切换失败${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`, `Failed to switch plan mode${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`));
-	const text = node.outcome.text ?? "";
-	if (node.args?.trim() === "off") {
-		if (text.includes("entry cancelled")) return color.success(ui("已取消进入计划模式", "Plan-mode entry cancelled"));
-		if (text.includes("already inactive")) return color.muted(ui("计划模式未开启", "Plan mode is not active"));
-		if (text.startsWith("Leaving ")) return color.success(ui("计划模式将在下一步关闭", "Plan mode will stop on the next step"));
-		return color.success(ui("计划模式已关闭", "Plan mode disabled"));
-	}
-	return color.success(text.startsWith("Entering ") ? ui("计划模式将在下一步开启", "Plan mode will start on the next step") : ui("计划模式已开启", "Plan mode enabled"));
-}
-function goalCommandText(node) {
-	if (node.name !== "goal") return void 0;
-	if (node.outcome === null) return color.warning(ui("正在处理目标", "Processing goal"));
-	const args = node.args?.trim() ?? "";
-	const action = args.toLowerCase();
-	if (node.outcome.kind !== "success") {
-		if (node.outcome.text?.startsWith("A goal is already ") === true) return color.danger(ui("已有进行中的目标；可编辑或清除后重新创建", "A goal is already active; edit or clear it before creating another"));
-		if (action === "edit") return color.danger(ui("请提供新的目标内容", "Provide the new goal text"));
-		if (node.outcome.text?.startsWith("No goal is currently set") === true) return color.danger(ui("当前没有目标", "No active goal"));
-		return color.danger(ui("当前状态不能执行此目标操作", "This goal action is not valid in the current state"));
-	}
-	if (action === "clear") return color.success(node.outcome.text === "No goal to clear." ? ui("当前没有目标", "No active goal") : ui("目标已清除", "Goal cleared"));
-	if (action === "pause") return color.success(ui("目标已暂停", "Goal paused"));
-	if (action === "resume") return color.success(ui("目标已继续", "Goal resumed"));
-	if (action.startsWith("edit ")) return color.success(ui(`目标已更新：${args.slice(5).trim()}`, `Goal updated: ${args.slice(5).trim()}`));
-	if (args !== "") return color.success(ui(`目标已创建：${args}`, `Goal created: ${args}`));
-	if (node.outcome.text?.startsWith("No goal is currently set.") === true) return color.muted(ui("当前没有目标", "No active goal"));
-	const objective = /^Objective: (.*)$/mu.exec(node.outcome.text ?? "")?.[1];
-	const phase = /^Status: (\S+)$/mu.exec(node.outcome.text ?? "")?.[1];
-	const blocker = /^Blocker: (.*)$/mu.exec(node.outcome.text ?? "")?.[1];
-	const phaseLabel = phase === "active" ? ui("进行中", "In progress") : phase === "paused" ? ui("已暂停", "Paused") : phase === "blocked" ? ui("受阻", "Blocked") : phase === "complete" ? ui("已完成", "Completed") : void 0;
-	return [
-		objective === void 0 ? ui("当前目标", "Current goal") : ui(`目标：${objective}`, `Goal: ${objective}`),
-		...phaseLabel === void 0 ? [] : [ui(`状态：${phaseLabel}`, `Status: ${phaseLabel}`)],
-		...blocker === void 0 ? [] : [ui(`阻塞原因：${blocker}`, `Blocked by: ${blocker}`)]
-	].join("\n");
-}
-function contentText(content) {
-	return content.map(contentBlockText).join("\n").trim();
-}
-function contentRows(content) {
-	return content.flatMap((block$1) => {
-		if (typeof block$1 !== "object" || block$1 === null) return [{
-			format: "plain",
-			text: String(block$1)
-		}];
-		const value = block$1;
-		if (value.type === "text" && typeof value.text === "string") return value.text === "" ? [] : [{
-			format: "markdown",
-			text: value.text
-		}];
-		if (value.type === "image") {
-			const attachment = imageAttachment(value.attachment);
-			return attachment === void 0 ? [{
-				format: "plain",
-				text: color.warning(ui("[图片附件元数据无效]", "[invalid image attachment metadata]"))
-			}] : [imageRow(attachment)];
-		}
-		return [{
-			format: "plain",
-			text: contentBlockText(block$1)
-		}];
-	});
-}
-function userContentRows(content, steering = false) {
-	const rows = contentRows(content).map((row) => row.format === "markdown" ? {
-		...row,
-		format: "plain"
-	} : row);
-	const prefix = steering ? `${color.brand(">")} ${color.muted(ui("引导", "Steering"))} ` : `${color.brand(">")} `;
-	const first = rows[0];
-	if (first === void 0) return [{
-		format: "plain",
-		text: prefix.trimEnd(),
-		userTurn: true
-	}];
-	if (first.format === "image") return [{
-		format: "plain",
-		text: prefix.trimEnd(),
-		userTurn: true
-	}, ...rows];
-	return [{
-		...first,
-		text: `${prefix}${first.text}`,
-		userTurn: true
-	}, ...rows.slice(1)];
-}
-function assistantBlockText(block$1, preferences) {
-	switch (block$1.kind) {
-		case "text": return block$1.text;
-		case "reasoning": return preferences.reasoning ? color.muted(`${ui("思考", "Reasoning")}\n${block$1.text}`) : "";
-		case "image": return color.muted(ui("[图片附件]", "[image attachment]"));
-		case "tool-call":
-			if (preferences.tools === "hidden") return "";
-			return color.accent(`◆ ${block$1.name}${preferences.tools === "expanded" ? `\n${prettyArgs(block$1.argsRaw)}` : ""}`);
-		case "other": return color.muted(ui("模型扩展内容 · /trajectory 查看详情", "Extended model content · use /trajectory for details"));
-	}
-}
-function assistantBlockRows(block$1, preferences) {
-	switch (block$1.kind) {
-		case "text": return block$1.text === "" ? [] : [{
-			format: "markdown",
-			text: block$1.text
-		}];
-		case "reasoning":
-			if (!preferences.reasoning || block$1.text === "") return [];
-			return [{
-				format: "markdown",
-				text: `> **${ui("思考", "Reasoning")}**\n>\n${block$1.text.split("\n").map((line) => `> ${line}`).join("\n")}`
-			}];
-		case "image": return [imageRow(block$1.attachment)];
-		case "tool-call":
-			if (preferences.tools === "hidden") return [];
-			return [{
-				format: "plain",
-				text: color.accent(`◆ ${block$1.name}`)
-			}, ...preferences.tools === "expanded" ? [{
-				format: "code",
-				text: prettyArgs(block$1.argsRaw),
-				language: "json"
-			}] : []];
-		case "other": return [{
-			format: "plain",
-			text: color.muted(ui("模型扩展内容 · /trajectory 查看详情", "Extended model content · use /trajectory for details"))
-		}];
-	}
-}
-function prettyArgs(argsRaw) {
-	try {
-		return jsonText(JSON.parse(argsRaw));
-	} catch {
-		return argsRaw;
-	}
-}
-function contentLines(text) {
-	return splitDiffLines(text);
-}
-function diffText(value) {
-	if (!Array.isArray(value) || value.length === 0) return jsonText(value);
-	const rows = [];
-	const paths = /* @__PURE__ */ new Set();
-	let added = 0;
-	let removed = 0;
-	for (const item of value) {
-		if (typeof item !== "object" || item === null) return jsonText(value);
-		const { path: path$1, oldText, newText } = item;
-		if (typeof path$1 !== "string" || oldText !== null && typeof oldText !== "string" || typeof newText !== "string") return jsonText(value);
-		paths.add(path$1);
-		rows.push(`diff -- ${path$1}`);
-		rows.push(oldText === null ? "--- /dev/null" : `--- a/${path$1}`);
-		rows.push(`+++ b/${path$1}`);
-		const previous = oldText === null ? [] : contentLines(oldText);
-		const next = contentLines(newText);
-		for (const line of unifiedHunks(previous, next)) {
-			if (line.startsWith("+")) added += 1;
-			else if (line.startsWith("-")) removed += 1;
-			rows.push(line);
-		}
-	}
-	const visible = rows.length <= 80 ? rows : [
-		...rows.slice(0, 40),
-		ui(`@@ … 省略 ${rows.length - 80} 行 … @@`, `@@ … ${rows.length - 80} lines omitted … @@`),
-		...rows.slice(-40)
-	];
-	visible.push(ui(`# +${added} -${removed} · ${paths.size} 个文件`, `# +${added} -${removed} · ${paths.size} file(s)`));
-	return visible.join("\n");
-}
-const PRODUCT_TOOL_TITLES = {
-	ask_user_question: ["向用户提问", "Ask user"],
-	create_goal: ["创建目标", "Create goal"],
-	exit_plan_mode: ["计划审查", "Plan review"],
-	get_goal: ["查看目标", "View goal"],
-	job_kill: ["停止后台任务", "Stop background job"],
-	job_list: ["查看后台任务", "View background jobs"],
-	job_output: ["读取后台任务", "Read background job"],
-	subagent: ["子 Agent", "Subagent"],
-	todo_write: ["更新任务清单", "Update task list"],
-	update_goal: ["更新目标", "Update goal"],
-	workflow: ["工作流", "Workflow"]
-};
-function toolTitle(node) {
-	const name$1 = "kind" in node ? node.call?.name : node.name;
-	const productTitle = name$1 === void 0 ? void 0 : PRODUCT_TOOL_TITLES[name$1];
-	if (productTitle !== void 0) return ui(productTitle[0], productTitle[1]);
-	const callView = node.callView;
-	if (callView?.card === "terminal") {
-		const description = callView.description?.trim();
-		return description === void 0 || description === "" ? ui("执行 Shell 指令", "Run shell command") : description;
-	}
-	if ("kind" in node) return node.resultView?.title ?? node.callView?.title ?? node.call?.name ?? node.callId;
-	return node.callView?.title ?? node.name;
-}
-function settledToolFailed(node) {
-	if (node.isError) return true;
-	const result = node.resultView;
-	return result?.card === "terminal" && (result.exitCode !== void 0 && result.exitCode !== 0 || result.signal !== void 0);
-}
-function contentDetails(content) {
-	return content.flatMap((block$1) => {
-		if (typeof block$1 !== "object" || block$1 === null) return [{
-			kind: "plain",
-			text: String(block$1)
-		}];
-		const value = block$1;
-		if ((value.type === "text" || value.type === "reasoning") && typeof value.text === "string") return value.text === "" ? [] : [{
-			kind: "markdown",
-			text: value.text
-		}];
-		return [{
-			kind: "plain",
-			text: contentBlockText(block$1)
-		}];
-	});
-}
-function invocationCode(name$1, value) {
-	return {
-		kind: "code",
-		text: `${name$1}(${typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length === 0 ? "" : jsonText(value)})`,
-		language: "typescript"
-	};
-}
-function toolInvocationDetail(name$1, argsRaw) {
-	try {
-		return invocationCode(name$1, JSON.parse(argsRaw));
-	} catch {
-		return {
-			kind: "code",
-			text: `${name$1}(${argsRaw})`,
-			language: "typescript"
-		};
-	}
-}
-function fallbackInvocationDetail(value) {
-	return invocationCode("tool", value);
-}
-function terminalCommandDetail(value) {
-	if (typeof value !== "object" || value === null) return void 0;
-	const view = value;
-	if (view.card !== "terminal" || typeof view.title !== "string" || view.title === "") return void 0;
-	return {
-		kind: "code",
-		text: `$ ${view.title}`,
-		language: "bash"
-	};
-}
-function readInvocationFallback(node) {
-	const result = node.resultView;
-	if (result?.card === "read") return invocationCode("read", { file_path: String(result.path) });
-	const call = node.callView;
-	if (call?.card !== "generic" || call.kind !== "read") return void 0;
-	const location$1 = (Array.isArray(call.locations) ? call.locations : []).find((candidate) => typeof candidate === "object" && candidate !== null && "path" in candidate && typeof candidate.path === "string" && candidate.path !== "");
-	return location$1 === void 0 ? void 0 : invocationCode("read", { file_path: location$1.path });
-}
-function settledInvocationDetails(node) {
-	const call = node.callView;
-	const details = [];
-	if (call?.card === "terminal") {
-		const command = terminalCommandDetail(call);
-		if (command !== void 0) details.push(command);
-	} else if (call?.card === "diff") details.push({
-		kind: "code",
-		text: diffText(call.diffs),
-		language: "diff"
-	});
-	else if (node.call !== null) details.push(toolInvocationDetail(node.call.name, node.call.argsRaw));
-	else if (call?.card === "generic" && call.rawInput !== void 0) details.push(fallbackInvocationDetail(call.rawInput));
-	const readFallback = details.length === 0 ? readInvocationFallback(node) : void 0;
-	if (readFallback !== void 0) details.push(readFallback);
-	return details;
-}
-function viewDetails(node) {
-	const result = node.resultView;
-	const details = settledInvocationDetails(node);
-	if (result?.card === "terminal") {
-		if (result.output !== void 0) details.push({
-			kind: "plain",
-			text: result.output
-		});
-		if (result.exitCode !== void 0) details.push({
-			kind: "plain",
-			text: ui(`退出码 ${result.exitCode}`, `Exit code ${result.exitCode}`)
-		});
-		if (result.signal !== void 0) details.push({
-			kind: "plain",
-			text: ui(`信号 ${result.signal}`, `Signal ${result.signal}`)
-		});
-	} else if (result?.card === "diff") details.push({
-		kind: "code",
-		text: diffText(result.diffs),
-		language: "diff"
-	});
-	else if (result?.card === "generic" && result.content !== void 0) details.push(...contentDetails(result.content));
-	else if (result?.card === "read") {
-		const lines = result.lines;
-		const path$1 = String(result.path);
-		const language = syntaxLanguageForPath(path$1, typeof result.lang === "string" ? result.lang : void 0);
-		const first = lines[0]?.number ?? Number(result.offset);
-		const last = lines.at(-1)?.number ?? first;
-		details.push({
-			kind: "code",
-			text: lines.map((line) => line.text).join("\n"),
-			...language === void 0 ? {} : { language },
-			caption: `${path$1} · ${String(first)}–${String(last)} / ${String(result.totalLines)}`,
-			lineNumbers: lines.map((line) => line.number)
-		});
-	} else if (result?.card === "search" && result.shape === "matches") {
-		const files = result.files;
-		for (const file of files) {
-			const language = syntaxLanguageForPath(file.path);
-			details.push({
-				kind: "code",
-				text: file.matches.map((match) => match.line).join("\n"),
-				...language === void 0 ? {} : { language },
-				caption: file.path,
-				lineNumbers: file.matches.map((match) => match.lineNumber)
-			});
-		}
-		if (result.truncated) details.push({
-			kind: "plain",
-			text: ui(`只显示部分结果 · 共 ${String(result.total)} 项`, `Partial results · ${String(result.total)} item(s) total`)
-		});
-	} else if (result?.card === "search") {
-		details.push({
-			kind: "plain",
-			text: result.paths.join("\n")
-		});
-		if (result.truncated) details.push({
-			kind: "plain",
-			text: ui(`只显示部分结果 · 共 ${String(result.total)} 项`, `Partial results · ${String(result.total)} item(s) total`)
-		});
-	} else if (result?.card === "web" && result.kind === "search") {
-		if (result.answer !== void 0) details.push({
-			kind: "markdown",
-			text: result.answer
-		});
-		const sources = result.sources;
-		details.push(...sources.map((source) => ({
-			kind: "plain",
-			text: `${source.title ?? source.url}\n${source.url}${source.snippet === void 0 ? "" : `\n${source.snippet}`}`
-		})));
-		if (result.truncated) details.push({
-			kind: "plain",
-			text: ui("来源列表已截断", "Source list truncated")
-		});
-	} else if (result?.card === "web") {
-		details.push({
-			kind: "plain",
-			text: `${result.statusCode} · ${result.url}${result.truncated ? ui(" · 内容已截断", " · content truncated") : ""}`
-		});
-		details.push(...contentDetails(node.content));
-	} else if (result?.card === "generic") details.push(...contentDetails(node.content));
-	else details.push(...contentDetails(node.content));
-	if (node.meta !== void 0) details.push({
-		kind: "code",
-		text: jsonText(node.meta),
-		language: "json",
-		caption: ui("元数据", "Metadata")
-	});
-	return details.filter((value) => value.text !== "");
-}
-function runningViewDetails(node) {
-	const view = node.callView;
-	if (view?.card === "terminal") {
-		const command = terminalCommandDetail(view);
-		return command === void 0 ? [] : [command];
-	}
-	if (view?.card === "diff") return [{
-		kind: "code",
-		text: diffText(view.diffs),
-		language: "diff"
-	}];
-	return [toolInvocationDetail(node.name, node.argsRaw)];
-}
-function detailRow(detail, depth) {
-	if (detail.kind === "plain") return {
-		format: "plain",
-		text: detail.text
-	};
-	if (detail.kind === "markdown") return {
-		format: "markdown",
-		text: detail.text
-	};
-	return {
-		format: "code",
-		text: detail.text,
-		...detail.language === void 0 ? {} : { language: detail.language },
-		...detail.caption === void 0 ? {} : { caption: detail.caption },
-		...detail.lineNumbers === void 0 ? {} : { lineNumbers: detail.lineNumbers },
-		prefix: `${"  ".repeat(depth + 1)}⎿  `
-	};
-}
-function toolBlockRows(block$1, preferences, depth) {
-	const prefix = depth === 0 ? "◆ " : `${"  ".repeat(depth)}↳ `;
-	if ("kind" in block$1) {
-		const duration = block$1.callTime === null ? "" : ` · ${toolDurationText(Math.max(0, block$1.time - block$1.callTime))}`;
-		const failed = settledToolFailed(block$1);
-		const details$1 = preferences.tools === "expanded" ? viewDetails(block$1) : settledInvocationDetails(block$1);
-		return [
-			{
-				format: "plain",
-				text: `${prefix}${color.accent(toolTitle(block$1))}${failed ? ` · ${color.danger(ui("失败", "Failed"))}` : ""}${duration}`
-			},
-			...details$1.map((detail) => detailRow(detail, depth)),
-			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
-		];
-	}
-	const details = runningViewDetails(block$1);
-	return [
-		{
-			format: "plain",
-			text: `${prefix}${color.accent(toolTitle(block$1))}`,
-			pulse: "marker",
-			liveDurationSince: block$1.time
-		},
-		...details.map((detail) => detailRow(detail, depth)),
-		...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
-	];
-}
-function toolBlockText(block$1, preferences, depth) {
-	return toolBlockRows(block$1, preferences, depth).map((row) => row.format === "image" ? imageLabel(row.attachment) : row.text).join("\n");
-}
-function nodeText(node, preferences) {
-	switch (node.kind) {
-		case "user": return `${color.brand(">")} ${contentText(node.content)}`;
-		case "steering": return `${color.brand(">")} ${color.muted(ui("引导", "Steering"))} ${contentText(node.content)}`;
-		case "context": return `${color.muted(`${node.provenance.role === "recall" ? ui("召回", "Recall") : ui("上下文", "Context")}${node.provenance.label === null ? "" : ` · ${node.provenance.label}`}${node.form === null ? ui(" · 未知格式", " · unknown format") : ` · ${node.form}`}`)}\n${contentText(node.content)}`;
-		case "assistant": return `${node.blocks.map((block$1) => assistantBlockText(block$1, preferences)).filter(Boolean).join("\n")}${node.interrupted === true ? color.warning(ui("\n已停止", "\nStopped")) : ""}`;
-		case "command": return permissionCommandText(node) ?? planCommandText(node) ?? goalCommandText(node) ?? (node.outcome === null ? color.warning(ui(`命令 /${node.name ?? "unknown"}${node.args ?? ""} · 执行中`, `Command /${node.name ?? "unknown"}${node.args ?? ""} · running`)) : `${node.outcome.kind === "success" ? color.success(ui("命令完成", "Command completed")) : color.danger(ui("命令失败", "Command failed"))} /${node.name ?? "unknown"}${node.args ?? ""}${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`);
-		case "tool-result": return preferences.tools === "hidden" ? "" : toolBlockText(node, preferences, 0);
-		case "compaction": return color.muted(ui(`上下文已压缩${node.shadowedItemCount === null ? "" : ` · ${node.shadowedItemCount} 项`}${node.shadowedTokenCount === null ? "" : ` · 约 ${node.shadowedTokenCount} Token`}${node.summary === null ? "" : `\n${node.summary}`}`, `Context compacted${node.shadowedItemCount === null ? "" : ` · ${node.shadowedItemCount} item(s)`}${node.shadowedTokenCount === null ? "" : ` · about ${node.shadowedTokenCount} tokens`}${node.summary === null ? "" : `\n${node.summary}`}`));
-		case "model-retry": return color.warning(ui(`模型请求${node.retryState === "scheduled" ? "等待重试" : node.retryState === "started" ? "正在重试" : "重试已取消"} · ${node.provider} · 第 ${node.retry} 次${node.mode === "normal" ? `/${node.maxRetries}` : ""} · ${node.delayMs} ms`, `Model request ${node.retryState === "scheduled" ? "waiting to retry" : node.retryState === "started" ? "retrying" : "retry cancelled"} · ${node.provider} · attempt ${node.retry}${node.mode === "normal" ? `/${node.maxRetries}` : ""} · ${node.delayMs} ms`));
-		case "turn-error": return color.danger(ui(`本轮执行失败${node.code === void 0 ? "" : ` [${node.code}]`}\n${node.message}`, `Turn failed${node.code === void 0 ? "" : ` [${node.code}]`}\n${node.message}`));
-		case "turn-max-tokens": return color.warning(ui("本轮已达到最大 Token 数", "This turn reached the token limit"));
-		case "unknown": return color.muted(ui(`未知事件 ${node.type} · /trajectory 查看详情`, `Unknown event ${node.type} · use /trajectory for details`));
-		default: return color.muted(ui("未知会话事件 · /trajectory 查看详情", "Unknown session event · use /trajectory for details"));
-	}
-}
-function textProperty(value) {
-	if (typeof value !== "object" || value === null || !("text" in value)) return void 0;
-	return typeof value.text === "string" ? value.text : void 0;
-}
-const CONVERSATION_KINDS = new Set([
-	"user",
-	"assistant",
-	"steering",
-	"context",
-	"model-retry",
-	"turn-error",
-	"turn-max-tokens",
-	"tool-result",
-	"command",
-	"compaction",
-	"unknown"
-]);
-function isConversationNode(value) {
-	return typeof value === "object" && value !== null && "kind" in value && typeof value.kind === "string" && CONVERSATION_KINDS.has(value.kind);
-}
-function workflowStatusLabel(status) {
-	switch (status) {
-		case "running": return ui("运行中", "Running");
-		case "completed": return ui("已完成", "Completed");
-		case "failed": return ui("失败", "Failed");
-		case "cancelled": return ui("已取消", "Cancelled");
-		case "interrupted": return ui("已中断", "Interrupted");
-		default: return escapeTerminalText(status);
-	}
-}
-function workflowStatusText(status) {
-	const label = workflowStatusLabel(status);
-	switch (status) {
-		case "completed": return color.success(label);
-		case "failed": return color.danger(label);
-		case "cancelled":
-		case "interrupted": return color.warning(label);
-		case "running": return color.accent(label);
-		default: return color.muted(label);
-	}
-}
-function workflowMemberLabel(member) {
-	const safe = escapeTerminalText(member.label.trim());
-	if (safe === "") return ui(`成员 ${member.seq}`, `Member ${member.seq}`);
-	const generated = /^agent-([a-z0-9]+)$/iu.exec(safe);
-	return generated === null ? safe : `Agent ${generated[1] ?? String(member.seq)}`;
-}
-function workflowText(value) {
-	if (typeof value !== "object" || value === null) return void 0;
-	const workflow = value;
-	if (typeof workflow.name !== "string" || typeof workflow.status !== "string" || !Array.isArray(workflow.phases)) return;
-	const rows = workflow.phases.flatMap((phase) => {
-		const phaseLabel = phase.phase === null ? void 0 : escapeTerminalText(phase.phase.trim()) || ui("未命名阶段", "Unnamed phase");
-		const members = phase.members.map((member) => `    ${workflowStatusText(member.status)} · ${workflowMemberLabel(member)}`);
-		return phaseLabel === void 0 ? members.map((row) => row.slice(2)) : [`  ${color.muted(phaseLabel)}`, ...members];
-	});
-	const name$1 = escapeTerminalText(workflow.name);
-	return `${color.accent(ui(`工作流 · ${name$1}`, `Workflow · ${name$1}`))} · ${workflowStatusText(workflow.status)}${rows.length === 0 ? "" : `\n${rows.join("\n")}`}`;
-}
-function deliverablesText(node, data) {
-	if (!isConversationNode(data) || data.kind !== "assistant") return "";
-	const location$1 = node.location;
-	if (location$1.kind !== "turn" && location$1.kind !== "step") return "";
-	const produced = producedForClosing(location$1.turn.data.get("deliverables"), data.seq);
-	return produced.length === 0 ? "" : `\n${color.success(ui(`生成文件 · ${produced.join(" · ")}`, `Produced files · ${produced.join(" · ")}`))}`;
-}
-function grouped(rows) {
-	return rows.map((row, index) => index === 0 ? {
-		...row,
-		gapBefore: true
-	} : row);
-}
-function nonnegativeNumber(value) {
-	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : void 0;
-}
-function durationText(milliseconds) {
-	const seconds = milliseconds / 1e3;
-	if (seconds < 60) return `${String(Math.round(seconds * 10) / 10)}s`;
-	const whole = Math.round(seconds);
-	return `${String(Math.floor(whole / 60))}m${String(whole % 60)}s`;
-}
-function toolDurationText(milliseconds) {
-	if (milliseconds <= 0) return "<1ms";
-	if (milliseconds < 1e3) return `${String(Math.round(milliseconds))}ms`;
-	return durationText(milliseconds);
-}
-function tokenText(value) {
-	const scaled = (number) => number >= 100 ? String(Math.round(number)) : String(Math.round(number * 10) / 10);
-	if (value < 1e3) return String(Math.round(value));
-	if (value < 1e6) return `${scaled(value / 1e3)}K`;
-	return `${scaled(value / 1e6)}M`;
-}
-function recordOf(value) {
-	return typeof value === "object" && value !== null ? value : void 0;
-}
-/** Render Grok-style groups from the engine-owned completed-Turn footer. */
-function turnTailText(data) {
-	const value = recordOf(data);
-	if (value === void 0) return "";
-	const statistics = recordOf(value.statistics);
-	const usage = recordOf(value.usage);
-	const groups = [];
-	const steps = nonnegativeNumber(statistics?.steps);
-	if (steps !== void 0 && steps > 0) groups.push(ui(`1 轮 · ${tokenText(steps)} 步`, `1 turn · ${tokenText(steps)} steps`));
-	const llmMs = nonnegativeNumber(statistics?.llmMs);
-	const toolMs = nonnegativeNumber(statistics?.toolMs);
-	const durations = [...llmMs === void 0 || llmMs === 0 ? [] : [`LLM ${durationText(llmMs)}`], ...toolMs === void 0 || toolMs === 0 ? [] : [ui(`工具调用 ${durationText(toolMs)}`, `Tools ${durationText(toolMs)}`)]];
-	if (durations.length > 0) groups.push(durations.join(" · "));
-	const ttftMs = nonnegativeNumber(statistics?.ttftMs);
-	const ttftSteps = nonnegativeNumber(statistics?.ttftSteps);
-	const decodeMs = nonnegativeNumber(statistics?.decodeMs);
-	const decodeTokens = nonnegativeNumber(statistics?.decodeTokens);
-	const performance$1 = [...ttftMs === void 0 || ttftSteps === void 0 || ttftSteps === 0 ? [] : [ui(`首 token 平均 ${durationText(ttftMs / ttftSteps)}`, `Average first token ${durationText(ttftMs / ttftSteps)}`)], ...decodeMs === void 0 || decodeTokens === void 0 || decodeMs === 0 ? [] : [`${String(Math.round(decodeTokens / (decodeMs / 1e3) * 10) / 10)} tok/s`]];
-	if (performance$1.length > 0) groups.push(performance$1.join(" · "));
-	const uncached = nonnegativeNumber(usage?.uncachedInputTokens);
-	const cacheRead = nonnegativeNumber(usage?.cacheReadTokens);
-	const cacheWrite = nonnegativeNumber(usage?.cacheWriteTokens);
-	const output = nonnegativeNumber(usage?.outputTokens);
-	if (uncached !== void 0 && cacheRead !== void 0 && cacheWrite !== void 0 && output !== void 0) {
-		const input = uncached + cacheRead + cacheWrite;
-		if (input > 0) groups.push(ui(`缓存命中 ${String(Math.round(cacheRead / input * 100))}%`, `Cache hit ${String(Math.round(cacheRead / input * 100))}%`));
-		if (input > 0 || output > 0) groups.push(ui(`输入 ${tokenText(input)} tok · 输出 ${tokenText(output)} tok`, `Input ${tokenText(input)} tok · output ${tokenText(output)} tok`));
-	}
-	if (groups.length > 0) return color.muted(groups.join("  |  "));
-	const legacy = [...nonnegativeNumber(value.ttftMs) === void 0 ? [] : [ui(`首 token ${durationText(nonnegativeNumber(value.ttftMs) ?? 0)}`, `First token ${durationText(nonnegativeNumber(value.ttftMs) ?? 0)}`)], ...nonnegativeNumber(value.tokensPerSecond) === void 0 ? [] : [`${String(Math.round((nonnegativeNumber(value.tokensPerSecond) ?? 0) * 10) / 10)} tok/s`]];
-	return legacy.length === 0 ? "" : color.muted(legacy.join(" · "));
-}
-function assistantStepData(data) {
-	if (typeof data !== "object" || data === null) return void 0;
-	const value = data;
-	return (value.status === "running" || value.status === "settled" || value.status === "interrupted") && Array.isArray(value.blocks) ? value : void 0;
-}
-function assistantStepRows(data, preferences) {
-	const step = assistantStepData(data);
-	if (step === void 0) return [];
-	const content = step.blocks.flatMap((block$1) => block$1.kind === "tool-call" ? [] : assistantBlockRows(block$1, preferences));
-	const hasFoldedReasoning = !preferences.reasoning && step.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "");
-	const hasAnswer = step.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "");
-	if (content.length === 0 && step.status === "settled" && !hasFoldedReasoning) return [];
-	const rows = [];
-	if (!hasAnswer && step.status === "running" && (hasFoldedReasoning || content.length === 0)) rows.push(thinkingRow());
-	rows.push(...content);
-	if (step.status === "interrupted") rows.push({
-		format: "plain",
-		text: color.warning(ui("已停止", "Stopped"))
-	});
-	return grouped(rows);
-}
-function toolChatData(data) {
-	if (typeof data !== "object" || data === null || !("root" in data)) return void 0;
-	const root = data.root;
-	if (typeof root !== "object" || root === null || !("callId" in root) || typeof root.callId !== "string" || !("subCalls" in root) || !Array.isArray(root.subCalls)) return void 0;
-	return data;
-}
-function compactContextRows(node) {
-	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "kind" in node.source && node.source.kind === "plugin" && "plugin" in node.source && node.source.plugin === "plan-mode") return [];
-	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "kind" in node.source && node.source.kind === "plugin" && "plugin" in node.source && node.source.plugin === "tool-jobs") return grouped([{
-		format: "plain",
-		text: color.muted(ui("◆ 后台任务已结束", "◆ Background job finished"))
-	}]);
-	if (node.provenance.role === "recall") {
-		const source = node.provenance.label === null ? "" : ` · ${node.provenance.label}`;
-		return grouped([{
-			format: "plain",
-			text: color.muted(ui(`跨会话召回${source} · /trajectory 查看`, `Cross-session recall${source} · view with /trajectory`))
-		}]);
-	}
-	if (node.form === "notice" && typeof node.source === "object" && node.source !== null && "summary" in node.source && typeof node.source.summary === "string") return grouped([{
-		format: "plain",
-		text: color.muted(node.source.summary)
-	}]);
-	return [];
-}
-function subagentUserRows(node) {
-	if (typeof node.source !== "object" || node.source === null || !("kind" in node.source)) return void 0;
-	if (node.source.kind === "subagent-settled") return grouped([{
-		format: "plain",
-		text: color.muted(ui("◆ 子 Agent 已结束", "◆ Subagent finished")),
-		userTurn: true
-	}]);
-	if (node.source.kind !== "subagent-report") return void 0;
-	return grouped([{
-		format: "plain",
-		text: `${color.brand(">")} ${color.muted(ui("子 Agent 报告", "Subagent report"))}`,
-		userTurn: true
-	}, ...contentRows(node.content.slice(1))]);
-}
-function manualCompactionRows(data, preferences) {
-	if (typeof data !== "object" || data === null || !("command" in data)) return [];
-	const value = data;
-	const rows = [];
-	if (isConversationNode(value.command)) {
-		const command = nodeText(value.command, preferences);
-		if (command !== "") rows.push({
-			format: "plain",
-			text: command
-		});
-	}
-	if (isConversationNode(value.compaction)) {
-		const compaction = nodeText(value.compaction, preferences);
-		if (compaction !== "") rows.push({
-			format: "plain",
-			text: compaction
-		});
-	}
-	return grouped(rows);
-}
-function retryRows(data, preferences) {
-	if (typeof data !== "object" || data === null || !("current" in data)) return [];
-	const retry = data.current;
-	if (!isConversationNode(retry)) return [];
-	const rendered = nodeText(retry, preferences);
-	return rendered === "" ? [] : grouped([{
-		format: "plain",
-		text: rendered
-	}]);
-}
-function chatNodeRows(node, preferences) {
-	if (node.kind === "assistant-step") return assistantStepRows(node.data, preferences);
-	if (node.kind === "tool-call") {
-		if (preferences.tools === "hidden") return [];
-		const data = toolChatData(node.data);
-		return data === void 0 ? [] : grouped(toolBlockRows(data.root, preferences, 0));
-	}
-	if (node.kind === "manual-compaction") return manualCompactionRows(node.data, preferences);
-	if (node.kind === "model-retry") return retryRows(node.data, preferences);
-	if (isConversationNode(node.data)) {
-		if (node.data.kind === "user" || node.data.kind === "steering" || node.data.kind === "context") {
-			if (node.data.kind === "context") return compactContextRows(node.data);
-			if (node.data.kind === "user") {
-				const subagent = subagentUserRows(node.data);
-				if (subagent !== void 0) return subagent;
-			}
-			return grouped(userContentRows(node.data.content, node.data.kind === "steering"));
-		}
-		if (node.data.kind === "assistant") {
-			const rows = [...node.data.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences))];
-			if (node.data.interrupted === true) rows.push({
-				format: "plain",
-				text: color.warning(ui("已停止", "Stopped"))
-			});
-			const deliverables = deliverablesText(node, node.data);
-			if (deliverables !== "") rows.push({
-				format: "plain",
-				text: deliverables.trimStart()
-			});
-			return grouped(rows);
-		}
-		const text = nodeText(node.data, preferences);
-		return text === "" ? [] : grouped([{
-			format: "plain",
-			text
-		}]);
-	}
-	const commandInputText = node.kind === "command-input" ? textProperty(node.data) : void 0;
-	if (commandInputText !== void 0) return grouped([{
-		format: "plain",
-		text: `${color.brand(">")} ${commandInputText}`,
-		userTurn: true
-	}]);
-	if (node.kind === "workflow-run") {
-		const rendered = workflowText(node.data);
-		if (rendered !== void 0) return grouped([{
-			format: "plain",
-			text: rendered
-		}]);
-	}
-	if (node.kind === "turn-tail") {
-		const rendered = turnTailText(node.data);
-		return rendered === "" ? [] : [{
-			format: "plain",
-			text: rendered
-		}];
-	}
-	return grouped([{
-		format: "plain",
-		text: color.muted(ui(`扩展节点 ${node.kind} · /trajectory 查看详情`, `Extended node ${node.kind} · use /trajectory for details`))
-	}]);
-}
-/** Mutable pi-tui component backed only by the official conversation snapshot. */
-var Transcript = class {
-	components = [new Text("", 0, 0)];
-	rows = [];
-	imageComponents = /* @__PURE__ */ new Map();
-	pendingImages = /* @__PURE__ */ new Set();
-	imageGeneration = 0;
-	imageLoader;
-	snapshot;
-	emptyMessage = "在下方输入消息，或用 /help 查看命令。";
-	sessionId;
-	toolVisibility = "collapsed";
-	reasoningVisible = false;
-	emptyState = true;
-	hasMore = false;
-	loadingOlder = false;
-	scrollOffset = 0;
-	renderedLineCount = 0;
-	turnAnchors = [];
-	turnCursor;
-	pulseFrame = 0;
-	pulseTimer;
-	focused = false;
-	/**
-	* @param viewportRows - current terminal-dependent transcript height.
-	* @param requestRender - schedule a TUI frame after local presentation state changes.
-	* @param requestOlder - ask Harness for the preceding durable history page.
-	*/
-	constructor(viewportRows = () => Number.POSITIVE_INFINITY, requestRender = () => void 0, requestOlder = () => void 0) {
-		this.viewportRows = viewportRows;
-		this.requestRender = requestRender;
-		this.requestOlder = requestOlder;
-	}
-	/**
-	* Cycle folded → expanded → hidden without mutating the Harness log.
-	* @returns the newly active tool visibility.
-	*/
-	cycleToolVisibility() {
-		this.toolVisibility = this.toolVisibility === "collapsed" ? "expanded" : this.toolVisibility === "expanded" ? "hidden" : "collapsed";
-		return this.toolVisibility;
-	}
-	/**
-	* Toggle reasoning presentation without changing model request parameters.
-	* @returns whether reasoning is now visible.
-	*/
-	toggleReasoning() {
-		this.reasoningVisible = !this.reasoningVisible;
-		return this.reasoningVisible;
-	}
-	/** Follow new transcript output after the user submits from a historical viewport. */
-	followLatest() {
-		this.turnCursor = void 0;
-		this.scrollOffset = 0;
-		this.requestRender();
-	}
-	/**
-	* Report whether the transcript is showing non-durable empty-session guidance.
-	* @returns true while the conversation has no visible durable content.
-	*/
-	isEmptyState() {
-		return this.emptyState;
-	}
-	/**
-	* Replace the transcript with non-durable empty-selection guidance.
-	* @param message - guidance rendered when no Session is active.
-	*/
-	empty(message = "在下方输入消息，或用 /help 查看命令。") {
-		this.imageGeneration += 1;
-		this.imageLoader = void 0;
-		this.snapshot = void 0;
-		this.emptyMessage = message;
-		this.sessionId = void 0;
-		this.pendingImages.clear();
-		this.imageComponents.clear();
-		this.emptyState = true;
-		this.hasMore = false;
-		this.loadingOlder = false;
-		this.replace([{
-			format: "plain",
-			text: color.muted(translateUiText(message))
-		}]);
-	}
-	/**
-	* Replace the rendered snapshot after a Harness observable notification.
-	* @param snapshot - authoritative Session conversation projection.
-	* @param imageLoader - authenticated reader for references in this Session.
-	*/
-	update(snapshot, imageLoader) {
-		this.snapshot = snapshot;
-		const sessionId = String(snapshot.sessionId);
-		if (sessionId !== this.sessionId) {
-			this.imageGeneration += 1;
-			this.pendingImages.clear();
-			this.imageComponents.clear();
-			this.sessionId = sessionId;
-		}
-		this.imageLoader = imageLoader;
-		this.hasMore = snapshot.hasMore;
-		this.loadingOlder = snapshot.loadingOlder;
-		const preferences = {
-			tools: this.toolVisibility,
-			reasoning: this.reasoningVisible
-		};
-		const visibleNodes = snapshot.chat.order.flatMap((key) => {
-			const node = snapshot.chat.nodes.get(key);
-			return node === void 0 || node.visibility !== "visible" ? [] : [node];
-		});
-		const rows = visibleNodes.flatMap((node) => chatNodeRows(node, preferences));
-		if (snapshot.partial !== null && !visibleNodes.some((node) => node.kind === "assistant-step")) {
-			const partialRows = snapshot.partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences));
-			rows.push(...grouped([...partialRows.length === 0 ? [thinkingRow()] : [], ...partialRows]));
-		}
-		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0))));
-		this.emptyState = rows.length === 0;
-		if (this.emptyState) rows.push({
-			format: "plain",
-			text: `${color.brand("deepseek")}\n${color.muted(ui("探索未至之境", "Explore beyond the known"))}\n${color.muted(ui("直接描述你想完成的事", "Describe what you want to accomplish"))}`
-		});
-		this.replace(rows);
-	}
-	/**
-	* Rebuild colorized rows after a live theme or lazy grammar change.
-	* The current viewport and durable turn cursor remain unchanged.
-	*/
-	refreshPresentation() {
-		const scrollOffset = this.scrollOffset;
-		const turnCursor = this.turnCursor;
-		const snapshot = this.snapshot;
-		if (snapshot === void 0) this.replace([{
-			format: "plain",
-			text: color.muted(translateUiText(this.emptyMessage))
-		}]);
-		else this.update(snapshot, this.imageLoader);
-		this.scrollOffset = scrollOffset;
-		this.turnCursor = turnCursor;
-		this.requestRender();
-	}
-	invalidate() {
-		for (const component of this.components) component.invalidate();
-	}
-	/** Stop pending attachment presentation updates during terminal teardown. */
-	dispose() {
-		this.stopPulseAnimation();
-		this.imageGeneration += 1;
-		this.imageLoader = void 0;
-		this.pendingImages.clear();
-		this.imageComponents.clear();
-	}
-	render(width) {
-		const inset = width >= 12 ? 2 : 0;
-		const contentWidth = Math.max(1, width - inset * 2);
-		const withInset = (values) => values.map((line) => line === "" ? "" : `${" ".repeat(inset)}${line}`);
-		const olderMarker = (count) => {
-			if (this.loadingOlder) return color.muted(ui("↑ 正在加载更早内容…", "↑ Loading older content…"));
-			const hint = this.focused ? "PgUp/Home" : ui("滚轮上翻", "Scroll up");
-			return color.muted(count === 0 ? ui(`↑ 还有更早内容 · ${hint}`, `↑ Older content available · ${hint}`) : ui(`↑ ${String(count)} 行更早内容 · ${hint}`, `↑ ${String(count)} older line(s) · ${hint}`));
-		};
-		const lines = [];
-		const anchors = [];
-		for (const [index, component] of this.components.entries()) {
-			if (lines.length > 0 && this.rows[index]?.gapBefore === true) lines.push("");
-			if (this.rows[index]?.userTurn === true) anchors.push(lines.length);
-			const row = this.rows[index];
-			const rendered = component.render(contentWidth);
-			const escaped = row?.format === "image" ? rendered : rendered.map(escapeTerminalText);
-			lines.push(...escaped);
-		}
-		if (this.emptyState) for (const [index, line] of lines.entries()) {
-			if (line === "") continue;
-			const content = line.trimEnd();
-			lines[index] = `${" ".repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`;
-		}
-		this.renderedLineCount = lines.length;
-		this.turnAnchors = anchors;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		if (!Number.isFinite(rows)) {
-			this.scrollOffset = 0;
-			return withInset(lines);
-		}
-		if (lines.length <= rows) {
-			this.scrollOffset = 0;
-			const remaining = rows - lines.length;
-			if (!this.emptyState && this.hasMore) {
-				if (remaining === 0) {
-					const visible$1 = [...lines];
-					visible$1[0] = olderMarker(0);
-					return withInset(visible$1);
-				}
-				return withInset([
-					...Array.from({ length: remaining - 1 }, () => ""),
-					olderMarker(0),
-					...lines
-				]);
-			}
-			const before = this.emptyState ? Math.floor(remaining / 2) : remaining;
-			return withInset([
-				...Array.from({ length: before }, () => ""),
-				...lines,
-				...Array.from({ length: remaining - before }, () => "")
-			]);
-		}
-		const maxOffset = Math.max(0, lines.length - rows);
-		this.scrollOffset = Math.min(this.scrollOffset, maxOffset);
-		const end = lines.length - this.scrollOffset;
-		const start = Math.max(0, end - rows);
-		if (this.scrollOffset === 0 && start > 0) {
-			const alignedStart = this.turnAnchors.find((anchor) => anchor >= start && end - anchor <= rows - 1);
-			if (alignedStart !== void 0) {
-				const latestTurnRows = lines.slice(alignedStart, end);
-				return withInset([
-					...Array.from({ length: rows - latestTurnRows.length - 1 }, () => ""),
-					olderMarker(alignedStart),
-					...latestTurnRows
-				]);
-			}
-		}
-		const visible = lines.slice(start, end);
-		if (start > 0 && visible.length > 0) visible[0] = olderMarker(start);
-		else if (this.hasMore && visible.length > 0) visible[0] = olderMarker(0);
-		if (end < lines.length && visible.length > 0) {
-			const hint = this.focused ? "PgDn/End" : ui("滚轮下翻", "Scroll down");
-			visible[visible.length - 1] = color.muted(ui(`↓ ${String(lines.length - end)} 行更新内容 · ${hint}`, `↓ ${String(lines.length - end)} newer line(s) · ${hint}`));
-		}
-		return withInset(visible);
-	}
-	handleInput(data) {
-		this.turnCursor = void 0;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		const maxOffset = Math.max(0, this.renderedLineCount - rows);
-		if (matchesKey(data, Key.up)) this.scrollBy(1);
-		else if (matchesKey(data, Key.down)) this.scrollBy(-1);
-		else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1));
-		else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
-		else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
-		else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset);
-	}
-	/**
-	* Move the conversation viewport while leaving the composer focus unchanged.
-	* @param lines - positive for older content, negative for newer content.
-	* @returns whether the viewport moved.
-	*/
-	scrollBy(lines) {
-		this.turnCursor = void 0;
-		const delta = Math.trunc(lines);
-		if (!Number.isFinite(delta) || delta === 0) return false;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		const maxOffset = Math.max(0, this.renderedLineCount - rows);
-		const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + delta));
-		if (nextOffset === this.scrollOffset) {
-			if (delta > 0 && this.scrollOffset === maxOffset && this.hasMore && !this.loadingOlder) this.requestOlder();
-			return false;
-		}
-		this.scrollOffset = nextOffset;
-		this.requestRender();
-		return true;
-	}
-	/**
-	* Move the viewport to an adjacent durable user-turn anchor.
-	* @param offset - negative for an older turn, positive for a newer turn.
-	* @returns whether an adjacent turn exists and was selected.
-	*/
-	navigateTurn(offset) {
-		if (offset === 0 || this.turnAnchors.length === 0) return false;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		const viewportTop = Math.max(0, this.renderedLineCount - this.scrollOffset - rows);
-		const viewportEnd = Math.min(this.renderedLineCount, viewportTop + rows);
-		const index = this.turnCursor === void 0 ? offset < 0 ? this.turnAnchors.findLastIndex((candidate) => candidate < viewportEnd) : this.turnAnchors.findIndex((candidate) => candidate > viewportTop) : this.turnCursor + Math.sign(offset);
-		const anchor = this.turnAnchors[index];
-		if (anchor === void 0) return false;
-		this.turnCursor = index;
-		this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows));
-		this.requestRender();
-		return true;
-	}
-	replace(rows) {
-		this.rows = rows;
-		this.turnCursor = void 0;
-		this.components = rows.map((row) => this.component(row));
-		this.syncPulseAnimation(rows.some((row) => row.liveDurationSince !== void 0 || row.pulse !== void 0 && terminalColorLevel() !== 0));
-	}
-	component(row) {
-		if (row.format === "markdown") return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme);
-		if (row.format === "plain") return row.pulse === void 0 ? new Text(escapeTerminalText(row.text), 0, 0) : new PulsingRow(row.text, row.pulse, () => this.pulseFrame, row.liveDurationSince);
-		if (row.format === "code") return new CodeRow(row);
-		const cacheKey = `${this.sessionId ?? "none"}:${row.key}`;
-		const cached = this.imageComponents.get(cacheKey);
-		if (cached !== void 0) return cached;
-		const fallback = new Text(color.muted(imageLabel(row.attachment)), 0, 0);
-		const loader = this.imageLoader;
-		if (loader === void 0 || this.pendingImages.has(cacheKey)) return fallback;
-		this.pendingImages.add(cacheKey);
-		const generation = this.imageGeneration;
-		loader(row.attachment).then((payload) => {
-			if (generation !== this.imageGeneration) return;
-			const attachment = payload.attachment;
-			this.imageComponents.set(cacheKey, new Image(payload.data, attachment.mediaType, { fallbackColor: (value) => color.muted(value) }, {
-				maxWidthCells: 60,
-				maxHeightCells: 20,
-				filename: escapeTerminalText(attachment.name ?? String(attachment.attachmentId))
-			}, {
-				widthPx: attachment.width,
-				heightPx: attachment.height
-			}));
-		}, (error) => {
-			if (generation !== this.imageGeneration) return;
-			const message = error instanceof Error ? error.message : String(error);
-			this.imageComponents.set(cacheKey, new Text(color.danger(ui(`${imageLabel(row.attachment)} · 读取失败：${message}`, `${imageLabel(row.attachment)} · failed to load: ${message}`)), 0, 0));
-		}).finally(() => {
-			if (generation !== this.imageGeneration) return;
-			this.pendingImages.delete(cacheKey);
-			this.components = this.rows.map((current) => this.component(current));
-			this.requestRender();
-		});
-		return fallback;
-	}
-	syncPulseAnimation(active) {
-		if (!active) {
-			this.stopPulseAnimation();
-			return;
-		}
-		if (this.pulseTimer !== void 0) return;
-		this.pulseFrame = 0;
-		this.pulseTimer = setInterval(() => {
-			this.pulseFrame = this.pulseFrame === Number.MAX_SAFE_INTEGER ? 0 : this.pulseFrame + 1;
-			this.requestRender();
-		}, PULSE_FRAME_MS);
-		this.pulseTimer.unref();
-	}
-	stopPulseAnimation() {
-		if (this.pulseTimer !== void 0) clearInterval(this.pulseTimer);
-		this.pulseTimer = void 0;
-		this.pulseFrame = 0;
 	}
 };
 

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -53,6 +53,8 @@ import {
   type TuiSettingsField,
 } from './settings.ts'
 import type { Transcript } from './transcript.ts'
+import { toolApprovalPreview } from './transcript.ts'
+import { composeApprovalDetail } from './approval-preview.ts'
 import {
   appearanceFromSettings,
   appearanceSettings,
@@ -3058,19 +3060,43 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
   }
 
   private async approval(wait: PendingWait<'approval'>): Promise<void> {
-    const selected = await this.host.overlays.select({
-      title: `工具审批 · ${wait.payload.toolName}`,
-      detail: wait.payload.reason ?? `调用 ${wait.payload.callId ?? wait.payload.approvalId}`,
-      searchable: false,
-      choices: [
-        { id: 'allow', label: '仅本次允许', description: '只允许这一次工具调用' },
-        { id: 'reject', label: '拒绝', description: '本次工具调用不会执行' },
-      ],
-      footer: 'Enter 确认 · Esc 安全拒绝',
-      options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
+    const snapshot = this.capabilities.active()?.session.getSnapshot()
+    const call = snapshot?.runningCalls?.find(candidate => candidate.callId === wait.payload.callId)
+    const composed = composeApprovalDetail({
+      ...(wait.payload.reason === undefined ? {} : { reason: wait.payload.reason }),
+      ...(wait.payload.callId === undefined ? {} : { callId: String(wait.payload.callId) }),
+      approvalId: String(wait.payload.approvalId),
+      preview: toolApprovalPreview(call),
     })
-    this.host.transcript.followLatest()
-    await this.capabilities.answerApproval(wait, selected?.id === 'allow' ? 'allowed-once' : 'rejected')
+    while (true) {
+      const selected = await this.host.overlays.select({
+        title: `工具审批 · ${wait.payload.toolName}`,
+        detail: composed.detail,
+        searchable: false,
+        choices: [
+          { id: 'allow', label: '仅本次允许', description: '只允许这一次工具调用' },
+          { id: 'reject', label: '拒绝', description: '本次工具调用不会执行' },
+          ...(composed.full === undefined ? [] : [{
+            id: 'inspect',
+            label: ui('查看完整参数', 'View full arguments'),
+            description: ui('打开只读子页，不批准也不拒绝', 'Open a read-only page; does not approve or reject'),
+          }]),
+        ],
+        footer: 'Enter 确认 · Esc 安全拒绝',
+        options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
+      })
+      if (selected?.id === 'inspect' && composed.full !== undefined) {
+        await this.host.overlays.detail({
+          title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
+          content: composed.full,
+          options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+        })
+        continue
+      }
+      this.host.transcript.followLatest()
+      await this.capabilities.answerApproval(wait, selected?.id === 'allow' ? 'allowed-once' : 'rejected')
+      return
+    }
   }
 
   private async question(wait: PendingWait<'question'>): Promise<void> {

--- a/src/client/approval-preview.ts
+++ b/src/client/approval-preview.ts
@@ -1,0 +1,23 @@
+/** Approval overlay copy: visible command/diff plus a full-parameter subpage when truncated. */
+
+export const APPROVAL_DETAIL_MAX_LINES = 16
+export const APPROVAL_DETAIL_MAX_CHARS = 1_200
+
+export function composeApprovalDetail(options: {
+  readonly reason?: string
+  readonly callId?: string
+  readonly approvalId?: string
+  readonly preview: string
+}): { readonly detail: string; readonly full?: string } {
+  const fallback = `调用 ${options.callId ?? options.approvalId ?? 'unknown'}`
+  const parts = [options.reason?.trim(), options.preview.trim()].filter(part => part !== undefined && part !== '')
+  const full = parts.length === 0 ? fallback : parts.join('\n\n')
+  const lines = full.split('\n')
+  if (lines.length <= APPROVAL_DETAIL_MAX_LINES && full.length <= APPROVAL_DETAIL_MAX_CHARS) {
+    return { detail: full }
+  }
+  return {
+    detail: `${lines.slice(0, APPROVAL_DETAIL_MAX_LINES).join('\n')}\n…`,
+    full,
+  }
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -627,6 +627,12 @@ function runningViewDetails(node: RunningToolCall): ToolDetail[] {
   return [toolInvocationDetail(node.name, node.argsRaw)]
 }
 
+/** Flatten the same tool preview the transcript uses so approval overlays are not blind. */
+export function toolApprovalPreview(call: RunningToolCall | undefined): string {
+  if (call === undefined) return ''
+  return runningViewDetails(call).map(detail => detail.text).filter(text => text !== '').join('\n')
+}
+
 function detailRow(detail: ToolDetail, depth: number): TranscriptRow {
   if (detail.kind === 'plain') return { format: 'plain', text: detail.text }
   if (detail.kind === 'markdown') return { format: 'markdown', text: detail.text }

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -75,4 +75,45 @@ describe('pending interaction continuation', () => {
       answers: [{ id: 'which_pkg', selected: ['visualtex-src 根目录 (Recommended)'] }],
     })
   })
+
+  it('shows the pending shell command inside the approval overlay', async () => {
+    const approval = {
+      key: 'approval:shell',
+      kind: 'approval',
+      sessionId: 'session' as SessionId,
+      payload: {
+        toolName: 'shell',
+        callId: 'call-shell',
+        approvalId: 'appr-1',
+        reason: '需要执行命令',
+      },
+    } as unknown as PendingWait<'approval'>
+    const snapshot = {
+      pending: [approval],
+      runningCalls: [{
+        callId: 'call-shell',
+        name: 'shell',
+        argsRaw: '{"command":"ls"}',
+        callView: { card: 'terminal', title: 'ls -la src' },
+      }],
+    } as unknown as ConversationSnapshot
+    const followLatest = vi.fn()
+    const answerApproval = vi.fn(async () => undefined)
+    const select = vi.fn(async (request: { detail?: string }) => {
+      expect(request.detail).toContain('$ ls -la src')
+      return { id: 'reject', label: '拒绝' }
+    })
+    const active = {
+      session: { getSnapshot: () => snapshot },
+    } as unknown as TuiActiveSession
+    const capabilities = {
+      active: () => active,
+      answerApproval,
+    } as unknown as HarnessTuiCapabilities
+    const actions = new TuiActions(capabilities, host({ select }, { followLatest }))
+
+    actions.syncPending(snapshot)
+    await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
+    expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
+  })
 })

--- a/tests/approval-preview.test.ts
+++ b/tests/approval-preview.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { RunningToolCall } from '@deepseek-ai/dsh-client-runtime/node-client'
+import { composeApprovalDetail } from '../src/client/approval-preview.ts'
+import { toolApprovalPreview } from '../src/client/transcript.ts'
+
+describe('approval overlay copy', () => {
+  it('embeds the full shell command', () => {
+    const call = {
+      callId: 'call-1',
+      name: 'shell',
+      argsRaw: '{"command":"ls"}',
+      callView: { card: 'terminal', title: 'rm -rf tmp' },
+    } as unknown as RunningToolCall
+    expect(toolApprovalPreview(call)).toBe('$ rm -rf tmp')
+    expect(composeApprovalDetail({
+      reason: '需要执行命令',
+      callId: 'call-1',
+      preview: toolApprovalPreview(call),
+    }).detail).toContain('$ rm -rf tmp')
+  })
+
+  it('embeds a line-level file diff', () => {
+    const call = {
+      callId: 'call-2',
+      name: 'edit',
+      argsRaw: '{}',
+      callView: {
+        card: 'diff',
+        diffs: [{ path: 'src/index.ts', oldText: 'old\n', newText: 'new\n' }],
+      },
+    } as unknown as RunningToolCall
+    const preview = toolApprovalPreview(call)
+    expect(preview).toContain('diff -- src/index.ts')
+    expect(preview).toContain('-old')
+    expect(preview).toContain('+new')
+  })
+
+  it('offers a full-parameter page when the preview is truncated', () => {
+    const preview = Array.from({ length: 40 }, (_, index) => `arg ${index}`).join('\n')
+    const composed = composeApprovalDetail({ reason: 'long', callId: 'c', preview })
+    expect(composed.full).toContain('arg 39')
+    expect(composed.detail.split('\n').length).toBeLessThanOrEqual(17)
+    expect(composed.detail.endsWith('…')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Stacks on #15 (P0-3). Approval overlays look up `wait.payload.callId` in `snapshot.runningCalls` and embed the same transcript renderers (`$ command`, unified diff, or tool args).
- Truncated previews add **查看完整参数** which opens a read-only detail page and returns to the approval without answering.
- Esc still rejects; allow/reject behavior is unchanged.

## Test plan
- [x] `vitest run tests/approval-preview.test.ts tests/actions-interaction.test.ts`
- [x] Rebuild `lib/index.js`
- [ ] Approve a shell tool: overlay shows `$` plus the full command
- [ ] Approve a file edit: overlay shows the line-level diff from #15


Made with [Cursor](https://cursor.com)