### PR TITLE
feat(tui): fold long tool output and persist the line cap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21205,10 +21205,13 @@ const DEFAULT_TUI_BEHAVIOR = Object.freeze({
 	followTerminalTitle: true,
 	composerHistoryLimit: 200,
 	statusElapsed: true,
-	clipboardFallback: "auto"
+	clipboardFallback: "auto",
+	toolOutputLineLimit: 200
 });
 /** Upper bound for persisted composer history entries. */
 const MAX_COMPOSER_HISTORY = 1e4;
+/** Upper bound for one expanded tool-output block; 0 disables folding. */
+const MAX_TOOL_OUTPUT_LINE_LIMIT = 1e4;
 /** A stale TUI Settings writer was rejected before changing durable state. */
 var TuiSettingsConflictError = class extends Error {
 	/** Stable machine-readable conflict discriminator. */
@@ -27087,6 +27090,10 @@ function historyLimitOf(value) {
 	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit;
 	return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value));
 }
+function toolOutputLineLimitOf(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit;
+	return Math.min(MAX_TOOL_OUTPUT_LINE_LIMIT, Math.floor(value));
+}
 function clipboardFallbackOf(value) {
 	return typeof value === "string" && CLIPBOARD_FALLBACK.has(value) ? value : DEFAULT_TUI_BEHAVIOR.clipboardFallback;
 }
@@ -27114,7 +27121,8 @@ function normalizeBehavior(value) {
 		followTerminalTitle: booleanOf(record.followTerminalTitle, DEFAULT_TUI_BEHAVIOR.followTerminalTitle),
 		composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
 		statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
-		clipboardFallback: clipboardFallbackOf(record.clipboardFallback)
+		clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
+		toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit)
 	};
 }
 /**
@@ -28470,6 +28478,31 @@ function scrollOffsetToReveal(lineCount, viewportRows, lineIndex) {
 }
 
 //#endregion
+//#region src/client/tool-output-limit.ts
+/**
+* Keep the first `limit` lines and append a remaining-count footer.
+* @param text - one tool-output block.
+* @param limit - line cap; 0 or negative means unlimited.
+*/
+function foldLineBlock(text, limit) {
+	if (!Number.isFinite(limit) || limit <= 0) return {
+		text,
+		omitted: 0
+	};
+	const cap = Math.floor(limit);
+	const lines = text.split("\n");
+	if (lines.length <= cap) return {
+		text,
+		omitted: 0
+	};
+	const omitted = lines.length - cap;
+	return {
+		text: `${lines.slice(0, cap).join("\n")}\n${ui(`还有 ${String(omitted)} 行`, `${String(omitted)} more line(s)`)}`,
+		omitted
+	};
+}
+
+//#endregion
 //#region src/client/transcript.ts
 const PULSE_FRAME_MS = 160;
 function thinkingRow() {
@@ -28943,6 +28976,13 @@ function runningViewDetails(node) {
 	}];
 	return [toolInvocationDetail(node.name, node.argsRaw)];
 }
+function foldDetail(detail, limit) {
+	const folded = foldLineBlock(detail.text, limit);
+	return folded.omitted === 0 ? detail : {
+		...detail,
+		text: folded.text
+	};
+}
 function detailRow(detail, depth) {
 	if (detail.kind === "plain") return {
 		format: "plain",
@@ -28972,7 +29012,7 @@ function toolBlockRows(block$1, preferences, depth) {
 				format: "plain",
 				text: `${prefix}${color.accent(toolTitle(block$1))}${failed ? ` · ${color.danger(ui("失败", "Failed"))}` : ""}${duration}`
 			},
-			...details$1.map((detail) => detailRow(detail, depth)),
+			...details$1.map((detail) => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
 			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
 		];
 	}
@@ -28984,7 +29024,7 @@ function toolBlockRows(block$1, preferences, depth) {
 			pulse: "marker",
 			liveDurationSince: block$1.time
 		},
-		...details.map((detail) => detailRow(detail, depth)),
+		...details.map((detail) => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
 		...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
 	];
 }
@@ -29299,6 +29339,7 @@ var Transcript = class {
 	sessionId;
 	toolVisibility = "collapsed";
 	reasoningVisible = false;
+	toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit;
 	emptyState = true;
 	hasMore = false;
 	loadingOlder = false;
@@ -29343,9 +29384,10 @@ var Transcript = class {
 	* @param tools - default tool-card shape.
 	* @param reasoning - whether reasoning blocks are visible at session open.
 	*/
-	applyPresentationDefaults(tools, reasoning) {
+	applyPresentationDefaults(tools, reasoning, toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit) {
 		this.toolVisibility = tools;
 		this.reasoningVisible = reasoning;
+		this.toolOutputLineLimit = toolOutputLineLimit;
 	}
 	/** Follow new transcript output after the user submits from a historical viewport. */
 	followLatest() {
@@ -29399,7 +29441,8 @@ var Transcript = class {
 		this.loadingOlder = snapshot.loadingOlder;
 		const preferences = {
 			tools: this.toolVisibility,
-			reasoning: this.reasoningVisible
+			reasoning: this.reasoningVisible,
+			toolOutputLineLimit: this.toolOutputLineLimit
 		};
 		const visibleNodes = snapshot.chat.order.flatMap((key) => {
 			const node = snapshot.chat.nodes.get(key);
@@ -30126,7 +30169,7 @@ async function startTuiSurface(options$1) {
 			const snapshot = current.session.getSnapshot();
 			if (snapshot.hasMore && !snapshot.loadingOlder) current.session.loadOlder();
 		});
-		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning);
+		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning, initialBehavior.toolOutputLineLimit);
 		const syntax = await SyntaxHighlighter.create(initialTheme, () => {
 			transcript.refreshPresentation();
 			tui.invalidate();
@@ -30815,7 +30858,8 @@ const BehaviorSettingsSchema = z$1.object({
 		"auto",
 		"osc52",
 		"off"
-	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。")
+	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。"),
+	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description("展开态工具输出单块行数上限；0 表示不折叠。")
 });
 function settingsDocument(descriptor) {
 	return {

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -3,6 +3,7 @@
 import {
   DEFAULT_TUI_BEHAVIOR,
   MAX_COMPOSER_HISTORY,
+  MAX_TOOL_OUTPUT_LINE_LIMIT,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   type TuiBehaviorSettings,
   type TuiClipboardFallback,
@@ -32,6 +33,13 @@ function historyLimitOf(value: unknown): number {
     return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit
   }
   return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value))
+}
+
+function toolOutputLineLimitOf(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit
+  }
+  return Math.min(MAX_TOOL_OUTPUT_LINE_LIMIT, Math.floor(value))
 }
 
 function clipboardFallbackOf(value: unknown): TuiClipboardFallback {
@@ -77,6 +85,7 @@ export function normalizeBehavior(value: unknown): TuiBehaviorSettings {
     composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
     statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
     clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
+    toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit),
   }
 }
 

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -167,7 +167,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         if (snapshot.hasMore && !snapshot.loadingOlder) void current.session.loadOlder()
       },
     )
-    transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning)
+    transcript.applyPresentationDefaults(
+      initialBehavior.toolCards,
+      initialBehavior.showReasoning,
+      initialBehavior.toolOutputLineLimit,
+    )
     const syntax = await SyntaxHighlighter.create(initialTheme, () => {
       transcript.refreshPresentation()
       tui.invalidate()

--- a/src/client/tool-output-limit.ts
+++ b/src/client/tool-output-limit.ts
@@ -1,0 +1,20 @@
+/** Fold one tool-output block to a bounded number of terminal lines. */
+
+import { ui } from './locale.ts'
+
+/**
+ * Keep the first `limit` lines and append a remaining-count footer.
+ * @param text - one tool-output block.
+ * @param limit - line cap; 0 or negative means unlimited.
+ */
+export function foldLineBlock(text: string, limit: number): { text: string; omitted: number } {
+  if (!Number.isFinite(limit) || limit <= 0) return { text, omitted: 0 }
+  const cap = Math.floor(limit)
+  const lines = text.split('\n')
+  if (lines.length <= cap) return { text, omitted: 0 }
+  const omitted = lines.length - cap
+  return {
+    text: `${lines.slice(0, cap).join('\n')}\n${ui(`还有 ${String(omitted)} 行`, `${String(omitted)} more line(s)`)}`,
+    omitted,
+  }
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -52,6 +52,8 @@ import {
   terminalColorLevel,
 } from './theme.ts'
 import { syntaxLanguageForPath } from './syntax-highlighter.ts'
+import { foldLineBlock } from './tool-output-limit.ts'
+import { DEFAULT_TUI_BEHAVIOR } from '@deepseek-ai/dsh-tui-protocol'
 
 const PULSE_FRAME_MS = 160
 
@@ -61,6 +63,7 @@ export type ToolVisibility = 'collapsed' | 'expanded' | 'hidden'
 interface TranscriptPreferences {
   readonly tools: ToolVisibility
   readonly reasoning: boolean
+  readonly toolOutputLineLimit: number
 }
 
 type TranscriptImageAttachment = Extract<AssistantBlock, { kind: 'image' }>['attachment']
@@ -648,6 +651,11 @@ function runningViewDetails(node: RunningToolCall): ToolDetail[] {
   return [toolInvocationDetail(node.name, node.argsRaw)]
 }
 
+function foldDetail(detail: ToolDetail, limit: number): ToolDetail {
+  const folded = foldLineBlock(detail.text, limit)
+  return folded.omitted === 0 ? detail : { ...detail, text: folded.text }
+}
+
 function detailRow(detail: ToolDetail, depth: number): TranscriptRow {
   if (detail.kind === 'plain') return { format: 'plain', text: detail.text }
   if (detail.kind === 'markdown') return { format: 'markdown', text: detail.text }
@@ -671,7 +679,7 @@ function toolBlockRows(block: ToolCallBlock, preferences: TranscriptPreferences,
       : settledInvocationDetails(block)
     return [
       { format: 'plain', text: `${prefix}${color.accent(toolTitle(block))}${failed ? ` · ${color.danger(ui('失败', 'Failed'))}` : ''}${duration}` },
-      ...details.map(detail => detailRow(detail, depth)),
+      ...details.map(detail => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
       ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
     ]
   }
@@ -683,7 +691,7 @@ function toolBlockRows(block: ToolCallBlock, preferences: TranscriptPreferences,
       pulse: 'marker',
       liveDurationSince: block.time,
     },
-    ...details.map(detail => detailRow(detail, depth)),
+    ...details.map(detail => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
     ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
   ]
 }
@@ -1069,6 +1077,7 @@ export class Transcript implements Component, Focusable {
   private sessionId: string | undefined
   private toolVisibility: ToolVisibility = 'collapsed'
   private reasoningVisible = false
+  private toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit
   private emptyState = true
   private hasMore = false
   private loadingOlder = false
@@ -1119,9 +1128,14 @@ export class Transcript implements Component, Focusable {
    * @param tools - default tool-card shape.
    * @param reasoning - whether reasoning blocks are visible at session open.
    */
-  applyPresentationDefaults(tools: ToolVisibility, reasoning: boolean): void {
+  applyPresentationDefaults(
+    tools: ToolVisibility,
+    reasoning: boolean,
+    toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit,
+  ): void {
     this.toolVisibility = tools
     this.reasoningVisible = reasoning
+    this.toolOutputLineLimit = toolOutputLineLimit
   }
 
   /** Follow new transcript output after the user submits from a historical viewport. */
@@ -1177,6 +1191,7 @@ export class Transcript implements Component, Focusable {
     const preferences: TranscriptPreferences = {
       tools: this.toolVisibility,
       reasoning: this.reasoningVisible,
+      toolOutputLineLimit: this.toolOutputLineLimit,
     }
     const visibleNodes = snapshot.chat.order.flatMap((key) => {
       const node = snapshot.chat.nodes.get(key)

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -19,6 +19,7 @@ import {
   MAX_COMPOSER_HISTORY,
   MAX_CUSTOM_THEMES,
   MAX_TEXTMATE_RULES,
+  MAX_TOOL_OUTPUT_LINE_LIMIT,
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
@@ -129,6 +130,9 @@ const BehaviorSettingsSchema = z.object({
   clipboardFallback: z.union(['auto', 'osc52', 'off'])
     .default(DEFAULT_TUI_BEHAVIOR.clipboardFallback)
     .description('OSC 52 失败后的剪贴板回退命令；auto 按平台探测。'),
+  toolOutputLineLimit: z.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT)
+    .default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit)
+    .description('展开态工具输出单块行数上限；0 表示不折叠。'),
 })
 
 interface StoredCatalogSource {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -123,6 +123,7 @@ export interface TuiBehaviorSettings {
   readonly composerHistoryLimit: number
   readonly statusElapsed: boolean
   readonly clipboardFallback: TuiClipboardFallback
+  readonly toolOutputLineLimit: number
 }
 
 /** First-run interaction defaults when no user override has been stored. */
@@ -134,10 +135,14 @@ export const DEFAULT_TUI_BEHAVIOR: TuiBehaviorSettings = Object.freeze({
   composerHistoryLimit: 200,
   statusElapsed: true,
   clipboardFallback: 'auto',
+  toolOutputLineLimit: 200,
 })
 
 /** Upper bound for persisted composer history entries. */
 export const MAX_COMPOSER_HISTORY = 10_000
+
+/** Upper bound for one expanded tool-output block; 0 disables folding. */
+export const MAX_TOOL_OUTPUT_LINE_LIMIT = 10_000
 
 /** One complete, redacted registered Settings namespace. */
 export interface TuiSettingsDocument {

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -41,6 +41,7 @@ describe('seektty-behavior settings', () => {
       composerHistoryLimit: 0,
       statusElapsed: false,
       clipboardFallback: 'osc52',
+      toolOutputLineLimit: 200,
     })
     expect(normalizeBehavior({
       toolCards: 'mystery',

--- a/tests/tool-output-limit.test.ts
+++ b/tests/tool-output-limit.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ChatConversationViewNode,
+  ConversationSnapshot,
+} from '@deepseek-ai/dsh-client-runtime/node-client'
+import { foldLineBlock } from '../src/client/tool-output-limit.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import { Transcript } from '../src/client/transcript.ts'
+import { DEFAULT_TUI_BEHAVIOR } from '../src/protocol.ts'
+import { normalizeBehavior } from '../src/client/behavior.ts'
+
+function chatNode(key: string, data: unknown): ChatConversationViewNode {
+  return {
+    key,
+    kind: 'fixture',
+    id: key,
+    target: 'chat',
+    anchorSeq: 1,
+    location: { kind: 'session' },
+    visibility: 'visible',
+    data,
+  }
+}
+
+function tool(output: string): ChatConversationViewNode {
+  return {
+    ...chatNode('shell-1', {
+      root: {
+        kind: 'tool-result',
+        callId: 'shell-1',
+        call: { name: 'bash', argsRaw: '{"command":"seq"}' },
+        callView: { card: 'terminal', title: 'seq 1 250' },
+        resultView: { card: 'terminal', output, exitCode: 0 },
+        content: [],
+        meta: undefined,
+        isError: false,
+        turn: 1,
+        step: 1,
+        time: 25,
+        callTime: 10,
+        subCalls: [],
+      },
+    }),
+    kind: 'tool-call',
+  }
+}
+
+function snapshot(nodes: readonly ChatConversationViewNode[]): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  return {
+    sessionId: 'session',
+    views: { get: () => undefined },
+    chat: {
+      order: nodes.map(node => node.key),
+      nodes: { get: (key: string) => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls: [],
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: false,
+    loadingOlder: false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  setUiLocale('zh')
+})
+
+describe('tool output folding', () => {
+  it('keeps the first N lines and appends a remaining-line footer', () => {
+    const lines = Array.from({ length: 250 }, (_, index) => `line-${String(index + 1)}`)
+    const folded = foldLineBlock(lines.join('\n'), 200)
+    expect(folded.omitted).toBe(50)
+    expect(folded.text.split('\n')).toEqual([
+      ...lines.slice(0, 200),
+      '还有 50 行',
+    ])
+    expect(foldLineBlock(lines.join('\n'), 0).omitted).toBe(0)
+    expect(foldLineBlock(lines.join('\n'), 0).text).toBe(lines.join('\n'))
+  })
+
+  it('folds expanded shell output using the behavior default of 200 lines', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    expect(normalizeBehavior(undefined).toolOutputLineLimit).toBe(200)
+    expect(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).toBe(200)
+    const output = Array.from({ length: 250 }, (_, index) => `line-${String(index + 1)}`).join('\n')
+    const transcript = new Transcript()
+    transcript.cycleToolVisibility()
+    transcript.update(snapshot([tool(output)]))
+    const rendered = stripAnsi(transcript.render(80).join('\n'))
+    expect(rendered).toContain('line-1')
+    expect(rendered).toContain('line-200')
+    expect(rendered).not.toContain('line-201')
+    expect(rendered).toContain('还有 50 行')
+  })
+})


### PR DESCRIPTION
## Summary
- Expanded tool-output blocks cap at 200 lines and end with “还有 N 行”.
- `seektty-behavior.toolOutputLineLimit` stores the cap; 0 disables folding.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/tool-output-limit.test.ts tests/behavior.test.ts tests/transcript.test.ts`
- [ ] Expand a long shell tool card and confirm the footer, not the full dump.