### PR TITLE
feat(tui): show live turn duration on the status strip

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-Bdn3XE4I.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-BFf35jwA.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -25909,6 +25909,21 @@ function commandOf(catalog, name$1) {
 }
 
 //#endregion
+//#region src/client/elapsed.ts
+/** Shared live-duration formatting for transcript rows and the status strip. */
+/**
+* Format an in-flight duration using the same compact clock as transcript rows.
+* @param milliseconds - elapsed milliseconds; negative values clamp to zero.
+* @returns `3.2s` under a minute, otherwise `1m5s`.
+*/
+function formatElapsed(milliseconds) {
+	const seconds = (Number.isFinite(milliseconds) ? Math.max(0, milliseconds) : 0) / 1e3;
+	if (seconds < 60) return `${String(Math.round(seconds * 10) / 10)}s`;
+	const whole = Math.round(seconds);
+	return `${String(Math.floor(whole / 60))}m${String(whole % 60)}s`;
+}
+
+//#endregion
 //#region src/client/chrome.ts
 function fit(text, width) {
 	return truncateToWidth(text, Math.max(1, width), "…");
@@ -26100,7 +26115,8 @@ var ContextBar = class {
 		if (this.state.kind === "facts") {
 			const facts = this.state.facts;
 			const context = facts.context?.split(" · ", 1)[0];
-			const runtime = facts.running ? color.accent(ui("● 生成中", "● Generating")) : color.muted(ui("就绪", "Ready"));
+			const elapsed = facts.running && facts.statusElapsed !== false && facts.runningSince !== void 0 ? ` ${formatElapsed(Date.now() - facts.runningSince)}` : "";
+			const runtime = facts.running ? color.accent(`${ui("● 生成中", "● Generating")}${elapsed}`) : color.muted(ui("就绪", "Ready"));
 			return [`${prefix}${columns("", context === void 0 ? runtime : `${color.muted(context)} · ${runtime}`, innerWidth)}`];
 		}
 		return [`${prefix}${columns("", this.state.kind === "error" ? color.danger(translateUiText(this.state.message)) : color.muted(this.state.kind === "loading" ? ui("正在连接 Harness…", "Connecting to Harness…") : ui("未打开会话", "No session open")), innerWidth)}`];
@@ -28709,6 +28725,8 @@ async function startTuiSurface(options$1) {
 		let notice;
 		let restartRequired;
 		let headerGeneration = 0;
+		let runningSince;
+		let elapsedTimer;
 		const focusEditor = () => {
 			transcriptFocused = false;
 			tui.setFocus(editor);
@@ -28738,12 +28756,27 @@ async function startTuiSurface(options$1) {
 		const updateStatus = () => {
 			if (stopping !== void 0) return;
 			const snapshot = active?.session.getSnapshot();
+			if (snapshot?.running === true) {
+				runningSince ??= Date.now();
+				if (elapsedTimer === void 0 && initialBehavior.statusElapsed) elapsedTimer = setInterval(() => {
+					if (stopping !== void 0) return;
+					updateStatus();
+					renderWhileOpen();
+				}, 500);
+			} else {
+				runningSince = void 0;
+				if (elapsedTimer !== void 0) {
+					clearInterval(elapsedTimer);
+					elapsedTimer = void 0;
+				}
+			}
 			if (snapshot === void 0) {
 				status.setDetail(color.warning(translateUiText("未打开会话")));
 				return;
 			}
 			const pendingCount = snapshot.pending.length;
-			const primary = snapshot.removed ? color.danger(translateUiText("会话已删除")) : snapshot.promptError !== null ? color.danger(translateUiText(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(translateUiText(`/pending 处理 ${String(pendingCount)} 项交互`)) : snapshot.running ? color.accent(translateUiText("生成中 · Ctrl+C 停止")) : void 0;
+			const generating = initialBehavior.statusElapsed && runningSince !== void 0 ? `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止` : "生成中 · Ctrl+C 停止";
+			const primary = snapshot.removed ? color.danger(translateUiText("会话已删除")) : snapshot.promptError !== null ? color.danger(translateUiText(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(translateUiText(`/pending 处理 ${String(pendingCount)} 项交互`)) : snapshot.running ? color.accent(translateUiText(generating)) : void 0;
 			const facts = [];
 			if (snapshot.queue.length > 0) facts.push(translateUiText(`队列 ${String(snapshot.queue.length)}`));
 			const jobCount = (active === void 0 ? void 0 : capabilities.jobs())?.filter((job) => job.status === "running" || job.status === "stopping").length ?? 0;
@@ -28764,7 +28797,11 @@ async function startTuiSurface(options$1) {
 			const generation = ++headerGeneration;
 			capabilities.headerFacts(forceModel).then((facts) => {
 				if (stopping !== void 0 || generation !== headerGeneration) return;
-				contextBar.setFacts(facts);
+				contextBar.setFacts({
+					...facts,
+					...runningSince === void 0 ? {} : { runningSince },
+					statusElapsed: initialBehavior.statusElapsed
+				});
 				editor.setFacts(facts);
 				status.setPermission(facts.permission);
 				renderWhileOpen();
@@ -28800,6 +28837,10 @@ async function startTuiSurface(options$1) {
 			if (stopping !== void 0) return stopping;
 			stopping = (async () => {
 				const failures = [];
+				if (elapsedTimer !== void 0) {
+					clearInterval(elapsedTimer);
+					elapsedTimer = void 0;
+				}
 				overlays.dispose();
 				transcript.dispose();
 				setCodeHighlighter(void 0);

--- a/lib/startup-BFf35jwA.js
+++ b/lib/startup-BFf35jwA.js
@@ -1187,6 +1187,10 @@ const ENGLISH_PATTERNS = [
 	{
 		pattern: /^(\d+-\d+\/\d+) 行 · ↑↓ 滚动 · PgUp\/PgDn 翻页 · Home\/End · Enter\/q 关闭 · Esc 返回$/u,
 		replace: (value) => `${value} lines · ↑↓ scroll · PgUp/PgDn page · Home/End · Enter/q close · Esc back`
+	},
+	{
+		pattern: /^生成中 · (.+) · Ctrl\+C 停止$/u,
+		replace: (value) => `Generating · ${value} · Ctrl+C to stop`
 	}
 ];
 function requestedEnvironmentLocale(env) {

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-Bdn3XE4I.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-BFf35jwA.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -105,6 +105,10 @@ export interface TuiHeaderFacts {
   readonly permission: string
   readonly running: boolean
   readonly context?: string
+  /** Epoch ms when the current turn started running; absent while idle. */
+  readonly runningSince?: number
+  /** Whether the context row should show a live elapsed clock. */
+  readonly statusElapsed?: boolean
 }
 
 /** Human-readable whole-session figures derived from registered projections. */

--- a/src/client/chrome.ts
+++ b/src/client/chrome.ts
@@ -9,6 +9,7 @@ import {
   type TUI,
 } from '@mariozechner/pi-tui'
 import type { TuiHeaderFacts } from './capabilities.ts'
+import { formatElapsed } from './elapsed.ts'
 import { translateUiText, ui } from './locale.ts'
 import { color, editorTheme } from './theme.ts'
 
@@ -222,7 +223,12 @@ export class ContextBar implements Component {
     if (this.state.kind === 'facts') {
       const facts = this.state.facts
       const context = facts.context?.split(' · ', 1)[0]
-      const runtime = facts.running ? color.accent(ui('● 生成中', '● Generating')) : color.muted(ui('就绪', 'Ready'))
+      const elapsed = facts.running && facts.statusElapsed !== false && facts.runningSince !== undefined
+        ? ` ${formatElapsed(Date.now() - facts.runningSince)}`
+        : ''
+      const runtime = facts.running
+        ? color.accent(`${ui('● 生成中', '● Generating')}${elapsed}`)
+        : color.muted(ui('就绪', 'Ready'))
       const right = context === undefined ? runtime : `${color.muted(context)} · ${runtime}`
       return [`${prefix}${columns('', right, innerWidth)}`]
     }

--- a/src/client/elapsed.ts
+++ b/src/client/elapsed.ts
@@ -1,0 +1,14 @@
+/** Shared live-duration formatting for transcript rows and the status strip. */
+
+/**
+ * Format an in-flight duration using the same compact clock as transcript rows.
+ * @param milliseconds - elapsed milliseconds; negative values clamp to zero.
+ * @returns `3.2s` under a minute, otherwise `1m5s`.
+ */
+export function formatElapsed(milliseconds: number): string {
+  const clamped = Number.isFinite(milliseconds) ? Math.max(0, milliseconds) : 0
+  const seconds = clamped / 1_000
+  if (seconds < 60) return `${String(Math.round(seconds * 10) / 10)}s`
+  const whole = Math.round(seconds)
+  return `${String(Math.floor(whole / 60))}m${String(whole % 60)}s`
+}

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -804,6 +804,7 @@ const ENGLISH_PATTERNS: readonly {
   { pattern: /^目标：(.+)$/su, replace: value => `Goal: ${value}` },
   { pattern: /^阻塞原因：(.+)$/su, replace: value => `Blocked by: ${value}` },
   { pattern: /^(\d+-\d+\/\d+) 行 · ↑↓ 滚动 · PgUp\/PgDn 翻页 · Home\/End · Enter\/q 关闭 · Esc 返回$/u, replace: value => `${value} lines · ↑↓ scroll · PgUp/PgDn page · Home/End · Enter/q close · Esc back` },
+  { pattern: /^生成中 · (.+) · Ctrl\+C 停止$/u, replace: value => `Generating · ${value} · Ctrl+C to stop` },
 ]
 
 function requestedEnvironmentLocale(env: NodeJS.ProcessEnv): LocaleId {

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -38,6 +38,7 @@ import { OverlayQueue } from './overlays.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
+import { formatElapsed } from './elapsed.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -182,6 +183,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     let notice: { message: string; tone: NoticeTone } | undefined
     let restartRequired: string | undefined
     let headerGeneration = 0
+    let runningSince: number | undefined
+    let elapsedTimer: ReturnType<typeof setInterval> | undefined
 
     const focusEditor = (): void => {
       transcriptFocused = false
@@ -216,11 +219,30 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const updateStatus = (): void => {
       if (stopping !== undefined) return
       const snapshot = active?.session.getSnapshot()
+      if (snapshot?.running === true) {
+        runningSince ??= Date.now()
+        if (elapsedTimer === undefined && initialBehavior.statusElapsed) {
+          elapsedTimer = setInterval(() => {
+            if (stopping !== undefined) return
+            updateStatus()
+            renderWhileOpen()
+          }, 500)
+        }
+      } else {
+        runningSince = undefined
+        if (elapsedTimer !== undefined) {
+          clearInterval(elapsedTimer)
+          elapsedTimer = undefined
+        }
+      }
       if (snapshot === undefined) {
         status.setDetail(color.warning(translateUiText('未打开会话')))
         return
       }
       const pendingCount = snapshot.pending.length
+      const generating = initialBehavior.statusElapsed && runningSince !== undefined
+        ? `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`
+        : '生成中 · Ctrl+C 停止'
       const primary = snapshot.removed
         ? color.danger(translateUiText('会话已删除'))
         : snapshot.promptError !== null
@@ -228,7 +250,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           : pendingCount > 0
             ? color.warning(translateUiText(`/pending 处理 ${String(pendingCount)} 项交互`))
             : snapshot.running
-              ? color.accent(translateUiText('生成中 · Ctrl+C 停止'))
+              ? color.accent(translateUiText(generating))
               : undefined
       const facts: string[] = []
       if (snapshot.queue.length > 0) facts.push(translateUiText(`队列 ${String(snapshot.queue.length)}`))
@@ -256,7 +278,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       const generation = ++headerGeneration
       void capabilities.headerFacts(forceModel).then((facts) => {
         if (stopping !== undefined || generation !== headerGeneration) return
-        contextBar.setFacts(facts)
+        contextBar.setFacts({
+          ...facts,
+          ...(runningSince === undefined ? {} : { runningSince }),
+          statusElapsed: initialBehavior.statusElapsed,
+        })
         editor.setFacts(facts)
         status.setPermission(facts.permission)
         renderWhileOpen()
@@ -294,6 +320,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (stopping !== undefined) return stopping
       stopping = (async () => {
         const failures: unknown[] = []
+        if (elapsedTimer !== undefined) {
+          clearInterval(elapsedTimer)
+          elapsedTimer = undefined
+        }
         overlays.dispose()
         transcript.dispose()
         setCodeHighlighter(undefined)

--- a/tests/elapsed.test.ts
+++ b/tests/elapsed.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatElapsed } from '../src/client/elapsed.ts'
+import { ContextBar } from '../src/client/chrome.ts'
+import type { TuiHeaderFacts } from '../src/client/capabilities.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+  setUiLocale('zh')
+})
+
+function facts(overrides: Partial<TuiHeaderFacts> = {}): TuiHeaderFacts {
+  return {
+    hostVersion: '0.1.0',
+    nodeVersion: '24.0.0',
+    platform: 'darwin',
+    architecture: 'arm64',
+    profile: 'tui',
+    workspace: '/workspace',
+    session: 'session',
+    mode: 'standard',
+    model: 'deepseek-official/deepseek-v4-pro',
+    permission: 'workspace-write',
+    running: false,
+    ...overrides,
+  }
+}
+
+describe('status elapsed clock', () => {
+  it('formats the same compact duration used beside in-flight transcript rows', () => {
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(3_200)).toBe('3.2s')
+    expect(formatElapsed(65_000)).toBe('1m5s')
+  })
+
+  it('shows the live duration on the context row while a turn is running', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    vi.stubEnv('NO_COLOR', '1')
+    setUiLocale('zh')
+    const bar = new ContextBar('tui', '/workspace')
+    bar.setFacts(facts({
+      running: true,
+      runningSince: 1_700_000_000_000 - 3_200,
+      statusElapsed: true,
+    }))
+    expect(bar.render(40).join('\n')).toContain('● 生成中 3.2s')
+
+    bar.setFacts(facts({
+      running: true,
+      runningSince: 1_700_000_000_000 - 3_200,
+      statusElapsed: false,
+    }))
+    expect(bar.render(40).join('\n')).toContain('● 生成中')
+    expect(bar.render(40).join('\n')).not.toContain('3.2s')
+  })
+})


### PR DESCRIPTION
## Summary
- Tick the current turn's elapsed time on the context row and status bar using the same compact clock as transcript rows.
- Honor `statusElapsed` from `seektty-behavior` (default on).
- Stacks on #19.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/elapsed.test.ts tests/chrome.test.ts`
- [ ] Start a turn and confirm `● 生成中 3.2s` updates about twice a second
- [ ] Disable the setting and confirm the static Generating label returns after restart


Made with [Cursor](https://cursor.com)