### PR TITLE
feat(tui): expand a single tool card with Enter in focus mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29001,16 +29001,31 @@ function detailRow(detail, depth) {
 		prefix: `${"  ".repeat(depth + 1)}⎿  `
 	};
 }
-function toolBlockRows(block$1, preferences, depth) {
+function toolCardExpanded(preferences, key) {
+	if (preferences.tools === "hidden") return false;
+	if (key !== void 0) {
+		if (preferences.expandedTools.has(key)) return true;
+		if (preferences.collapsedTools.has(key)) return false;
+	}
+	return preferences.tools === "expanded";
+}
+function callKey(block$1, fallback) {
+	if ("callId" in block$1 && typeof block$1.callId === "string" && block$1.callId !== "") return block$1.callId;
+	return fallback;
+}
+function toolBlockRows(block$1, preferences, depth, cardKey) {
 	const prefix = depth === 0 ? "◆ " : `${"  ".repeat(depth)}↳ `;
+	const key = callKey(block$1, cardKey);
+	const expanded = toolCardExpanded(preferences, key);
 	if ("kind" in block$1) {
 		const duration = block$1.callTime === null ? "" : ` · ${toolDurationText(Math.max(0, block$1.time - block$1.callTime))}`;
 		const failed = settledToolFailed(block$1);
-		const details$1 = preferences.tools === "expanded" ? viewDetails(block$1) : settledInvocationDetails(block$1);
+		const details$1 = expanded ? viewDetails(block$1) : settledInvocationDetails(block$1);
 		return [
 			{
 				format: "plain",
-				text: `${prefix}${color.accent(toolTitle(block$1))}${failed ? ` · ${color.danger(ui("失败", "Failed"))}` : ""}${duration}`
+				text: `${prefix}${color.accent(toolTitle(block$1))}${failed ? ` · ${color.danger(ui("失败", "Failed"))}` : ""}${duration}`,
+				...depth === 0 && key !== void 0 ? { toolKey: key } : {}
 			},
 			...details$1.map((detail) => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
 			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
@@ -29022,7 +29037,8 @@ function toolBlockRows(block$1, preferences, depth) {
 			format: "plain",
 			text: `${prefix}${color.accent(toolTitle(block$1))}`,
 			pulse: "marker",
-			liveDurationSince: block$1.time
+			liveDurationSince: block$1.time,
+			...depth === 0 && key !== void 0 ? { toolKey: key } : {}
 		},
 		...details.map((detail) => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
 		...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
@@ -29269,7 +29285,7 @@ function chatNodeRows(node, preferences) {
 	if (node.kind === "tool-call") {
 		if (preferences.tools === "hidden") return [];
 		const data = toolChatData(node.data);
-		return data === void 0 ? [] : grouped(toolBlockRows(data.root, preferences, 0));
+		return data === void 0 ? [] : grouped(toolBlockRows(data.root, preferences, 0, node.key));
 	}
 	if (node.kind === "manual-compaction") return manualCompactionRows(node.data, preferences);
 	if (node.kind === "model-retry") return retryRows(node.data, preferences);
@@ -29352,6 +29368,9 @@ var Transcript = class {
 	lastFullLines = [];
 	search;
 	exampleCursor = 0;
+	toolCursor = 0;
+	expandedTools = /* @__PURE__ */ new Set();
+	collapsedTools = /* @__PURE__ */ new Set();
 	focused = false;
 	/**
 	* @param viewportRows - current terminal-dependent transcript height.
@@ -29435,6 +29454,9 @@ var Transcript = class {
 			this.pendingImages.clear();
 			this.imageComponents.clear();
 			this.sessionId = sessionId;
+			this.expandedTools.clear();
+			this.collapsedTools.clear();
+			this.toolCursor = 0;
 		}
 		this.imageLoader = imageLoader;
 		this.hasMore = snapshot.hasMore;
@@ -29442,7 +29464,9 @@ var Transcript = class {
 		const preferences = {
 			tools: this.toolVisibility,
 			reasoning: this.reasoningVisible,
-			toolOutputLineLimit: this.toolOutputLineLimit
+			toolOutputLineLimit: this.toolOutputLineLimit,
+			expandedTools: this.expandedTools,
+			collapsedTools: this.collapsedTools
 		};
 		const visibleNodes = snapshot.chat.order.flatMap((key) => {
 			const node = snapshot.chat.nodes.get(key);
@@ -29453,21 +29477,32 @@ var Transcript = class {
 			const partialRows = snapshot.partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences));
 			rows.push(...grouped([...partialRows.length === 0 ? [thinkingRow()] : [], ...partialRows]));
 		}
-		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0))));
+		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0, call.callId))));
 		this.emptyState = rows.length === 0;
 		if (this.emptyState) rows.push(...this.emptySessionRows());
 		this.replace(rows);
+		const keys = this.toolKeys();
+		if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1);
 	}
 	/**
 	* Submit the focused empty-session example when the transcript has browse focus.
 	* @returns the prompt to send, or undefined when Enter has no local action.
 	*/
 	activateFocused() {
-		if (!this.emptyState || this.snapshot === void 0) return void 0;
-		const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor];
-		return example === void 0 ? void 0 : {
-			kind: "example",
-			text: emptyExampleText(example)
+		if (this.emptyState && this.snapshot !== void 0) {
+			const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor];
+			return example === void 0 ? void 0 : {
+				kind: "example",
+				text: emptyExampleText(example)
+			};
+		}
+		const key = this.toolKeys()[this.toolCursor];
+		if (key === void 0 || this.snapshot === void 0) return void 0;
+		this.toggleToolCard(key);
+		this.update(this.snapshot, this.imageLoader);
+		return {
+			kind: "tool",
+			key
 		};
 	}
 	/**
@@ -29614,6 +29649,18 @@ var Transcript = class {
 				if (next >= 0 && next < EMPTY_SESSION_EXAMPLES.length) {
 					this.exampleCursor = next;
 					this.replace(this.emptySessionRows());
+					this.requestRender();
+				}
+				return;
+			}
+		}
+		if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+			const keys = this.toolKeys();
+			if (keys.length > 0) {
+				const delta = matchesKey(data, Key.up) ? -1 : 1;
+				const next = this.toolCursor + delta;
+				if (next >= 0 && next < keys.length) {
+					this.toolCursor = next;
 					this.requestRender();
 				}
 				return;
@@ -29772,6 +29819,24 @@ var Transcript = class {
 		this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows));
 		this.requestRender();
 		return true;
+	}
+	toolKeys() {
+		return [...new Set(this.rows.flatMap((row) => row.toolKey === void 0 ? [] : [row.toolKey]))];
+	}
+	toggleToolCard(key) {
+		if (toolCardExpanded({
+			tools: this.toolVisibility,
+			reasoning: this.reasoningVisible,
+			toolOutputLineLimit: this.toolOutputLineLimit,
+			expandedTools: this.expandedTools,
+			collapsedTools: this.collapsedTools
+		}, key)) {
+			this.expandedTools.delete(key);
+			if (this.toolVisibility === "expanded") this.collapsedTools.add(key);
+		} else {
+			this.collapsedTools.delete(key);
+			this.expandedTools.add(key);
+		}
 	}
 	emptySessionRows() {
 		this.exampleCursor = Math.max(0, Math.min(this.exampleCursor, EMPTY_SESSION_EXAMPLES.length - 1));
@@ -30597,6 +30662,10 @@ async function startTuiSurface(options$1) {
 				if (action?.kind === "example") {
 					focusEditor();
 					sendPrompt(action.text);
+					return { consume: true };
+				}
+				if (action?.kind === "tool") {
+					refresh();
 					return { consume: true };
 				}
 			}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -628,6 +628,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           void sendPrompt(action.text)
           return { consume: true }
         }
+        if (action?.kind === 'tool') {
+          refresh()
+          return { consume: true }
+        }
       }
       if (matchesBinding('cyclePermission', data)) {
         void actions.cyclePermission()

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -64,6 +64,8 @@ interface TranscriptPreferences {
   readonly tools: ToolVisibility
   readonly reasoning: boolean
   readonly toolOutputLineLimit: number
+  readonly expandedTools: ReadonlySet<string>
+  readonly collapsedTools: ReadonlySet<string>
 }
 
 type TranscriptImageAttachment = Extract<AssistantBlock, { kind: 'image' }>['attachment']
@@ -107,12 +109,17 @@ type TranscriptRow = ({
   readonly liveDurationSince?: number
   /** Empty-session starter prompt that Enter can submit while browsing. */
   readonly exampleId?: string
+  /** Tool-card identity for per-card expand in focus mode. */
+  readonly toolKey?: string
 }
 
 /** Result of Enter on the focused transcript row. */
 export type TranscriptFocusAction = {
   readonly kind: 'example'
   readonly text: string
+} | {
+  readonly kind: 'tool'
+  readonly key: string
 }
 
 function thinkingRow(): TranscriptRow {
@@ -669,16 +676,39 @@ function detailRow(detail: ToolDetail, depth: number): TranscriptRow {
   }
 }
 
-function toolBlockRows(block: ToolCallBlock, preferences: TranscriptPreferences, depth: number): TranscriptRow[] {
+function toolCardExpanded(preferences: TranscriptPreferences, key: string | undefined): boolean {
+  if (preferences.tools === 'hidden') return false
+  if (key !== undefined) {
+    if (preferences.expandedTools.has(key)) return true
+    if (preferences.collapsedTools.has(key)) return false
+  }
+  return preferences.tools === 'expanded'
+}
+
+function callKey(block: ToolCallBlock, fallback?: string): string | undefined {
+  if ('callId' in block && typeof block.callId === 'string' && block.callId !== '') return block.callId
+  return fallback
+}
+
+function toolBlockRows(
+  block: ToolCallBlock,
+  preferences: TranscriptPreferences,
+  depth: number,
+  cardKey?: string,
+): TranscriptRow[] {
   const prefix = depth === 0 ? '◆ ' : `${'  '.repeat(depth)}↳ `
+  const key = callKey(block, cardKey)
+  const expanded = toolCardExpanded(preferences, key)
   if ('kind' in block) {
     const duration = block.callTime === null ? '' : ` · ${toolDurationText(Math.max(0, block.time - block.callTime))}`
     const failed = settledToolFailed(block)
-    const details = preferences.tools === 'expanded'
-      ? viewDetails(block)
-      : settledInvocationDetails(block)
+    const details = expanded ? viewDetails(block) : settledInvocationDetails(block)
     return [
-      { format: 'plain', text: `${prefix}${color.accent(toolTitle(block))}${failed ? ` · ${color.danger(ui('失败', 'Failed'))}` : ''}${duration}` },
+      {
+        format: 'plain',
+        text: `${prefix}${color.accent(toolTitle(block))}${failed ? ` · ${color.danger(ui('失败', 'Failed'))}` : ''}${duration}`,
+        ...(depth === 0 && key !== undefined ? { toolKey: key } : {}),
+      },
       ...details.map(detail => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
       ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
     ]
@@ -690,6 +720,7 @@ function toolBlockRows(block: ToolCallBlock, preferences: TranscriptPreferences,
       text: `${prefix}${color.accent(toolTitle(block))}`,
       pulse: 'marker',
       liveDurationSince: block.time,
+      ...(depth === 0 && key !== undefined ? { toolKey: key } : {}),
     },
     ...details.map(detail => detailRow(foldDetail(detail, preferences.toolOutputLineLimit), depth)),
     ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
@@ -1021,7 +1052,7 @@ function chatNodeRows(node: ChatConversationViewNode, preferences: TranscriptPre
   if (node.kind === 'tool-call') {
     if (preferences.tools === 'hidden') return []
     const data = toolChatData(node.data)
-    return data === undefined ? [] : grouped(toolBlockRows(data.root, preferences, 0))
+    return data === undefined ? [] : grouped(toolBlockRows(data.root, preferences, 0, node.key))
   }
   if (node.kind === 'manual-compaction') return manualCompactionRows(node.data, preferences)
   if (node.kind === 'model-retry') return retryRows(node.data, preferences)
@@ -1090,6 +1121,9 @@ export class Transcript implements Component, Focusable {
   private lastFullLines: readonly string[] = []
   private search: { query: string; composing: boolean; matchIndex: number } | undefined
   private exampleCursor = 0
+  private toolCursor = 0
+  private readonly expandedTools = new Set<string>()
+  private readonly collapsedTools = new Set<string>()
   focused = false
 
   /**
@@ -1184,6 +1218,9 @@ export class Transcript implements Component, Focusable {
       this.pendingImages.clear()
       this.imageComponents.clear()
       this.sessionId = sessionId
+      this.expandedTools.clear()
+      this.collapsedTools.clear()
+      this.toolCursor = 0
     }
     this.imageLoader = imageLoader
     this.hasMore = snapshot.hasMore
@@ -1192,6 +1229,8 @@ export class Transcript implements Component, Focusable {
       tools: this.toolVisibility,
       reasoning: this.reasoningVisible,
       toolOutputLineLimit: this.toolOutputLineLimit,
+      expandedTools: this.expandedTools,
+      collapsedTools: this.collapsedTools,
     }
     const visibleNodes = snapshot.chat.order.flatMap((key) => {
       const node = snapshot.chat.nodes.get(key)
@@ -1208,11 +1247,13 @@ export class Transcript implements Component, Focusable {
       ]))
     }
     if (preferences.tools !== 'hidden' && !visibleNodes.some(node => node.kind === 'tool-call')) {
-      rows.push(...snapshot.runningCalls.flatMap(call => grouped(toolBlockRows(call, preferences, 0))))
+      rows.push(...snapshot.runningCalls.flatMap(call => grouped(toolBlockRows(call, preferences, 0, call.callId))))
     }
     this.emptyState = rows.length === 0
     if (this.emptyState) rows.push(...this.emptySessionRows())
     this.replace(rows)
+    const keys = this.toolKeys()
+    if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1)
   }
 
   /**
@@ -1220,9 +1261,15 @@ export class Transcript implements Component, Focusable {
    * @returns the prompt to send, or undefined when Enter has no local action.
    */
   activateFocused(): TranscriptFocusAction | undefined {
-    if (!this.emptyState || this.snapshot === undefined) return undefined
-    const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor]
-    return example === undefined ? undefined : { kind: 'example', text: emptyExampleText(example) }
+    if (this.emptyState && this.snapshot !== undefined) {
+      const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor]
+      return example === undefined ? undefined : { kind: 'example', text: emptyExampleText(example) }
+    }
+    const key = this.toolKeys()[this.toolCursor]
+    if (key === undefined || this.snapshot === undefined) return undefined
+    this.toggleToolCard(key)
+    this.update(this.snapshot, this.imageLoader)
+    return { kind: 'tool', key }
   }
 
   /**
@@ -1389,6 +1436,18 @@ export class Transcript implements Component, Focusable {
         if (next >= 0 && next < EMPTY_SESSION_EXAMPLES.length) {
           this.exampleCursor = next
           this.replace(this.emptySessionRows())
+          this.requestRender()
+        }
+        return
+      }
+    }
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      const keys = this.toolKeys()
+      if (keys.length > 0) {
+        const delta = matchesKey(data, Key.up) ? -1 : 1
+        const next = this.toolCursor + delta
+        if (next >= 0 && next < keys.length) {
+          this.toolCursor = next
           this.requestRender()
         }
         return
@@ -1564,6 +1623,27 @@ export class Transcript implements Component, Focusable {
     this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows))
     this.requestRender()
     return true
+  }
+
+  private toolKeys(): readonly string[] {
+    return [...new Set(this.rows.flatMap(row => row.toolKey === undefined ? [] : [row.toolKey]))]
+  }
+
+  private toggleToolCard(key: string): void {
+    const expanded = toolCardExpanded({
+      tools: this.toolVisibility,
+      reasoning: this.reasoningVisible,
+      toolOutputLineLimit: this.toolOutputLineLimit,
+      expandedTools: this.expandedTools,
+      collapsedTools: this.collapsedTools,
+    }, key)
+    if (expanded) {
+      this.expandedTools.delete(key)
+      if (this.toolVisibility === 'expanded') this.collapsedTools.add(key)
+    } else {
+      this.collapsedTools.delete(key)
+      this.expandedTools.add(key)
+    }
   }
 
   private emptySessionRows(): TranscriptRow[] {

--- a/tests/tool-card-expand.test.ts
+++ b/tests/tool-card-expand.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ChatConversationViewNode,
+  ConversationSnapshot,
+} from '@deepseek-ai/dsh-client-runtime/node-client'
+import { setUiLocale } from '../src/client/locale.ts'
+import { Transcript } from '../src/client/transcript.ts'
+
+function chatNode(key: string, data: unknown): ChatConversationViewNode {
+  return {
+    key,
+    kind: 'fixture',
+    id: key,
+    target: 'chat',
+    anchorSeq: 1,
+    location: { kind: 'session' },
+    visibility: 'visible',
+    data,
+  }
+}
+
+function tool(key: string, title: string, result: string): ChatConversationViewNode {
+  return {
+    ...chatNode(key, {
+      root: {
+        kind: 'tool-result',
+        callId: key,
+        call: { name: 'fixture_tool', argsRaw: `{"title":"${title}"}` },
+        callView: { card: 'generic', title, rawInput: { title } },
+        resultView: { card: 'generic', content: [{ type: 'text', text: result }] },
+        content: [],
+        meta: undefined,
+        isError: false,
+        turn: 1,
+        step: 1,
+        time: 25,
+        callTime: 10,
+        subCalls: [],
+      },
+    }),
+    kind: 'tool-call',
+  }
+}
+
+function snapshot(nodes: readonly ChatConversationViewNode[]): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  return {
+    sessionId: 'session',
+    views: { get: () => undefined },
+    chat: {
+      order: nodes.map(node => node.key),
+      nodes: { get: (key: string) => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls: [],
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: false,
+    loadingOlder: false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  setUiLocale('zh')
+})
+
+describe('per-card tool expand', () => {
+  it('expands only the focused tool card on Enter while leaving others collapsed', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript()
+    transcript.update(snapshot([
+      tool('a', 'First tool', 'result-a'),
+      tool('b', 'Second tool', 'result-b'),
+    ]))
+    transcript.focused = true
+    expect(stripAnsi(transcript.render(80).join('\n'))).not.toContain('result-a')
+    expect(stripAnsi(transcript.render(80).join('\n'))).not.toContain('result-b')
+
+    expect(transcript.activateFocused()).toEqual({ kind: 'tool', key: 'a' })
+    const first = stripAnsi(transcript.render(80).join('\n'))
+    expect(first).toContain('result-a')
+    expect(first).not.toContain('result-b')
+
+    transcript.handleInput('\u001b[B')
+    expect(transcript.activateFocused()).toEqual({ kind: 'tool', key: 'b' })
+    const both = stripAnsi(transcript.render(80).join('\n'))
+    expect(both).toContain('result-a')
+    expect(both).toContain('result-b')
+  })
+})


### PR DESCRIPTION
## Summary
- In transcript focus, Enter toggles only the focused tool card.
- Sibling cards stay at the global Ctrl+O shape.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/tool-card-expand.test.ts tests/transcript.test.ts`
- [ ] Tab into a session with two collapsed tools, Enter, confirm only the first result body appears.