### PR TITLE
feat(tui): follow the current session in the terminal title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28666,6 +28666,23 @@ function desktopNotifyBody(kind, locale) {
 }
 
 //#endregion
+//#region src/client/terminal-title.ts
+/** OSC window-title text derived from the current Session facts. */
+const DEFAULT_TERMINAL_TITLE = "DeepSeek Harness";
+/**
+* Choose the terminal window title for the current Session state.
+* @param facts - live Session presentation facts.
+* @returns a single-line title without control characters.
+*/
+function sessionTerminalTitle(facts) {
+	const session = facts.sessionTitle.replace(/[\u0000-\u001F\u007F]/gu, " ").replace(/\s+/gu, " ").trim() || DEFAULT_TERMINAL_TITLE;
+	if (!facts.follow) return DEFAULT_TERMINAL_TITLE;
+	if (facts.running) return `⏺ ${session}`;
+	if (facts.pendingApproval) return `⚠ ${session}`;
+	return session;
+}
+
+//#endregion
 //#region src/client/surface.ts
 /** Replaceable terminal seams used by virtual-terminal tests. */
 const internals$1 = {
@@ -28803,6 +28820,15 @@ async function startTuiSurface(options$1) {
 			updateStatus();
 			renderWhileOpen();
 		};
+		const applyTerminalTitle = () => {
+			const snapshot = active?.session.getSnapshot();
+			terminal.setTitle(sessionTerminalTitle({
+				follow: initialBehavior.followTerminalTitle,
+				sessionTitle: active?.summary.displayTitle ?? "",
+				running: snapshot?.running === true,
+				pendingApproval: snapshot?.pending.some((wait) => wait.kind === "approval") === true
+			}));
+		};
 		const updateStatus = () => {
 			if (stopping !== void 0) return;
 			const snapshot = active?.session.getSnapshot();
@@ -28827,6 +28853,7 @@ async function startTuiSurface(options$1) {
 				};
 				notifyPrimed = false;
 				status.setDetail(color.warning(translateUiText("未打开会话")));
+				applyTerminalTitle();
 				return;
 			}
 			const currentNotify = {
@@ -28860,6 +28887,7 @@ async function startTuiSurface(options$1) {
 			if (restartRequired !== void 0) facts.push(translateUiText("需要重启"));
 			const secondary = notice === void 0 ? [primary, facts.length === 0 ? void 0 : color.muted(facts.join(" · "))].filter((value) => value !== void 0).join(" · ") || void 0 : noticeText(notice.message, notice.tone);
 			status.setDetail(secondary);
+			applyTerminalTitle();
 		};
 		const refreshHeader = (forceModel = false) => {
 			const generation = ++headerGeneration;

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -46,6 +46,7 @@ import {
   nextDesktopNotify,
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
+import { sessionTerminalTitle } from './terminal-title.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -225,6 +226,16 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       renderWhileOpen()
     }
 
+    const applyTerminalTitle = (): void => {
+      const snapshot = active?.session.getSnapshot()
+      terminal.setTitle(sessionTerminalTitle({
+        follow: initialBehavior.followTerminalTitle,
+        sessionTitle: active?.summary.displayTitle ?? '',
+        running: snapshot?.running === true,
+        pendingApproval: snapshot?.pending.some(wait => wait.kind === 'approval') === true,
+      }))
+    }
+
     const updateStatus = (): void => {
       if (stopping !== undefined) return
       const snapshot = active?.session.getSnapshot()
@@ -248,6 +259,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         notifySnapshot = { running: false, pending: [] }
         notifyPrimed = false
         status.setDetail(color.warning(translateUiText('未打开会话')))
+        applyTerminalTitle()
         return
       }
       const currentNotify: DesktopNotifySnapshot = {
@@ -295,6 +307,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           .join(' · ') || undefined
         : noticeText(notice.message, notice.tone)
       status.setDetail(secondary)
+      applyTerminalTitle()
     }
 
     const refreshHeader = (forceModel = false): void => {
@@ -673,7 +686,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       return { consume: true }
     })
 
-    terminal.setTitle('DeepSeek Harness')
+    applyTerminalTitle()
     tui.start()
     refreshHeader(true)
     refresh()

--- a/src/client/terminal-title.ts
+++ b/src/client/terminal-title.ts
@@ -1,0 +1,24 @@
+/** OSC window-title text derived from the current Session facts. */
+
+export const DEFAULT_TERMINAL_TITLE = 'DeepSeek Harness'
+
+export interface TerminalTitleFacts {
+  readonly follow: boolean
+  readonly sessionTitle: string
+  readonly running: boolean
+  readonly pendingApproval: boolean
+}
+
+/**
+ * Choose the terminal window title for the current Session state.
+ * @param facts - live Session presentation facts.
+ * @returns a single-line title without control characters.
+ */
+export function sessionTerminalTitle(facts: TerminalTitleFacts): string {
+  const session = facts.sessionTitle.replace(/[\u0000-\u001F\u007F]/gu, ' ').replace(/\s+/gu, ' ').trim()
+    || DEFAULT_TERMINAL_TITLE
+  if (!facts.follow) return DEFAULT_TERMINAL_TITLE
+  if (facts.running) return `⏺ ${session}`
+  if (facts.pendingApproval) return `⚠ ${session}`
+  return session
+}

--- a/tests/terminal-title.test.ts
+++ b/tests/terminal-title.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_TERMINAL_TITLE, sessionTerminalTitle } from '../src/client/terminal-title.ts'
+
+describe('terminal title', () => {
+  it('follows running and pending-approval state, or stays on the product name when disabled', () => {
+    expect(sessionTerminalTitle({
+      follow: false,
+      sessionTitle: 'Inspect theme',
+      running: true,
+      pendingApproval: true,
+    })).toBe(DEFAULT_TERMINAL_TITLE)
+    expect(sessionTerminalTitle({
+      follow: true,
+      sessionTitle: 'Inspect theme',
+      running: true,
+      pendingApproval: false,
+    })).toBe('⏺ Inspect theme')
+    expect(sessionTerminalTitle({
+      follow: true,
+      sessionTitle: 'Inspect theme',
+      running: false,
+      pendingApproval: true,
+    })).toBe('⚠ Inspect theme')
+    expect(sessionTerminalTitle({
+      follow: true,
+      sessionTitle: 'Inspect theme',
+      running: false,
+      pendingApproval: false,
+    })).toBe('Inspect theme')
+    expect(sessionTerminalTitle({
+      follow: true,
+      sessionTitle: '',
+      running: false,
+      pendingApproval: false,
+    })).toBe(DEFAULT_TERMINAL_TITLE)
+  })
+})


### PR DESCRIPTION
## Summary
- Set the terminal title to the session name, prefix `⏺` while generating, and `⚠` while a tool approval is pending.
- Honor `followTerminalTitle` from `seektty-behavior` (default on).
- Stacks on #21.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/terminal-title.test.ts`
- [ ] Open a named session and confirm the tab title matches
- [ ] Start a turn and confirm the title gains `⏺`
- [ ] Disable the setting and confirm the title stays `DeepSeek Harness` after restart