### PR TITLE
feat(tui): add partitioned /help and bind F1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 | PgUp / PgDn / Home / End | Page through the transcript, jump to the oldest content, or return to the latest |
 | Shift+Tab | Cycle the current permission, confirming full access first |
 | Shift+Left / Shift+Right | Jump to the previous or next user turn |
+| F1 | Open in-app help |
 | Ctrl+P | Open the complete command palette |
 | Ctrl+M | Open model selection when the terminal exposes an extended keyboard protocol |
 | Ctrl+S | Open session resume |

--- a/README.zh.md
+++ b/README.zh.md
@@ -118,6 +118,7 @@ dsh --profile tui
 | PgUp / PgDn / Home / End | 浏览 Transcript 时翻页、跳到最早或回到最新内容 |
 | Shift+Tab | 循环当前权限，进入完全访问前确认 |
 | Shift+Left / Shift+Right | 跳到上一个或下一个用户轮次 |
+| F1 | 打开应用内帮助 |
 | Ctrl+P | 打开完整命令面板 |
 | Ctrl+M | 支持扩展键盘协议时打开模型选择器 |
 | Ctrl+S | 打开会话恢复选择器 |

--- a/lib/index.js
+++ b/lib/index.js
@@ -10867,11 +10867,11 @@ function mergeOrderedBaseline(current, baseline, keyOf) {
 * @returns display rows in render order.
 */
 function flattenLineage(summaries, pendingInteractions, completed) {
-	const byId = /* @__PURE__ */ new Map();
-	for (const s of summaries) byId.set(s.sessionId, s);
+	const byId$1 = /* @__PURE__ */ new Map();
+	for (const s of summaries) byId$1.set(s.sessionId, s);
 	const children = /* @__PURE__ */ new Map();
 	const roots = [];
-	for (const s of summaries) if (s.parentSessionId !== void 0 && byId.has(s.parentSessionId)) {
+	for (const s of summaries) if (s.parentSessionId !== void 0 && byId$1.has(s.parentSessionId)) {
 		const list$1 = children.get(s.parentSessionId) ?? [];
 		list$1.push(s);
 		children.set(s.parentSessionId, list$1);
@@ -14498,10 +14498,10 @@ var SessionRuntime = class {
 	projectList() {
 		const { items, current, phase, subagentsByParent, jobsBySession, currentAddress } = this.manager.getListSnapshot();
 		const ids = [];
-		const byId = {};
+		const byId$1 = {};
 		for (const entry of items) {
 			ids.push(entry.sessionId);
-			byId[entry.sessionId] = {
+			byId$1[entry.sessionId] = {
 				id: entry.sessionId,
 				displayTitle: displayTitleOf(entry.title, entry.cwd, entry.sessionId),
 				running: entry.running,
@@ -14526,8 +14526,8 @@ var SessionRuntime = class {
 				const child = subagentsByParent[address.parentSessionId]?.entries.find((entry) => entry.kind === "child" && entry.id === childId);
 				if (child?.kind !== "child") break;
 				const displayTitle = child.label ?? childId;
-				const summary = byId[childId];
-				if (summary === void 0) byId[childId] = {
+				const summary = byId$1[childId];
+				if (summary === void 0) byId$1[childId] = {
 					id: childId,
 					displayTitle,
 					parentId: address.parentSessionId,
@@ -14536,11 +14536,11 @@ var SessionRuntime = class {
 					blank: false,
 					updatedAt: 0
 				};
-				else if (summary.displayTitle !== displayTitle) byId[childId] = {
+				else if (summary.displayTitle !== displayTitle) byId$1[childId] = {
 					...summary,
 					displayTitle
 				};
-				const parent = byId[address.parentSessionId];
+				const parent = byId$1[address.parentSessionId];
 				if (parent !== void 0 && parent.origin !== "subagent") break;
 				address = this.manager.navigationAddress(address.parentSessionId);
 			}
@@ -14548,13 +14548,13 @@ var SessionRuntime = class {
 		const persisted = this.selection.getSnapshot().sessionId;
 		if (current === void 0) {
 			if (persisted !== void 0) this.selection.set({});
-		} else if (byId[current] !== void 0 && (persisted !== current || this.selection.getSnapshot().subagentAddress?.childSessionId !== currentAddress?.childSessionId || this.selection.getSnapshot().subagentAddress?.parentSessionId !== currentAddress?.parentSessionId || this.selection.getSnapshot().subagentAddress?.mode !== currentAddress?.mode)) this.selection.set({
+		} else if (byId$1[current] !== void 0 && (persisted !== current || this.selection.getSnapshot().subagentAddress?.childSessionId !== currentAddress?.childSessionId || this.selection.getSnapshot().subagentAddress?.parentSessionId !== currentAddress?.parentSessionId || this.selection.getSnapshot().subagentAddress?.mode !== currentAddress?.mode)) this.selection.set({
 			sessionId: current,
 			...currentAddress === void 0 ? {} : { subagentAddress: currentAddress }
 		});
 		this.list.set({
 			ids,
-			byId,
+			byId: byId$1,
 			current,
 			phase,
 			subagentsByParent,
@@ -22278,6 +22278,194 @@ function formatByteSize(bytes) {
 }
 
 //#endregion
+//#region src/client/keymap.ts
+/** Product shortcuts handled by the terminal Surface. */
+const SURFACE_KEYMAP = [
+	{
+		id: "help",
+		keys: ["F1"],
+		zh: "打开帮助",
+		en: "Open help",
+		match: (data) => matchesKey(data, Key.f1)
+	},
+	{
+		id: "commandPalette",
+		keys: ["Ctrl+P"],
+		zh: "打开命令面板",
+		en: "Open the command palette",
+		match: (data) => matchesKey(data, Key.ctrl("p"))
+	},
+	{
+		id: "historySearch",
+		keys: ["Ctrl+R"],
+		zh: "搜索输入历史",
+		en: "Search input history",
+		match: (data) => matchesKey(data, Key.ctrl("r"))
+	},
+	{
+		id: "sessions",
+		keys: ["Ctrl+S"],
+		zh: "打开会话列表",
+		en: "Open the session list",
+		match: (data) => matchesKey(data, Key.ctrl("s"))
+	},
+	{
+		id: "model",
+		keys: ["Ctrl+M"],
+		zh: "打开模型选择（需扩展键盘协议）",
+		en: "Open model selection (extended keyboard protocol)",
+		match: (data) => data !== "\r" && data !== "\n" && matchesKey(data, Key.ctrl("m"))
+	},
+	{
+		id: "toolsDisplay",
+		keys: ["Ctrl+O"],
+		zh: "循环工具卡片显示",
+		en: "Cycle tool-card display",
+		match: (data) => matchesKey(data, Key.ctrl("o"))
+	},
+	{
+		id: "reasoning",
+		keys: ["Ctrl+T"],
+		zh: "显示或隐藏推理",
+		en: "Show or hide reasoning",
+		match: (data) => matchesKey(data, Key.ctrl("t"))
+	},
+	{
+		id: "settings",
+		keys: [
+			"F2",
+			"Ctrl+,",
+			"Cmd+,"
+		],
+		zh: "打开设置",
+		en: "Open Settings",
+		match: (data) => matchesKey(data, Key.f2) || matchesKey(data, Key.ctrl(Key.comma)) || matchesKey(data, Key.super(Key.comma))
+	},
+	{
+		id: "cyclePermission",
+		keys: ["Shift+Tab"],
+		zh: "循环当前权限",
+		en: "Cycle the current permission",
+		match: (data) => matchesKey(data, Key.shift(Key.tab))
+	},
+	{
+		id: "focusToggle",
+		keys: ["Tab"],
+		zh: "在输入区和对话区之间切换",
+		en: "Switch between composer and transcript",
+		match: (data) => matchesKey(data, Key.tab)
+	},
+	{
+		id: "previousTurn",
+		keys: ["Shift+Left"],
+		zh: "跳到上一个用户轮次",
+		en: "Jump to the previous user turn",
+		match: (data) => matchesKey(data, Key.shift(Key.left))
+	},
+	{
+		id: "nextTurn",
+		keys: ["Shift+Right"],
+		zh: "跳到下一个用户轮次",
+		en: "Jump to the next user turn",
+		match: (data) => matchesKey(data, Key.shift(Key.right))
+	},
+	{
+		id: "interrupt",
+		keys: ["Ctrl+C"],
+		zh: "停止当前轮次、清空草稿，或再按一次退出",
+		en: "Stop the active turn, clear a draft, or press again to exit",
+		match: (data) => matchesKey(data, Key.ctrl("c"))
+	},
+	{
+		id: "submit",
+		keys: ["Enter"],
+		zh: "提交或确认",
+		en: "Submit or confirm",
+		match: () => false
+	},
+	{
+		id: "newline",
+		keys: ["Shift+Enter"],
+		zh: "在输入区插入换行",
+		en: "Insert a newline in the composer",
+		match: () => false
+	},
+	{
+		id: "transcriptSearch",
+		keys: ["/"],
+		zh: "对话浏览时增量查找",
+		en: "Incremental search while browsing the transcript",
+		match: () => false
+	}
+];
+const byId = new Map(SURFACE_KEYMAP.map((binding) => [binding.id, binding]));
+/**
+* Match one named surface binding against a raw input chunk.
+* @param id - SURFACE_KEYMAP id.
+* @param data - terminal input.
+*/
+function matchesBinding(id, data) {
+	return byId.get(id)?.match(data) === true;
+}
+/**
+* Render the shared keymap for the help overlay.
+*/
+function helpKeymapText() {
+	return SURFACE_KEYMAP.map((binding) => `${binding.keys.join(" / ")} · ${ui(binding.zh, binding.en)}`).join("\n");
+}
+
+//#endregion
+//#region src/client/help.ts
+function helpSectionChoices() {
+	return [
+		{
+			id: "keys",
+			label: ui("键位速查", "Keyboard shortcuts"),
+			description: ui("与当前 TUI 绑定共用一张表", "Same table as the live TUI bindings")
+		},
+		{
+			id: "flows",
+			label: ui("常用流程", "Common workflows"),
+			description: ui("审批、粘贴、导出和查找", "Approvals, paste, export, and search")
+		},
+		{
+			id: "doctor",
+			label: ui("/doctor 与安装", "/doctor and setup"),
+			description: ui("环境检查和 QUICKSTART", "Environment checks and QUICKSTART")
+		}
+	];
+}
+function helpSectionText(id) {
+	if (id === "keys") return helpKeymapText();
+	if (id === "flows") return ui([
+		"审批工具：弹窗里查看命令或 diff，再选仅本次允许或拒绝。",
+		"粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。",
+		"查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。",
+		"导出会话：/export 保存 ZIP，/export md 保存 Markdown。",
+		"命令面板：Ctrl+P；完整帮助：F1 或 /help。"
+	].join("\n"), [
+		"Approve tools: inspect the command or diff in the overlay, then allow once or reject.",
+		"Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.",
+		"Search the transcript: Tab into browse mode, press / to search, then n/N to jump.",
+		"Export: /export saves a ZIP; /export md saves Markdown.",
+		"Command palette: Ctrl+P. Full help: F1 or /help."
+	].join("\n"));
+	return ui([
+		"输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。",
+		"启动前需要 Node、pnpm 和官方 dsh，且 dsh 需在 PATH 或 DSH_BIN 中。",
+		"安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0",
+		"然后运行 deepseek。版本与兼容范围见 deepseek --version。",
+		"更多步骤见仓库 QUICKSTART 与 README。"
+	].join("\n"), [
+		"Run /doctor to check pnpm, Profile plugins, and Bundle compatibility.",
+		"Before launch you need Node, pnpm, and official dsh on PATH or DSH_BIN.",
+		"Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0",
+		"Then run deepseek. See deepseek --version for the version and compatibility range.",
+		"More steps are in the repository QUICKSTART and README."
+	].join("\n"));
+}
+
+//#endregion
 //#region src/client/job-control.ts
 /**
 * Whether the user can still request cancellation.
@@ -23289,7 +23477,7 @@ var TuiActions = class {
 					this.retryPending();
 					break;
 				case "help":
-					await this.commandPalette();
+					await this.help();
 					break;
 				case "quit":
 				case "exit":
@@ -23348,6 +23536,32 @@ var TuiActions = class {
 		} catch (error) {
 			this.host.notice(capabilityError(error), "error");
 		}
+	}
+	/** F1 / `/help`: partitioned shortcuts, workflows, and doctor guidance. */
+	async help() {
+		const selected = await this.host.overlays.select({
+			title: ui("帮助", "Help"),
+			detail: ui("F1 与 /help 打开此页；Ctrl+P 仍是命令面板", "F1 and /help open this page; Ctrl+P remains the command palette"),
+			choices: helpSectionChoices(),
+			searchable: false,
+			options: {
+				width: "90%",
+				maxHeight: "90%",
+				anchor: "center",
+				margin: 1
+			}
+		});
+		if (selected === void 0) return;
+		await this.host.overlays.detail({
+			title: selected.label,
+			content: helpSectionText(selected.id),
+			options: {
+				width: "90%",
+				maxHeight: "90%",
+				anchor: "center",
+				margin: 1
+			}
+		});
 	}
 	/** Shift+Tab: use Host order and apply the same risk gate as /permission. */
 	async cyclePermission() {
@@ -30120,7 +30334,7 @@ async function startTuiSurface(options$1) {
 				const safeContent = escapeTerminalText(content);
 				if (safeContent !== content) return { data: `\u001B[200~${safeContent}\u001B[201~` };
 			}
-			if (matchesKey(data, Key.tab) && (transcriptFocused || editor.getText() === "")) {
+			if (matchesBinding("focusToggle", data) && (transcriptFocused || editor.getText() === "")) {
 				transcript.cancelSearch();
 				transcriptFocused = !transcriptFocused;
 				tui.setFocus(transcriptFocused ? transcript : editor);
@@ -30136,15 +30350,19 @@ async function startTuiSurface(options$1) {
 				setNotice("已返回输入区", "info");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.shift(Key.tab))) {
+			if (matchesBinding("cyclePermission", data)) {
 				actions.cyclePermission();
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.ctrl("p"))) {
+			if (matchesBinding("help", data)) {
+				actions.help();
+				return { consume: true };
+			}
+			if (matchesBinding("commandPalette", data)) {
 				actions.commandPalette();
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.ctrl("r"))) {
+			if (matchesBinding("historySearch", data)) {
 				if (historyLimit <= 0) {
 					setNotice("输入历史已关闭", "info");
 					return { consume: true };
@@ -30177,34 +30395,34 @@ async function startTuiSurface(options$1) {
 				});
 				return { consume: true };
 			}
-			if (data !== "\r" && data !== "\n" && matchesKey(data, Key.ctrl("m"))) {
+			if (matchesBinding("model", data)) {
 				actions.execute("model", "");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.ctrl("s"))) {
+			if (matchesBinding("sessions", data)) {
 				actions.execute("sessions", "");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.ctrl("o"))) {
+			if (matchesBinding("toolsDisplay", data)) {
 				actions.execute("tools", "display");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.ctrl("t"))) {
+			if (matchesBinding("reasoning", data)) {
 				setNotice(`推理内容：${transcript.toggleReasoning() ? "显示" : "隐藏"}`, "info");
 				refresh();
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.shift(Key.left)) || matchesKey(data, Key.shift(Key.right))) {
+			if (matchesBinding("previousTurn", data) || matchesBinding("nextTurn", data)) {
 				if (!transcriptFocused) {
 					transcriptFocused = true;
 					tui.setFocus(transcript);
 				}
-				const offset = matchesKey(data, Key.shift(Key.left)) ? -1 : 1;
+				const offset = matchesBinding("previousTurn", data) ? -1 : 1;
 				const moved = transcript.navigateTurn(offset);
 				setNotice(moved ? `已跳到${offset < 0 ? "上一个" : "下一个"}用户轮次` : "没有可跳转的用户轮次", moved ? "info" : "warning");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.f2) || matchesKey(data, Key.ctrl(Key.comma)) || matchesKey(data, Key.super(Key.comma))) {
+			if (matchesBinding("settings", data)) {
 				actions.execute("settings", "");
 				return { consume: true };
 			}
@@ -30214,7 +30432,7 @@ async function startTuiSurface(options$1) {
 				renderWhileOpen();
 				return { consume: true };
 			}
-			if (!matchesKey(data, Key.ctrl("c"))) return void 0;
+			if (!matchesBinding("interrupt", data)) return void 0;
 			const current = capabilities.active();
 			if (current !== void 0 && current.session.getSnapshot().running) {
 				current.session.cancel();

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -24,6 +24,7 @@ import {
 import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
 import { lastFencedCode } from './copy-content.ts'
 import { formatByteSize } from './byte-size.ts'
+import { helpSectionChoices, helpSectionText, type HelpSectionId } from './help.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
 import { moveIndex } from './queue-order.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
@@ -399,7 +400,7 @@ export class TuiActions {
         case 'mcp': await this.mcp(); break
         case 'status': await this.status(); break
         case 'pending': this.retryPending(); break
-        case 'help': await this.commandPalette(); break
+        case 'help': await this.help(); break
         case 'quit':
         case 'exit': this.host.close(0); break
         default: throw new Error(`TUI 未实现 /${name}`)
@@ -458,6 +459,23 @@ export class TuiActions {
     } catch (error) {
       this.host.notice(capabilityError(error), 'error')
     }
+  }
+
+  /** F1 / `/help`: partitioned shortcuts, workflows, and doctor guidance. */
+  async help(): Promise<void> {
+    const selected = await this.host.overlays.select({
+      title: ui('帮助', 'Help'),
+      detail: ui('F1 与 /help 打开此页；Ctrl+P 仍是命令面板', 'F1 and /help open this page; Ctrl+P remains the command palette'),
+      choices: helpSectionChoices(),
+      searchable: false,
+      options: { width: '90%', maxHeight: '90%', anchor: 'center', margin: 1 },
+    })
+    if (selected === undefined) return
+    await this.host.overlays.detail({
+      title: selected.label,
+      content: helpSectionText(selected.id as HelpSectionId),
+      options: { width: '90%', maxHeight: '90%', anchor: 'center', margin: 1 },
+    })
   }
 
   /** Shift+Tab: use Host order and apply the same risk gate as /permission. */

--- a/src/client/help.ts
+++ b/src/client/help.ts
@@ -1,0 +1,52 @@
+/** Partitioned in-app help used by `/help` and F1. */
+
+import { helpKeymapText } from './keymap.ts'
+import { ui } from './locale.ts'
+
+export type HelpSectionId = 'keys' | 'flows' | 'doctor'
+
+export function helpSectionChoices(): readonly { id: HelpSectionId; label: string; description: string }[] {
+  return [
+    { id: 'keys', label: ui('键位速查', 'Keyboard shortcuts'), description: ui('与当前 TUI 绑定共用一张表', 'Same table as the live TUI bindings') },
+    { id: 'flows', label: ui('常用流程', 'Common workflows'), description: ui('审批、粘贴、导出和查找', 'Approvals, paste, export, and search') },
+    { id: 'doctor', label: ui('/doctor 与安装', '/doctor and setup'), description: ui('环境检查和 QUICKSTART', 'Environment checks and QUICKSTART') },
+  ]
+}
+
+export function helpSectionText(id: HelpSectionId): string {
+  if (id === 'keys') return helpKeymapText()
+  if (id === 'flows') {
+    return ui(
+      [
+        '审批工具：弹窗里查看命令或 diff，再选仅本次允许或拒绝。',
+        '粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。',
+        '查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。',
+        '导出会话：/export 保存 ZIP，/export md 保存 Markdown。',
+        '命令面板：Ctrl+P；完整帮助：F1 或 /help。',
+      ].join('\n'),
+      [
+        'Approve tools: inspect the command or diff in the overlay, then allow once or reject.',
+        'Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.',
+        'Search the transcript: Tab into browse mode, press / to search, then n/N to jump.',
+        'Export: /export saves a ZIP; /export md saves Markdown.',
+        'Command palette: Ctrl+P. Full help: F1 or /help.',
+      ].join('\n'),
+    )
+  }
+  return ui(
+    [
+      '输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。',
+      '启动前需要 Node、pnpm 和官方 dsh，且 dsh 需在 PATH 或 DSH_BIN 中。',
+      '安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0',
+      '然后运行 deepseek。版本与兼容范围见 deepseek --version。',
+      '更多步骤见仓库 QUICKSTART 与 README。',
+    ].join('\n'),
+    [
+      'Run /doctor to check pnpm, Profile plugins, and Bundle compatibility.',
+      'Before launch you need Node, pnpm, and official dsh on PATH or DSH_BIN.',
+      'Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.0',
+      'Then run deepseek. See deepseek --version for the version and compatibility range.',
+      'More steps are in the repository QUICKSTART and README.',
+    ].join('\n'),
+  )
+}

--- a/src/client/keymap.ts
+++ b/src/client/keymap.ts
@@ -1,0 +1,148 @@
+/** Single source of surface key bindings shared with `/help`. */
+
+import { Key, matchesKey } from '@mariozechner/pi-tui'
+import { ui } from './locale.ts'
+
+export interface SurfaceKeyBinding {
+  readonly id: string
+  readonly keys: readonly string[]
+  readonly zh: string
+  readonly en: string
+  readonly match: (data: string) => boolean
+}
+
+/** Product shortcuts handled by the terminal Surface. */
+export const SURFACE_KEYMAP: readonly SurfaceKeyBinding[] = [
+  {
+    id: 'help',
+    keys: ['F1'],
+    zh: '打开帮助',
+    en: 'Open help',
+    match: data => matchesKey(data, Key.f1),
+  },
+  {
+    id: 'commandPalette',
+    keys: ['Ctrl+P'],
+    zh: '打开命令面板',
+    en: 'Open the command palette',
+    match: data => matchesKey(data, Key.ctrl('p')),
+  },
+  {
+    id: 'historySearch',
+    keys: ['Ctrl+R'],
+    zh: '搜索输入历史',
+    en: 'Search input history',
+    match: data => matchesKey(data, Key.ctrl('r')),
+  },
+  {
+    id: 'sessions',
+    keys: ['Ctrl+S'],
+    zh: '打开会话列表',
+    en: 'Open the session list',
+    match: data => matchesKey(data, Key.ctrl('s')),
+  },
+  {
+    id: 'model',
+    keys: ['Ctrl+M'],
+    zh: '打开模型选择（需扩展键盘协议）',
+    en: 'Open model selection (extended keyboard protocol)',
+    match: data => data !== '\r' && data !== '\n' && matchesKey(data, Key.ctrl('m')),
+  },
+  {
+    id: 'toolsDisplay',
+    keys: ['Ctrl+O'],
+    zh: '循环工具卡片显示',
+    en: 'Cycle tool-card display',
+    match: data => matchesKey(data, Key.ctrl('o')),
+  },
+  {
+    id: 'reasoning',
+    keys: ['Ctrl+T'],
+    zh: '显示或隐藏推理',
+    en: 'Show or hide reasoning',
+    match: data => matchesKey(data, Key.ctrl('t')),
+  },
+  {
+    id: 'settings',
+    keys: ['F2', 'Ctrl+,', 'Cmd+,'],
+    zh: '打开设置',
+    en: 'Open Settings',
+    match: data => matchesKey(data, Key.f2)
+      || matchesKey(data, Key.ctrl(Key.comma))
+      || matchesKey(data, Key.super(Key.comma)),
+  },
+  {
+    id: 'cyclePermission',
+    keys: ['Shift+Tab'],
+    zh: '循环当前权限',
+    en: 'Cycle the current permission',
+    match: data => matchesKey(data, Key.shift(Key.tab)),
+  },
+  {
+    id: 'focusToggle',
+    keys: ['Tab'],
+    zh: '在输入区和对话区之间切换',
+    en: 'Switch between composer and transcript',
+    match: data => matchesKey(data, Key.tab),
+  },
+  {
+    id: 'previousTurn',
+    keys: ['Shift+Left'],
+    zh: '跳到上一个用户轮次',
+    en: 'Jump to the previous user turn',
+    match: data => matchesKey(data, Key.shift(Key.left)),
+  },
+  {
+    id: 'nextTurn',
+    keys: ['Shift+Right'],
+    zh: '跳到下一个用户轮次',
+    en: 'Jump to the next user turn',
+    match: data => matchesKey(data, Key.shift(Key.right)),
+  },
+  {
+    id: 'interrupt',
+    keys: ['Ctrl+C'],
+    zh: '停止当前轮次、清空草稿，或再按一次退出',
+    en: 'Stop the active turn, clear a draft, or press again to exit',
+    match: data => matchesKey(data, Key.ctrl('c')),
+  },
+  {
+    id: 'submit',
+    keys: ['Enter'],
+    zh: '提交或确认',
+    en: 'Submit or confirm',
+    match: () => false,
+  },
+  {
+    id: 'newline',
+    keys: ['Shift+Enter'],
+    zh: '在输入区插入换行',
+    en: 'Insert a newline in the composer',
+    match: () => false,
+  },
+  {
+    id: 'transcriptSearch',
+    keys: ['/'],
+    zh: '对话浏览时增量查找',
+    en: 'Incremental search while browsing the transcript',
+    match: () => false,
+  },
+]
+
+const byId = new Map(SURFACE_KEYMAP.map(binding => [binding.id, binding]))
+
+/**
+ * Match one named surface binding against a raw input chunk.
+ * @param id - SURFACE_KEYMAP id.
+ * @param data - terminal input.
+ */
+export function matchesBinding(id: string, data: string): boolean {
+  return byId.get(id)?.match(data) === true
+}
+
+/**
+ * Render the shared keymap for the help overlay.
+ */
+export function helpKeymapText(): string {
+  return SURFACE_KEYMAP.map(binding => `${binding.keys.join(' / ')} · ${ui(binding.zh, binding.en)}`).join('\n')
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -52,6 +52,7 @@ import {
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
+import { matchesBinding } from './keymap.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -594,7 +595,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           return { data: `\u001B[200~${safeContent}\u001B[201~` }
         }
       }
-      if (matchesKey(data, Key.tab) && (transcriptFocused || editor.getText() === '')) {
+      if (matchesBinding('focusToggle', data) && (transcriptFocused || editor.getText() === '')) {
         transcript.cancelSearch()
         transcriptFocused = !transcriptFocused
         tui.setFocus(transcriptFocused ? transcript : editor)
@@ -610,15 +611,19 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         setNotice('已返回输入区', 'info')
         return { consume: true }
       }
-      if (matchesKey(data, Key.shift(Key.tab))) {
+      if (matchesBinding('cyclePermission', data)) {
         void actions.cyclePermission()
         return { consume: true }
       }
-      if (matchesKey(data, Key.ctrl('p'))) {
+      if (matchesBinding('help', data)) {
+        void actions.help()
+        return { consume: true }
+      }
+      if (matchesBinding('commandPalette', data)) {
         void actions.commandPalette()
         return { consume: true }
       }
-      if (matchesKey(data, Key.ctrl('r'))) {
+      if (matchesBinding('historySearch', data)) {
         if (historyLimit <= 0) {
           setNotice('输入历史已关闭', 'info')
           return { consume: true }
@@ -648,30 +653,30 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       }
       // Legacy terminals encode both Enter and Ctrl+M as CR. Only an extended
       // keyboard protocol can identify Ctrl+M without stealing every submit.
-      if (data !== '\r' && data !== '\n' && matchesKey(data, Key.ctrl('m'))) {
+      if (matchesBinding('model', data)) {
         void actions.execute('model', '')
         return { consume: true }
       }
-      if (matchesKey(data, Key.ctrl('s'))) {
+      if (matchesBinding('sessions', data)) {
         void actions.execute('sessions', '')
         return { consume: true }
       }
-      if (matchesKey(data, Key.ctrl('o'))) {
+      if (matchesBinding('toolsDisplay', data)) {
         void actions.execute('tools', 'display')
         return { consume: true }
       }
-      if (matchesKey(data, Key.ctrl('t'))) {
+      if (matchesBinding('reasoning', data)) {
         const visible = transcript.toggleReasoning()
         setNotice(`推理内容：${visible ? '显示' : '隐藏'}`, 'info')
         refresh()
         return { consume: true }
       }
-      if (matchesKey(data, Key.shift(Key.left)) || matchesKey(data, Key.shift(Key.right))) {
+      if (matchesBinding('previousTurn', data) || matchesBinding('nextTurn', data)) {
         if (!transcriptFocused) {
           transcriptFocused = true
           tui.setFocus(transcript)
         }
-        const offset = matchesKey(data, Key.shift(Key.left)) ? -1 : 1
+        const offset = matchesBinding('previousTurn', data) ? -1 : 1
         const moved = transcript.navigateTurn(offset)
         setNotice(
           moved ? `已跳到${offset < 0 ? '上一个' : '下一个'}用户轮次` : '没有可跳转的用户轮次',
@@ -679,9 +684,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         )
         return { consume: true }
       }
-      if (matchesKey(data, Key.f2)
-        || matchesKey(data, Key.ctrl(Key.comma))
-        || matchesKey(data, Key.super(Key.comma))) {
+      if (matchesBinding('settings', data)) {
         void actions.execute('settings', '')
         return { consume: true }
       }
@@ -691,7 +694,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         renderWhileOpen()
         return { consume: true }
       }
-      if (!matchesKey(data, Key.ctrl('c'))) return undefined
+      if (!matchesBinding('interrupt', data)) return undefined
       const current = capabilities.active()
       if (current !== undefined && current.session.getSnapshot().running) {
         void current.session.cancel()

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { helpSectionText } from '../src/client/help.ts'
+import { SURFACE_KEYMAP, helpKeymapText, matchesBinding } from '../src/client/keymap.ts'
+
+describe('in-app help keymap', () => {
+  it('lists F1 help and Ctrl+P palette from the same table surface matches', () => {
+    expect(SURFACE_KEYMAP.some(binding => binding.id === 'help' && binding.keys.includes('F1'))).toBe(true)
+    expect(matchesBinding('help', '\u001bOP')).toBe(true)
+    expect(matchesBinding('commandPalette', '\u0010')).toBe(true)
+    expect(helpKeymapText()).toContain('F1')
+    expect(helpKeymapText()).toContain('Ctrl+P')
+    expect(helpSectionText('doctor')).toContain('/doctor')
+  })
+})


### PR DESCRIPTION
## Summary
- `/help` and F1 open partitioned help: shortcuts, common workflows, and `/doctor` / QUICKSTART.
- Surface shortcuts now match against the same `SURFACE_KEYMAP` table the help page renders.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/help.test.ts`
- [ ] Press F1 and `/help` to open help; Ctrl+P still opens the command palette.
- [ ] Shortcut list includes F1 and Ctrl+P.