### PR TITLE
feat(tui): search settings fields across namespaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22691,7 +22691,7 @@ function fieldOf(document, node, path$1) {
 	const description = descriptionOf(node);
 	return {
 		path: path$1,
-		label: path$1.length === 0 ? document.namespace : path$1.join("."),
+		label: settingsFieldLabel(document.namespace, path$1),
 		...description === void 0 ? {} : { description },
 		schemaType: node.type,
 		control: controlOf(node, secret !== void 0),
@@ -22775,6 +22775,76 @@ function settingsSectionLabel(namespace) {
 	if (namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) return ui("SeekTTY 行为", "SeekTTY behavior");
 	if (namespace === "tui-plugin-marketplace") return ui("插件市场来源", "Plugin marketplace sources");
 	return ui("通用设置", "General settings");
+}
+const FIELD_LABELS = {
+	defaultPreset: ["默认 Agent 模式", "Default Agent preset"],
+	default: ["默认权限", "Default permission"],
+	theme: ["界面主题", "Interface theme"],
+	codeTheme: ["代码块主题", "Code theme"],
+	toolCards: ["工具卡片默认形态", "Default tool-card shape"],
+	showReasoning: ["推理默认显示", "Show reasoning by default"],
+	desktopNotifications: ["完成/审批桌面通知", "Desktop notifications"],
+	followTerminalTitle: ["终端标题跟随", "Follow the terminal title"],
+	composerHistoryLimit: ["输入历史条数", "Composer history size"],
+	statusElapsed: ["状态栏实时耗时", "Live status elapsed time"],
+	clipboardFallback: ["剪贴板回退", "Clipboard fallback"],
+	toolOutputLineLimit: ["工具输出行数上限", "Tool output line limit"]
+};
+/**
+* Label a known high-frequency field while keeping unknown paths visible.
+* @param namespace - registered Harness Settings namespace.
+* @param path - schema path inside that namespace.
+*/
+function settingsFieldLabel(namespace, path$1) {
+	if (path$1.length === 0) return namespace;
+	const dotted = path$1.join(".");
+	const named = FIELD_LABELS[`${namespace}.${dotted}`] ?? FIELD_LABELS[dotted];
+	return named === void 0 ? dotted : ui(named[0], named[1]);
+}
+/**
+* Flatten every registered Settings document into a cross-namespace field index.
+* @param documents - redacted Settings descriptors.
+*/
+function indexSettingsFields(documents) {
+	return documents.flatMap((document) => settingsFields(document).map((field) => ({
+		namespace: document.namespace,
+		section: settingsSectionLabel(document.namespace),
+		field
+	})));
+}
+/**
+* Build the searchable Settings root: namespaces first, then every field.
+* @param documents - redacted Settings descriptors.
+*/
+function settingsRootChoices(documents) {
+	return [...documents.map((document) => ({
+		id: document.namespace,
+		label: document.namespace,
+		description: `${settingsSectionLabel(document.namespace)} · ${document.applies === "live" ? ui("立即生效", "applies immediately") : ui("需重启", "restart required")}`
+	})), ...indexSettingsFields(documents).map((item) => ({
+		id: `field:${item.namespace}:${JSON.stringify(item.field.path)}`,
+		label: item.field.label,
+		description: `${item.namespace}.${item.field.path.join(".")} · ${item.section}`
+	}))];
+}
+function parseSettingsRootChoice(id) {
+	if (id.startsWith("field:")) {
+		const separator = id.indexOf(":", 6);
+		if (separator === -1) return void 0;
+		const namespace = id.slice(6, separator);
+		try {
+			const path$1 = JSON.parse(id.slice(separator + 1));
+			if (!Array.isArray(path$1) || path$1.some((part) => typeof part !== "string")) return void 0;
+			return {
+				namespace,
+				fieldPath: path$1
+			};
+		} catch {
+			return;
+		}
+	}
+	if (id === "") return void 0;
+	return { namespace: id };
 }
 
 //#endregion
@@ -24956,13 +25026,11 @@ var TuiActions = class {
 			const root = navigation.selectPage({
 				title: "设置",
 				detail: "搜索并修改全部功能设置",
-				choices: documents.map((candidate) => ({
-					id: candidate.namespace,
-					label: candidate.namespace,
-					description: `${settingsSectionLabel(candidate.namespace)} · ${candidate.applies === "live" ? "立即生效" : "需重启"}`
-				}))
+				choices: settingsRootChoices(documents)
 			}, async (selected) => {
-				await this.settingsNamespace(navigation, selected.id);
+				const parsed = parseSettingsRootChoice(selected.id);
+				if (parsed === void 0) return;
+				await this.settingsNamespace(navigation, parsed.namespace, parsed.fieldPath === void 0 ? void 0 : JSON.stringify(parsed.fieldPath));
 			});
 			if (args !== "") await this.settingsNamespace(navigation, args);
 			await root;
@@ -24973,7 +25041,7 @@ var TuiActions = class {
 			margin: 1
 		});
 	}
-	async settingsNamespace(navigation, namespace) {
+	async settingsNamespace(navigation, namespace, initialChoiceId) {
 		const bridge = this.capabilities.managementBridge().settings;
 		const initialDocument = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
 		if (initialDocument === void 0) throw new Error(`Settings 命名空间 ${JSON.stringify(namespace)} 不存在`);
@@ -24984,7 +25052,7 @@ var TuiActions = class {
 			this.host.notice(`${document.namespace} 没有可见设置字段`, "info");
 			return;
 		}
-		const request = (initialChoiceId) => ({
+		const request = (initialChoiceId$1) => ({
 			title: `设置 · ${document.namespace}`,
 			detail: `${settingsSectionLabel(document.namespace)} · ${document.applies === "live" ? "修改立即生效" : "修改后需重启"}`,
 			choices: [...special, ...fields.map((field) => ({
@@ -24993,7 +25061,7 @@ var TuiActions = class {
 				description: `${fieldState(field)}${field.description === void 0 ? "" : ` · ${field.description}`}`,
 				...field.disabled ? { disabledReason: "该字段当前不可编辑" } : {}
 			}))],
-			...initialChoiceId === void 0 ? {} : { initialChoiceId }
+			...initialChoiceId$1 === void 0 ? {} : { initialChoiceId: initialChoiceId$1 }
 		});
 		const handle = async (selected) => {
 			if (selected.id.startsWith("__settings_")) await this.editSpecialSetting(navigation, document, selected.id);
@@ -25017,7 +25085,7 @@ var TuiActions = class {
 			}
 			navigation.replaceSelectPage(request(selected.id), handle);
 		};
-		await navigation.selectPage(request(), handle);
+		await navigation.selectPage(request(initialChoiceId), handle);
 	}
 	settingsSpecialChoices(document) {
 		switch (document.namespace) {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -48,8 +48,10 @@ import type {
 import { OverlayQueue } from './overlays.ts'
 import {
   formatSettingsValue,
+  parseSettingsRootChoice,
   parseSettingsValue,
   settingsFields,
+  settingsRootChoices,
   settingsSectionLabel,
   type TuiSettingsField,
 } from './settings.ts'
@@ -1785,13 +1787,15 @@ export class TuiActions {
       const root = navigation.selectPage({
         title: '设置',
         detail: '搜索并修改全部功能设置',
-        choices: documents.map(candidate => ({
-          id: candidate.namespace,
-          label: candidate.namespace,
-          description: `${settingsSectionLabel(candidate.namespace)} · ${candidate.applies === 'live' ? '立即生效' : '需重启'}`,
-        })),
+        choices: settingsRootChoices(documents),
       }, async (selected) => {
-        await this.settingsNamespace(navigation, selected.id)
+        const parsed = parseSettingsRootChoice(selected.id)
+        if (parsed === undefined) return
+        await this.settingsNamespace(
+          navigation,
+          parsed.namespace,
+          parsed.fieldPath === undefined ? undefined : JSON.stringify(parsed.fieldPath),
+        )
       })
       if (args !== '') await this.settingsNamespace(navigation, args)
       await root
@@ -1801,6 +1805,7 @@ export class TuiActions {
   private async settingsNamespace(
     navigation: OverlayNavigation<void>,
     namespace: string,
+    initialChoiceId?: string,
   ): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
     const initialDocument = (await bridge.describe()).find(candidate => candidate.namespace === namespace)
@@ -1849,7 +1854,7 @@ export class TuiActions {
       }
       navigation.replaceSelectPage(request(selected.id), handle)
     }
-    await navigation.selectPage(request(), handle)
+    await navigation.selectPage(request(initialChoiceId), handle)
   }
 
   private settingsSpecialChoices(document: TuiSettingsDocument): readonly OverlayChoice[] {

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -92,7 +92,7 @@ function fieldOf(
   const description = descriptionOf(node)
   return {
     path,
-    label: path.length === 0 ? document.namespace : path.join('.'),
+    label: settingsFieldLabel(document.namespace, path),
     ...(description === undefined ? {} : { description }),
     schemaType: node.type,
     control: controlOf(node, secret !== undefined),
@@ -201,4 +201,100 @@ export function settingsSectionLabel(namespace: string): string {
   if (namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) return ui('SeekTTY 行为', 'SeekTTY behavior')
   if (namespace === 'tui-plugin-marketplace') return ui('插件市场来源', 'Plugin marketplace sources')
   return ui('通用设置', 'General settings')
+}
+
+const FIELD_LABELS: Readonly<Record<string, readonly [zh: string, en: string]>> = {
+  defaultPreset: ['默认 Agent 模式', 'Default Agent preset'],
+  default: ['默认权限', 'Default permission'],
+  theme: ['界面主题', 'Interface theme'],
+  codeTheme: ['代码块主题', 'Code theme'],
+  toolCards: ['工具卡片默认形态', 'Default tool-card shape'],
+  showReasoning: ['推理默认显示', 'Show reasoning by default'],
+  desktopNotifications: ['完成/审批桌面通知', 'Desktop notifications'],
+  followTerminalTitle: ['终端标题跟随', 'Follow the terminal title'],
+  composerHistoryLimit: ['输入历史条数', 'Composer history size'],
+  statusElapsed: ['状态栏实时耗时', 'Live status elapsed time'],
+  clipboardFallback: ['剪贴板回退', 'Clipboard fallback'],
+  toolOutputLineLimit: ['工具输出行数上限', 'Tool output line limit'],
+}
+
+/**
+ * Label a known high-frequency field while keeping unknown paths visible.
+ * @param namespace - registered Harness Settings namespace.
+ * @param path - schema path inside that namespace.
+ */
+export function settingsFieldLabel(namespace: string, path: readonly string[]): string {
+  if (path.length === 0) return namespace
+  const dotted = path.join('.')
+  const named = FIELD_LABELS[`${namespace}.${dotted}`] ?? FIELD_LABELS[dotted]
+  return named === undefined ? dotted : ui(named[0], named[1])
+}
+
+/** One flattened Settings field with its owning namespace. */
+export interface IndexedSettingsField {
+  readonly namespace: string
+  readonly section: string
+  readonly field: TuiSettingsField
+}
+
+/**
+ * Flatten every registered Settings document into a cross-namespace field index.
+ * @param documents - redacted Settings descriptors.
+ */
+export function indexSettingsFields(
+  documents: readonly TuiSettingsDocument[],
+): readonly IndexedSettingsField[] {
+  return documents.flatMap(document => settingsFields(document).map(field => ({
+    namespace: document.namespace,
+    section: settingsSectionLabel(document.namespace),
+    field,
+  })))
+}
+
+/** One row in the searchable Settings root list. */
+export interface SettingsRootChoice {
+  readonly id: string
+  readonly label: string
+  readonly description: string
+}
+
+/**
+ * Build the searchable Settings root: namespaces first, then every field.
+ * @param documents - redacted Settings descriptors.
+ */
+export function settingsRootChoices(
+  documents: readonly TuiSettingsDocument[],
+): readonly SettingsRootChoice[] {
+  return [
+    ...documents.map(document => ({
+      id: document.namespace,
+      label: document.namespace,
+      description: `${settingsSectionLabel(document.namespace)} · ${document.applies === 'live' ? ui('立即生效', 'applies immediately') : ui('需重启', 'restart required')}`,
+    })),
+    ...indexSettingsFields(documents).map(item => ({
+      id: `field:${item.namespace}:${JSON.stringify(item.field.path)}`,
+      label: item.field.label,
+      description: `${item.namespace}.${item.field.path.join('.')} · ${item.section}`,
+    })),
+  ]
+}
+
+export function parseSettingsRootChoice(id: string): {
+  readonly namespace: string
+  readonly fieldPath?: readonly string[]
+} | undefined {
+  if (id.startsWith('field:')) {
+    const separator = id.indexOf(':', 'field:'.length)
+    if (separator === -1) return undefined
+    const namespace = id.slice('field:'.length, separator)
+    try {
+      const path = JSON.parse(id.slice(separator + 1)) as unknown
+      if (!Array.isArray(path) || path.some(part => typeof part !== 'string')) return undefined
+      return { namespace, fieldPath: path as readonly string[] }
+    } catch {
+      return undefined
+    }
+  }
+  if (id === '') return undefined
+  return { namespace: id }
 }

--- a/tests/actions-settings-navigation.test.ts
+++ b/tests/actions-settings-navigation.test.ts
@@ -105,7 +105,7 @@ describe('/settings overlay navigation', () => {
     })
     harness.component().handleInput(ENTER)
     await vi.waitFor(() => {
-      expect(plain(harness.component().render(90))).toContain('设置 · example')
+      expect(plain(harness.component().render(90))).toContain('修改立即生效')
     })
     harness.component().handleInput(ENTER)
     await vi.waitFor(() => {
@@ -151,7 +151,7 @@ describe('/settings overlay navigation', () => {
     await vi.waitFor(() => { expect(harness.component()).toBeDefined() })
     harness.component().handleInput(ENTER)
     await vi.waitFor(() => {
-      expect(plain(harness.component().render(90))).toContain('设置 · example')
+      expect(plain(harness.component().render(90))).toContain('修改立即生效')
     })
     harness.component().handleInput(ENTER)
     await vi.waitFor(() => {

--- a/tests/settings-search.test.ts
+++ b/tests/settings-search.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import z from '@deepseek-ai/schemastery'
+import { setUiLocale } from '../src/client/locale.ts'
+import {
+  indexSettingsFields,
+  parseSettingsRootChoice,
+  settingsFieldLabel,
+  settingsRootChoices,
+} from '../src/client/settings.ts'
+import type { TuiSettingsDocument } from '../src/protocol.ts'
+
+function document(namespace: string, schema: unknown, value: unknown): TuiSettingsDocument {
+  return {
+    namespace,
+    schema,
+    value,
+    revision: 1,
+    applies: 'live',
+    secrets: [],
+  }
+}
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('settings field index', () => {
+  it('gives high-frequency fields bilingual labels and searches across namespaces', () => {
+    const presets = document(
+      'agent-presets',
+      z.object({ defaultPreset: z.string().default('code') }).toJSON(),
+      { defaultPreset: 'code' },
+    )
+    const behavior = document(
+      'seektty-behavior',
+      z.object({ toolCards: z.string().default('collapsed') }).toJSON(),
+      { toolCards: 'collapsed' },
+    )
+    expect(settingsFieldLabel('agent-presets', ['defaultPreset'])).toBe('默认 Agent 模式')
+    setUiLocale('en')
+    expect(settingsFieldLabel('agent-presets', ['defaultPreset'])).toBe('Default Agent preset')
+    setUiLocale('zh')
+
+    const indexed = indexSettingsFields([presets, behavior])
+    expect(indexed.map(item => item.field.label)).toEqual([
+      '默认 Agent 模式',
+      '工具卡片默认形态',
+    ])
+
+    const root = settingsRootChoices([presets, behavior])
+    expect(root.some(choice => choice.id === 'agent-presets')).toBe(true)
+    const field = root.find(choice => choice.label === '默认 Agent 模式')
+    expect(field?.id).toBe(`field:agent-presets:${JSON.stringify(['defaultPreset'])}`)
+    expect(field?.description).toContain('agent-presets.defaultPreset')
+    expect(parseSettingsRootChoice(field?.id ?? '')).toEqual({
+      namespace: 'agent-presets',
+      fieldPath: ['defaultPreset'],
+    })
+    expect(parseSettingsRootChoice('agent-presets')).toEqual({ namespace: 'agent-presets' })
+  })
+})


### PR DESCRIPTION
## Summary
- `/settings` root lists namespaces first, then every field, so search is not namespace-gated.
- High-frequency fields get bilingual labels; selecting a field opens that namespace on the matching row.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/settings-search.test.ts tests/actions-settings-navigation.test.ts`
- [ ] Open `/settings`, type a field name such as `defaultPreset` or `工具卡片`, Enter, confirm the namespace lands on that field.