### PR TITLE
feat(tui): let /keymap rebind surface shortcuts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2336,7 +2336,7 @@ const SYMBOL_KEYS = new Set([
 	">",
 	"?"
 ]);
-const MODIFIERS = {
+const MODIFIERS$1 = {
 	shift: 1,
 	alt: 2,
 	ctrl: 4,
@@ -2398,7 +2398,7 @@ function normalizeKittyFunctionalCodepoint(codepoint) {
 	return KITTY_FUNCTIONAL_KEY_EQUIVALENTS.get(codepoint) ?? codepoint;
 }
 function normalizeShiftedLetterIdentityCodepoint(codepoint, modifier) {
-	if ((modifier & ~LOCK_MASK & MODIFIERS.shift) !== 0 && codepoint >= 65 && codepoint <= 90) return codepoint + 32;
+	if ((modifier & ~LOCK_MASK & MODIFIERS$1.shift) !== 0 && codepoint >= 65 && codepoint <= 90) return codepoint + 32;
 	return codepoint;
 }
 const LEGACY_KEY_SEQUENCES = {
@@ -2480,8 +2480,8 @@ const LEGACY_CTRL_SEQUENCES = {
 };
 const matchesLegacySequence = (data, sequences) => sequences.includes(data);
 const matchesLegacyModifierSequence = (data, key, modifier) => {
-	if (modifier === MODIFIERS.shift) return matchesLegacySequence(data, LEGACY_SHIFT_SEQUENCES[key]);
-	if (modifier === MODIFIERS.ctrl) return matchesLegacySequence(data, LEGACY_CTRL_SEQUENCES[key]);
+	if (modifier === MODIFIERS$1.shift) return matchesLegacySequence(data, LEGACY_SHIFT_SEQUENCES[key]);
+	if (modifier === MODIFIERS$1.ctrl) return matchesLegacySequence(data, LEGACY_CTRL_SEQUENCES[key]);
 	return false;
 };
 /**
@@ -2610,7 +2610,7 @@ function isWindowsTerminalSession() {
 function matchesRawBackspace(data, expectedModifier) {
 	if (data === "") return expectedModifier === 0;
 	if (data !== "\b") return false;
-	return isWindowsTerminalSession() ? expectedModifier === MODIFIERS.ctrl : expectedModifier === 0;
+	return isWindowsTerminalSession() ? expectedModifier === MODIFIERS$1.ctrl : expectedModifier === 0;
 }
 /**
 * Get the control character for a key.
@@ -2671,10 +2671,10 @@ function matchesKey(data, keyId) {
 	if (!parsed) return false;
 	const { key, ctrl, shift, alt, super: superModifier } = parsed;
 	let modifier = 0;
-	if (shift) modifier |= MODIFIERS.shift;
-	if (alt) modifier |= MODIFIERS.alt;
-	if (ctrl) modifier |= MODIFIERS.ctrl;
-	if (superModifier) modifier |= MODIFIERS.super;
+	if (shift) modifier |= MODIFIERS$1.shift;
+	if (alt) modifier |= MODIFIERS$1.alt;
+	if (ctrl) modifier |= MODIFIERS$1.ctrl;
+	if (superModifier) modifier |= MODIFIERS$1.super;
 	switch (key) {
 		case "escape":
 		case "esc":
@@ -2682,39 +2682,39 @@ function matchesKey(data, keyId) {
 			return data === "\x1B" || matchesKittySequence(data, CODEPOINTS.escape, 0) || matchesModifyOtherKeys(data, CODEPOINTS.escape, 0);
 		case "space":
 			if (!_kittyProtocolActive) {
-				if (modifier === MODIFIERS.ctrl && data === "\0") return true;
-				if (modifier === MODIFIERS.alt && data === "\x1B ") return true;
+				if (modifier === MODIFIERS$1.ctrl && data === "\0") return true;
+				if (modifier === MODIFIERS$1.alt && data === "\x1B ") return true;
 			}
 			if (modifier === 0) return data === " " || matchesKittySequence(data, CODEPOINTS.space, 0) || matchesModifyOtherKeys(data, CODEPOINTS.space, 0);
 			return matchesKittySequence(data, CODEPOINTS.space, modifier) || matchesModifyOtherKeys(data, CODEPOINTS.space, modifier);
 		case "tab":
-			if (modifier === MODIFIERS.shift) return data === "\x1B[Z" || matchesKittySequence(data, CODEPOINTS.tab, MODIFIERS.shift) || matchesModifyOtherKeys(data, CODEPOINTS.tab, MODIFIERS.shift);
+			if (modifier === MODIFIERS$1.shift) return data === "\x1B[Z" || matchesKittySequence(data, CODEPOINTS.tab, MODIFIERS$1.shift) || matchesModifyOtherKeys(data, CODEPOINTS.tab, MODIFIERS$1.shift);
 			if (modifier === 0) return data === "	" || matchesKittySequence(data, CODEPOINTS.tab, 0);
 			return matchesKittySequence(data, CODEPOINTS.tab, modifier) || matchesModifyOtherKeys(data, CODEPOINTS.tab, modifier);
 		case "enter":
 		case "return":
-			if (modifier === MODIFIERS.shift) {
-				if (matchesKittySequence(data, CODEPOINTS.enter, MODIFIERS.shift) || matchesKittySequence(data, CODEPOINTS.kpEnter, MODIFIERS.shift)) return true;
-				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS.shift)) return true;
+			if (modifier === MODIFIERS$1.shift) {
+				if (matchesKittySequence(data, CODEPOINTS.enter, MODIFIERS$1.shift) || matchesKittySequence(data, CODEPOINTS.kpEnter, MODIFIERS$1.shift)) return true;
+				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS$1.shift)) return true;
 				if (_kittyProtocolActive) return data === "\x1B\r" || data === "\n";
 				return false;
 			}
-			if (modifier === MODIFIERS.alt) {
-				if (matchesKittySequence(data, CODEPOINTS.enter, MODIFIERS.alt) || matchesKittySequence(data, CODEPOINTS.kpEnter, MODIFIERS.alt)) return true;
-				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS.alt)) return true;
+			if (modifier === MODIFIERS$1.alt) {
+				if (matchesKittySequence(data, CODEPOINTS.enter, MODIFIERS$1.alt) || matchesKittySequence(data, CODEPOINTS.kpEnter, MODIFIERS$1.alt)) return true;
+				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS$1.alt)) return true;
 				if (!_kittyProtocolActive) return data === "\x1B\r";
 				return false;
 			}
 			if (modifier === 0) return data === "\r" || !_kittyProtocolActive && data === "\n" || data === "\x1BOM" || matchesKittySequence(data, CODEPOINTS.enter, 0) || matchesKittySequence(data, CODEPOINTS.kpEnter, 0);
 			return matchesKittySequence(data, CODEPOINTS.enter, modifier) || matchesKittySequence(data, CODEPOINTS.kpEnter, modifier) || matchesModifyOtherKeys(data, CODEPOINTS.enter, modifier);
 		case "backspace":
-			if (modifier === MODIFIERS.alt) {
+			if (modifier === MODIFIERS$1.alt) {
 				if (data === "\x1B" || data === "\x1B\b") return true;
-				return matchesKittySequence(data, CODEPOINTS.backspace, MODIFIERS.alt) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, MODIFIERS.alt);
+				return matchesKittySequence(data, CODEPOINTS.backspace, MODIFIERS$1.alt) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, MODIFIERS$1.alt);
 			}
-			if (modifier === MODIFIERS.ctrl) {
-				if (matchesRawBackspace(data, MODIFIERS.ctrl)) return true;
-				return matchesKittySequence(data, CODEPOINTS.backspace, MODIFIERS.ctrl) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, MODIFIERS.ctrl);
+			if (modifier === MODIFIERS$1.ctrl) {
+				if (matchesRawBackspace(data, MODIFIERS$1.ctrl)) return true;
+				return matchesKittySequence(data, CODEPOINTS.backspace, MODIFIERS$1.ctrl) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, MODIFIERS$1.ctrl);
 			}
 			if (modifier === 0) return matchesRawBackspace(data, 0) || matchesKittySequence(data, CODEPOINTS.backspace, 0) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, 0);
 			return matchesKittySequence(data, CODEPOINTS.backspace, modifier) || matchesModifyOtherKeys(data, CODEPOINTS.backspace, modifier);
@@ -2746,24 +2746,24 @@ function matchesKey(data, keyId) {
 			if (matchesLegacyModifierSequence(data, "pageDown", modifier)) return true;
 			return matchesKittySequence(data, FUNCTIONAL_CODEPOINTS.pageDown, modifier);
 		case "up":
-			if (modifier === MODIFIERS.alt) return data === "\x1Bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
+			if (modifier === MODIFIERS$1.alt) return data === "\x1Bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS$1.alt);
 			if (modifier === 0) return matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.up) || matchesKittySequence(data, ARROW_CODEPOINTS.up, 0);
 			if (matchesLegacyModifierSequence(data, "up", modifier)) return true;
 			return matchesKittySequence(data, ARROW_CODEPOINTS.up, modifier);
 		case "down":
-			if (modifier === MODIFIERS.alt) return data === "\x1Bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
+			if (modifier === MODIFIERS$1.alt) return data === "\x1Bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS$1.alt);
 			if (modifier === 0) return matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.down) || matchesKittySequence(data, ARROW_CODEPOINTS.down, 0);
 			if (matchesLegacyModifierSequence(data, "down", modifier)) return true;
 			return matchesKittySequence(data, ARROW_CODEPOINTS.down, modifier);
 		case "left":
-			if (modifier === MODIFIERS.alt) return data === "\x1B[1;3D" || !_kittyProtocolActive && data === "\x1BB" || data === "\x1Bb" || matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.alt);
-			if (modifier === MODIFIERS.ctrl) return data === "\x1B[1;5D" || matchesLegacyModifierSequence(data, "left", MODIFIERS.ctrl) || matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.ctrl);
+			if (modifier === MODIFIERS$1.alt) return data === "\x1B[1;3D" || !_kittyProtocolActive && data === "\x1BB" || data === "\x1Bb" || matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS$1.alt);
+			if (modifier === MODIFIERS$1.ctrl) return data === "\x1B[1;5D" || matchesLegacyModifierSequence(data, "left", MODIFIERS$1.ctrl) || matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS$1.ctrl);
 			if (modifier === 0) return matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.left) || matchesKittySequence(data, ARROW_CODEPOINTS.left, 0);
 			if (matchesLegacyModifierSequence(data, "left", modifier)) return true;
 			return matchesKittySequence(data, ARROW_CODEPOINTS.left, modifier);
 		case "right":
-			if (modifier === MODIFIERS.alt) return data === "\x1B[1;3C" || !_kittyProtocolActive && data === "\x1BF" || data === "\x1Bf" || matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.alt);
-			if (modifier === MODIFIERS.ctrl) return data === "\x1B[1;5C" || matchesLegacyModifierSequence(data, "right", MODIFIERS.ctrl) || matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.ctrl);
+			if (modifier === MODIFIERS$1.alt) return data === "\x1B[1;3C" || !_kittyProtocolActive && data === "\x1BF" || data === "\x1Bf" || matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS$1.alt);
+			if (modifier === MODIFIERS$1.ctrl) return data === "\x1B[1;5C" || matchesLegacyModifierSequence(data, "right", MODIFIERS$1.ctrl) || matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS$1.ctrl);
 			if (modifier === 0) return matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.right) || matchesKittySequence(data, ARROW_CODEPOINTS.right, 0);
 			if (matchesLegacyModifierSequence(data, "right", modifier)) return true;
 			return matchesKittySequence(data, ARROW_CODEPOINTS.right, modifier);
@@ -2787,20 +2787,20 @@ function matchesKey(data, keyId) {
 		const rawCtrl = rawCtrlChar(key);
 		const isLetter = key >= "a" && key <= "z";
 		const isDigit = isDigitKey(key);
-		if (modifier === MODIFIERS.ctrl + MODIFIERS.alt && !_kittyProtocolActive && rawCtrl) {
+		if (modifier === MODIFIERS$1.ctrl + MODIFIERS$1.alt && !_kittyProtocolActive && rawCtrl) {
 			if (data === `\x1b${rawCtrl}`) return true;
 		}
-		if (modifier === MODIFIERS.alt && !_kittyProtocolActive && (isLetter || isDigit)) {
+		if (modifier === MODIFIERS$1.alt && !_kittyProtocolActive && (isLetter || isDigit)) {
 			if (data === `\x1b${key}`) return true;
 		}
-		if (modifier === MODIFIERS.ctrl) {
+		if (modifier === MODIFIERS$1.ctrl) {
 			if (rawCtrl && data === rawCtrl) return true;
-			return matchesKittySequence(data, codepoint, MODIFIERS.ctrl) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.ctrl);
+			return matchesKittySequence(data, codepoint, MODIFIERS$1.ctrl) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS$1.ctrl);
 		}
-		if (modifier === MODIFIERS.shift + MODIFIERS.ctrl) return matchesKittySequence(data, codepoint, MODIFIERS.shift + MODIFIERS.ctrl) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.shift + MODIFIERS.ctrl);
-		if (modifier === MODIFIERS.shift) {
+		if (modifier === MODIFIERS$1.shift + MODIFIERS$1.ctrl) return matchesKittySequence(data, codepoint, MODIFIERS$1.shift + MODIFIERS$1.ctrl) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS$1.shift + MODIFIERS$1.ctrl);
+		if (modifier === MODIFIERS$1.shift) {
 			if (isLetter && data === key.toUpperCase()) return true;
-			return matchesKittySequence(data, codepoint, MODIFIERS.shift) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.shift);
+			return matchesKittySequence(data, codepoint, MODIFIERS$1.shift) || matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS$1.shift);
 		}
 		if (modifier !== 0) return matchesKittySequence(data, codepoint, modifier) || matchesPrintableModifyOtherKeys(data, codepoint, modifier);
 		return data === key || matchesKittySequence(data, codepoint, 0);
@@ -2808,7 +2808,7 @@ function matchesKey(data, keyId) {
 	return false;
 }
 const KITTY_CSI_U_REGEX = /^\x1b\[(\d+)(?::(\d*))?(?::(\d+))?(?:;(\d+))?(?::(\d+))?u$/;
-const KITTY_PRINTABLE_ALLOWED_MODIFIERS = MODIFIERS.shift | LOCK_MASK;
+const KITTY_PRINTABLE_ALLOWED_MODIFIERS = MODIFIERS$1.shift | LOCK_MASK;
 /**
 * Decode a Kitty CSI-u sequence into a printable character, if applicable.
 *
@@ -2832,9 +2832,9 @@ function decodeKittyPrintable(data) {
 	const modValue = match[4] ? Number.parseInt(match[4], 10) : 1;
 	const modifier = Number.isFinite(modValue) ? modValue - 1 : 0;
 	if ((modifier & ~KITTY_PRINTABLE_ALLOWED_MODIFIERS) !== 0) return void 0;
-	if (modifier & (MODIFIERS.alt | MODIFIERS.ctrl)) return void 0;
+	if (modifier & (MODIFIERS$1.alt | MODIFIERS$1.ctrl)) return void 0;
 	let effectiveCodepoint = codepoint;
-	if (modifier & MODIFIERS.shift && typeof shiftedKey === "number") effectiveCodepoint = shiftedKey;
+	if (modifier & MODIFIERS$1.shift && typeof shiftedKey === "number") effectiveCodepoint = shiftedKey;
 	effectiveCodepoint = normalizeKittyFunctionalCodepoint(effectiveCodepoint);
 	if (!Number.isFinite(effectiveCodepoint) || effectiveCodepoint < 32) return void 0;
 	try {
@@ -2846,7 +2846,7 @@ function decodeKittyPrintable(data) {
 function decodeModifyOtherKeysPrintable(data) {
 	const parsed = parseModifyOtherKeysSequence(data);
 	if (!parsed) return void 0;
-	if ((parsed.modifier & ~LOCK_MASK & ~MODIFIERS.shift) !== 0) return void 0;
+	if ((parsed.modifier & ~LOCK_MASK & ~MODIFIERS$1.shift) !== 0) return void 0;
 	if (!Number.isFinite(parsed.codepoint) || parsed.codepoint < 32) return void 0;
 	try {
 		return String.fromCodePoint(parsed.codepoint);
@@ -19849,6 +19849,13 @@ const TUI_COMMANDS = Object.freeze([
 		behavior: "local"
 	},
 	{
+		name: "keymap",
+		description: "自定义快捷键",
+		argumentHint: "[binding [chord|reset]]",
+		source: "TUI",
+		behavior: "local"
+	},
+	{
 		name: "plugin",
 		description: "打开插件中心",
 		argumentHint: "[子命令]",
@@ -21206,7 +21213,8 @@ const DEFAULT_TUI_BEHAVIOR = Object.freeze({
 	composerHistoryLimit: 200,
 	statusElapsed: true,
 	clipboardFallback: "auto",
-	toolOutputLineLimit: 200
+	toolOutputLineLimit: 200,
+	keyBindings: Object.freeze({})
 });
 /** Upper bound for persisted composer history entries. */
 const MAX_COMPOSER_HISTORY = 1e4;
@@ -22290,33 +22298,6 @@ var HarnessAutocompleteProvider = class {
 };
 
 //#endregion
-//#region src/client/byte-size.ts
-/** Human-readable byte counts for export notices. */
-const UNITS = [
-	"B",
-	"KB",
-	"MB",
-	"GB",
-	"TB"
-];
-/**
-* Format a byte count using 1024-based units.
-* @param bytes - non-negative integer byte length.
-* @returns a compact label such as `11.8 MB`.
-*/
-function formatByteSize(bytes) {
-	const amount = Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
-	let value = amount;
-	let unit = 0;
-	while (value >= 1024 && unit < UNITS.length - 1) {
-		value /= 1024;
-		unit += 1;
-	}
-	if (unit === 0) return `${Math.round(amount)} B`;
-	return `${value >= 100 ? String(Math.round(value)) : String(Math.round(value * 10) / 10)} ${UNITS[unit]}`;
-}
-
-//#endregion
 //#region src/client/keymap.ts
 /** Product shortcuts handled by the terminal Surface. */
 const SURFACE_KEYMAP = [
@@ -22420,37 +22401,281 @@ const SURFACE_KEYMAP = [
 		keys: ["Enter"],
 		zh: "提交或确认",
 		en: "Submit or confirm",
-		match: () => false
+		match: () => false,
+		configurable: false
 	},
 	{
 		id: "newline",
 		keys: ["Shift+Enter"],
 		zh: "在输入区插入换行",
 		en: "Insert a newline in the composer",
-		match: () => false
+		match: () => false,
+		configurable: false
 	},
 	{
 		id: "transcriptSearch",
 		keys: ["/"],
 		zh: "对话浏览时增量查找",
 		en: "Incremental search while browsing the transcript",
-		match: () => false
+		match: () => false,
+		configurable: false
 	}
 ];
 const byId = new Map(SURFACE_KEYMAP.map((binding) => [binding.id, binding]));
+const MODIFIER_ORDER = [
+	"ctrl",
+	"alt",
+	"shift",
+	"super"
+];
+const MODIFIERS = {
+	ctrl: "ctrl",
+	control: "ctrl",
+	alt: "alt",
+	option: "alt",
+	opt: "alt",
+	shift: "shift",
+	super: "super",
+	cmd: "super",
+	command: "super",
+	win: "super",
+	windows: "super",
+	meta: "super"
+};
+const NAMED_KEYS = {
+	",": ",",
+	comma: ",",
+	"/": "/",
+	slash: "/",
+	tab: "tab",
+	enter: "enter",
+	return: "enter",
+	space: "space",
+	escape: "escape",
+	esc: "escape",
+	left: "left",
+	right: "right",
+	up: "up",
+	down: "down",
+	home: "home",
+	end: "end",
+	backspace: "backspace",
+	delete: "delete"
+};
+let overrides = {};
+function isConfigurable(binding) {
+	return binding.configurable !== false;
+}
+function namedKey(token) {
+	if (token === "") return void 0;
+	const lower = token.toLowerCase();
+	if (NAMED_KEYS[lower] !== void 0) return NAMED_KEYS[lower];
+	if (/^f([1-9]|1[0-2])$/u.test(lower)) return lower;
+	if (/^[a-z0-9]$/u.test(lower)) return lower;
+	if (token.length === 1) return lower;
+}
+/**
+* Normalize a typed chord such as `Ctrl+P` or `Cmd+,` into a pi-tui key id.
+* @param input - user-facing shortcut text.
+* @returns canonical key id, or undefined when the chord is empty or incomplete.
+*/
+function normalizeChord(input) {
+	const tokens = input.trim().split("+").map((part) => part.trim());
+	if (tokens.length === 0 || tokens.some((token) => token === "")) return void 0;
+	const modifiers = /* @__PURE__ */ new Set();
+	const last = tokens.at(-1);
+	if (last === void 0) return void 0;
+	for (const token of tokens.slice(0, -1)) {
+		const modifier = MODIFIERS[token.toLowerCase()];
+		if (modifier === void 0) return void 0;
+		modifiers.add(modifier);
+	}
+	const key = namedKey(last);
+	if (key === void 0 || MODIFIERS[last.toLowerCase()] !== void 0) return void 0;
+	const prefix = MODIFIER_ORDER.filter((name$1) => modifiers.has(name$1)).join("+");
+	return prefix === "" ? key : `${prefix}+${key}`;
+}
+function formatChord(chord) {
+	return chord.split("+").map((part) => {
+		if (part === "," || part === "/") return part;
+		if (/^f\d{1,2}$/u.test(part)) return part.toUpperCase();
+		return `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`;
+	}).join("+");
+}
+function matchChord(data, chord) {
+	if (chord === "ctrl+m" && (data === "\r" || data === "\n")) return false;
+	return matchesKey(data, chord);
+}
+function effectiveChords(binding) {
+	const override = overrides[binding.id];
+	if (override !== void 0) return [override];
+	return binding.keys.flatMap((key) => {
+		const chord = normalizeChord(key);
+		return chord === void 0 ? [] : [chord];
+	});
+}
+/**
+* Drop unknown ids, documentation-only rows, and chords that cannot be parsed.
+* @param value - persisted or typed override map.
+*/
+function sanitizeKeyBindings(value) {
+	if (typeof value !== "object" || value === null) return {};
+	const next = {};
+	for (const [id, raw] of Object.entries(value)) {
+		if (typeof raw !== "string") continue;
+		const binding = byId.get(id);
+		if (binding === void 0 || !isConfigurable(binding)) continue;
+		const chord = normalizeChord(raw);
+		if (chord === void 0) continue;
+		next[id] = chord;
+	}
+	return next;
+}
+/**
+* Replace the live override table used by matching and help text.
+* @param value - canonical or user-typed override map; empty restores defaults.
+*/
+function applyKeyBindingOverrides(value) {
+	overrides = sanitizeKeyBindings(value);
+}
 /**
 * Match one named surface binding against a raw input chunk.
 * @param id - SURFACE_KEYMAP id.
 * @param data - terminal input.
 */
 function matchesBinding(id, data) {
-	return byId.get(id)?.match(data) === true;
+	const binding = byId.get(id);
+	if (binding === void 0) return false;
+	const override = overrides[id];
+	if (override !== void 0) return matchChord(data, override);
+	return binding.match(data) === true;
+}
+/**
+* Find another action that already owns this chord.
+* @param id - binding being assigned.
+* @param typed - user-facing or canonical chord.
+* @returns the conflicting binding id, if any.
+*/
+function bindingConflict(id, typed) {
+	const chord = normalizeChord(typed);
+	if (chord === void 0) return void 0;
+	for (const binding of SURFACE_KEYMAP) {
+		if (binding.id === id) continue;
+		if (effectiveChords(binding).includes(chord)) return binding.id;
+	}
+}
+/**
+* Display the live chords for one binding, using the override when present.
+* @param id - SURFACE_KEYMAP id.
+*/
+function bindingKeysLabel(id) {
+	const binding = byId.get(id);
+	if (binding === void 0) return id;
+	const override = overrides[id];
+	return override === void 0 ? binding.keys.join(" / ") : formatChord(override);
 }
 /**
 * Render the shared keymap for the help overlay.
 */
 function helpKeymapText() {
-	return SURFACE_KEYMAP.map((binding) => `${binding.keys.join(" / ")} · ${ui(binding.zh, binding.en)}`).join("\n");
+	return SURFACE_KEYMAP.map((binding) => `${bindingKeysLabel(binding.id)} · ${ui(binding.zh, binding.en)}`).join("\n");
+}
+
+//#endregion
+//#region src/client/behavior.ts
+const TOOL_CARDS = new Set([
+	"collapsed",
+	"expanded",
+	"hidden"
+]);
+const CLIPBOARD_FALLBACK = new Set([
+	"auto",
+	"osc52",
+	"off"
+]);
+function recordOf$1(value) {
+	return typeof value === "object" && value !== null ? value : {};
+}
+function toolCardsOf(value) {
+	return typeof value === "string" && TOOL_CARDS.has(value) ? value : DEFAULT_TUI_BEHAVIOR.toolCards;
+}
+function booleanOf(value, fallback) {
+	return typeof value === "boolean" ? value : fallback;
+}
+function historyLimitOf(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit;
+	return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value));
+}
+function toolOutputLineLimitOf(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit;
+	return Math.min(MAX_TOOL_OUTPUT_LINE_LIMIT, Math.floor(value));
+}
+function clipboardFallbackOf(value) {
+	return typeof value === "string" && CLIPBOARD_FALLBACK.has(value) ? value : DEFAULT_TUI_BEHAVIOR.clipboardFallback;
+}
+/**
+* Find the behavior descriptor registered by the Host bridge.
+* @param documents - redacted Harness Settings descriptors.
+* @returns the SeekTTY behavior descriptor.
+*/
+function behaviorSettings(documents) {
+	const document = documents.find((candidate) => candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE);
+	if (document === void 0) throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`);
+	return document;
+}
+/**
+* Coerce one stored document into complete, bounded behavior settings.
+* @param value - raw Settings value, possibly partial or legacy.
+* @returns validated behavior settings.
+*/
+function normalizeBehavior(value) {
+	const record = recordOf$1(value);
+	return {
+		toolCards: toolCardsOf(record.toolCards),
+		showReasoning: booleanOf(record.showReasoning, DEFAULT_TUI_BEHAVIOR.showReasoning),
+		desktopNotifications: booleanOf(record.desktopNotifications, DEFAULT_TUI_BEHAVIOR.desktopNotifications),
+		followTerminalTitle: booleanOf(record.followTerminalTitle, DEFAULT_TUI_BEHAVIOR.followTerminalTitle),
+		composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
+		statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
+		clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
+		toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit),
+		keyBindings: sanitizeKeyBindings(record.keyBindings)
+	};
+}
+/**
+* Read and normalize the complete behavior value.
+* @param document - behavior descriptor returned by Harness Settings.
+* @returns validated behavior settings.
+*/
+function behaviorFromSettings(document) {
+	return normalizeBehavior(document.value);
+}
+
+//#endregion
+//#region src/client/byte-size.ts
+/** Human-readable byte counts for export notices. */
+const UNITS = [
+	"B",
+	"KB",
+	"MB",
+	"GB",
+	"TB"
+];
+/**
+* Format a byte count using 1024-based units.
+* @param bytes - non-negative integer byte length.
+* @returns a compact label such as `11.8 MB`.
+*/
+function formatByteSize(bytes) {
+	const amount = Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
+	let value = amount;
+	let unit = 0;
+	while (value >= 1024 && unit < UNITS.length - 1) {
+		value /= 1024;
+		unit += 1;
+	}
+	if (unit === 0) return `${Math.round(amount)} B`;
+	return `${value >= 100 ? String(Math.round(value)) : String(Math.round(value * 10) / 10)} ${UNITS[unit]}`;
 }
 
 //#endregion
@@ -22481,12 +22706,14 @@ function helpSectionText(id) {
 		"粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。",
 		"查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。",
 		"导出会话：/export 保存 ZIP，/export md 保存 Markdown。",
+		"自定义快捷键：/keymap commandPalette Ctrl+K，或 /keymap commandPalette reset 恢复默认。",
 		"命令面板：Ctrl+P；完整帮助：F1 或 /help。"
 	].join("\n"), [
 		"Approve tools: inspect the command or diff in the overlay, then allow once or reject.",
 		"Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.",
 		"Search the transcript: Tab into browse mode, press / to search, then n/N to jump.",
 		"Export: /export saves a ZIP; /export md saves Markdown.",
+		"Custom shortcuts: /keymap commandPalette Ctrl+K, or /keymap commandPalette reset to restore.",
 		"Command palette: Ctrl+P. Full help: F1 or /help."
 	].join("\n"));
 	return ui([
@@ -22788,7 +23015,8 @@ const FIELD_LABELS = {
 	composerHistoryLimit: ["输入历史条数", "Composer history size"],
 	statusElapsed: ["状态栏实时耗时", "Live status elapsed time"],
 	clipboardFallback: ["剪贴板回退", "Clipboard fallback"],
-	toolOutputLineLimit: ["工具输出行数上限", "Tool output line limit"]
+	toolOutputLineLimit: ["工具输出行数上限", "Tool output line limit"],
+	keyBindings: ["快捷键覆盖", "Key binding overrides"]
 };
 /**
 * Label a known high-frequency field while keeping unknown paths visible.
@@ -23582,6 +23810,9 @@ var TuiActions = class {
 					break;
 				case "settings":
 					await this.settings(args);
+					break;
+				case "keymap":
+					await this.keymap(args);
 					break;
 				case "plugin":
 				case "plugins":
@@ -25041,6 +25272,73 @@ var TuiActions = class {
 			margin: 1
 		});
 	}
+	async keymap(args) {
+		const settings = this.capabilities.managementBridge().settings;
+		const document = behaviorSettings(await settings.describe());
+		const current = behaviorFromSettings(document);
+		applyKeyBindingOverrides(current.keyBindings);
+		const { first, rest } = argumentPair(args);
+		if (first === "") {
+			await this.keymapOverlay(document, current);
+			return;
+		}
+		await this.keymapAssign(document, current, first, rest);
+	}
+	async keymapOverlay(document, current) {
+		const selected = await this.host.overlays.select({
+			title: ui("快捷键", "Key bindings"),
+			detail: ui("选择一项以改绑或恢复默认。Enter、换行和对话查找不可改。", "Choose a shortcut to rebind or restore. Enter, newline, and transcript search stay fixed."),
+			choices: SURFACE_KEYMAP.filter((binding) => binding.configurable !== false).map((binding) => ({
+				id: binding.id,
+				label: ui(binding.zh, binding.en),
+				description: bindingKeysLabel(binding.id)
+			}))
+		});
+		if (selected === void 0) return;
+		const target = SURFACE_KEYMAP.find((binding) => binding.id === selected.id);
+		const action = await this.host.overlays.select({
+			title: ui(target?.zh ?? selected.id, target?.en ?? selected.id),
+			detail: ui(`当前：${bindingKeysLabel(selected.id)}。输入 Ctrl+K 或 Cmd+, 这类组合。`, `Current: ${bindingKeysLabel(selected.id)}. Type a chord such as Ctrl+K or Cmd+,.`),
+			choices: [{
+				id: "set",
+				label: ui("设置新组合…", "Set a new chord…")
+			}, {
+				id: "reset",
+				label: ui("恢复默认", "Restore default")
+			}]
+		});
+		if (action === void 0) return;
+		if (action.id === "reset") {
+			await this.keymapAssign(document, current, selected.id, "reset");
+			return;
+		}
+		const typed = await this.host.overlays.input({
+			title: ui("新组合键", "New chord"),
+			placeholder: "Ctrl+K"
+		});
+		if (typed === void 0 || typed.trim() === "") return;
+		await this.keymapAssign(document, current, selected.id, typed);
+	}
+	async keymapAssign(document, current, id, rest) {
+		const binding = SURFACE_KEYMAP.find((candidate) => candidate.id === id);
+		if (binding === void 0 || binding.configurable === false) throw new Error(ui(`未知或不可配置的键位 ${id}。用法：/keymap [binding [chord|reset]]`, `Unknown or non-configurable binding ${id}. Usage: /keymap [binding [chord|reset]]`));
+		if (rest === "") throw new Error(ui("用法：/keymap [binding [chord|reset]]", "Usage: /keymap [binding [chord|reset]]"));
+		const next = { ...current.keyBindings };
+		if (rest.toLowerCase() === "reset" || rest.toLowerCase() === "default") delete next[id];
+		else {
+			const chord = normalizeChord(rest);
+			if (chord === void 0) throw new Error(ui(`无法解析组合键 ${rest}`, `Cannot parse chord ${rest}`));
+			const conflict = bindingConflict(id, chord);
+			if (conflict !== void 0) throw new Error(ui(`与 ${conflict} 冲突`, `Conflicts with ${conflict}`));
+			next[id] = chord;
+		}
+		const updated = await this.capabilities.managementBridge().settings.mutate(TUI_BEHAVIOR_SETTINGS_NAMESPACE, [{
+			op: "set",
+			path: ["keyBindings"],
+			value: next
+		}], document.revision);
+		await this.settingsChanged(updated, ui(`键位 ${id}`, `Key binding ${id}`));
+	}
 	async settingsNamespace(navigation, namespace, initialChoiceId) {
 		const bridge = this.capabilities.managementBridge().settings;
 		const initialDocument = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
@@ -25377,6 +25675,7 @@ var TuiActions = class {
 	async settingsChanged(document, label, overlays = this.host.overlays) {
 		if (document.applies === "live") {
 			if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) this.host.applyTheme(themeFromAppearance(document));
+			if (document.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) this.host.applyBehavior?.(behaviorFromSettings(document));
 			if (document.namespace === LOCALE_SETTINGS_NAMESPACE) this.host.applyLocale(localeFromSettings([document]));
 			this.host.notice(`${label} 已更新并立即生效`, "success");
 			return;
@@ -27132,75 +27431,6 @@ var PromptEditor = class extends Editor {
 		].map((line) => `${prefix}${line}`);
 	}
 };
-
-//#endregion
-//#region src/client/behavior.ts
-const TOOL_CARDS = new Set([
-	"collapsed",
-	"expanded",
-	"hidden"
-]);
-const CLIPBOARD_FALLBACK = new Set([
-	"auto",
-	"osc52",
-	"off"
-]);
-function recordOf$1(value) {
-	return typeof value === "object" && value !== null ? value : {};
-}
-function toolCardsOf(value) {
-	return typeof value === "string" && TOOL_CARDS.has(value) ? value : DEFAULT_TUI_BEHAVIOR.toolCards;
-}
-function booleanOf(value, fallback) {
-	return typeof value === "boolean" ? value : fallback;
-}
-function historyLimitOf(value) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.composerHistoryLimit;
-	return Math.min(MAX_COMPOSER_HISTORY, Math.floor(value));
-}
-function toolOutputLineLimitOf(value) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit;
-	return Math.min(MAX_TOOL_OUTPUT_LINE_LIMIT, Math.floor(value));
-}
-function clipboardFallbackOf(value) {
-	return typeof value === "string" && CLIPBOARD_FALLBACK.has(value) ? value : DEFAULT_TUI_BEHAVIOR.clipboardFallback;
-}
-/**
-* Find the behavior descriptor registered by the Host bridge.
-* @param documents - redacted Harness Settings descriptors.
-* @returns the SeekTTY behavior descriptor.
-*/
-function behaviorSettings(documents) {
-	const document = documents.find((candidate) => candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE);
-	if (document === void 0) throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`);
-	return document;
-}
-/**
-* Coerce one stored document into complete, bounded behavior settings.
-* @param value - raw Settings value, possibly partial or legacy.
-* @returns validated behavior settings.
-*/
-function normalizeBehavior(value) {
-	const record = recordOf$1(value);
-	return {
-		toolCards: toolCardsOf(record.toolCards),
-		showReasoning: booleanOf(record.showReasoning, DEFAULT_TUI_BEHAVIOR.showReasoning),
-		desktopNotifications: booleanOf(record.desktopNotifications, DEFAULT_TUI_BEHAVIOR.desktopNotifications),
-		followTerminalTitle: booleanOf(record.followTerminalTitle, DEFAULT_TUI_BEHAVIOR.followTerminalTitle),
-		composerHistoryLimit: historyLimitOf(record.composerHistoryLimit),
-		statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
-		clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
-		toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit)
-	};
-}
-/**
-* Read and normalize the complete behavior value.
-* @param document - behavior descriptor returned by Harness Settings.
-* @returns validated behavior settings.
-*/
-function behaviorFromSettings(document) {
-	return normalizeBehavior(document.value);
-}
 
 //#endregion
 //#region src/client/composer-history.ts
@@ -30278,6 +30508,7 @@ async function startTuiSurface(options$1) {
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
 		const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments));
+		applyKeyBindingOverrides(initialBehavior.keyBindings);
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
 		stopConstructedTui = () => {
@@ -30544,6 +30775,9 @@ async function startTuiSurface(options$1) {
 				refresh();
 				tui.invalidate();
 				tui.requestRender(true);
+			},
+			applyBehavior: (behavior) => {
+				applyKeyBindingOverrides(behavior.keyBindings);
 			},
 			setEditor: (text) => {
 				editor.setText(escapeTerminalText(text));
@@ -30996,7 +31230,8 @@ const BehaviorSettingsSchema = z$1.object({
 		"osc52",
 		"off"
 	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。"),
-	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description("展开态工具输出单块行数上限；0 表示不折叠。")
+	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description("展开态工具输出单块行数上限；0 表示不折叠。"),
+	keyBindings: z$1.dict(z$1.string()).default({}).description("覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。")
 });
 function settingsDocument(descriptor) {
 	return {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -15,16 +15,26 @@ import type {
 } from '@deepseek-ai/dsh-client-runtime/node-client'
 import {
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
   type TuiAppearanceSettings,
+  type TuiBehaviorSettings,
   type TuiCodeThemeId,
   type TuiCustomTheme,
   type TuiThemeId,
 } from '@deepseek-ai/dsh-tui-protocol'
 import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
+import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
 import { lastFencedCode } from './copy-content.ts'
 import { formatByteSize } from './byte-size.ts'
 import { helpSectionChoices, helpSectionText, type HelpSectionId } from './help.ts'
+import {
+  applyKeyBindingOverrides,
+  bindingConflict,
+  bindingKeysLabel,
+  normalizeChord,
+  SURFACE_KEYMAP,
+} from './keymap.ts'
 import { pluginFailureDetail } from './error-advice.ts'
 import { SessionToolAllowlist } from './session-tool-allowlist.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
@@ -103,6 +113,7 @@ export interface TuiActionHost {
   refreshHeader(): void
   applyTheme(theme: ResolvedTuiTheme): void
   applyLocale(locale: LocaleId): void
+  applyBehavior?(behavior: TuiBehaviorSettings): void
   setEditor(text: string): void
   copy(text: string): void
   close(code: number): void
@@ -391,6 +402,7 @@ export class TuiActions {
         case 'attach': await this.attach(args); break
         case 'attachments': await this.attachments(); break
         case 'settings': await this.settings(args); break
+        case 'keymap': await this.keymap(args); break
         case 'plugin':
         case 'plugins': await this.plugin(args); break
         case 'doctor': await this.doctor(); break
@@ -1802,6 +1814,108 @@ export class TuiActions {
     }, { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 })
   }
 
+  private async keymap(args: string): Promise<void> {
+    const settings = this.capabilities.managementBridge().settings
+    const document = behaviorSettings(await settings.describe())
+    const current = behaviorFromSettings(document)
+    applyKeyBindingOverrides(current.keyBindings)
+    const { first, rest } = argumentPair(args)
+    if (first === '') {
+      await this.keymapOverlay(document, current)
+      return
+    }
+    await this.keymapAssign(document, current, first, rest)
+  }
+
+  private async keymapOverlay(
+    document: TuiSettingsDocument,
+    current: TuiBehaviorSettings,
+  ): Promise<void> {
+    const selected = await this.host.overlays.select({
+      title: ui('快捷键', 'Key bindings'),
+      detail: ui(
+        '选择一项以改绑或恢复默认。Enter、换行和对话查找不可改。',
+        'Choose a shortcut to rebind or restore. Enter, newline, and transcript search stay fixed.',
+      ),
+      choices: SURFACE_KEYMAP.filter(binding => binding.configurable !== false).map(binding => ({
+        id: binding.id,
+        label: ui(binding.zh, binding.en),
+        description: bindingKeysLabel(binding.id),
+      })),
+    })
+    if (selected === undefined) return
+    const target = SURFACE_KEYMAP.find(binding => binding.id === selected.id)
+    const action = await this.host.overlays.select({
+      title: ui(target?.zh ?? selected.id, target?.en ?? selected.id),
+      detail: ui(
+        `当前：${bindingKeysLabel(selected.id)}。输入 Ctrl+K 或 Cmd+, 这类组合。`,
+        `Current: ${bindingKeysLabel(selected.id)}. Type a chord such as Ctrl+K or Cmd+,.`,
+      ),
+      choices: [
+        { id: 'set', label: ui('设置新组合…', 'Set a new chord…') },
+        { id: 'reset', label: ui('恢复默认', 'Restore default') },
+      ],
+    })
+    if (action === undefined) return
+    if (action.id === 'reset') {
+      await this.keymapAssign(document, current, selected.id, 'reset')
+      return
+    }
+    const typed = await this.host.overlays.input({
+      title: ui('新组合键', 'New chord'),
+      placeholder: 'Ctrl+K',
+    })
+    if (typed === undefined || typed.trim() === '') return
+    await this.keymapAssign(document, current, selected.id, typed)
+  }
+
+  private async keymapAssign(
+    document: TuiSettingsDocument,
+    current: TuiBehaviorSettings,
+    id: string,
+    rest: string,
+  ): Promise<void> {
+    const binding = SURFACE_KEYMAP.find(candidate => candidate.id === id)
+    if (binding === undefined || binding.configurable === false) {
+      throw new Error(ui(
+        `未知或不可配置的键位 ${id}。用法：/keymap [binding [chord|reset]]`,
+        `Unknown or non-configurable binding ${id}. Usage: /keymap [binding [chord|reset]]`,
+      ))
+    }
+    if (rest === '') {
+      throw new Error(ui(
+        '用法：/keymap [binding [chord|reset]]',
+        'Usage: /keymap [binding [chord|reset]]',
+      ))
+    }
+    const next: Record<string, string> = { ...current.keyBindings }
+    if (rest.toLowerCase() === 'reset' || rest.toLowerCase() === 'default') {
+      delete next[id]
+    } else {
+      const chord = normalizeChord(rest)
+      if (chord === undefined) {
+        throw new Error(ui(
+          `无法解析组合键 ${rest}`,
+          `Cannot parse chord ${rest}`,
+        ))
+      }
+      const conflict = bindingConflict(id, chord)
+      if (conflict !== undefined) {
+        throw new Error(ui(
+          `与 ${conflict} 冲突`,
+          `Conflicts with ${conflict}`,
+        ))
+      }
+      next[id] = chord
+    }
+    const updated = await this.capabilities.managementBridge().settings.mutate(
+      TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+      [{ op: 'set', path: ['keyBindings'], value: next }],
+      document.revision,
+    )
+    await this.settingsChanged(updated, ui(`键位 ${id}`, `Key binding ${id}`))
+  }
+
   private async settingsNamespace(
     navigation: OverlayNavigation<void>,
     namespace: string,
@@ -2164,6 +2278,9 @@ export class TuiActions {
     if (document.applies === 'live') {
       if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) {
         this.host.applyTheme(themeFromAppearance(document))
+      }
+      if (document.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) {
+        this.host.applyBehavior?.(behaviorFromSettings(document))
       }
       if (document.namespace === LOCALE_SETTINGS_NAMESPACE) {
         this.host.applyLocale(localeFromSettings([document]))

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -10,6 +10,7 @@ import {
   type TuiSettingsDocument,
   type TuiToolCardDisplay,
 } from '@deepseek-ai/dsh-tui-protocol'
+import { sanitizeKeyBindings } from './keymap.ts'
 
 const TOOL_CARDS = new Set<TuiToolCardDisplay>(['collapsed', 'expanded', 'hidden'])
 const CLIPBOARD_FALLBACK = new Set<TuiClipboardFallback>(['auto', 'osc52', 'off'])
@@ -86,6 +87,7 @@ export function normalizeBehavior(value: unknown): TuiBehaviorSettings {
     statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
     clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
     toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit),
+    keyBindings: sanitizeKeyBindings(record.keyBindings),
   }
 }
 

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -231,6 +231,7 @@ export const TUI_COMMANDS: readonly TuiCommandCandidate[] = Object.freeze([
   { name: 'attachments', description: '管理待发送图片', source: 'TUI', behavior: 'local' },
   { name: 'pending', description: '处理待审批或待回答事项', source: 'TUI', behavior: 'local' },
   { name: 'settings', description: '打开设置', argumentHint: '[namespace]', source: 'TUI', behavior: 'local' },
+  { name: 'keymap', description: '自定义快捷键', argumentHint: '[binding [chord|reset]]', source: 'TUI', behavior: 'local' },
   { name: 'plugin', description: '打开插件中心', argumentHint: '[子命令]', source: 'TUI', behavior: 'local' },
   { name: 'plugins', description: '打开插件中心', argumentHint: '[子命令]', source: 'TUI', behavior: 'local' },
   { name: 'doctor', description: '检查运行环境', source: 'TUI', behavior: 'local' },

--- a/src/client/help.ts
+++ b/src/client/help.ts
@@ -22,6 +22,7 @@ export function helpSectionText(id: HelpSectionId): string {
         '粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。',
         '查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。',
         '导出会话：/export 保存 ZIP，/export md 保存 Markdown。',
+        '自定义快捷键：/keymap commandPalette Ctrl+K，或 /keymap commandPalette reset 恢复默认。',
         '命令面板：Ctrl+P；完整帮助：F1 或 /help。',
       ].join('\n'),
       [
@@ -29,6 +30,7 @@ export function helpSectionText(id: HelpSectionId): string {
         'Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.',
         'Search the transcript: Tab into browse mode, press / to search, then n/N to jump.',
         'Export: /export saves a ZIP; /export md saves Markdown.',
+        'Custom shortcuts: /keymap commandPalette Ctrl+K, or /keymap commandPalette reset to restore.',
         'Command palette: Ctrl+P. Full help: F1 or /help.',
       ].join('\n'),
     )

--- a/src/client/keymap.ts
+++ b/src/client/keymap.ts
@@ -1,6 +1,6 @@
 /** Single source of surface key bindings shared with `/help`. */
 
-import { Key, matchesKey } from '@mariozechner/pi-tui'
+import { Key, matchesKey, type KeyId } from '@mariozechner/pi-tui'
 import { ui } from './locale.ts'
 
 export interface SurfaceKeyBinding {
@@ -9,6 +9,7 @@ export interface SurfaceKeyBinding {
   readonly zh: string
   readonly en: string
   readonly match: (data: string) => boolean
+  readonly configurable?: boolean
 }
 
 /** Product shortcuts handled by the terminal Surface. */
@@ -112,6 +113,7 @@ export const SURFACE_KEYMAP: readonly SurfaceKeyBinding[] = [
     zh: '提交或确认',
     en: 'Submit or confirm',
     match: () => false,
+    configurable: false,
   },
   {
     id: 'newline',
@@ -119,6 +121,7 @@ export const SURFACE_KEYMAP: readonly SurfaceKeyBinding[] = [
     zh: '在输入区插入换行',
     en: 'Insert a newline in the composer',
     match: () => false,
+    configurable: false,
   },
   {
     id: 'transcriptSearch',
@@ -126,10 +129,132 @@ export const SURFACE_KEYMAP: readonly SurfaceKeyBinding[] = [
     zh: '对话浏览时增量查找',
     en: 'Incremental search while browsing the transcript',
     match: () => false,
+    configurable: false,
   },
 ]
 
 const byId = new Map(SURFACE_KEYMAP.map(binding => [binding.id, binding]))
+const MODIFIER_ORDER = ['ctrl', 'alt', 'shift', 'super'] as const
+const MODIFIERS: Readonly<Record<string, (typeof MODIFIER_ORDER)[number]>> = {
+  ctrl: 'ctrl',
+  control: 'ctrl',
+  alt: 'alt',
+  option: 'alt',
+  opt: 'alt',
+  shift: 'shift',
+  super: 'super',
+  cmd: 'super',
+  command: 'super',
+  win: 'super',
+  windows: 'super',
+  meta: 'super',
+}
+const NAMED_KEYS: Readonly<Record<string, string>> = {
+  ',': ',',
+  comma: ',',
+  '/': '/',
+  slash: '/',
+  tab: 'tab',
+  enter: 'enter',
+  return: 'enter',
+  space: 'space',
+  escape: 'escape',
+  esc: 'escape',
+  left: 'left',
+  right: 'right',
+  up: 'up',
+  down: 'down',
+  home: 'home',
+  end: 'end',
+  backspace: 'backspace',
+  delete: 'delete',
+}
+
+let overrides: Readonly<Record<string, string>> = {}
+
+function isConfigurable(binding: SurfaceKeyBinding): boolean {
+  return binding.configurable !== false
+}
+
+function namedKey(token: string): string | undefined {
+  if (token === '') return undefined
+  const lower = token.toLowerCase()
+  if (NAMED_KEYS[lower] !== undefined) return NAMED_KEYS[lower]
+  if (/^f([1-9]|1[0-2])$/u.test(lower)) return lower
+  if (/^[a-z0-9]$/u.test(lower)) return lower
+  if (token.length === 1) return lower
+  return undefined
+}
+
+/**
+ * Normalize a typed chord such as `Ctrl+P` or `Cmd+,` into a pi-tui key id.
+ * @param input - user-facing shortcut text.
+ * @returns canonical key id, or undefined when the chord is empty or incomplete.
+ */
+export function normalizeChord(input: string): string | undefined {
+  const tokens = input.trim().split('+').map(part => part.trim())
+  if (tokens.length === 0 || tokens.some(token => token === '')) return undefined
+  const modifiers = new Set<(typeof MODIFIER_ORDER)[number]>()
+  const last = tokens.at(-1)
+  if (last === undefined) return undefined
+  for (const token of tokens.slice(0, -1)) {
+    const modifier = MODIFIERS[token.toLowerCase()]
+    if (modifier === undefined) return undefined
+    modifiers.add(modifier)
+  }
+  const key = namedKey(last)
+  if (key === undefined || MODIFIERS[last.toLowerCase()] !== undefined) return undefined
+  const prefix = MODIFIER_ORDER.filter(name => modifiers.has(name)).join('+')
+  return prefix === '' ? key : `${prefix}+${key}`
+}
+
+function formatChord(chord: string): string {
+  return chord.split('+').map(part => {
+    if (part === ',' || part === '/') return part
+    if (/^f\d{1,2}$/u.test(part)) return part.toUpperCase()
+    return `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`
+  }).join('+')
+}
+
+function matchChord(data: string, chord: string): boolean {
+  if (chord === 'ctrl+m' && (data === '\r' || data === '\n')) return false
+  return matchesKey(data, chord as KeyId)
+}
+
+function effectiveChords(binding: SurfaceKeyBinding): readonly string[] {
+  const override = overrides[binding.id]
+  if (override !== undefined) return [override]
+  return binding.keys.flatMap(key => {
+    const chord = normalizeChord(key)
+    return chord === undefined ? [] : [chord]
+  })
+}
+
+/**
+ * Drop unknown ids, documentation-only rows, and chords that cannot be parsed.
+ * @param value - persisted or typed override map.
+ */
+export function sanitizeKeyBindings(value: unknown): Readonly<Record<string, string>> {
+  if (typeof value !== 'object' || value === null) return {}
+  const next: Record<string, string> = {}
+  for (const [id, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw !== 'string') continue
+    const binding = byId.get(id)
+    if (binding === undefined || !isConfigurable(binding)) continue
+    const chord = normalizeChord(raw)
+    if (chord === undefined) continue
+    next[id] = chord
+  }
+  return next
+}
+
+/**
+ * Replace the live override table used by matching and help text.
+ * @param value - canonical or user-typed override map; empty restores defaults.
+ */
+export function applyKeyBindingOverrides(value: Readonly<Record<string, string>>): void {
+  overrides = sanitizeKeyBindings(value)
+}
 
 /**
  * Match one named surface binding against a raw input chunk.
@@ -137,12 +262,44 @@ const byId = new Map(SURFACE_KEYMAP.map(binding => [binding.id, binding]))
  * @param data - terminal input.
  */
 export function matchesBinding(id: string, data: string): boolean {
-  return byId.get(id)?.match(data) === true
+  const binding = byId.get(id)
+  if (binding === undefined) return false
+  const override = overrides[id]
+  if (override !== undefined) return matchChord(data, override)
+  return binding.match(data) === true
+}
+
+/**
+ * Find another action that already owns this chord.
+ * @param id - binding being assigned.
+ * @param typed - user-facing or canonical chord.
+ * @returns the conflicting binding id, if any.
+ */
+export function bindingConflict(id: string, typed: string): string | undefined {
+  const chord = normalizeChord(typed)
+  if (chord === undefined) return undefined
+  for (const binding of SURFACE_KEYMAP) {
+    if (binding.id === id) continue
+    if (effectiveChords(binding).includes(chord)) return binding.id
+  }
+  return undefined
+}
+
+/**
+ * Display the live chords for one binding, using the override when present.
+ * @param id - SURFACE_KEYMAP id.
+ */
+export function bindingKeysLabel(id: string): string {
+  const binding = byId.get(id)
+  if (binding === undefined) return id
+  const override = overrides[id]
+  return override === undefined ? binding.keys.join(' / ') : formatChord(override)
 }
 
 /**
  * Render the shared keymap for the help overlay.
  */
 export function helpKeymapText(): string {
-  return SURFACE_KEYMAP.map(binding => `${binding.keys.join(' / ')} · ${ui(binding.zh, binding.en)}`).join('\n')
+  return SURFACE_KEYMAP.map(binding =>
+    `${bindingKeysLabel(binding.id)} · ${ui(binding.zh, binding.en)}`).join('\n')
 }

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -216,6 +216,7 @@ const FIELD_LABELS: Readonly<Record<string, readonly [zh: string, en: string]>> 
   statusElapsed: ['状态栏实时耗时', 'Live status elapsed time'],
   clipboardFallback: ['剪贴板回退', 'Clipboard fallback'],
   toolOutputLineLimit: ['工具输出行数上限', 'Tool output line limit'],
+  keyBindings: ['快捷键覆盖', 'Key binding overrides'],
 }
 
 /**

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -52,7 +52,7 @@ import {
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
-import { matchesBinding } from './keymap.ts'
+import { applyKeyBindingOverrides, matchesBinding } from './keymap.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -137,6 +137,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
     const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments))
+    applyKeyBindingOverrides(initialBehavior.keyBindings)
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
     stopConstructedTui = () => {
@@ -427,6 +428,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         refresh()
         tui.invalidate()
         tui.requestRender(true)
+      },
+      applyBehavior: (behavior) => {
+        applyKeyBindingOverrides(behavior.keyBindings)
       },
       setEditor: (text) => {
         editor.setText(escapeTerminalText(text))

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -133,6 +133,8 @@ const BehaviorSettingsSchema = z.object({
   toolOutputLineLimit: z.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT)
     .default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit)
     .description('展开态工具输出单块行数上限；0 表示不折叠。'),
+  keyBindings: z.dict(z.string()).default({})
+    .description('覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。'),
 })
 
 interface StoredCatalogSource {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -124,6 +124,7 @@ export interface TuiBehaviorSettings {
   readonly statusElapsed: boolean
   readonly clipboardFallback: TuiClipboardFallback
   readonly toolOutputLineLimit: number
+  readonly keyBindings: Readonly<Record<string, string>>
 }
 
 /** First-run interaction defaults when no user override has been stored. */
@@ -136,6 +137,7 @@ export const DEFAULT_TUI_BEHAVIOR: TuiBehaviorSettings = Object.freeze({
   statusElapsed: true,
   clipboardFallback: 'auto',
   toolOutputLineLimit: 200,
+  keyBindings: Object.freeze({}),
 })
 
 /** Upper bound for persisted composer history entries. */

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -42,7 +42,11 @@ describe('seektty-behavior settings', () => {
       statusElapsed: false,
       clipboardFallback: 'osc52',
       toolOutputLineLimit: 200,
+      keyBindings: {},
     })
+    expect(normalizeBehavior({
+      keyBindings: { commandPalette: 'Ctrl+K', submit: 'ctrl+n', mystery: 'ctrl+f' },
+    }).keyBindings).toEqual({ commandPalette: 'ctrl+k' })
     expect(normalizeBehavior({
       toolCards: 'mystery',
       composerHistoryLimit: 99_999,

--- a/tests/keymap-bindings.test.ts
+++ b/tests/keymap-bindings.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  applyKeyBindingOverrides,
+  bindingConflict,
+  helpKeymapText,
+  matchesBinding,
+  normalizeChord,
+  SURFACE_KEYMAP,
+} from '../src/client/keymap.ts'
+
+afterEach(() => {
+  applyKeyBindingOverrides({})
+})
+
+describe('normalizeChord', () => {
+  it('maps typed shortcuts onto pi-tui key ids', () => {
+    expect(normalizeChord('Ctrl+P')).toBe('ctrl+p')
+    expect(normalizeChord('ctrl+p')).toBe('ctrl+p')
+    expect(normalizeChord('Cmd+,')).toBe('super+,')
+    expect(normalizeChord('Command+,')).toBe('super+,')
+    expect(normalizeChord('Win+,')).toBe('super+,')
+    expect(normalizeChord('Meta+,')).toBe('super+,')
+    expect(normalizeChord('F2')).toBe('f2')
+    expect(normalizeChord('Shift+Tab')).toBe('shift+tab')
+    expect(normalizeChord('Shift+Left')).toBe('shift+left')
+    expect(normalizeChord('  Ctrl+O  ')).toBe('ctrl+o')
+    expect(normalizeChord('')).toBeUndefined()
+    expect(normalizeChord('Ctrl+')).toBeUndefined()
+  })
+})
+
+describe('key binding overrides', () => {
+  it('matches the override chord instead of the shipped default', () => {
+    expect(matchesBinding('commandPalette', '\u0010')).toBe(true)
+    applyKeyBindingOverrides({ commandPalette: 'ctrl+k' })
+    expect(matchesBinding('commandPalette', '\u0010')).toBe(false)
+    expect(matchesBinding('commandPalette', '\u000b')).toBe(true)
+    expect(helpKeymapText()).toContain('Ctrl+K')
+    expect(helpKeymapText()).not.toContain('Ctrl+P')
+  })
+
+  it('never treats Enter as Ctrl+M, even after a rebind to ctrl+m', () => {
+    expect(matchesBinding('model', '\r')).toBe(false)
+    expect(matchesBinding('model', '\n')).toBe(false)
+    applyKeyBindingOverrides({ commandPalette: 'ctrl+m' })
+    expect(matchesBinding('commandPalette', '\r')).toBe(false)
+    expect(matchesBinding('commandPalette', '\n')).toBe(false)
+  })
+
+  it('ignores overrides for documentation-only bindings', () => {
+    applyKeyBindingOverrides({
+      submit: 'ctrl+k',
+      newline: 'ctrl+n',
+      transcriptSearch: 'ctrl+f',
+    })
+    expect(matchesBinding('submit', '\u000b')).toBe(false)
+    expect(SURFACE_KEYMAP.filter(binding => binding.configurable === false).map(binding => binding.id))
+      .toEqual(['submit', 'newline', 'transcriptSearch'])
+  })
+
+  it('reports conflicts against the effective keymap', () => {
+    expect(bindingConflict('commandPalette', 'ctrl+s')).toBe('sessions')
+    expect(bindingConflict('commandPalette', 'Ctrl+P')).toBeUndefined()
+    expect(bindingConflict('commandPalette', 'Enter')).toBe('submit')
+    applyKeyBindingOverrides({ sessions: 'ctrl+k' })
+    expect(bindingConflict('commandPalette', 'ctrl+k')).toBe('sessions')
+    expect(bindingConflict('historySearch', 'ctrl+s')).toBeUndefined()
+  })
+})

--- a/tests/keymap.test.ts
+++ b/tests/keymap.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
+import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
+import { applyKeyBindingOverrides, matchesBinding } from '../src/client/keymap.ts'
+import type { OverlayQueue } from '../src/client/overlays.ts'
+import type { Transcript } from '../src/client/transcript.ts'
+import {
+  DEFAULT_TUI_BEHAVIOR,
+  TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+  type TuiBehaviorSettings,
+  type TuiManagementBridge,
+  type TuiSettingsDocument,
+  type TuiSettingsPathOp,
+} from '../src/protocol.ts'
+
+afterEach(() => {
+  applyKeyBindingOverrides({})
+})
+
+function document(value: TuiBehaviorSettings, revision = 0): TuiSettingsDocument {
+  return {
+    namespace: TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+    schema: {},
+    value,
+    revision,
+    applies: 'live',
+    secrets: [],
+  }
+}
+
+function actionHarness(initial: TuiBehaviorSettings = DEFAULT_TUI_BEHAVIOR): {
+  readonly actions: TuiActions
+  readonly host: TuiActionHost
+  readonly mutate: ReturnType<typeof vi.fn>
+} {
+  let current = document(initial)
+  const mutate = vi.fn(async (
+    _namespace: string,
+    ops: readonly TuiSettingsPathOp[],
+    expectedRevision: number,
+  ): Promise<TuiSettingsDocument> => {
+    expect(expectedRevision).toBe(current.revision)
+    const value = { ...(current.value as TuiBehaviorSettings) } as Record<string, unknown>
+    for (const op of ops) {
+      expect(op.path).toHaveLength(1)
+      const key = op.path[0]
+      if (key === undefined) continue
+      if (op.op === 'set') value[key] = op.value
+      else delete value[key]
+    }
+    current = document(value as unknown as TuiBehaviorSettings, current.revision + 1)
+    return current
+  })
+  const settings = {
+    describe: vi.fn(async () => [current]),
+    mutate,
+  } as unknown as TuiManagementBridge['settings']
+  const management = { settings } as unknown as TuiManagementBridge
+  const capabilities = {
+    managementBridge: () => management,
+    active: () => undefined,
+  } as unknown as HarnessTuiCapabilities
+  const host: TuiActionHost = {
+    overlays: {} as OverlayQueue,
+    transcript: {} as Transcript,
+    notice: vi.fn(),
+    refresh: vi.fn(),
+    refreshHeader: vi.fn(),
+    applyTheme: vi.fn(),
+    applyLocale: vi.fn(),
+    applyBehavior: vi.fn((behavior: TuiBehaviorSettings) => {
+      applyKeyBindingOverrides(behavior.keyBindings)
+    }),
+    setEditor: vi.fn(),
+    copy: vi.fn(),
+    close: vi.fn(),
+    restart: vi.fn(),
+    requireRestart: vi.fn(),
+  }
+  return { actions: new TuiActions(capabilities, host), host, mutate }
+}
+
+describe('/keymap', () => {
+  it('persists a chord override and applies it live', async () => {
+    const { actions, host, mutate } = actionHarness()
+    await actions.execute('keymap', 'commandPalette Ctrl+K')
+    expect(mutate).toHaveBeenCalledWith(
+      TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+      [{ op: 'set', path: ['keyBindings'], value: { commandPalette: 'ctrl+k' } }],
+      0,
+    )
+    expect(host.applyBehavior).toHaveBeenCalled()
+    expect(matchesBinding('commandPalette', '\u0010')).toBe(false)
+    expect(matchesBinding('commandPalette', '\u000b')).toBe(true)
+  })
+
+  it('refuses a chord that another action already owns', async () => {
+    const { actions, host, mutate } = actionHarness()
+    await actions.execute('keymap', 'commandPalette Ctrl+S')
+    expect(mutate).not.toHaveBeenCalled()
+    expect(host.applyBehavior).not.toHaveBeenCalled()
+    expect(host.notice).toHaveBeenCalledWith(expect.stringContaining('sessions'), 'error')
+  })
+
+  it('restores the shipped default for one action', async () => {
+    const { actions, mutate } = actionHarness({
+      ...DEFAULT_TUI_BEHAVIOR,
+      keyBindings: { commandPalette: 'ctrl+k' },
+    })
+    await actions.execute('keymap', 'commandPalette reset')
+    expect(mutate).toHaveBeenCalledWith(
+      TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+      [{ op: 'set', path: ['keyBindings'], value: {} }],
+      0,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Persist optional chord overrides in `seektty-behavior.keyBindings` and apply them live from the shared keymap table.
- `/keymap <binding> <chord|reset>` rebinds or restores; conflicting chords are rejected. Enter, newline, and transcript search stay fixed; Ctrl+M still does not steal Enter.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/keymap-bindings.test.ts tests/keymap.test.ts tests/behavior.test.ts tests/help.test.ts`
- [ ] `/keymap commandPalette Ctrl+K`, confirm Ctrl+K opens the palette and `/help` shows Ctrl+K. `/keymap commandPalette reset` restores Ctrl+P.