### PR TITLE
feat(tui): export Markdown transcripts and human-size ZIP notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current release covers these capabilities:
 | Area | Available operations |
 | --- | --- |
 | Conversation and runs | Streaming responses, Markdown/GFM, fence-free theme-aware syntax-highlighted code blocks, links, tables, reasoning visibility, collapsed/expanded/hidden tool cards, model retries, compaction, output-limit and error states, and Ctrl+C cancellation |
-| Sessions | Create, resume, list, full-text search, rename, fork, archive, copy the last answer, and export the current session or its complete subagent tree and attachments as ZIP |
+| Sessions | Create, resume, list, full-text search, rename, fork, archive, copy the last answer, export ZIP, or `/export md` Markdown |
 | Workspaces | Start from the current directory; add, select, rename, unregister, reorder, and reorder sessions within a workspace; unregistering never deletes files or session logs |
 | Agent modes | Standard, Code/PTC, Minimal, and Cordis/Create baseline modes plus dynamically registered Agent Presets; switching an active conversation creates a new session in the same workspace |
 | Models and Providers | Dynamic Provider, model, and supported reasoning-effort discovery; current route display; per-session switching; catalog, credential, and routing diagnostics |
@@ -95,7 +95,7 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 
 | Category | Commands |
 | --- | --- |
-| Sessions | `/new`, `/resume`, `/sessions`, `/rename`, `/fork`, `/archive`, `/export`, `/copy` |
+| Sessions | `/new`, `/resume`, `/sessions`, `/rename`, `/fork`, `/archive`, `/export`, `/export md`, `/copy` |
 | Work environment | `/workspace`, `/profile` |
 | Agent | `/mode`, `/model`, `/permission`, `/plan`, `/goal`, `/compact` |
 | Runtime interaction | `/queue`, `/steer`, `/attach`, `/attachments`, `/pending` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,7 +39,7 @@ Markdown 围栏会直接渲染成连续代码色块。助手代码、Shell 指�
 | 能力 | 当前可用操作 |
 | --- | --- |
 | 对话与运行 | 流式回复、Markdown/GFM、不显示围栏的主题语法高亮代码色块、链接、表格、推理显示切换、工具卡片折叠/展开/隐藏、模型重试、上下文压缩、最大输出与错误状态、Ctrl+C 停止当前轮次 |
-| 会话 | 新建、恢复、列表、全文搜索、重命名、Fork、归档、复制最后一条回复、导出当前会话或连同子 Agent 会话及附件一起导出 ZIP |
+| 会话 | 新建、恢复、列表、全文搜索、重命名、Fork、归档、复制最后一条回复、导出 ZIP，或 `/export md` 导出 Markdown |
 | 工作区 | 从当前目录启动，添加、选择、重命名、移除注册、调整工作区顺序和工作区内会话顺序；移除注册不会删除目录、文件或会话日志 |
 | Agent 模式 | 支持 Standard、Code/PTC、Minimal、Cordis/Create 四种基线模式，并动态显示插件注册的新 Agent Preset；活跃会话切换模式时在同一工作区创建新会话 |
 | 模型与 Provider | 动态读取 Provider、模型和模型支持的推理强度，显示当前实际路由，切换当前会话模型，并报告目录、凭证和路由错误 |
@@ -95,7 +95,7 @@ dsh --profile tui
 
 | 分类 | 命令 |
 | --- | --- |
-| 会话 | `/new`、`/resume`、`/sessions`、`/rename`、`/fork`、`/archive`、`/export`、`/copy` |
+| 会话 | `/new`、`/resume`、`/sessions`、`/rename`、`/fork`、`/archive`、`/export`、`/export md`、`/copy` |
 | 工作环境 | `/workspace`、`/profile` |
 | Agent | `/mode`、`/model`、`/permission`、`/plan`、`/goal`、`/compact` |
 | 运行交互 | `/queue`、`/steer`、`/attach`、`/attachments`、`/pending` |

--- a/lib/index.js
+++ b/lib/index.js
@@ -19573,6 +19573,50 @@ function copyTargets(entries) {
 }
 
 //#endregion
+//#region src/client/conversation-markdown.ts
+function contentBlockText$1(block$1) {
+	if (typeof block$1 !== "object" || block$1 === null) return String(block$1);
+	const value = block$1;
+	if (value.type === "text" || value.type === "reasoning") return typeof value.text === "string" ? value.text : `[${value.type}]`;
+	if (value.type === "image") return "[image]";
+	if (value.type === "tool-result") return "[tool result]";
+	return `[${typeof value.type === "string" ? value.type : "content"}]`;
+}
+function userSection(heading$1, content) {
+	const text = content.map(contentBlockText$1).join("\n").trim();
+	if (text === "") return void 0;
+	return `## ${heading$1}\n\n${text}`;
+}
+function assistantSection(node) {
+	const parts = [];
+	for (const block$1 of node.blocks) if (block$1.kind === "text" && block$1.text !== void 0 && block$1.text.trim() !== "") parts.push(block$1.text.trimEnd());
+	else if (block$1.kind === "tool-call" && block$1.name !== void 0) parts.push(`- tool \`${block$1.name}\``);
+	else if (block$1.kind === "image") parts.push("[image]");
+	if (parts.length === 0) return void 0;
+	return `## Assistant\n\n${parts.join("\n\n")}`;
+}
+/**
+* Render visible conversation nodes as Markdown for `/export md`.
+* @param title - session display title used as the document heading.
+* @param nodes - Runtime conversation nodes in display order.
+* @returns Markdown with a trailing newline.
+*/
+function conversationMarkdown(title, nodes) {
+	const sections = [`# ${title === "" ? "Session" : title}`];
+	for (const node of nodes) if (node.kind === "user" && "content" in node) {
+		const section = userSection("User", node.content);
+		if (section !== void 0) sections.push(section);
+	} else if (node.kind === "steering" && "content" in node) {
+		const section = userSection("Steering", node.content);
+		if (section !== void 0) sections.push(section);
+	} else if (node.kind === "assistant" && "blocks" in node) {
+		const section = assistantSection(node);
+		if (section !== void 0) sections.push(section);
+	}
+	return `${sections.join("\n\n")}\n`;
+}
+
+//#endregion
 //#region src/client/capabilities.ts
 const SAFE_PERMISSION_PRESETS = new Set(["read-only", "workspace-write"]);
 const FULL_ACCESS_PRESET = "danger-full-access";
@@ -19635,7 +19679,7 @@ const TUI_COMMANDS = Object.freeze([
 	{
 		name: "export",
 		description: "导出当前会话",
-		argumentHint: "[路径]",
+		argumentHint: "[md] [路径]",
 		source: "TUI",
 		behavior: "local"
 	},
@@ -19895,6 +19939,25 @@ async function saveExport(path$1, stream) {
 		await file.close().catch(() => void 0);
 		if (!complete) await unlink(path$1).catch(() => void 0);
 	}
+}
+async function saveTextExport(path$1, text) {
+	await mkdir(dirname(path$1), { recursive: true });
+	const file = await open(path$1, "wx");
+	let complete = false;
+	try {
+		const bytes = Buffer.byteLength(text, "utf8");
+		await file.write(Buffer.from(text, "utf8"));
+		await file.sync();
+		complete = true;
+		return bytes;
+	} finally {
+		await file.close().catch(() => void 0);
+		if (!complete) await unlink(path$1).catch(() => void 0);
+	}
+}
+function markdownExportName(title) {
+	const slug = title.replace(/[^\p{L}\p{N}._-]+/gu, "-").replace(/^-+|-+$/gu, "").slice(0, 80);
+	return `${slug === "" ? "session" : slug}.md`;
 }
 function isPermissionSelect(value) {
 	if (typeof value !== "object" || value === null) return false;
@@ -20766,6 +20829,22 @@ var HarnessTuiCapabilities = class {
 			bytes: await saveExport(path$1, payload.stream),
 			mediaType: payload.mediaType,
 			includeDescendants
+		};
+	}
+	/**
+	* Write a client-rendered Markdown transcript beside the workspace.
+	* @param requestedPath - absolute or Workspace-relative destination.
+	* @returns saved path, byte count, and Markdown media type.
+	*/
+	async exportMarkdown(requestedPath) {
+		const active = this.requireActive();
+		const markdown = conversationMarkdown(active.summary.displayTitle, active.session.getSnapshot().nodes);
+		const path$1 = resolve(active.workspacePath, requestedPath ?? markdownExportName(active.summary.displayTitle));
+		return {
+			path: path$1,
+			bytes: await saveTextExport(path$1, markdown),
+			mediaType: "text/markdown",
+			includeDescendants: false
 		};
 	}
 	/**
@@ -22117,6 +22196,33 @@ var HarnessAutocompleteProvider = class {
 };
 
 //#endregion
+//#region src/client/byte-size.ts
+/** Human-readable byte counts for export notices. */
+const UNITS = [
+	"B",
+	"KB",
+	"MB",
+	"GB",
+	"TB"
+];
+/**
+* Format a byte count using 1024-based units.
+* @param bytes - non-negative integer byte length.
+* @returns a compact label such as `11.8 MB`.
+*/
+function formatByteSize(bytes) {
+	const amount = Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
+	let value = amount;
+	let unit = 0;
+	while (value >= 1024 && unit < UNITS.length - 1) {
+		value /= 1024;
+		unit += 1;
+	}
+	if (unit === 0) return `${Math.round(amount)} B`;
+	return `${value >= 100 ? String(Math.round(value)) : String(Math.round(value * 10) / 10)} ${UNITS[unit]}`;
+}
+
+//#endregion
 //#region src/client/job-control.ts
 /**
 * Whether the user can still request cancellation.
@@ -23270,6 +23376,11 @@ var TuiActions = class {
 		this.host.notice("会话已归档；当前不能在这里恢复", "success");
 	}
 	async exportSession(args) {
+		const parsed = commandParts(args);
+		if (parsed.command === "md") {
+			await this.exportMarkdown(parsed.rest);
+			return;
+		}
 		const scope = await this.host.overlays.select({
 			title: "导出会话",
 			detail: "将原始会话记录和附件保存为 ZIP 文件",
@@ -23292,7 +23403,17 @@ var TuiActions = class {
 		}) : args;
 		if (requested === void 0) return;
 		const result = await this.capabilities.exportSession(requested.trim() === "" ? void 0 : requested.trim(), scope.id === "descendants");
-		this.host.notice(`已保存会话 ZIP（${String(result.bytes)} 字节）到 ${result.path}`, "success");
+		this.host.notice(ui(`已保存会话 ZIP（${formatByteSize(result.bytes)}）到 ${result.path}`, `Saved session ZIP (${formatByteSize(result.bytes)}) to ${result.path}`), "success");
+	}
+	async exportMarkdown(requested) {
+		const path$1 = requested === "" ? await this.host.overlays.input({
+			title: ui("保存会话 Markdown", "Save session Markdown"),
+			detail: ui("留空则保存到工作区根目录；已有文件不会被覆盖", "Leave empty to save at the workspace root; existing files are not overwritten"),
+			placeholder: ui("可选：相对工作区或绝对路径", "Optional: workspace-relative or absolute path")
+		}) : requested;
+		if (path$1 === void 0) return;
+		const result = await this.capabilities.exportMarkdown(path$1.trim() === "" ? void 0 : path$1.trim());
+		this.host.notice(ui(`已保存会话 Markdown（${formatByteSize(result.bytes)}）到 ${result.path}`, `Saved session Markdown (${formatByteSize(result.bytes)}) to ${result.path}`), "success");
 	}
 	async copy(args) {
 		const parsed = commandParts(args);

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -23,6 +23,7 @@ import {
 } from '@deepseek-ai/dsh-tui-protocol'
 import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
 import { lastFencedCode } from './copy-content.ts'
+import { formatByteSize } from './byte-size.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
 import { moveIndex } from './queue-order.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
@@ -558,6 +559,11 @@ export class TuiActions {
   }
 
   private async exportSession(args: string): Promise<void> {
+    const parsed = commandParts(args)
+    if (parsed.command === 'md') {
+      await this.exportMarkdown(parsed.rest)
+      return
+    }
     const scope = await this.host.overlays.select({
       title: '导出会话',
       detail: '将原始会话记录和附件保存为 ZIP 文件',
@@ -580,7 +586,26 @@ export class TuiActions {
       requested.trim() === '' ? undefined : requested.trim(),
       scope.id === 'descendants',
     )
-    this.host.notice(`已保存会话 ZIP（${String(result.bytes)} 字节）到 ${result.path}`, 'success')
+    this.host.notice(ui(
+      `已保存会话 ZIP（${formatByteSize(result.bytes)}）到 ${result.path}`,
+      `Saved session ZIP (${formatByteSize(result.bytes)}) to ${result.path}`,
+    ), 'success')
+  }
+
+  private async exportMarkdown(requested: string): Promise<void> {
+    const path = requested === ''
+      ? await this.host.overlays.input({
+        title: ui('保存会话 Markdown', 'Save session Markdown'),
+        detail: ui('留空则保存到工作区根目录；已有文件不会被覆盖', 'Leave empty to save at the workspace root; existing files are not overwritten'),
+        placeholder: ui('可选：相对工作区或绝对路径', 'Optional: workspace-relative or absolute path'),
+      })
+      : requested
+    if (path === undefined) return
+    const result = await this.capabilities.exportMarkdown(path.trim() === '' ? undefined : path.trim())
+    this.host.notice(ui(
+      `已保存会话 Markdown（${formatByteSize(result.bytes)}）到 ${result.path}`,
+      `Saved session Markdown (${formatByteSize(result.bytes)}) to ${result.path}`,
+    ), 'success')
   }
 
   private async copy(args: string): Promise<void> {

--- a/src/client/byte-size.ts
+++ b/src/client/byte-size.ts
@@ -1,0 +1,21 @@
+/** Human-readable byte counts for export notices. */
+
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const
+
+/**
+ * Format a byte count using 1024-based units.
+ * @param bytes - non-negative integer byte length.
+ * @returns a compact label such as `11.8 MB`.
+ */
+export function formatByteSize(bytes: number): string {
+  const amount = Number.isFinite(bytes) && bytes > 0 ? bytes : 0
+  let value = amount
+  let unit = 0
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  if (unit === 0) return `${Math.round(amount)} B`
+  const scaled = value >= 100 ? String(Math.round(value)) : String(Math.round(value * 10) / 10)
+  return `${scaled} ${UNITS[unit]}`
+}

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -41,6 +41,7 @@ import type { TuiManagementBridge } from './management.ts'
 import type { TuiClientContext } from './context.ts'
 import { producedForClosing } from './compat/deliverables-rc6.ts'
 import { copyTargets } from './copy-content.ts'
+import { conversationMarkdown } from './conversation-markdown.ts'
 import { ui } from './locale.ts'
 
 /** A command shown by the terminal's merged slash directory. */
@@ -215,7 +216,7 @@ export const TUI_COMMANDS: readonly TuiCommandCandidate[] = Object.freeze([
   { name: 'rename', description: '重命名当前会话', argumentHint: '<标题>', source: 'TUI', behavior: 'local' },
   { name: 'fork', description: '从当前会话创建分支', source: 'TUI', behavior: 'local' },
   { name: 'archive', description: '归档当前会话', source: 'TUI', behavior: 'local' },
-  { name: 'export', description: '导出当前会话', argumentHint: '[路径]', source: 'TUI', behavior: 'local' },
+  { name: 'export', description: '导出当前会话', argumentHint: '[md] [路径]', source: 'TUI', behavior: 'local' },
   { name: 'copy', description: '复制最后一条回复', argumentHint: '[pick|code]', source: 'TUI', behavior: 'local' },
   { name: 'workspace', description: '管理工作区', argumentHint: '[子命令|路径]', source: 'TUI', behavior: 'local' },
   { name: 'profile', description: '管理 Profile', argumentHint: '[list|switch|create|copy]', source: 'TUI', behavior: 'local' },
@@ -339,6 +340,27 @@ async function saveExport(path: string, stream: ReadableStream<Uint8Array>): Pro
     await file.close().catch(() => undefined)
     if (!complete) await unlink(path).catch(() => undefined)
   }
+}
+
+async function saveTextExport(path: string, text: string): Promise<number> {
+  await mkdir(dirname(path), { recursive: true })
+  const file = await open(path, 'wx')
+  let complete = false
+  try {
+    const bytes = Buffer.byteLength(text, 'utf8')
+    await file.write(Buffer.from(text, 'utf8'))
+    await file.sync()
+    complete = true
+    return bytes
+  } finally {
+    await file.close().catch(() => undefined)
+    if (!complete) await unlink(path).catch(() => undefined)
+  }
+}
+
+function markdownExportName(title: string): string {
+  const slug = title.replace(/[^\p{L}\p{N}._-]+/gu, '-').replace(/^-+|-+$/gu, '').slice(0, 80)
+  return `${slug === '' ? 'session' : slug}.md`
 }
 
 function isPermissionSelect(value: unknown): value is PermissionSelectValue {
@@ -1364,6 +1386,22 @@ export class HarnessTuiCapabilities {
     const path = resolve(active.workspacePath, requestedPath ?? payload.suggestedFilename)
     const bytes = await saveExport(path, payload.stream)
     return { path, bytes, mediaType: payload.mediaType, includeDescendants }
+  }
+
+  /**
+   * Write a client-rendered Markdown transcript beside the workspace.
+   * @param requestedPath - absolute or Workspace-relative destination.
+   * @returns saved path, byte count, and Markdown media type.
+   */
+  async exportMarkdown(requestedPath?: string): Promise<TuiExportResult> {
+    const active = this.requireActive()
+    const markdown = conversationMarkdown(
+      active.summary.displayTitle,
+      active.session.getSnapshot().nodes,
+    )
+    const path = resolve(active.workspacePath, requestedPath ?? markdownExportName(active.summary.displayTitle))
+    const bytes = await saveTextExport(path, markdown)
+    return { path, bytes, mediaType: 'text/markdown', includeDescendants: false }
   }
 
   /**

--- a/src/client/conversation-markdown.ts
+++ b/src/client/conversation-markdown.ts
@@ -1,0 +1,84 @@
+/** Client-side Markdown export of a conversation snapshot. */
+
+export interface MarkdownUserNode {
+  readonly kind: 'user'
+  readonly content: readonly unknown[]
+}
+
+export interface MarkdownAssistantNode {
+  readonly kind: 'assistant'
+  readonly blocks: readonly {
+    readonly kind: string
+    readonly text?: string
+    readonly name?: string
+  }[]
+}
+
+export interface MarkdownSteeringNode {
+  readonly kind: 'steering'
+  readonly content: readonly unknown[]
+}
+
+export type MarkdownConversationNode =
+  | MarkdownUserNode
+  | MarkdownAssistantNode
+  | MarkdownSteeringNode
+  | { readonly kind: string }
+
+function contentBlockText(block: unknown): string {
+  if (typeof block !== 'object' || block === null) return String(block)
+  const value = block as Record<string, unknown>
+  if (value.type === 'text' || value.type === 'reasoning') {
+    return typeof value.text === 'string' ? value.text : `[${value.type}]`
+  }
+  if (value.type === 'image') return '[image]'
+  if (value.type === 'tool-result') return '[tool result]'
+  return `[${typeof value.type === 'string' ? value.type : 'content'}]`
+}
+
+function userSection(heading: string, content: readonly unknown[]): string | undefined {
+  const text = content.map(contentBlockText).join('\n').trim()
+  if (text === '') return undefined
+  return `## ${heading}\n\n${text}`
+}
+
+function assistantSection(node: MarkdownAssistantNode): string | undefined {
+  const parts: string[] = []
+  for (const block of node.blocks) {
+    if (block.kind === 'text' && block.text !== undefined && block.text.trim() !== '') {
+      parts.push(block.text.trimEnd())
+    } else if (block.kind === 'tool-call' && block.name !== undefined) {
+      parts.push(`- tool \`${block.name}\``)
+    } else if (block.kind === 'image') {
+      parts.push('[image]')
+    }
+  }
+  if (parts.length === 0) return undefined
+  return `## Assistant\n\n${parts.join('\n\n')}`
+}
+
+/**
+ * Render visible conversation nodes as Markdown for `/export md`.
+ * @param title - session display title used as the document heading.
+ * @param nodes - Runtime conversation nodes in display order.
+ * @returns Markdown with a trailing newline.
+ */
+export function conversationMarkdown(
+  title: string,
+  nodes: readonly MarkdownConversationNode[],
+): string {
+  const sections: string[] = [`# ${title === '' ? 'Session' : title}`]
+  for (const node of nodes) {
+    if (node.kind === 'user' && 'content' in node) {
+      const section = userSection('User', node.content)
+      if (section !== undefined) sections.push(section)
+    } else if (node.kind === 'steering' && 'content' in node) {
+      const section = userSection('Steering', node.content)
+      if (section !== undefined) sections.push(section)
+    } else if (node.kind === 'assistant' && 'blocks' in node) {
+      const section = assistantSection(node)
+      if (section !== undefined) sections.push(section)
+    }
+  }
+  return `${sections.join('\n\n')}\n`
+}

--- a/tests/export-markdown.test.ts
+++ b/tests/export-markdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { formatByteSize } from '../src/client/byte-size.ts'
+import { conversationMarkdown } from '../src/client/conversation-markdown.ts'
+
+describe('export size and markdown', () => {
+  it('renders binary byte sizes with one decimal below 100 units', () => {
+    expect(formatByteSize(0)).toBe('0 B')
+    expect(formatByteSize(500)).toBe('500 B')
+    expect(formatByteSize(1024)).toBe('1 KB')
+    expect(formatByteSize(12_345_678)).toBe('11.8 MB')
+  })
+
+  it('renders user and assistant turns as Markdown without ANSI', () => {
+    const markdown = conversationMarkdown('Demo session', [
+      {
+        kind: 'user',
+        content: [{ type: 'text', text: '列出改动' }],
+      },
+      {
+        kind: 'assistant',
+        blocks: [
+          { kind: 'text', text: '改了 `src/bin.ts`。' },
+          { kind: 'tool-call', name: 'Read' },
+        ],
+      },
+    ])
+    expect(markdown).toBe([
+      '# Demo session',
+      '',
+      '## User',
+      '',
+      '列出改动',
+      '',
+      '## Assistant',
+      '',
+      '改了 `src/bin.ts`。',
+      '',
+      '- tool `Read`',
+      '',
+    ].join('\n'))
+  })
+})


### PR DESCRIPTION
## Summary
- `/export md [path]` renders the current conversation to Markdown and writes it exclusively beside the workspace.
- ZIP and Markdown save notices use human-readable sizes such as `11.8 MB`.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/export-markdown.test.ts`
- [ ] `/export md` writes a new `.md` file and refuses to overwrite an existing path.
- [ ] `/export` ZIP notice shows a formatted size instead of a raw byte count.