### PR TITLE
feat(tui): add incremental transcript search in focus mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-B4FBGWMO.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-cOck0GdD.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -27592,6 +27592,71 @@ var SyntaxHighlighter = class SyntaxHighlighter {
 };
 
 //#endregion
+//#region src/client/transcript-search.ts
+/** Incremental search over already-rendered transcript lines. */
+const ANSI = /\u001B\[[0-9;:]*m/gu;
+/**
+* Remove SGR sequences so search can match what the user sees.
+* @param value - possibly colorized terminal text.
+* @returns the printable text without SGR.
+*/
+function stripAnsi(value) {
+	return value.replace(ANSI, "");
+}
+/**
+* Find rendered lines that contain the query, ignoring color and case.
+* @param lines - full transcript lines before viewport clipping.
+* @param query - user-typed needle; blank queries match nothing.
+* @returns matching line indexes in document order.
+*/
+function findLineMatches(lines, query) {
+	const needle = query.trim().toLowerCase();
+	if (needle === "") return [];
+	return lines.flatMap((line, index) => stripAnsi(line).toLowerCase().includes(needle) ? [index] : []);
+}
+/**
+* Move to the next or previous match, wrapping at the ends.
+* @param matches - document-order line indexes.
+* @param current - current line index, which may be absent from matches.
+* @param direction - +1 for next, -1 for previous.
+* @returns the selected line index, or -1 when there are no matches.
+*/
+function nextMatchIndex(matches$1, current, direction) {
+	if (matches$1.length === 0) return -1;
+	const index = matches$1.indexOf(current);
+	if (index === -1) return matches$1[0] ?? -1;
+	return matches$1[(index + direction + matches$1.length) % matches$1.length] ?? -1;
+}
+/**
+* Highlight the first case-insensitive occurrence of the query on a stripped line.
+* @param line - a rendered line, possibly with SGR.
+* @param query - needle already known to occur on this line.
+* @param paint - wrap the matched substring.
+* @returns a stripped line with the first match painted.
+*/
+function highlightQuery(line, query, paint$1) {
+	const plain = stripAnsi(line);
+	const needle = query.trim();
+	if (needle === "") return plain;
+	const index = plain.toLowerCase().indexOf(needle.toLowerCase());
+	if (index < 0) return plain;
+	return `${plain.slice(0, index)}${paint$1(plain.slice(index, index + needle.length))}${plain.slice(index + needle.length)}`;
+}
+/**
+* Scroll so the matched line sits at the top of the viewport when possible.
+* @param lineCount - total rendered lines.
+* @param viewportRows - visible transcript rows.
+* @param lineIndex - document index to reveal.
+* @returns a bottom-origin scrollOffset compatible with Transcript.render.
+*/
+function scrollOffsetToReveal(lineCount, viewportRows, lineIndex) {
+	const rows = Math.max(1, Math.floor(viewportRows));
+	const maxOffset = Math.max(0, lineCount - rows);
+	const preferred = lineCount - lineIndex - rows;
+	return Math.max(0, Math.min(maxOffset, preferred));
+}
+
+//#endregion
 //#region src/client/transcript.ts
 const PULSE_FRAME_MS = 160;
 function thinkingRow() {
@@ -28430,6 +28495,8 @@ var Transcript = class {
 	turnCursor;
 	pulseFrame = 0;
 	pulseTimer;
+	lastFullLines = [];
+	search;
 	focused = false;
 	/**
 	* @param viewportRows - current terminal-dependent transcript height.
@@ -28568,7 +28635,14 @@ var Transcript = class {
 	render(width) {
 		const inset = width >= 12 ? 2 : 0;
 		const contentWidth = Math.max(1, width - inset * 2);
-		const withInset = (values) => values.map((line) => line === "" ? "" : `${" ".repeat(inset)}${line}`);
+		const totalRows = Math.max(1, Math.floor(this.viewportRows()));
+		const withInset = (values) => {
+			const body = values.map((line) => line === "" ? "" : `${" ".repeat(inset)}${line}`);
+			if (this.search === void 0) return body;
+			const label = `${" ".repeat(inset)}${color.accent(this.searchLabel())}`;
+			if (!Number.isFinite(totalRows)) return [...body, label];
+			return [...body.slice(0, Math.max(0, totalRows - 1)), label];
+		};
 		const olderMarker = (count) => {
 			if (this.loadingOlder) return color.muted(ui("↑ 正在加载更早内容…", "↑ Loading older content…"));
 			const hint = this.focused ? "PgUp/Home" : ui("滚轮上翻", "Scroll up");
@@ -28589,9 +28663,20 @@ var Transcript = class {
 			const content = line.trimEnd();
 			lines[index] = `${" ".repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`;
 		}
+		this.lastFullLines = [...lines];
 		this.renderedLineCount = lines.length;
 		this.turnAnchors = anchors;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
+		if (this.search !== void 0) {
+			const matches$1 = findLineMatches(lines, this.search.query);
+			if (this.search.matchIndex >= matches$1.length) this.search.matchIndex = 0;
+			const current = matches$1[this.search.matchIndex];
+			const query = this.search.query;
+			if (query.trim() !== "") for (const [index, line] of lines.entries()) {
+				if (!matches$1.includes(index)) continue;
+				lines[index] = highlightQuery(line, query, (matched) => index === current ? `\u001B[7m${matched}\u001B[0m` : color.accent(matched));
+			}
+		}
+		const rows = this.search !== void 0 && Number.isFinite(totalRows) ? Math.max(1, totalRows - 1) : totalRows;
 		if (!Number.isFinite(rows)) {
 			this.scrollOffset = 0;
 			return withInset(lines);
@@ -28643,6 +28728,19 @@ var Transcript = class {
 		return withInset(visible);
 	}
 	handleInput(data) {
+		if (this.search !== void 0) {
+			this.handleSearchInput(data);
+			return;
+		}
+		if (data === "/") {
+			this.search = {
+				query: "",
+				composing: true,
+				matchIndex: 0
+			};
+			this.requestRender();
+			return;
+		}
 		this.turnCursor = void 0;
 		const rows = Math.max(1, Math.floor(this.viewportRows()));
 		const maxOffset = Math.max(0, this.renderedLineCount - rows);
@@ -28652,6 +28750,112 @@ var Transcript = class {
 		else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
 		else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
 		else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset);
+	}
+	/**
+	* Leave incremental search and restore the ordinary transcript chrome.
+	* @returns true when a search session was closed.
+	*/
+	cancelSearch() {
+		if (this.search === void 0) return false;
+		this.search = void 0;
+		this.requestRender();
+		return true;
+	}
+	searchLabel() {
+		const query = this.search?.query ?? "";
+		const matches$1 = findLineMatches(this.lastFullLines, query);
+		if (query.trim() === "") return ui("查找：", "Find:");
+		if (matches$1.length === 0) return ui(`查找 ${query} · 无匹配 · Esc 取消`, `Find ${query} · no matches · Esc cancel`);
+		if (this.search?.composing === true) return ui(`查找 ${query} · ${String(matches$1.length)} 处 · Enter 确认 · Esc 取消`, `Find ${query} · ${String(matches$1.length)} match(es) · Enter confirm · Esc cancel`);
+		const current = Math.min((this.search?.matchIndex ?? 0) + 1, matches$1.length);
+		return ui(`查找 ${query} · ${String(current)}/${String(matches$1.length)} · n 下一个 · N 上一个 · Esc 取消`, `Find ${query} · ${String(current)}/${String(matches$1.length)} · n next · N previous · Esc cancel`);
+	}
+	handleSearchInput(data) {
+		if (matchesKey(data, Key.escape)) {
+			this.cancelSearch();
+			return;
+		}
+		if (matchesKey(data, Key.enter) || data === "\r" || data === "\n") {
+			if ((this.search?.query.trim() ?? "") === "") this.cancelSearch();
+			else {
+				this.search = {
+					...this.search,
+					composing: false
+				};
+				this.revealCurrentMatch();
+				this.requestRender();
+			}
+			return;
+		}
+		if (data === "" || data === "\b") {
+			const chars = Array.from(this.search?.query ?? "");
+			chars.pop();
+			this.search = {
+				query: chars.join(""),
+				composing: true,
+				matchIndex: 0
+			};
+			this.revealCurrentMatch();
+			this.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.up) || matchesKey(data, Key.down) || matchesKey(data, Key.pageUp) || matchesKey(data, Key.pageDown) || matchesKey(data, Key.home) || matchesKey(data, Key.end)) {
+			this.turnCursor = void 0;
+			const rows = Math.max(1, Math.floor(this.viewportRows()));
+			const maxOffset = Math.max(0, this.renderedLineCount - rows);
+			if (matchesKey(data, Key.up)) this.scrollBy(1);
+			else if (matchesKey(data, Key.down)) this.scrollBy(-1);
+			else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1));
+			else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
+			else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
+			else this.scrollBy(-this.scrollOffset);
+			return;
+		}
+		if (this.search?.composing === false) {
+			if (data === "n") {
+				this.stepSearch(1);
+				return;
+			}
+			if (data === "N") {
+				this.stepSearch(-1);
+				return;
+			}
+			if (data === "/") {
+				this.search = {
+					query: "",
+					composing: true,
+					matchIndex: 0
+				};
+				this.requestRender();
+				return;
+			}
+		}
+		if (data.includes("\x1B") || [...data].some((character) => character < " ")) return;
+		this.search = {
+			query: `${this.search?.query ?? ""}${data}`,
+			composing: true,
+			matchIndex: 0
+		};
+		this.revealCurrentMatch();
+		this.requestRender();
+	}
+	stepSearch(direction) {
+		if (this.search === void 0) return;
+		const matches$1 = findLineMatches(this.lastFullLines, this.search.query);
+		const next = nextMatchIndex(matches$1, matches$1[this.search.matchIndex] ?? -1, direction);
+		if (next < 0) return;
+		this.search = {
+			...this.search,
+			matchIndex: Math.max(0, matches$1.indexOf(next))
+		};
+		this.revealCurrentMatch();
+		this.requestRender();
+	}
+	revealCurrentMatch() {
+		if (this.search === void 0) return;
+		const lineIndex = findLineMatches(this.lastFullLines, this.search.query)[this.search.matchIndex];
+		if (lineIndex === void 0) return;
+		this.scrollOffset = scrollOffsetToReveal(this.lastFullLines.length, this.viewportRows(), lineIndex);
 	}
 	/**
 	* Move the conversation viewport while leaving the composer focus unchanged.
@@ -29373,12 +29577,17 @@ async function startTuiSurface(options$1) {
 				if (safeContent !== content) return { data: `\u001B[200~${safeContent}\u001B[201~` };
 			}
 			if (matchesKey(data, Key.tab) && (transcriptFocused || editor.getText() === "")) {
+				transcript.cancelSearch();
 				transcriptFocused = !transcriptFocused;
 				tui.setFocus(transcriptFocused ? transcript : editor);
 				setNotice(transcriptFocused ? "对话浏览 · Tab/Escape 返回输入" : "已返回输入区", "info");
 				return { consume: true };
 			}
 			if (transcriptFocused && matchesKey(data, Key.escape)) {
+				if (transcript.cancelSearch()) {
+					setNotice("已取消查找", "info");
+					return { consume: true };
+				}
 				focusEditor();
 				setNotice("已返回输入区", "info");
 				return { consume: true };

--- a/lib/startup-cOck0GdD.js
+++ b/lib/startup-cOck0GdD.js
@@ -99,6 +99,7 @@ const ENGLISH_TEXT = new Map([
 	["已清空输入草稿", "Draft cleared"],
 	["已返回输入区", "Returned to the composer"],
 	["对话浏览 · Tab/Escape 返回输入", "Transcript navigation · Tab/Escape returns to the composer"],
+	["已取消查找", "Search cancelled"],
 	["没有可跳转的用户轮次", "No user turn to jump to"],
 	["命令面板", "Command palette"],
 	["选择要使用的功能", "Choose a command"],
@@ -1211,6 +1212,18 @@ const ENGLISH_PATTERNS = [
 	{
 		pattern: /^生成中 · (.+) · Ctrl\+C 停止$/u,
 		replace: (value) => `Generating · ${value} · Ctrl+C to stop`
+	},
+	{
+		pattern: /^查找 (.+) · (\d+) 处 · Enter 确认 · Esc 取消$/u,
+		replace: (query, count) => `Find ${query} · ${count} match(es) · Enter confirm · Esc cancel`
+	},
+	{
+		pattern: /^查找 (.+) · (\d+)\/(\d+) · n 下一个 · N 上一个 · Esc 取消$/u,
+		replace: (query, current, total) => `Find ${query} · ${current}/${total} · n next · N previous · Esc cancel`
+	},
+	{
+		pattern: /^查找 (.+) · 无匹配 · Esc 取消$/u,
+		replace: (query) => `Find ${query} · no matches · Esc cancel`
 	}
 ];
 function requestedEnvironmentLocale(env) {

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-B4FBGWMO.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-cOck0GdD.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -104,6 +104,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['已清空输入草稿', 'Draft cleared'],
   ['已返回输入区', 'Returned to the composer'],
   ['对话浏览 · Tab/Escape 返回输入', 'Transcript navigation · Tab/Escape returns to the composer'],
+  ['已取消查找', 'Search cancelled'],
   ['没有可跳转的用户轮次', 'No user turn to jump to'],
   ['命令面板', 'Command palette'],
   ['选择要使用的功能', 'Choose a command'],
@@ -813,6 +814,9 @@ const ENGLISH_PATTERNS: readonly {
   { pattern: /^阻塞原因：(.+)$/su, replace: value => `Blocked by: ${value}` },
   { pattern: /^(\d+-\d+\/\d+) 行 · ↑↓ 滚动 · PgUp\/PgDn 翻页 · Home\/End · Enter\/q 关闭 · Esc 返回$/u, replace: value => `${value} lines · ↑↓ scroll · PgUp/PgDn page · Home/End · Enter/q close · Esc back` },
   { pattern: /^生成中 · (.+) · Ctrl\+C 停止$/u, replace: value => `Generating · ${value} · Ctrl+C to stop` },
+  { pattern: /^查找 (.+) · (\d+) 处 · Enter 确认 · Esc 取消$/u, replace: (query, count) => `Find ${query} · ${count} match(es) · Enter confirm · Esc cancel` },
+  { pattern: /^查找 (.+) · (\d+)\/(\d+) · n 下一个 · N 上一个 · Esc 取消$/u, replace: (query, current, total) => `Find ${query} · ${current}/${total} · n next · N previous · Esc cancel` },
+  { pattern: /^查找 (.+) · 无匹配 · Esc 取消$/u, replace: query => `Find ${query} · no matches · Esc cancel` },
 ]
 
 function requestedEnvironmentLocale(env: NodeJS.ProcessEnv): LocaleId {

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -576,12 +576,17 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         }
       }
       if (matchesKey(data, Key.tab) && (transcriptFocused || editor.getText() === '')) {
+        transcript.cancelSearch()
         transcriptFocused = !transcriptFocused
         tui.setFocus(transcriptFocused ? transcript : editor)
         setNotice(transcriptFocused ? '对话浏览 · Tab/Escape 返回输入' : '已返回输入区', 'info')
         return { consume: true }
       }
       if (transcriptFocused && matchesKey(data, Key.escape)) {
+        if (transcript.cancelSearch()) {
+          setNotice('已取消查找', 'info')
+          return { consume: true }
+        }
         focusEditor()
         setNotice('已返回输入区', 'info')
         return { consume: true }

--- a/src/client/transcript-search.ts
+++ b/src/client/transcript-search.ts
@@ -1,0 +1,82 @@
+/** Incremental search over already-rendered transcript lines. */
+
+const ANSI = /\u001B\[[0-9;:]*m/gu
+
+/**
+ * Remove SGR sequences so search can match what the user sees.
+ * @param value - possibly colorized terminal text.
+ * @returns the printable text without SGR.
+ */
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI, '')
+}
+
+/**
+ * Find rendered lines that contain the query, ignoring color and case.
+ * @param lines - full transcript lines before viewport clipping.
+ * @param query - user-typed needle; blank queries match nothing.
+ * @returns matching line indexes in document order.
+ */
+export function findLineMatches(lines: readonly string[], query: string): number[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return []
+  return lines.flatMap((line, index) =>
+    stripAnsi(line).toLowerCase().includes(needle) ? [index] : [])
+}
+
+/**
+ * Move to the next or previous match, wrapping at the ends.
+ * @param matches - document-order line indexes.
+ * @param current - current line index, which may be absent from matches.
+ * @param direction - +1 for next, -1 for previous.
+ * @returns the selected line index, or -1 when there are no matches.
+ */
+export function nextMatchIndex(
+  matches: readonly number[],
+  current: number,
+  direction: 1 | -1,
+): number {
+  if (matches.length === 0) return -1
+  const index = matches.indexOf(current)
+  if (index === -1) return matches[0] ?? -1
+  const next = (index + direction + matches.length) % matches.length
+  return matches[next] ?? -1
+}
+
+/**
+ * Highlight the first case-insensitive occurrence of the query on a stripped line.
+ * @param line - a rendered line, possibly with SGR.
+ * @param query - needle already known to occur on this line.
+ * @param paint - wrap the matched substring.
+ * @returns a stripped line with the first match painted.
+ */
+export function highlightQuery(
+  line: string,
+  query: string,
+  paint: (matched: string) => string,
+): string {
+  const plain = stripAnsi(line)
+  const needle = query.trim()
+  if (needle === '') return plain
+  const index = plain.toLowerCase().indexOf(needle.toLowerCase())
+  if (index < 0) return plain
+  return `${plain.slice(0, index)}${paint(plain.slice(index, index + needle.length))}${plain.slice(index + needle.length)}`
+}
+
+/**
+ * Scroll so the matched line sits at the top of the viewport when possible.
+ * @param lineCount - total rendered lines.
+ * @param viewportRows - visible transcript rows.
+ * @param lineIndex - document index to reveal.
+ * @returns a bottom-origin scrollOffset compatible with Transcript.render.
+ */
+export function scrollOffsetToReveal(
+  lineCount: number,
+  viewportRows: number,
+  lineIndex: number,
+): number {
+  const rows = Math.max(1, Math.floor(viewportRows))
+  const maxOffset = Math.max(0, lineCount - rows)
+  const preferred = lineCount - lineIndex - rows
+  return Math.max(0, Math.min(maxOffset, preferred))
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -34,6 +34,12 @@ import type {
 import { producedForClosing } from './compat/deliverables-rc6.ts'
 import { translateUiText, ui } from './locale.ts'
 import {
+  findLineMatches,
+  highlightQuery,
+  nextMatchIndex,
+  scrollOffsetToReveal,
+} from './transcript-search.ts'
+import {
   background,
   color,
   escapeTerminalText,
@@ -1060,6 +1066,8 @@ export class Transcript implements Component, Focusable {
   private turnCursor: number | undefined
   private pulseFrame = 0
   private pulseTimer: ReturnType<typeof setInterval> | undefined
+  private lastFullLines: readonly string[] = []
+  private search: { query: string; composing: boolean; matchIndex: number } | undefined
   focused = false
 
   /**
@@ -1216,8 +1224,14 @@ export class Transcript implements Component, Focusable {
   render(width: number): string[] {
     const inset = width >= 12 ? 2 : 0
     const contentWidth = Math.max(1, width - inset * 2)
-    const withInset = (values: readonly string[]): string[] => values.map(line =>
-      line === '' ? '' : `${' '.repeat(inset)}${line}`)
+    const totalRows = Math.max(1, Math.floor(this.viewportRows()))
+    const withInset = (values: readonly string[]): string[] => {
+      const body = values.map(line => line === '' ? '' : `${' '.repeat(inset)}${line}`)
+      if (this.search === undefined) return body
+      const label = `${' '.repeat(inset)}${color.accent(this.searchLabel())}`
+      if (!Number.isFinite(totalRows)) return [...body, label]
+      return [...body.slice(0, Math.max(0, totalRows - 1)), label]
+    }
     const olderMarker = (count: number): string => {
       if (this.loadingOlder) return color.muted(ui('↑ 正在加载更早内容…', '↑ Loading older content…'))
       const hint = this.focused ? 'PgUp/Home' : ui('滚轮上翻', 'Scroll up')
@@ -1246,9 +1260,25 @@ export class Transcript implements Component, Focusable {
         lines[index] = `${' '.repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`
       }
     }
+    this.lastFullLines = [...lines]
     this.renderedLineCount = lines.length
     this.turnAnchors = anchors
-    const rows = Math.max(1, Math.floor(this.viewportRows()))
+    if (this.search !== undefined) {
+      const matches = findLineMatches(lines, this.search.query)
+      if (this.search.matchIndex >= matches.length) this.search.matchIndex = 0
+      const current = matches[this.search.matchIndex]
+      const query = this.search.query
+      if (query.trim() !== '') {
+        for (const [index, line] of lines.entries()) {
+          if (!matches.includes(index)) continue
+          lines[index] = highlightQuery(line, query, matched =>
+            index === current ? `\u001B[7m${matched}\u001B[0m` : color.accent(matched))
+        }
+      }
+    }
+    const rows = this.search !== undefined && Number.isFinite(totalRows)
+      ? Math.max(1, totalRows - 1)
+      : totalRows
     if (!Number.isFinite(rows)) {
       this.scrollOffset = 0
       return withInset(lines)
@@ -1308,6 +1338,15 @@ export class Transcript implements Component, Focusable {
   }
 
   handleInput(data: string): void {
+    if (this.search !== undefined) {
+      this.handleSearchInput(data)
+      return
+    }
+    if (data === '/') {
+      this.search = { query: '', composing: true, matchIndex: 0 }
+      this.requestRender()
+      return
+    }
     this.turnCursor = undefined
     const rows = Math.max(1, Math.floor(this.viewportRows()))
     const maxOffset = Math.max(0, this.renderedLineCount - rows)
@@ -1317,6 +1356,121 @@ export class Transcript implements Component, Focusable {
     else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1))
     else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset)
     else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset)
+  }
+
+  /**
+   * Leave incremental search and restore the ordinary transcript chrome.
+   * @returns true when a search session was closed.
+   */
+  cancelSearch(): boolean {
+    if (this.search === undefined) return false
+    this.search = undefined
+    this.requestRender()
+    return true
+  }
+
+  private searchLabel(): string {
+    const query = this.search?.query ?? ''
+    const matches = findLineMatches(this.lastFullLines, query)
+    if (query.trim() === '') return ui('查找：', 'Find:')
+    if (matches.length === 0) {
+      return ui(`查找 ${query} · 无匹配 · Esc 取消`, `Find ${query} · no matches · Esc cancel`)
+    }
+    if (this.search?.composing === true) {
+      return ui(
+        `查找 ${query} · ${String(matches.length)} 处 · Enter 确认 · Esc 取消`,
+        `Find ${query} · ${String(matches.length)} match(es) · Enter confirm · Esc cancel`,
+      )
+    }
+    const current = Math.min((this.search?.matchIndex ?? 0) + 1, matches.length)
+    return ui(
+      `查找 ${query} · ${String(current)}/${String(matches.length)} · n 下一个 · N 上一个 · Esc 取消`,
+      `Find ${query} · ${String(current)}/${String(matches.length)} · n next · N previous · Esc cancel`,
+    )
+  }
+
+  private handleSearchInput(data: string): void {
+    if (matchesKey(data, Key.escape)) {
+      this.cancelSearch()
+      return
+    }
+    if (matchesKey(data, Key.enter) || data === '\r' || data === '\n') {
+      if ((this.search?.query.trim() ?? '') === '') this.cancelSearch()
+      else {
+        this.search = { ...this.search!, composing: false }
+        this.revealCurrentMatch()
+        this.requestRender()
+      }
+      return
+    }
+    if (data === '\x7f' || data === '\b') {
+      const chars = Array.from(this.search?.query ?? '')
+      chars.pop()
+      this.search = { query: chars.join(''), composing: true, matchIndex: 0 }
+      this.revealCurrentMatch()
+      this.requestRender()
+      return
+    }
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)
+      || matchesKey(data, Key.pageUp) || matchesKey(data, Key.pageDown)
+      || matchesKey(data, Key.home) || matchesKey(data, Key.end)) {
+      this.turnCursor = undefined
+      const rows = Math.max(1, Math.floor(this.viewportRows()))
+      const maxOffset = Math.max(0, this.renderedLineCount - rows)
+      if (matchesKey(data, Key.up)) this.scrollBy(1)
+      else if (matchesKey(data, Key.down)) this.scrollBy(-1)
+      else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1))
+      else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1))
+      else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset)
+      else this.scrollBy(-this.scrollOffset)
+      return
+    }
+    if (this.search?.composing === false) {
+      if (data === 'n') {
+        this.stepSearch(1)
+        return
+      }
+      if (data === 'N') {
+        this.stepSearch(-1)
+        return
+      }
+      if (data === '/') {
+        this.search = { query: '', composing: true, matchIndex: 0 }
+        this.requestRender()
+        return
+      }
+    }
+    if (data.includes('\u001B') || [...data].some(character => character < ' ')) return
+    this.search = {
+      query: `${this.search?.query ?? ''}${data}`,
+      composing: true,
+      matchIndex: 0,
+    }
+    this.revealCurrentMatch()
+    this.requestRender()
+  }
+
+  private stepSearch(direction: 1 | -1): void {
+    if (this.search === undefined) return
+    const matches = findLineMatches(this.lastFullLines, this.search.query)
+    const current = matches[this.search.matchIndex] ?? -1
+    const next = nextMatchIndex(matches, current, direction)
+    if (next < 0) return
+    this.search = { ...this.search, matchIndex: Math.max(0, matches.indexOf(next)) }
+    this.revealCurrentMatch()
+    this.requestRender()
+  }
+
+  private revealCurrentMatch(): void {
+    if (this.search === undefined) return
+    const matches = findLineMatches(this.lastFullLines, this.search.query)
+    const lineIndex = matches[this.search.matchIndex]
+    if (lineIndex === undefined) return
+    this.scrollOffset = scrollOffsetToReveal(
+      this.lastFullLines.length,
+      this.viewportRows(),
+      lineIndex,
+    )
   }
 
   /**

--- a/tests/transcript-search.test.ts
+++ b/tests/transcript-search.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findLineMatches,
+  highlightQuery,
+  nextMatchIndex,
+  scrollOffsetToReveal,
+  stripAnsi,
+} from '../src/client/transcript-search.ts'
+
+describe('transcript in-session search', () => {
+  it('matches stripped lines case-insensitively and steps circularly', () => {
+    const lines = ['Hello World', '\u001B[32mhello\u001B[0m there', 'nope']
+    expect(findLineMatches(lines, 'HELLO')).toEqual([0, 1])
+    expect(findLineMatches(lines, '   ')).toEqual([])
+    expect(nextMatchIndex([0, 5], 0, 1)).toBe(5)
+    expect(nextMatchIndex([0, 5], 5, 1)).toBe(0)
+    expect(nextMatchIndex([0, 5], 5, -1)).toBe(0)
+    expect(highlightQuery('Hello World', 'lo', text => `[${text}]`)).toBe('Hel[lo] World')
+    expect(stripAnsi('\u001B[7mhit\u001B[0m')).toBe('hit')
+    expect(scrollOffsetToReveal(20, 8, 2)).toBe(10)
+  })
+})

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -697,4 +697,25 @@ describe('conversation viewport', () => {
     expect(after).not.toBe(before)
     expect(requestRender).toHaveBeenCalledTimes(2)
   })
+
+  it('searches rendered lines from focus mode and jumps with n/N', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 12)
+    transcript.update(snapshot([
+      user('u1', 'alpha unique-token'),
+      assistant('a1', 'beta unique-token gamma'),
+    ]))
+    transcript.render(60)
+    transcript.handleInput('/')
+    for (const character of 'unique-token') transcript.handleInput(character)
+    const composing = stripAnsi(transcript.render(60).join('\n'))
+    expect(composing).toContain('查找 unique-token')
+    transcript.handleInput('\r')
+    transcript.handleInput('n')
+    const jumped = stripAnsi(transcript.render(60).join('\n'))
+    expect(jumped).toMatch(/查找 unique-token · 2\/2/)
+    expect(transcript.cancelSearch()).toBe(true)
+    expect(transcript.cancelSearch()).toBe(false)
+    expect(stripAnsi(transcript.render(60).join('\n'))).not.toContain('查找 unique-token')
+  })
 })


### PR DESCRIPTION
## Summary
- Transcript focus `/` starts incremental search over already-rendered lines.
- Matches are highlighted; Enter confirms, `n`/`N` jump, Esc cancels (before leaving focus).
- Stacks on #24.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/transcript-search.test.ts tests/transcript.test.ts`
- [ ] Tab to transcript, `/query`, Enter, then `n`/`N`