### PR TITLE
feat(tui): offer Enter-to-send examples on an empty session

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28377,6 +28377,34 @@ var SyntaxHighlighter = class SyntaxHighlighter {
 };
 
 //#endregion
+//#region src/client/empty-examples.ts
+/** Two or three tasks a coding session can send without typing. */
+const EMPTY_SESSION_EXAMPLES = [
+	{
+		id: "review",
+		zh: "审查当前改动并指出风险",
+		en: "Review the current changes and call out risks"
+	},
+	{
+		id: "test",
+		zh: "为刚才改过的文件补测试",
+		en: "Add tests for the files just changed"
+	},
+	{
+		id: "boot",
+		zh: "解释这个仓库怎么启动和验证",
+		en: "Explain how this repo starts and how to verify it"
+	}
+];
+/**
+* Localized prompt text for one empty-session example.
+* @param example - catalog entry.
+*/
+function emptyExampleText(example) {
+	return ui(example.zh, example.en);
+}
+
+//#endregion
 //#region src/client/transcript-search.ts
 /** Incremental search over already-rendered transcript lines. */
 const ANSI = /\u001B\[[0-9;:]*m/gu;
@@ -29282,6 +29310,7 @@ var Transcript = class {
 	pulseTimer;
 	lastFullLines = [];
 	search;
+	exampleCursor = 0;
 	focused = false;
 	/**
 	* @param viewportRows - current terminal-dependent transcript height.
@@ -29383,11 +29412,20 @@ var Transcript = class {
 		}
 		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0))));
 		this.emptyState = rows.length === 0;
-		if (this.emptyState) rows.push({
-			format: "plain",
-			text: `${color.brand("deepseek")}\n${color.muted(ui("探索未至之境", "Explore beyond the known"))}\n${color.muted(ui("直接描述你想完成的事", "Describe what you want to accomplish"))}`
-		});
+		if (this.emptyState) rows.push(...this.emptySessionRows());
 		this.replace(rows);
+	}
+	/**
+	* Submit the focused empty-session example when the transcript has browse focus.
+	* @returns the prompt to send, or undefined when Enter has no local action.
+	*/
+	activateFocused() {
+		if (!this.emptyState || this.snapshot === void 0) return void 0;
+		const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor];
+		return example === void 0 ? void 0 : {
+			kind: "example",
+			text: emptyExampleText(example)
+		};
 	}
 	/**
 	* Rebuild colorized rows after a live theme or lazy grammar change.
@@ -29489,7 +29527,7 @@ var Transcript = class {
 			]);
 		}
 		const maxOffset = Math.max(0, lines.length - rows);
-		this.scrollOffset = Math.min(this.scrollOffset, maxOffset);
+		this.scrollOffset = this.emptyState ? maxOffset : Math.min(this.scrollOffset, maxOffset);
 		const end = lines.length - this.scrollOffset;
 		const start = Math.max(0, end - rows);
 		if (this.scrollOffset === 0 && start > 0) {
@@ -29525,6 +29563,18 @@ var Transcript = class {
 			};
 			this.requestRender();
 			return;
+		}
+		if (this.emptyState && this.snapshot !== void 0) {
+			if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+				const delta = matchesKey(data, Key.up) ? -1 : 1;
+				const next = this.exampleCursor + delta;
+				if (next >= 0 && next < EMPTY_SESSION_EXAMPLES.length) {
+					this.exampleCursor = next;
+					this.replace(this.emptySessionRows());
+					this.requestRender();
+				}
+				return;
+			}
 		}
 		this.turnCursor = void 0;
 		const rows = Math.max(1, Math.floor(this.viewportRows()));
@@ -29679,6 +29729,25 @@ var Transcript = class {
 		this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows));
 		this.requestRender();
 		return true;
+	}
+	emptySessionRows() {
+		this.exampleCursor = Math.max(0, Math.min(this.exampleCursor, EMPTY_SESSION_EXAMPLES.length - 1));
+		return [
+			{
+				format: "plain",
+				text: `${color.brand("deepseek")}\n${color.muted(ui("探索未至之境", "Explore beyond the known"))}\n${color.muted(ui("直接描述你想完成的事", "Describe what you want to accomplish"))}`
+			},
+			{
+				format: "plain",
+				text: color.muted(ui("试试这些，Tab 后回车发送：", "Try one of these; Tab then Enter to send:")),
+				gapBefore: true
+			},
+			...EMPTY_SESSION_EXAMPLES.map((example, index) => ({
+				format: "plain",
+				text: `${index === this.exampleCursor ? color.accent("› ") : "  "}${emptyExampleText(example)}`,
+				exampleId: example.id
+			}))
+		];
 	}
 	replace(rows) {
 		this.rows = rows;
@@ -30479,6 +30548,14 @@ async function startTuiSurface(options$1) {
 				focusEditor();
 				setNotice("已返回输入区", "info");
 				return { consume: true };
+			}
+			if (transcriptFocused && (matchesKey(data, Key.enter) || data === "\r" || data === "\n")) {
+				const action = transcript.activateFocused();
+				if (action?.kind === "example") {
+					focusEditor();
+					sendPrompt(action.text);
+					return { consume: true };
+				}
 			}
 			if (matchesBinding("cyclePermission", data)) {
 				actions.cyclePermission();

--- a/src/client/empty-examples.ts
+++ b/src/client/empty-examples.ts
@@ -1,0 +1,44 @@
+/** Starter prompts shown on an empty session; Enter submits the focused one. */
+
+import { ui } from './locale.ts'
+
+export interface EmptySessionExample {
+  readonly id: string
+  readonly zh: string
+  readonly en: string
+}
+
+/** Two or three tasks a coding session can send without typing. */
+export const EMPTY_SESSION_EXAMPLES: readonly EmptySessionExample[] = [
+  {
+    id: 'review',
+    zh: '审查当前改动并指出风险',
+    en: 'Review the current changes and call out risks',
+  },
+  {
+    id: 'test',
+    zh: '为刚才改过的文件补测试',
+    en: 'Add tests for the files just changed',
+  },
+  {
+    id: 'boot',
+    zh: '解释这个仓库怎么启动和验证',
+    en: 'Explain how this repo starts and how to verify it',
+  },
+]
+
+/**
+ * Localized prompt text for one empty-session example.
+ * @param example - catalog entry.
+ */
+export function emptyExampleText(example: EmptySessionExample): string {
+  return ui(example.zh, example.en)
+}
+
+/**
+ * Resolve one example by id.
+ * @param id - EMPTY_SESSION_EXAMPLES id.
+ */
+export function emptyExampleById(id: string): EmptySessionExample | undefined {
+  return EMPTY_SESSION_EXAMPLES.find(example => example.id === id)
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -617,6 +617,14 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         setNotice('已返回输入区', 'info')
         return { consume: true }
       }
+      if (transcriptFocused && (matchesKey(data, Key.enter) || data === '\r' || data === '\n')) {
+        const action = transcript.activateFocused()
+        if (action?.kind === 'example') {
+          focusEditor()
+          void sendPrompt(action.text)
+          return { consume: true }
+        }
+      }
       if (matchesBinding('cyclePermission', data)) {
         void actions.cyclePermission()
         return { consume: true }

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -32,6 +32,10 @@ import type {
   WorkflowRunPhaseData,
 } from '@deepseek-ai/dsh-client-ui-workflow-run/projection'
 import { producedForClosing } from './compat/deliverables-rc6.ts'
+import {
+  EMPTY_SESSION_EXAMPLES,
+  emptyExampleText,
+} from './empty-examples.ts'
 import { translateUiText, ui } from './locale.ts'
 import {
   findLineMatches,
@@ -98,6 +102,14 @@ type TranscriptRow = ({
   readonly pulse?: 'thinking' | 'marker'
   /** Unix epoch ms used to render an in-flight duration beside this row. */
   readonly liveDurationSince?: number
+  /** Empty-session starter prompt that Enter can submit while browsing. */
+  readonly exampleId?: string
+}
+
+/** Result of Enter on the focused transcript row. */
+export type TranscriptFocusAction = {
+  readonly kind: 'example'
+  readonly text: string
 }
 
 function thinkingRow(): TranscriptRow {
@@ -1068,6 +1080,7 @@ export class Transcript implements Component, Focusable {
   private pulseTimer: ReturnType<typeof setInterval> | undefined
   private lastFullLines: readonly string[] = []
   private search: { query: string; composing: boolean; matchIndex: number } | undefined
+  private exampleCursor = 0
   focused = false
 
   /**
@@ -1183,11 +1196,18 @@ export class Transcript implements Component, Focusable {
       rows.push(...snapshot.runningCalls.flatMap(call => grouped(toolBlockRows(call, preferences, 0))))
     }
     this.emptyState = rows.length === 0
-    if (this.emptyState) rows.push({
-      format: 'plain',
-      text: `${color.brand('deepseek')}\n${color.muted(ui('探索未至之境', 'Explore beyond the known'))}\n${color.muted(ui('直接描述你想完成的事', 'Describe what you want to accomplish'))}`,
-    })
+    if (this.emptyState) rows.push(...this.emptySessionRows())
     this.replace(rows)
+  }
+
+  /**
+   * Submit the focused empty-session example when the transcript has browse focus.
+   * @returns the prompt to send, or undefined when Enter has no local action.
+   */
+  activateFocused(): TranscriptFocusAction | undefined {
+    if (!this.emptyState || this.snapshot === undefined) return undefined
+    const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor]
+    return example === undefined ? undefined : { kind: 'example', text: emptyExampleText(example) }
   }
 
   /**
@@ -1306,7 +1326,7 @@ export class Transcript implements Component, Focusable {
       ])
     }
     const maxOffset = Math.max(0, lines.length - rows)
-    this.scrollOffset = Math.min(this.scrollOffset, maxOffset)
+    this.scrollOffset = this.emptyState ? maxOffset : Math.min(this.scrollOffset, maxOffset)
     const end = lines.length - this.scrollOffset
     const start = Math.max(0, end - rows)
     if (this.scrollOffset === 0 && start > 0) {
@@ -1346,6 +1366,18 @@ export class Transcript implements Component, Focusable {
       this.search = { query: '', composing: true, matchIndex: 0 }
       this.requestRender()
       return
+    }
+    if (this.emptyState && this.snapshot !== undefined) {
+      if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+        const delta = matchesKey(data, Key.up) ? -1 : 1
+        const next = this.exampleCursor + delta
+        if (next >= 0 && next < EMPTY_SESSION_EXAMPLES.length) {
+          this.exampleCursor = next
+          this.replace(this.emptySessionRows())
+          this.requestRender()
+        }
+        return
+      }
     }
     this.turnCursor = undefined
     const rows = Math.max(1, Math.floor(this.viewportRows()))
@@ -1517,6 +1549,26 @@ export class Transcript implements Component, Focusable {
     this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows))
     this.requestRender()
     return true
+  }
+
+  private emptySessionRows(): TranscriptRow[] {
+    this.exampleCursor = Math.max(0, Math.min(this.exampleCursor, EMPTY_SESSION_EXAMPLES.length - 1))
+    return [
+      {
+        format: 'plain',
+        text: `${color.brand('deepseek')}\n${color.muted(ui('探索未至之境', 'Explore beyond the known'))}\n${color.muted(ui('直接描述你想完成的事', 'Describe what you want to accomplish'))}`,
+      },
+      {
+        format: 'plain',
+        text: color.muted(ui('试试这些，Tab 后回车发送：', 'Try one of these; Tab then Enter to send:')),
+        gapBefore: true,
+      },
+      ...EMPTY_SESSION_EXAMPLES.map((example, index) => ({
+        format: 'plain' as const,
+        text: `${index === this.exampleCursor ? color.accent('› ') : '  '}${emptyExampleText(example)}`,
+        exampleId: example.id,
+      })),
+    ]
   }
 
   private replace(rows: readonly TranscriptRow[]): void {

--- a/tests/empty-examples.test.ts
+++ b/tests/empty-examples.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ConversationSnapshot } from '@deepseek-ai/dsh-client-runtime/node-client'
+import {
+  EMPTY_SESSION_EXAMPLES,
+  emptyExampleText,
+} from '../src/client/empty-examples.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import { Transcript } from '../src/client/transcript.ts'
+
+function snapshot(): ConversationSnapshot {
+  return {
+    sessionId: 'session',
+    views: { get: () => undefined },
+    chat: {
+      order: [],
+      nodes: { get: () => undefined, values: () => [] },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls: [],
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: false,
+    loadingOlder: false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  setUiLocale('zh')
+})
+
+describe('empty session examples', () => {
+  it('lists three sendable starter prompts on an empty session', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 20)
+    transcript.update(snapshot())
+    const rendered = stripAnsi(transcript.render(80).join('\n'))
+    expect(rendered).toContain('探索未至之境')
+    for (const example of EMPTY_SESSION_EXAMPLES) {
+      expect(rendered).toContain(emptyExampleText(example))
+    }
+    transcript.focused = true
+    expect(transcript.activateFocused()).toEqual({
+      kind: 'example',
+      text: emptyExampleText(EMPTY_SESSION_EXAMPLES[0]!),
+    })
+    transcript.handleInput('\u001b[B')
+    expect(transcript.activateFocused()).toEqual({
+      kind: 'example',
+      text: emptyExampleText(EMPTY_SESSION_EXAMPLES[1]!),
+    })
+  })
+
+  it('localizes starter prompts without translating a later user message', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    setUiLocale('en')
+    const transcript = new Transcript(() => 20)
+    transcript.update(snapshot())
+    const rendered = stripAnsi(transcript.render(80).join('\n'))
+    expect(rendered).toContain('Explore beyond the known')
+    expect(rendered).toContain('Review the current changes and call out risks')
+    expect(rendered).not.toContain('审查当前改动并指出风险')
+  })
+})


### PR DESCRIPTION
## Summary
- Empty sessions show three starter prompts under the existing slogans.
- Tab into the transcript, ↑↓ to choose, Enter submits the focused prompt.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/empty-examples.test.ts tests/transcript.test.ts`
- [ ] Open a new session, Tab into the transcript, Enter sends the first example.