### PR TITLE
feat(tui): persist SeekTTY interaction defaults in seektty-behavior

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-fAI-vm30.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-9bp0AEnJ.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -54,7 +54,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -144,7 +144,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -599,7 +599,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1222,7 +1222,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1244,7 +1244,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1276,7 +1276,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1287,7 +1287,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2103,7 +2103,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2181,7 +2181,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2855,7 +2855,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3073,7 +3073,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3149,7 +3149,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3191,7 +3191,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3463,7 +3463,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4247,7 +4247,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4274,7 +4274,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4401,7 +4401,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5864,7 +5864,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5928,7 +5928,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6257,7 +6257,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8091,7 +8091,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8588,7 +8588,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8822,7 +8822,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../../../../../../../Volumes/huawei/项目实战/deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -20974,6 +20974,20 @@ const DEFAULT_TUI_CODE_THEME = "auto";
 const MAX_CUSTOM_THEMES = 32;
 /** Maximum imported TextMate rules stored in one custom theme. */
 const MAX_TEXTMATE_RULES = 4096;
+/** Harness Settings namespace that persists SeekTTY interaction defaults. */
+const TUI_BEHAVIOR_SETTINGS_NAMESPACE = "seektty-behavior";
+/** First-run interaction defaults when no user override has been stored. */
+const DEFAULT_TUI_BEHAVIOR = Object.freeze({
+	toolCards: "collapsed",
+	showReasoning: false,
+	desktopNotifications: true,
+	followTerminalTitle: true,
+	composerHistoryLimit: 200,
+	statusElapsed: true,
+	clipboardFallback: "auto"
+});
+/** Upper bound for persisted composer history entries. */
+const MAX_COMPOSER_HISTORY = 1e4;
 /** A stale TUI Settings writer was rejected before changing durable state. */
 var TuiSettingsConflictError = class extends Error {
 	/** Stable machine-readable conflict discriminator. */
@@ -21445,7 +21459,7 @@ function themeIdFromName(name$1) {
 	}
 	return `theme-${(hash >>> 0).toString(16).padStart(8, "0")}`;
 }
-function recordOf$1(value, label) {
+function recordOf$2(value, label) {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} 必须是对象`);
 	return value;
 }
@@ -21455,7 +21469,7 @@ function stringOf(record, key, label) {
 	return value;
 }
 function colorRecord(value, keys, label) {
-	const record = recordOf$1(value, label);
+	const record = recordOf$2(value, label);
 	return Object.fromEntries(keys.map((key) => [key, normalizeThemeColor(stringOf(record, key, label))]));
 }
 const TOKEN_FONT_STYLES = new Set([
@@ -21469,7 +21483,7 @@ function textMateRules$1(value) {
 	if (!Array.isArray(value) || value.length > MAX_TEXTMATE_RULES) throw new Error(`customThemes[].tokenColors 最多包含 ${String(MAX_TEXTMATE_RULES)} 条规则`);
 	return value.map((entry, index) => {
 		const label = `customThemes[].tokenColors[${String(index)}]`;
-		const record = recordOf$1(entry, label);
+		const record = recordOf$2(entry, label);
 		if (!Array.isArray(record.scope) || record.scope.length === 0 || record.scope.length > 64) throw new Error(`${label}.scope 必须包含 1–64 个 TextMate scope`);
 		const scope = [...new Set(record.scope.map((item) => {
 			if (typeof item !== "string" || item === "" || item.length > 256 || /[\u0000-\u001F\u007F-\u009F]/u.test(item)) throw new Error(`${label}.scope 包含无效值`);
@@ -21500,7 +21514,7 @@ function textMateRules$1(value) {
 * @returns normalized custom theme.
 */
 function normalizeCustomTheme(value) {
-	const record = recordOf$1(value, "customThemes[]");
+	const record = recordOf$2(value, "customThemes[]");
 	const id = stringOf(record, "id", "customThemes[]");
 	const name$1 = stringOf(record, "name", "customThemes[]").trim();
 	const tone = stringOf(record, "tone", "customThemes[]");
@@ -21526,7 +21540,7 @@ function normalizeCustomTheme(value) {
 * @returns normalized appearance settings.
 */
 function normalizeAppearance(value) {
-	const record = recordOf$1(value, "SeekTTY appearance");
+	const record = recordOf$2(value, "SeekTTY appearance");
 	const rawTheme = stringOf(record, "theme", "SeekTTY appearance");
 	if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) throw new Error(`SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`);
 	const rawThemes = record.customThemes ?? [];
@@ -22191,6 +22205,7 @@ function settingsSectionLabel(namespace) {
 	if (namespace === "agent-presets") return ui("默认 Agent Preset", "Default Agent Preset");
 	if (namespace === "agent-default-model" || namespace.startsWith("llm-")) return ui("模型与 Provider", "Models and Providers");
 	if (namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) return ui("SeekTTY 主题", "SeekTTY themes");
+	if (namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) return ui("SeekTTY 行为", "SeekTTY behavior");
 	if (namespace === "tui-plugin-marketplace") return ui("插件市场来源", "Plugin marketplace sources");
 	return ui("通用设置", "General settings");
 }
@@ -26168,6 +26183,70 @@ var PromptEditor = class extends Editor {
 };
 
 //#endregion
+//#region src/client/behavior.ts
+const TOOL_CARDS = new Set([
+	"collapsed",
+	"expanded",
+	"hidden"
+]);
+const CLIPBOARD_FALLBACK = new Set([
+	"auto",
+	"osc52",
+	"off"
+]);
+function recordOf$1(value) {
+	return typeof value === "object" && value !== null ? value : {};
+}
+function toolCardsOf(value) {
+	return typeof value === "string" && TOOL_CARDS.has(value) ? value : DEFAULT_TUI_BEHAVIOR.toolCards;
+}
+function booleanOf(value, fallback) {
+	return typeof value === "boolean" ? value : fallback;
+}
+function historyLimitOf(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit;
+	return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value));
+}
+function clipboardFallbackOf(value) {
+	return typeof value === "string" && CLIPBOARD_FALLBACK.has(value) ? value : DEFAULT_TUI_BEHAVIOR.clipboardFallback;
+}
+/**
+* Find the behavior descriptor registered by the Host bridge.
+* @param documents - redacted Harness Settings descriptors.
+* @returns the SeekTTY behavior descriptor.
+*/
+function behaviorSettings(documents) {
+	const document = documents.find((candidate) => candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE);
+	if (document === void 0) throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`);
+	return document;
+}
+/**
+* Coerce one stored document into complete, bounded behavior settings.
+* @param value - raw Settings value, possibly partial or legacy.
+* @returns validated behavior settings.
+*/
+function normalizeBehavior(value) {
+	const record = recordOf$1(value);
+	return {
+		toolCards: toolCardsOf(record.toolCards),
+		showReasoning: booleanOf(record.showReasoning, DEFAULT_TUI_BEHAVIOR.showReasoning),
+		desktopNotifications: booleanOf(record.desktopNotifications, DEFAULT_TUI_BEHAVIOR.desktopNotifications),
+		followTerminalTitle: booleanOf(record.followTerminalTitle, DEFAULT_TUI_BEHAVIOR.followTerminalTitle),
+		composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
+		statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
+		clipboardFallback: clipboardFallbackOf(record.clipboardFallback)
+	};
+}
+/**
+* Read and normalize the complete behavior value.
+* @param document - behavior descriptor returned by Harness Settings.
+* @returns validated behavior settings.
+*/
+function behaviorFromSettings(document) {
+	return normalizeBehavior(document.value);
+}
+
+//#endregion
 //#region src/client/overlays.ts
 function rowOf(choice, descriptionWidth) {
 	const state = choice.active === true ? "● " : choice.disabledReason === void 0 ? "  " : "× ";
@@ -28171,6 +28250,15 @@ var Transcript = class {
 		this.reasoningVisible = !this.reasoningVisible;
 		return this.reasoningVisible;
 	}
+	/**
+	* Restore the Settings-owned startup presentation without mutating the Harness log.
+	* @param tools - default tool-card shape.
+	* @param reasoning - whether reasoning blocks are visible at session open.
+	*/
+	applyPresentationDefaults(tools, reasoning) {
+		this.toolVisibility = tools;
+		this.reasoningVisible = reasoning;
+	}
 	/** Follow new transcript output after the user submits from a historical viewport. */
 	followLatest() {
 		this.turnCursor = void 0;
@@ -28511,6 +28599,7 @@ async function startTuiSurface(options$1) {
 	let disposeConstructedSyntax = () => void 0;
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
+		const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments));
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
 		stopConstructedTui = () => {
@@ -28531,6 +28620,7 @@ async function startTuiSurface(options$1) {
 			const snapshot = current.session.getSnapshot();
 			if (snapshot.hasMore && !snapshot.loadingOlder) current.session.loadOlder();
 		});
+		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning);
 		const syntax = await SyntaxHighlighter.create(initialTheme, () => {
 			transcript.refreshPresentation();
 			tui.invalidate();
@@ -28992,6 +29082,7 @@ function startTui(options$1) {
 //#region src/host/management.ts
 const MARKETPLACE_NAMESPACE = settingsNamespace("tui-plugin-marketplace");
 const APPEARANCE_NAMESPACE = settingsNamespace(TUI_APPEARANCE_SETTINGS_NAMESPACE);
+const BEHAVIOR_NAMESPACE = settingsNamespace(TUI_BEHAVIOR_SETTINGS_NAMESPACE);
 const TUI_BUNDLE = "seektty";
 const NON_TUI_SURFACE_BUNDLES = ["@deepseek-ai/dsh-web-app", "@deepseek-ai/dsh-headless"];
 const NPM_SOURCE = Object.freeze({
@@ -29072,6 +29163,23 @@ const AppearanceSettingsSchema = z$1.object({
 	codeTheme: z$1.string().pattern(/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_CODE_THEME).description("代码块独立主题；auto 跟随当前界面主题。"),
 	customThemes: z$1.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([]).description("SeekTTY 命名自定义主题。")
 });
+const BehaviorSettingsSchema = z$1.object({
+	toolCards: z$1.union([
+		"collapsed",
+		"expanded",
+		"hidden"
+	]).default(DEFAULT_TUI_BEHAVIOR.toolCards).description("工具卡片默认形态；启动时应用到当前会话。"),
+	showReasoning: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.showReasoning).description("推理内容默认是否显示。"),
+	desktopNotifications: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.desktopNotifications).description("回合完成或待审批时发送终端桌面通知。"),
+	followTerminalTitle: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.followTerminalTitle).description("终端标题跟随当前会话运行状态。"),
+	composerHistoryLimit: z$1.natural().max(MAX_COMPOSER_HISTORY).default(DEFAULT_TUI_BEHAVIOR.composerHistoryLimit).description("输入历史持久化条数；0 表示关闭。"),
+	statusElapsed: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.statusElapsed).description("状态栏显示当前回合实时耗时。"),
+	clipboardFallback: z$1.union([
+		"auto",
+		"osc52",
+		"off"
+	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。")
+});
 function settingsDocument(descriptor) {
 	return {
 		namespace: descriptor.ns,
@@ -29140,6 +29248,7 @@ function createTuiManagementBridge(ctx, cwd) {
 	if (manager === void 0) throw new Error("tui-runner: Settings、Credentials 或 Profile Plugin Manager 未装配");
 	settings.register(MARKETPLACE_NAMESPACE, MarketplaceSettingsSchema, { applies: "live" });
 	settings.register(APPEARANCE_NAMESPACE, AppearanceSettingsSchema, { applies: "live" });
+	settings.register(BEHAVIOR_NAMESPACE, BehaviorSettingsSchema, { applies: "live" });
 	const marketplace = new PluginMarketplace({
 		cwd,
 		resolveCredential: async (ref) => (await credentials.resolve(credentialRef(ref)))?.value,

--- a/lib/startup-9bp0AEnJ.js
+++ b/lib/startup-9bp0AEnJ.js
@@ -181,6 +181,7 @@ const ENGLISH_TEXT = new Map([
 	["默认 Agent Preset", "Default Agent Preset"],
 	["模型与 Provider", "Models and Providers"],
 	["SeekTTY 主题", "SeekTTY themes"],
+	["SeekTTY 行为", "SeekTTY behavior"],
 	["插件市场来源", "Plugin marketplace sources"],
 	["通用设置", "General settings"],
 	["空字符串", "Empty string"],

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-fAI-vm30.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-9bp0AEnJ.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -1,0 +1,90 @@
+/** Validation helpers for the Harness-owned SeekTTY behavior setting. */
+
+import {
+  DEFAULT_TUI_BEHAVIOR,
+  MAX_COMPOSER_HISTORY,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+  type TuiBehaviorSettings,
+  type TuiClipboardFallback,
+  type TuiSettingsDocument,
+  type TuiToolCardDisplay,
+} from '@deepseek-ai/dsh-tui-protocol'
+
+const TOOL_CARDS = new Set<TuiToolCardDisplay>(['collapsed', 'expanded', 'hidden'])
+const CLIPBOARD_FALLBACK = new Set<TuiClipboardFallback>(['auto', 'osc52', 'off'])
+
+function recordOf(value: unknown): Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null ? value as Readonly<Record<string, unknown>> : {}
+}
+
+function toolCardsOf(value: unknown): TuiToolCardDisplay {
+  return typeof value === 'string' && TOOL_CARDS.has(value as TuiToolCardDisplay)
+    ? value as TuiToolCardDisplay
+    : DEFAULT_TUI_BEHAVIOR.toolCards
+}
+
+function booleanOf(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function historyLimitOf(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit
+  }
+  return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value))
+}
+
+function clipboardFallbackOf(value: unknown): TuiClipboardFallback {
+  return typeof value === 'string' && CLIPBOARD_FALLBACK.has(value as TuiClipboardFallback)
+    ? value as TuiClipboardFallback
+    : DEFAULT_TUI_BEHAVIOR.clipboardFallback
+}
+
+/**
+ * Find the behavior descriptor registered by the Host bridge.
+ * @param documents - redacted Harness Settings descriptors.
+ * @returns the SeekTTY behavior descriptor.
+ */
+export function behaviorSettings(
+  documents: readonly TuiSettingsDocument[],
+): TuiSettingsDocument {
+  const document = documents.find(candidate =>
+    candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE)
+  if (document === undefined) {
+    throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`)
+  }
+  return document
+}
+
+/**
+ * Coerce one stored document into complete, bounded behavior settings.
+ * @param value - raw Settings value, possibly partial or legacy.
+ * @returns validated behavior settings.
+ */
+export function normalizeBehavior(value: unknown): TuiBehaviorSettings {
+  const record = recordOf(value)
+  return {
+    toolCards: toolCardsOf(record.toolCards),
+    showReasoning: booleanOf(record.showReasoning, DEFAULT_TUI_BEHAVIOR.showReasoning),
+    desktopNotifications: booleanOf(
+      record.desktopNotifications,
+      DEFAULT_TUI_BEHAVIOR.desktopNotifications,
+    ),
+    followTerminalTitle: booleanOf(
+      record.followTerminalTitle,
+      DEFAULT_TUI_BEHAVIOR.followTerminalTitle,
+    ),
+    composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
+    statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
+    clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
+  }
+}
+
+/**
+ * Read and normalize the complete behavior value.
+ * @param document - behavior descriptor returned by Harness Settings.
+ * @returns validated behavior settings.
+ */
+export function behaviorFromSettings(document: TuiSettingsDocument): TuiBehaviorSettings {
+  return normalizeBehavior(document.value)
+}

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -186,6 +186,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['默认 Agent Preset', 'Default Agent Preset'],
   ['模型与 Provider', 'Models and Providers'],
   ['SeekTTY 主题', 'SeekTTY themes'],
+  ['SeekTTY 行为', 'SeekTTY behavior'],
   ['插件市场来源', 'Plugin marketplace sources'],
   ['通用设置', 'General settings'],
   ['空字符串', 'Empty string'],

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -7,7 +7,10 @@ import {
   type SchemaNode,
 } from '@deepseek-ai/dsh-client-schema-form'
 import { LOCALE_SETTINGS_NAMESPACE } from '@deepseek-ai/dsh-client-locale'
-import { TUI_APPEARANCE_SETTINGS_NAMESPACE } from '@deepseek-ai/dsh-tui-protocol'
+import {
+  TUI_APPEARANCE_SETTINGS_NAMESPACE,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+} from '@deepseek-ai/dsh-tui-protocol'
 import { ui, uiLocale } from './locale.ts'
 import type { TuiSettingsDocument } from './management.ts'
 
@@ -195,6 +198,7 @@ export function settingsSectionLabel(namespace: string): string {
   if (namespace === 'agent-presets') return ui('默认 Agent Preset', 'Default Agent Preset')
   if (namespace === 'agent-default-model' || namespace.startsWith('llm-')) return ui('模型与 Provider', 'Models and Providers')
   if (namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) return ui('SeekTTY 主题', 'SeekTTY themes')
+  if (namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) return ui('SeekTTY 行为', 'SeekTTY behavior')
   if (namespace === 'tui-plugin-marketplace') return ui('插件市场来源', 'Plugin marketplace sources')
   return ui('通用设置', 'General settings')
 }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -21,6 +21,7 @@ import {
   transcriptViewportRows,
 } from './chrome.ts'
 import { appearanceSettings, themeFromAppearance } from './appearance.ts'
+import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
 import {
   localeFromSettings,
   setUiLocale,
@@ -114,6 +115,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let disposeConstructedSyntax = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
+    const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments))
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
     stopConstructedTui = () => {
@@ -140,6 +142,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         if (snapshot.hasMore && !snapshot.loadingOlder) void current.session.loadOlder()
       },
     )
+    transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning)
     const syntax = await SyntaxHighlighter.create(initialTheme, () => {
       transcript.refreshPresentation()
       tui.invalidate()

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -1093,6 +1093,16 @@ export class Transcript implements Component, Focusable {
     return this.reasoningVisible
   }
 
+  /**
+   * Restore the Settings-owned startup presentation without mutating the Harness log.
+   * @param tools - default tool-card shape.
+   * @param reasoning - whether reasoning blocks are visible at session open.
+   */
+  applyPresentationDefaults(tools: ToolVisibility, reasoning: boolean): void {
+    this.toolVisibility = tools
+    this.reasoningVisible = reasoning
+  }
+
   /** Follow new transcript output after the user submits from a historical viewport. */
   followLatest(): void {
     this.turnCursor = undefined

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -13,11 +13,14 @@ import type {
   TuiSettingsDocument,
 } from '@deepseek-ai/dsh-tui-protocol'
 import {
+  DEFAULT_TUI_BEHAVIOR,
   DEFAULT_TUI_CODE_THEME,
   DEFAULT_TUI_THEME,
+  MAX_COMPOSER_HISTORY,
   MAX_CUSTOM_THEMES,
   MAX_TEXTMATE_RULES,
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
 } from '@deepseek-ai/dsh-tui-protocol'
 import type {} from './marketplace-provider.ts'
@@ -25,6 +28,7 @@ import { assertCredentialFreeUrl, PluginMarketplace } from './plugin-marketplace
 
 const MARKETPLACE_NAMESPACE = settingsNamespace('tui-plugin-marketplace')
 const APPEARANCE_NAMESPACE = settingsNamespace(TUI_APPEARANCE_SETTINGS_NAMESPACE)
+const BEHAVIOR_NAMESPACE = settingsNamespace(TUI_BEHAVIOR_SETTINGS_NAMESPACE)
 const TUI_BUNDLE = 'seektty'
 const NON_TUI_SURFACE_BUNDLES = ['@deepseek-ai/dsh-web-app', '@deepseek-ai/dsh-headless'] as const
 const NPM_SOURCE: TuiMarketplaceSource = Object.freeze({
@@ -105,6 +109,25 @@ const AppearanceSettingsSchema = z.object({
     .description('代码块独立主题；auto 跟随当前界面主题。'),
   customThemes: z.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([])
     .description('SeekTTY 命名自定义主题。'),
+})
+const BehaviorSettingsSchema = z.object({
+  toolCards: z.union(['collapsed', 'expanded', 'hidden'])
+    .default(DEFAULT_TUI_BEHAVIOR.toolCards)
+    .description('工具卡片默认形态；启动时应用到当前会话。'),
+  showReasoning: z.boolean().default(DEFAULT_TUI_BEHAVIOR.showReasoning)
+    .description('推理内容默认是否显示。'),
+  desktopNotifications: z.boolean().default(DEFAULT_TUI_BEHAVIOR.desktopNotifications)
+    .description('回合完成或待审批时发送终端桌面通知。'),
+  followTerminalTitle: z.boolean().default(DEFAULT_TUI_BEHAVIOR.followTerminalTitle)
+    .description('终端标题跟随当前会话运行状态。'),
+  composerHistoryLimit: z.natural().max(MAX_COMPOSER_HISTORY)
+    .default(DEFAULT_TUI_BEHAVIOR.composerHistoryLimit)
+    .description('输入历史持久化条数；0 表示关闭。'),
+  statusElapsed: z.boolean().default(DEFAULT_TUI_BEHAVIOR.statusElapsed)
+    .description('状态栏显示当前回合实时耗时。'),
+  clipboardFallback: z.union(['auto', 'osc52', 'off'])
+    .default(DEFAULT_TUI_BEHAVIOR.clipboardFallback)
+    .description('OSC 52 失败后的剪贴板回退命令；auto 按平台探测。'),
 })
 
 interface StoredCatalogSource {
@@ -208,6 +231,7 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
   }
   settings.register(MARKETPLACE_NAMESPACE, MarketplaceSettingsSchema, { applies: 'live' })
   settings.register(APPEARANCE_NAMESPACE, AppearanceSettingsSchema, { applies: 'live' })
+  settings.register(BEHAVIOR_NAMESPACE, BehaviorSettingsSchema, { applies: 'live' })
   const marketplace = new PluginMarketplace({
     cwd,
     resolveCredential: async ref => (await credentials.resolve(credentialRef(ref)))?.value,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -105,6 +105,40 @@ export const MAX_CUSTOM_THEMES = 32
 /** Maximum imported TextMate rules stored in one custom theme. */
 export const MAX_TEXTMATE_RULES = 4_096
 
+/** Harness Settings namespace that persists SeekTTY interaction defaults. */
+export const TUI_BEHAVIOR_SETTINGS_NAMESPACE = 'seektty-behavior'
+
+/** Startup presentation for tool cards in the transcript. */
+export type TuiToolCardDisplay = 'collapsed' | 'expanded' | 'hidden'
+
+/** How `/copy` writes the system clipboard after OSC 52. */
+export type TuiClipboardFallback = 'auto' | 'osc52' | 'off'
+
+/** Complete behavior value owned by the SeekTTY Settings namespace. */
+export interface TuiBehaviorSettings {
+  readonly toolCards: TuiToolCardDisplay
+  readonly showReasoning: boolean
+  readonly desktopNotifications: boolean
+  readonly followTerminalTitle: boolean
+  readonly composerHistoryLimit: number
+  readonly statusElapsed: boolean
+  readonly clipboardFallback: TuiClipboardFallback
+}
+
+/** First-run interaction defaults when no user override has been stored. */
+export const DEFAULT_TUI_BEHAVIOR: TuiBehaviorSettings = Object.freeze({
+  toolCards: 'collapsed',
+  showReasoning: false,
+  desktopNotifications: true,
+  followTerminalTitle: true,
+  composerHistoryLimit: 200,
+  statusElapsed: true,
+  clipboardFallback: 'auto',
+})
+
+/** Upper bound for persisted composer history entries. */
+export const MAX_COMPOSER_HISTORY = 10_000
+
 /** One complete, redacted registered Settings namespace. */
 export interface TuiSettingsDocument {
   readonly namespace: string

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_TUI_BEHAVIOR,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+  type TuiSettingsDocument,
+} from '../src/protocol.ts'
+import {
+  behaviorFromSettings,
+  behaviorSettings,
+  normalizeBehavior,
+} from '../src/client/behavior.ts'
+import { Transcript } from '../src/client/transcript.ts'
+
+function document(value: unknown): TuiSettingsDocument {
+  return {
+    namespace: TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+    schema: {},
+    value,
+    revision: 1,
+    applies: 'live',
+    secrets: [],
+  }
+}
+
+describe('seektty-behavior settings', () => {
+  it('fills first-run defaults and rejects unknown or unbounded values', () => {
+    expect(normalizeBehavior(undefined)).toEqual(DEFAULT_TUI_BEHAVIOR)
+    expect(normalizeBehavior({
+      toolCards: 'expanded',
+      showReasoning: true,
+      desktopNotifications: false,
+      followTerminalTitle: false,
+      composerHistoryLimit: 0,
+      statusElapsed: false,
+      clipboardFallback: 'osc52',
+    })).toEqual({
+      toolCards: 'expanded',
+      showReasoning: true,
+      desktopNotifications: false,
+      followTerminalTitle: false,
+      composerHistoryLimit: 0,
+      statusElapsed: false,
+      clipboardFallback: 'osc52',
+    })
+    expect(normalizeBehavior({
+      toolCards: 'mystery',
+      composerHistoryLimit: 99_999,
+      clipboardFallback: 'pbcopy',
+    })).toMatchObject({
+      toolCards: 'collapsed',
+      composerHistoryLimit: 10_000,
+      clipboardFallback: 'auto',
+    })
+  })
+
+  it('reads the registered namespace and applies transcript startup defaults', () => {
+    expect(behaviorSettings([document({})]).namespace).toBe(TUI_BEHAVIOR_SETTINGS_NAMESPACE)
+    expect(() => behaviorSettings([])).toThrow(TUI_BEHAVIOR_SETTINGS_NAMESPACE)
+
+    const transcript = new Transcript(() => 8)
+    const behavior = behaviorFromSettings(document({
+      toolCards: 'hidden',
+      showReasoning: true,
+    }))
+    transcript.applyPresentationDefaults(behavior.toolCards, behavior.showReasoning)
+    expect(transcript.cycleToolVisibility()).toBe('collapsed')
+    expect(transcript.toggleReasoning()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Register the live `seektty-behavior` Settings namespace (section 8) with startup defaults for tool cards, reasoning, notifications, terminal title, composer history, status elapsed time, and clipboard fallback.
- Apply tool-card and reasoning defaults when the Surface starts so those presentation choices survive a restart.
- Later P1 PRs read the same document instead of adding unused Settings keys.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/behavior.test.ts`
- [ ] Open `/settings` and confirm **SeekTTY 行为** is listed with the new fields
- [ ] Set tool cards to expanded / reasoning on, restart, confirm the transcript uses those defaults


Made with [Cursor](https://cursor.com)