### PR TITLE
feat(tui): add a multiline overlay for queue edits and custom answers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DmgP3Q1N.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-YFvzJx56.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D5nWF8rN.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -24400,7 +24400,7 @@ var TuiActions = class {
 		if (action.id === "steer") await this.capabilities.updateQueue(row.id, { kind: "steer" });
 		if (action.id === "remove") await this.capabilities.updateQueue(row.id, { kind: "remove" });
 		if (action.id === "edit" && row.text !== null) {
-			const text = await nav.input({
+			const text = await nav.multilineInput({
 				title: "编辑排队消息",
 				initialValue: row.text
 			});
@@ -26189,7 +26189,7 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 				return;
 			}
 			if (picked.id === "__custom__") {
-				const custom = await this.host.overlays.input({
+				const custom = await this.host.overlays.multilineInput({
 					title: question.question,
 					...question.detail === void 0 ? {} : { detail: question.detail },
 					options: {
@@ -26815,6 +26815,45 @@ var TextInputOverlay = class {
 		this.input.handleInput(data);
 	}
 };
+/** Multiline editor overlay: Enter inserts a newline, Ctrl+Enter submits. */
+var MultilineEditorOverlay = class {
+	focused = false;
+	editor;
+	constructor(tui, request, submit) {
+		this.request = request;
+		this.submit = submit;
+		this.editor = new Editor(tui, editorTheme, {
+			paddingX: 0,
+			autocompleteMaxVisible: 3
+		});
+		this.editor.disableSubmit = true;
+		this.editor.setText(escapeTerminalText(request.initialValue ?? ""));
+	}
+	invalidate() {
+		this.editor.invalidate();
+	}
+	render(width) {
+		const safeWidth = frameContentWidth(width);
+		this.editor.focused = this.focused;
+		const body = this.editor.render(Math.max(8, safeWidth)).slice(0, 12);
+		return modalFrame(this.request.title, [
+			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
+			...body,
+			color.muted(translateUiText("Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭"))
+		], width);
+	}
+	handleInput(data) {
+		if (matchesKey(data, Key.ctrl(Key.enter)) || data === "\n") {
+			this.submit(escapeTerminalText(this.editor.getExpandedText()));
+			return;
+		}
+		if (matchesKey(data, Key.enter) || data === "\r") {
+			this.editor.insertTextAtCursor("\n");
+			return;
+		}
+		this.editor.handleInput(data);
+	}
+};
 /** Write-only secret input: the underlying value is never returned by render(). */
 var SecretInputOverlay = class {
 	focused = false;
@@ -26972,7 +27011,8 @@ var NavigationOverlay = class {
 	stack = [];
 	closed = false;
 	pendingBack;
-	constructor(run$1, settle, reject, requestRender) {
+	constructor(tui, run$1, settle, reject, requestRender) {
+		this.tui = tui;
 		this.settle = settle;
 		this.reject = reject;
 		this.requestRender = requestRender;
@@ -27043,6 +27083,9 @@ var NavigationOverlay = class {
 	}
 	input(request) {
 		return this.prompt((submit) => new TextInputOverlay(request, submit));
+	}
+	multilineInput(request) {
+		return this.prompt((submit) => new MultilineEditorOverlay(this.tui, request, submit));
 	}
 	secretInput(request) {
 		return this.prompt((submit) => new SecretInputOverlay(request, submit));
@@ -27186,7 +27229,7 @@ var OverlayQueue = class {
 	* @returns the explicit session result, or undefined after root Back/abort.
 	*/
 	navigate(run$1, options$1) {
-		return this.enqueue((settle, reject) => new NavigationOverlay(run$1, settle, reject, () => {
+		return this.enqueue((settle, reject) => new NavigationOverlay(this.tui, run$1, settle, reject, () => {
 			this.tui.requestRender();
 		}), options$1);
 	}
@@ -27209,6 +27252,17 @@ var OverlayQueue = class {
 	input(request) {
 		return this.navigate(async (navigation) => {
 			const value = await navigation.input(request);
+			navigation.finish(value);
+		}, request.options);
+	}
+	/**
+	* Open a multiline editor: Enter inserts a newline, Ctrl+Enter submits.
+	* @param request - title, optional detail, and initial value.
+	* @returns submitted text, or undefined after cancellation.
+	*/
+	multilineInput(request) {
+		return this.navigate(async (navigation) => {
+			const value = await navigation.multilineInput(request);
 			navigation.finish(value);
 		}, request.options);
 	}

--- a/lib/startup-YFvzJx56.js
+++ b/lib/startup-YFvzJx56.js
@@ -120,6 +120,7 @@ const ENGLISH_TEXT = new Map([
 	["↑↓ 选择 · Enter 确认 · Esc 返回/关闭", "↑↓ Select · Enter confirm · Esc back/close"],
 	["↑↓ 选择 · Enter 确认 · Esc 关闭", "↑↓ Select · Enter confirm · Esc close"],
 	["Enter 确认 · Esc 返回/关闭", "Enter confirm · Esc back/close"],
+	["Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭", "Enter newline · Ctrl+Enter submit · Esc back/close"],
 	["↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭", "↑↓ Select · Space toggle · Enter submit · Esc back/close"],
 	["输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭", "Input is never displayed or logged · Enter save · Esc back/close"],
 	["Enter 确认 · Esc 安全拒绝", "Enter confirm · Esc safely denies"],

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DmgP3Q1N.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-YFvzJx56.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1642,7 +1642,7 @@ export class TuiActions {
     if (action.id === 'steer') await this.capabilities.updateQueue(row.id, { kind: 'steer' })
     if (action.id === 'remove') await this.capabilities.updateQueue(row.id, { kind: 'remove' })
     if (action.id === 'edit' && row.text !== null) {
-      const text = await nav.input({ title: '编辑排队消息', initialValue: row.text })
+      const text = await nav.multilineInput({ title: '编辑排队消息', initialValue: row.text })
       if (text !== undefined) await this.capabilities.updateQueue(row.id, { kind: 'edit', content: [{ type: 'text', text }] })
     }
     if (action.id === 'up' || action.id === 'down') {
@@ -3324,7 +3324,7 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
         return
       }
       if (picked.id === '__custom__') {
-        const custom = await this.host.overlays.input({
+        const custom = await this.host.overlays.multilineInput({
           title: question.question,
           ...(question.detail === undefined ? {} : { detail: question.detail }),
           options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -125,6 +125,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['↑↓ 选择 · Enter 确认 · Esc 返回/关闭', '↑↓ Select · Enter confirm · Esc back/close'],
   ['↑↓ 选择 · Enter 确认 · Esc 关闭', '↑↓ Select · Enter confirm · Esc close'],
   ['Enter 确认 · Esc 返回/关闭', 'Enter confirm · Esc back/close'],
+  ['Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭', 'Enter newline · Ctrl+Enter submit · Esc back/close'],
   ['↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭', '↑↓ Select · Space toggle · Enter submit · Esc back/close'],
   ['输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭', 'Input is never displayed or logged · Enter save · Esc back/close'],
   ['Enter 确认 · Esc 安全拒绝', 'Enter confirm · Esc safely denies'],

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -2,6 +2,7 @@
 
 import {
   CURSOR_MARKER,
+  Editor,
   fuzzyFilter,
   Input,
   Key,
@@ -62,6 +63,7 @@ export interface DetailOverlayRequest {
 export interface OverlayPrompts {
   select(request: SelectOverlayRequest): Promise<OverlayChoice | undefined>
   input(request: InputOverlayRequest): Promise<string | undefined>
+  multilineInput(request: InputOverlayRequest): Promise<string | undefined>
   secretInput(request: InputOverlayRequest): Promise<string | undefined>
   multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined>
   detail(request: DetailOverlayRequest): Promise<void>
@@ -304,6 +306,49 @@ class TextInputOverlay implements Component {
   }
 }
 
+/** Multiline editor overlay: Enter inserts a newline, Ctrl+Enter submits. */
+class MultilineEditorOverlay implements Component {
+  focused = false
+  private readonly editor: Editor
+
+  constructor(
+    tui: TUI,
+    private readonly request: InputOverlayRequest,
+    private readonly submit: (value: string) => void,
+  ) {
+    this.editor = new Editor(tui, editorTheme, { paddingX: 0, autocompleteMaxVisible: 3 })
+    this.editor.disableSubmit = true
+    this.editor.setText(escapeTerminalText(request.initialValue ?? ''))
+  }
+
+  invalidate(): void { this.editor.invalidate() }
+
+  render(width: number): string[] {
+    const safeWidth = frameContentWidth(width)
+    this.editor.focused = this.focused
+    const body = this.editor.render(Math.max(8, safeWidth)).slice(0, 12)
+    return modalFrame(this.request.title, [
+      ...(this.request.detail === undefined
+        ? []
+        : wrappedDetail(this.request.detail, safeWidth)),
+      ...body,
+      color.muted(translateUiText('Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭')),
+    ], width)
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.ctrl(Key.enter)) || data === '\n') {
+      this.submit(escapeTerminalText(this.editor.getExpandedText()))
+      return
+    }
+    if (matchesKey(data, Key.enter) || data === '\r') {
+      this.editor.insertTextAtCursor('\n')
+      return
+    }
+    this.editor.handleInput(data)
+  }
+}
+
 /** Write-only secret input: the underlying value is never returned by render(). */
 class SecretInputOverlay implements Component {
   focused = false
@@ -494,6 +539,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
   private pendingBack: NavigationEntry | undefined
 
   constructor(
+    private readonly tui: TUI,
     run: (navigation: OverlayNavigation<TResult>) => void | Promise<void>,
     private readonly settle: (value: TResult | undefined) => void,
     private readonly reject: (error: unknown) => void,
@@ -576,6 +622,10 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
 
   input(request: InputOverlayRequest): Promise<string | undefined> {
     return this.prompt(submit => new TextInputOverlay(request, submit))
+  }
+
+  multilineInput(request: InputOverlayRequest): Promise<string | undefined> {
+    return this.prompt(submit => new MultilineEditorOverlay(this.tui, request, submit))
   }
 
   secretInput(request: InputOverlayRequest): Promise<string | undefined> {
@@ -720,7 +770,7 @@ export class OverlayQueue implements OverlayPrompts {
     options?: OverlayOptions,
   ): Promise<TResult | undefined> {
     return this.enqueue(
-      (settle, reject) => new NavigationOverlay(run, settle, reject, () => {
+      (settle, reject) => new NavigationOverlay(this.tui, run, settle, reject, () => {
         this.tui.requestRender()
       }),
       options,
@@ -747,6 +797,18 @@ export class OverlayQueue implements OverlayPrompts {
   input(request: InputOverlayRequest): Promise<string | undefined> {
     return this.navigate<string>(async (navigation) => {
       const value = await navigation.input(request)
+      navigation.finish(value)
+    }, request.options)
+  }
+
+  /**
+   * Open a multiline editor: Enter inserts a newline, Ctrl+Enter submits.
+   * @param request - title, optional detail, and initial value.
+   * @returns submitted text, or undefined after cancellation.
+   */
+  multilineInput(request: InputOverlayRequest): Promise<string | undefined> {
+    return this.navigate<string>(async (navigation) => {
+      const value = await navigation.multilineInput(request)
       navigation.finish(value)
     }, request.options)
   }

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -23,6 +23,7 @@ function overlayHarness(): {
       return { hide } as unknown as OverlayHandle
     }),
     requestRender: vi.fn(),
+    terminal: { rows: 24, cols: 80 },
   } as unknown as TUI
   return {
     overlays: new OverlayQueue(tui),
@@ -124,5 +125,21 @@ describe('overlay navigation', () => {
     expect(harness.hide).not.toHaveBeenCalled()
     harness.component().handleInput(ESCAPE)
     await expect(session).resolves.toBeUndefined()
+  })
+
+  it('submits multiline overlay text with Ctrl+Enter and keeps Enter as a newline', async () => {
+    const harness = overlayHarness()
+    const submitted = harness.overlays.multilineInput({
+      title: 'edit queued',
+      initialValue: 'hello',
+    })
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('edit queued')
+    })
+    harness.component().handleInput(ENTER)
+    harness.component().handleInput('x')
+    expect(plain(harness.component().render(80))).toContain('Ctrl+Enter')
+    harness.component().handleInput('\n')
+    await expect(submitted).resolves.toBe('hello\nx')
   })
 })


### PR DESCRIPTION
## Summary
- New multiline overlay: Enter inserts a newline, Ctrl+Enter submits.
- Used for queue message edits and custom question answers.
- Stacks on #27.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/overlays-navigation.test.ts`
- [ ] Edit a queued message with a line break, then submit with Ctrl+Enter