### PR TITLE
fix(tui): turn opaque errors into what happened and what to do

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19663,6 +19663,38 @@ function flattenProducedFiles(groups) {
 }
 
 //#endregion
+//#region src/client/error-advice.ts
+function unwrapTransport(message) {
+	const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message);
+	return match === null ? void 0 : match[1]?.trim();
+}
+/**
+* Combine installer streams so pnpm PATH warnings survive a non-zero exit.
+* @param result - host plugin operation output.
+*/
+function pluginFailureDetail(result) {
+	const chunks = [
+		...result.warnings,
+		result.stderr,
+		result.stdout
+	].map((chunk) => chunk.trim()).filter((chunk) => chunk !== "");
+	return chunks.length === 0 ? ui("无 pnpm 输出", "No pnpm output") : chunks.join("\n");
+}
+/**
+* Rewrite a raw failure message into what happened plus a next action.
+* @param message - original Error.message or stringified failure.
+*/
+function explainFailure(message) {
+	const inner = unwrapTransport(message);
+	if (inner !== void 0) return ui(`内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`, `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`);
+	if (message.includes("超时") && message.includes("/doctor")) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
+	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui(`${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`, `${message}\nNext: install pnpm, keep it on PATH, then retry.`);
+	if (/\bENOENT\b/u.test(message)) return ui(`${message}\n下一步：确认路径存在且当前进程有权读取。`, `${message}\nNext: confirm the path exists and this process can read it.`);
+	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui(`${message}\n下一步：检查文件权限，或换一个可写目录。`, `${message}\nNext: check file permissions, or use a writable directory.`);
+	return message;
+}
+
+//#endregion
 //#region src/client/capabilities.ts
 const SAFE_PERMISSION_PRESETS = new Set(["read-only", "workspace-write"]);
 const FULL_ACCESS_PRESET = "danger-full-access";
@@ -21029,7 +21061,7 @@ var HarnessTuiCapabilities = class {
 * @returns a safe user-facing failure message.
 */
 function capabilityError(error) {
-	return messageOf(error);
+	return explainFailure(messageOf(error));
 }
 
 //#endregion
@@ -21062,7 +21094,7 @@ function waitForSnapshot(source, accepts, label) {
 			if (settled) return;
 			settled = true;
 			unsubscribe();
-			reject(/* @__PURE__ */ new Error(`${label}超时，请运行 /doctor 检查 Harness 状态`));
+			reject(/* @__PURE__ */ new Error(`${label}超时。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek`));
 		}, STARTUP_TIMEOUT_MS);
 		unsubscribe = source.subscribe(() => {
 			const snapshot = source.getSnapshot();
@@ -25535,7 +25567,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 	}
 	async pluginOperation(label, result) {
 		if (result.exitCode !== 0) {
-			const detail = result.stderr.trim() || result.stdout.trim() || "无 pnpm 输出";
+			const detail = pluginFailureDetail(result);
 			throw new Error(`${label} 失败（exit ${result.exitCode}）：${detail.slice(-1200)}`);
 		}
 		const warnings = result.warnings.length === 0 ? "" : `；${result.warnings.join("；")}`;

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -25,6 +25,7 @@ import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type
 import { lastFencedCode } from './copy-content.ts'
 import { formatByteSize } from './byte-size.ts'
 import { helpSectionChoices, helpSectionText, type HelpSectionId } from './help.ts'
+import { pluginFailureDetail } from './error-advice.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
 import { moveIndex } from './queue-order.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
@@ -2429,7 +2430,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 
   private async pluginOperation(label: string, result: TuiPluginOperation): Promise<void> {
     if (result.exitCode !== 0) {
-      const detail = result.stderr.trim() || result.stdout.trim() || '无 pnpm 输出'
+      const detail = pluginFailureDetail(result)
       throw new Error(`${label} 失败（exit ${result.exitCode}）：${detail.slice(-1200)}`)
     }
     const warnings = result.warnings.length === 0 ? '' : `；${result.warnings.join('；')}`

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -42,6 +42,7 @@ import type { TuiClientContext } from './context.ts'
 import { copyTargets } from './copy-content.ts'
 import { conversationMarkdown } from './conversation-markdown.ts'
 import { flattenProducedFiles, groupProducedFiles } from './produced-files.ts'
+import { explainFailure } from './error-advice.ts'
 import { ui } from './locale.ts'
 
 /** A command shown by the terminal's merged slash directory. */
@@ -1553,5 +1554,5 @@ export class HarnessTuiCapabilities {
  * @returns a safe user-facing failure message.
  */
 export function capabilityError(error: unknown): string {
-  return messageOf(error)
+  return explainFailure(messageOf(error))
 }

--- a/src/client/client-runtime.ts
+++ b/src/client/client-runtime.ts
@@ -70,7 +70,7 @@ export function waitForSnapshot<T>(
       if (settled) return
       settled = true
       unsubscribe()
-      reject(new Error(`${label}超时，请运行 /doctor 检查 Harness 状态`))
+      reject(new Error(`${label}超时。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek`))
     }, STARTUP_TIMEOUT_MS)
     const registeredUnsubscribe = source.subscribe(() => {
       const snapshot = source.getSnapshot()

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -1,0 +1,64 @@
+/** Map opaque Host/runtime failures into what happened plus a next step. */
+
+import { ui } from './locale.ts'
+
+export interface PluginFailureOutput {
+  readonly stderr: string
+  readonly stdout: string
+  readonly warnings: readonly string[]
+}
+
+function unwrapTransport(message: string): string | undefined {
+  const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message)
+  return match === null ? undefined : match[1]?.trim()
+}
+
+/**
+ * Combine installer streams so pnpm PATH warnings survive a non-zero exit.
+ * @param result - host plugin operation output.
+ */
+export function pluginFailureDetail(result: PluginFailureOutput): string {
+  const chunks = [...result.warnings, result.stderr, result.stdout]
+    .map(chunk => chunk.trim())
+    .filter(chunk => chunk !== '')
+  return chunks.length === 0 ? ui('无 pnpm 输出', 'No pnpm output') : chunks.join('\n')
+}
+
+/**
+ * Rewrite a raw failure message into what happened plus a next action.
+ * @param message - original Error.message or stringified failure.
+ */
+export function explainFailure(message: string): string {
+  const inner = unwrapTransport(message)
+  if (inner !== undefined) {
+    return ui(
+      `内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`,
+      `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`,
+    )
+  }
+  if (message.includes('超时') && message.includes('/doctor')) {
+    return ui(
+      `${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, '')}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`,
+      'Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
+    )
+  }
+  if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) {
+    return ui(
+      `${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`,
+      `${message}\nNext: install pnpm, keep it on PATH, then retry.`,
+    )
+  }
+  if (/\bENOENT\b/u.test(message)) {
+    return ui(
+      `${message}\n下一步：确认路径存在且当前进程有权读取。`,
+      `${message}\nNext: confirm the path exists and this process can read it.`,
+    )
+  }
+  if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) {
+    return ui(
+      `${message}\n下一步：检查文件权限，或换一个可写目录。`,
+      `${message}\nNext: check file permissions, or use a writable directory.`,
+    )
+  }
+  return message
+}

--- a/tests/error-advice.test.ts
+++ b/tests/error-advice.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { explainFailure, pluginFailureDetail } from '../src/client/error-advice.ts'
+
+describe('actionable failure text', () => {
+  it('unwraps in-process transport failures and keeps installer warnings', () => {
+    expect(explainFailure('transport failure for /api/foo: handler failure: boom')).toContain('内部调用失败：boom')
+    expect(explainFailure('transport failure for /api/foo: handler failure: boom')).toContain('下一步')
+    expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).not.toContain('/doctor')
+    expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).toContain('重新运行 deepseek')
+    expect(pluginFailureDetail({
+      stderr: '',
+      stdout: '',
+      warnings: ['pnpm 不在 PATH 中；请安装 pnpm 后重试'],
+    })).toContain('pnpm 不在 PATH')
+  })
+})


### PR DESCRIPTION
## Summary
- `capabilityError` maps transport failures, startup timeouts, missing pnpm, and common OS errors into what happened plus a next step.
- Plugin install/remove/update failures now include host `warnings`, so a missing pnpm is visible instead of “无 pnpm 输出”.
- Startup waits no longer tell the user to type `/doctor` before the TUI exists.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/error-advice.test.ts`
- [ ] Force a plugin install without pnpm and confirm the notice mentions PATH.
- [ ] Confirm a transport-style error shows 下一步 instead of the raw `/api/...` wrapper.