### PR TITLE
feat(tui): show relative updated time in the session list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22116,6 +22116,44 @@ var HarnessAutocompleteProvider = class {
 };
 
 //#endregion
+//#region src/client/relative-time.ts
+/**
+* Format an updatedAt epoch as a compact relative clock.
+* @param updatedAt - epoch milliseconds.
+* @param now - comparison instant; defaults to Date.now().
+* @returns a short relative label, or a calendar date after seven days.
+*/
+function relativeTime(updatedAt, now = Date.now()) {
+	if (!Number.isFinite(updatedAt) || updatedAt <= 0) return ui("未知时间", "unknown time");
+	const delta = now - updatedAt;
+	if (delta < 45e3) return ui("刚刚", "just now");
+	if (delta < 9e4) return ui("1 分钟前", "1 minute ago");
+	if (delta < 36e5) {
+		const minutes = Math.round(delta / 6e4);
+		return ui(`${String(minutes)} 分钟前`, `${String(minutes)} minutes ago`);
+	}
+	if (delta < 54e5) return ui("1 小时前", "1 hour ago");
+	if (delta < 864e5) {
+		const hours = Math.round(delta / 36e5);
+		return ui(`${String(hours)} 小时前`, `${String(hours)} hours ago`);
+	}
+	if (delta < 1728e5) return ui("昨天", "yesterday");
+	if (delta < 7 * 864e5) {
+		const days = Math.round(delta / 864e5);
+		return ui(`${String(days)} 天前`, `${String(days)} days ago`);
+	}
+	return new Date(updatedAt).toISOString().slice(0, 10);
+}
+/**
+* Sort session rows by recency without mutating the Host list order.
+* @param rows - current Session summaries.
+* @returns newest-first copies.
+*/
+function sortSessionsByUpdatedAt(rows) {
+	return [...rows].sort((left, right) => right.updatedAt - left.updatedAt);
+}
+
+//#endregion
 //#region src/client/settings.ts
 function descriptionOf(node) {
 	const description = node.meta.description;
@@ -23125,13 +23163,13 @@ var TuiActions = class {
 	}
 	async sessions(query) {
 		const current = this.capabilities.active()?.sessionId;
-		const rows = this.capabilities.listSessions();
+		const rows = sortSessionsByUpdatedAt(this.capabilities.listSessions());
 		if (rows.length === 0) throw new Error("没有可恢复的会话");
 		const hits = query === "" ? void 0 : await this.capabilities.searchSessions(query, new AbortController().signal);
 		const choices = hits === void 0 ? rows.map((row) => ({
 			id: row.id,
 			label: `${row.id === current ? "● " : ""}${row.displayTitle}`,
-			description: `${row.cwd ?? "无工作区"} · ${row.running ? "运行中" : row.pendingInteraction ?? "空闲"}`
+			description: `${row.cwd ?? "无工作区"} · ${relativeTime(row.updatedAt)} · ${row.running ? "运行中" : row.pendingInteraction ?? "空闲"}`
 		})) : hits.items.map((hit) => {
 			const row = rows.find((candidate) => candidate.id === hit.sessionId);
 			return {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -23,6 +23,7 @@ import {
 } from '@deepseek-ai/dsh-tui-protocol'
 import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
 import { lastFencedCode } from './copy-content.ts'
+import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
 import type {
   TuiMarketplaceCandidate,
   TuiMarketplaceSource,
@@ -492,7 +493,7 @@ export class TuiActions {
 
   private async sessions(query: string): Promise<void> {
     const current = this.capabilities.active()?.sessionId
-    const rows = this.capabilities.listSessions()
+    const rows = sortSessionsByUpdatedAt(this.capabilities.listSessions())
     if (rows.length === 0) throw new Error('没有可恢复的会话')
     const hits = query === ''
       ? undefined
@@ -501,7 +502,7 @@ export class TuiActions {
       ? rows.map(row => ({
         id: row.id,
         label: `${row.id === current ? '● ' : ''}${row.displayTitle}`,
-        description: `${row.cwd ?? '无工作区'} · ${row.running ? '运行中' : row.pendingInteraction ?? '空闲'}`,
+        description: `${row.cwd ?? '无工作区'} · ${relativeTime(row.updatedAt)} · ${row.running ? '运行中' : row.pendingInteraction ?? '空闲'}`,
       }))
       : hits.items.map((hit) => {
         const row = rows.find(candidate => candidate.id === hit.sessionId)

--- a/src/client/relative-time.ts
+++ b/src/client/relative-time.ts
@@ -1,0 +1,42 @@
+/** Relative timestamps for session list rows. */
+
+import { ui } from './locale.ts'
+
+/**
+ * Format an updatedAt epoch as a compact relative clock.
+ * @param updatedAt - epoch milliseconds.
+ * @param now - comparison instant; defaults to Date.now().
+ * @returns a short relative label, or a calendar date after seven days.
+ */
+export function relativeTime(updatedAt: number, now = Date.now()): string {
+  if (!Number.isFinite(updatedAt) || updatedAt <= 0) return ui('未知时间', 'unknown time')
+  const delta = now - updatedAt
+  if (delta < 45_000) return ui('刚刚', 'just now')
+  if (delta < 90_000) return ui('1 分钟前', '1 minute ago')
+  if (delta < 3_600_000) {
+    const minutes = Math.round(delta / 60_000)
+    return ui(`${String(minutes)} 分钟前`, `${String(minutes)} minutes ago`)
+  }
+  if (delta < 5_400_000) return ui('1 小时前', '1 hour ago')
+  if (delta < 86_400_000) {
+    const hours = Math.round(delta / 3_600_000)
+    return ui(`${String(hours)} 小时前`, `${String(hours)} hours ago`)
+  }
+  if (delta < 172_800_000) return ui('昨天', 'yesterday')
+  if (delta < 7 * 86_400_000) {
+    const days = Math.round(delta / 86_400_000)
+    return ui(`${String(days)} 天前`, `${String(days)} days ago`)
+  }
+  return new Date(updatedAt).toISOString().slice(0, 10)
+}
+
+/**
+ * Sort session rows by recency without mutating the Host list order.
+ * @param rows - current Session summaries.
+ * @returns newest-first copies.
+ */
+export function sortSessionsByUpdatedAt<T extends { readonly updatedAt: number }>(
+  rows: readonly T[],
+): T[] {
+  return [...rows].sort((left, right) => right.updatedAt - left.updatedAt)
+}

--- a/tests/relative-time.test.ts
+++ b/tests/relative-time.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { setUiLocale } from '../src/client/locale.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from '../src/client/relative-time.ts'
+
+afterEach(() => { setUiLocale('zh') })
 
 describe('session relative time', () => {
   it('formats compact relative clocks and sorts by updatedAt descending', () => {

--- a/tests/relative-time.test.ts
+++ b/tests/relative-time.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { setUiLocale } from '../src/client/locale.ts'
+import { relativeTime, sortSessionsByUpdatedAt } from '../src/client/relative-time.ts'
+
+describe('session relative time', () => {
+  it('formats compact relative clocks and sorts by updatedAt descending', () => {
+    const now = Date.parse('2026-08-18T00:00:00.000Z')
+    expect(relativeTime(now - 10_000, now)).toBe('刚刚')
+    expect(relativeTime(now - 5 * 60_000, now)).toBe('5 分钟前')
+    expect(relativeTime(now - 3 * 3_600_000, now)).toBe('3 小时前')
+    expect(relativeTime(now - 2 * 86_400_000, now)).toBe('2 天前')
+    expect(relativeTime(now - 10 * 86_400_000, now)).toBe('2026-08-08')
+    setUiLocale('en')
+    expect(relativeTime(now - 10_000, now)).toBe('just now')
+    expect(sortSessionsByUpdatedAt([
+      { id: 'old', updatedAt: 1 },
+      { id: 'new', updatedAt: 3 },
+      { id: 'mid', updatedAt: 2 },
+    ]).map(row => row.id)).toEqual(['new', 'mid', 'old'])
+  })
+})


### PR DESCRIPTION
## Summary
- Sort `/sessions` by `updatedAt` and show a relative clock (`刚刚`, `5 分钟前`, calendar date after a week).
- Stacks on #23.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/relative-time.test.ts`
- [ ] Open `/sessions` and confirm recent sessions appear first with relative times