### PR TITLE
feat(tui): ring BEL and OSC 9 when a turn finishes or waits

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28621,6 +28621,51 @@ var Transcript = class {
 };
 
 //#endregion
+//#region src/client/desktop-notify.ts
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu;
+/**
+* Build a BEL + OSC 9 sequence for terminals that surface desktop notifications.
+* @param message - short human-readable body; control characters are stripped.
+* @returns the exact bytes to write to the terminal.
+*/
+function desktopNotifySequence(message) {
+	const body = message.replace(CONTROL_CHARS, " ").replace(/\s+/gu, " ").trim().slice(0, 200);
+	if (body === "") return "\x07";
+	return `\u0007\u001B]9;${body}\u0007`;
+}
+/**
+* Decide whether a snapshot transition should ring the terminal bell.
+* @param previous - last observed running/pending facts.
+* @param current - newly observed facts.
+* @param primed - false skips the first snapshot so reconnects do not notify.
+* @returns the event to announce, or undefined when nothing changed for the user.
+*/
+function nextDesktopNotify(previous, current, primed) {
+	if (!primed) return void 0;
+	const previousKeys = new Set(previous.pending.map((wait) => wait.key));
+	const added = current.pending.filter((wait) => !previousKeys.has(wait.key));
+	if (added.some((wait) => wait.kind === "approval")) return "approval";
+	if (added.some((wait) => wait.kind === "question")) return "question";
+	if (previous.running && !current.running && current.pending.length === 0) return "turn-complete";
+}
+/**
+* Localized body for one desktop-notify event.
+* @param kind - event selected by {@link nextDesktopNotify}.
+* @param locale - current terminal locale.
+* @returns a short notification body.
+*/
+function desktopNotifyBody(kind, locale) {
+	if (locale === "en") {
+		if (kind === "approval") return "SeekTTY: tool approval needed";
+		if (kind === "question") return "SeekTTY: a question is waiting";
+		return "SeekTTY: turn complete";
+	}
+	if (kind === "approval") return "SeekTTY：需要工具审批";
+	if (kind === "question") return "SeekTTY：有问题待回答";
+	return "SeekTTY：回合完成";
+}
+
+//#endregion
 //#region src/client/surface.ts
 /** Replaceable terminal seams used by virtual-terminal tests. */
 const internals$1 = {
@@ -28727,6 +28772,11 @@ async function startTuiSurface(options$1) {
 		let headerGeneration = 0;
 		let runningSince;
 		let elapsedTimer;
+		let notifySnapshot = {
+			running: false,
+			pending: []
+		};
+		let notifyPrimed = false;
 		const focusEditor = () => {
 			transcriptFocused = false;
 			tui.setFocus(editor);
@@ -28771,9 +28821,27 @@ async function startTuiSurface(options$1) {
 				}
 			}
 			if (snapshot === void 0) {
+				notifySnapshot = {
+					running: false,
+					pending: []
+				};
+				notifyPrimed = false;
 				status.setDetail(color.warning(translateUiText("未打开会话")));
 				return;
 			}
+			const currentNotify = {
+				running: snapshot.running,
+				pending: snapshot.pending.map((wait) => ({
+					key: wait.key,
+					kind: wait.kind
+				}))
+			};
+			if (initialBehavior.desktopNotifications) {
+				const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed);
+				if (kind !== void 0) terminal.write(desktopNotifySequence(desktopNotifyBody(kind, uiLocale())));
+			}
+			notifySnapshot = currentNotify;
+			notifyPrimed = true;
 			const pendingCount = snapshot.pending.length;
 			const generating = initialBehavior.statusElapsed && runningSince !== void 0 ? `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止` : "生成中 · Ctrl+C 停止";
 			const primary = snapshot.removed ? color.danger(translateUiText("会话已删除")) : snapshot.promptError !== null ? color.danger(translateUiText(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(translateUiText(`/pending 处理 ${String(pendingCount)} 项交互`)) : snapshot.running ? color.accent(translateUiText(generating)) : void 0;

--- a/src/client/desktop-notify.ts
+++ b/src/client/desktop-notify.ts
@@ -1,0 +1,59 @@
+/** Terminal BEL + OSC 9 notices for turn completion and pending interactions. */
+
+export type DesktopNotifyKind = 'turn-complete' | 'approval' | 'question'
+
+export interface DesktopNotifySnapshot {
+  readonly running: boolean
+  readonly pending: readonly { readonly key: string; readonly kind: string }[]
+}
+
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu
+
+/**
+ * Build a BEL + OSC 9 sequence for terminals that surface desktop notifications.
+ * @param message - short human-readable body; control characters are stripped.
+ * @returns the exact bytes to write to the terminal.
+ */
+export function desktopNotifySequence(message: string): string {
+  const body = message.replace(CONTROL_CHARS, ' ').replace(/\s+/gu, ' ').trim().slice(0, 200)
+  if (body === '') return '\u0007'
+  return `\u0007\u001B]9;${body}\u0007`
+}
+
+/**
+ * Decide whether a snapshot transition should ring the terminal bell.
+ * @param previous - last observed running/pending facts.
+ * @param current - newly observed facts.
+ * @param primed - false skips the first snapshot so reconnects do not notify.
+ * @returns the event to announce, or undefined when nothing changed for the user.
+ */
+export function nextDesktopNotify(
+  previous: DesktopNotifySnapshot,
+  current: DesktopNotifySnapshot,
+  primed: boolean,
+): DesktopNotifyKind | undefined {
+  if (!primed) return undefined
+  const previousKeys = new Set(previous.pending.map(wait => wait.key))
+  const added = current.pending.filter(wait => !previousKeys.has(wait.key))
+  if (added.some(wait => wait.kind === 'approval')) return 'approval'
+  if (added.some(wait => wait.kind === 'question')) return 'question'
+  if (previous.running && !current.running && current.pending.length === 0) return 'turn-complete'
+  return undefined
+}
+
+/**
+ * Localized body for one desktop-notify event.
+ * @param kind - event selected by {@link nextDesktopNotify}.
+ * @param locale - current terminal locale.
+ * @returns a short notification body.
+ */
+export function desktopNotifyBody(kind: DesktopNotifyKind, locale: 'zh' | 'en'): string {
+  if (locale === 'en') {
+    if (kind === 'approval') return 'SeekTTY: tool approval needed'
+    if (kind === 'question') return 'SeekTTY: a question is waiting'
+    return 'SeekTTY: turn complete'
+  }
+  if (kind === 'approval') return 'SeekTTY：需要工具审批'
+  if (kind === 'question') return 'SeekTTY：有问题待回答'
+  return 'SeekTTY：回合完成'
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -33,12 +33,19 @@ import {
   setUiLocale,
   translateUiText,
   ui,
+  uiLocale,
 } from './locale.ts'
 import { OverlayQueue } from './overlays.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
 import { formatElapsed } from './elapsed.ts'
+import {
+  desktopNotifyBody,
+  desktopNotifySequence,
+  nextDesktopNotify,
+  type DesktopNotifySnapshot,
+} from './desktop-notify.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -185,6 +192,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     let headerGeneration = 0
     let runningSince: number | undefined
     let elapsedTimer: ReturnType<typeof setInterval> | undefined
+    let notifySnapshot: DesktopNotifySnapshot = { running: false, pending: [] }
+    let notifyPrimed = false
 
     const focusEditor = (): void => {
       transcriptFocused = false
@@ -236,9 +245,23 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         }
       }
       if (snapshot === undefined) {
+        notifySnapshot = { running: false, pending: [] }
+        notifyPrimed = false
         status.setDetail(color.warning(translateUiText('未打开会话')))
         return
       }
+      const currentNotify: DesktopNotifySnapshot = {
+        running: snapshot.running,
+        pending: snapshot.pending.map(wait => ({ key: wait.key, kind: wait.kind })),
+      }
+      if (initialBehavior.desktopNotifications) {
+        const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed)
+        if (kind !== undefined) {
+          terminal.write(desktopNotifySequence(desktopNotifyBody(kind, uiLocale())))
+        }
+      }
+      notifySnapshot = currentNotify
+      notifyPrimed = true
       const pendingCount = snapshot.pending.length
       const generating = initialBehavior.statusElapsed && runningSince !== undefined
         ? `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`

--- a/tests/desktop-notify.test.ts
+++ b/tests/desktop-notify.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  desktopNotifyBody,
+  desktopNotifySequence,
+  nextDesktopNotify,
+} from '../src/client/desktop-notify.ts'
+
+describe('desktop notifications', () => {
+  it('emits BEL plus OSC 9 and strips control characters from the body', () => {
+    expect(desktopNotifySequence('回合完成')).toBe('\u0007\u001B]9;回合完成\u0007')
+    expect(desktopNotifySequence('bad\u0007bell')).toBe('\u0007\u001B]9;bad bell\u0007')
+  })
+
+  it('notifies on turn completion, new approvals, and new questions after the first snapshot', () => {
+    const idle = { running: false, pending: [] }
+    const running = { running: true, pending: [] }
+    const approval = { running: false, pending: [{ key: 'a1', kind: 'approval' }] }
+    const question = { running: false, pending: [{ key: 'q1', kind: 'question' }] }
+
+    expect(nextDesktopNotify(idle, running, false)).toBeUndefined()
+    expect(nextDesktopNotify(running, idle, true)).toBe('turn-complete')
+    expect(nextDesktopNotify(running, approval, true)).toBe('approval')
+    expect(nextDesktopNotify(idle, question, true)).toBe('question')
+    expect(nextDesktopNotify(approval, approval, true)).toBeUndefined()
+    expect(desktopNotifyBody('approval', 'en')).toContain('approval')
+  })
+})


### PR DESCRIPTION
## Summary
- Write BEL + OSC 9 when a turn completes, a tool approval appears, or a question appears.
- Skip the first snapshot so resume/reconnect does not notify.
- Honor `desktopNotifications` from `seektty-behavior` (default on).
- Stacks on #20.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/desktop-notify.test.ts`
- [ ] Complete a turn in iTerm2/Kitty and confirm a desktop/terminal notification
- [ ] Trigger a tool approval and confirm a second notification
- [ ] Disable the setting and confirm the terminal stays silent after restart