### PR TITLE
feat(tui): shorten the first TUI frame on the startup path

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { c as versionMessage, i as defaultPluginSpec, n as PACKAGE_NAME, o as isVersionRequest, r as PACKAGE_VERSION, s as launcherPrefersEnglish, t as DSH_COMPATIBILITY } from "./dsh-compat-B1JJ9lMI.js";
+import { a as PACKAGE_VERSION, c as isVersionRequest, i as PACKAGE_NAME, l as launcherPrefersEnglish, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as versionMessage } from "./startup-trace-FL9vmf08.js";
 import { join } from "node:path";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -34,13 +34,16 @@ function launcherArgs(args) {
 		inner
 	};
 }
-function hasDependency(profile, name) {
+function profileManifest(profile) {
 	const manifestPath = join(resolveProfileDir(profile), "package.json");
-	if (!existsSync(manifestPath)) return false;
-	return JSON.parse(readFileSync(manifestPath, "utf8")).dependencies?.[name] !== void 0;
+	if (!existsSync(manifestPath)) return void 0;
+	return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
+function hasDependency(manifest, name) {
+	return manifest?.dependencies?.[name] !== void 0;
 }
 function installed(profile) {
-	return hasDependency(profile, PACKAGE_NAME);
+	return hasDependency(profileManifest(profile), PACKAGE_NAME);
 }
 function run(command, args) {
 	const result = spawnSync(command, [...args], { stdio: "inherit" });
@@ -61,7 +64,11 @@ function launch(args, environment = process.env, execute = run, write = (chunk) 
 	}
 	const { profile, inner } = launcherArgs(args);
 	const dsh = environment.DSH_BIN?.trim() || "dsh";
-	if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
+	const stderr = (chunk) => {
+		process.stderr.write(chunk);
+	};
+	let manifest = measureStartupSync("launcher-manifest", () => profileManifest(profile), environment, stderr);
+	if (hasDependency(manifest, LEGACY_PACKAGE_NAME)) {
 		const status = execute(dsh, [
 			"plugin",
 			"--profile",
@@ -70,15 +77,17 @@ function launch(args, environment = process.env, execute = run, write = (chunk) 
 			LEGACY_PACKAGE_NAME
 		]);
 		if (status !== 0) return status;
+		manifest = measureStartupSync("launcher-manifest", () => profileManifest(profile), environment, stderr);
 	}
-	if (!installed(profile)) {
-		const status = execute(dsh, [
+	if (!hasDependency(manifest, PACKAGE_NAME)) {
+		const spec = environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC;
+		const status = measureStartupSync("plugin-add", () => execute(dsh, [
 			"plugin",
 			"--profile",
 			profile,
 			"add",
-			environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC
-		]);
+			spec
+		]), environment, stderr);
 		if (status !== 0) return status;
 	}
 	return execute(dsh, [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-CRzxAYsO.js";
-import { a as dshCompatibilityError, s as launcherPrefersEnglish, t as DSH_COMPATIBILITY } from "./dsh-compat-B1JJ9lMI.js";
+import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-CVMll_8y.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -40,7 +40,7 @@ import { LOCALE_SETTINGS_NAMESPACE } from "@deepseek-ai/dsh-client-locale";
 import { getPath, hasPath, rehydrateSchema } from "@deepseek-ai/dsh-client-schema-form";
 import { parse, printParseErrorCode } from "jsonc-parser";
 import { createHighlighterCore } from "@shikijs/core";
-import { createJavaScriptRegexEngine, defaultJavaScriptRegexConstructor } from "@shikijs/engine-javascript";
+import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
 import { spawnSync } from "node:child_process";
 import z$1 from "@deepseek-ai/schemastery";
 import { credentialRef } from "@deepseek-ai/dsh-credentials";
@@ -21159,10 +21159,14 @@ async function startTuiClient(options$1) {
 			rpc: options$1.rpc,
 			isLoopback: true
 		}));
-		await ctx.plugin(client_exports$3).await();
-		await ctx.plugin(client_exports).await();
-		await ctx.plugin(client_exports$1).await();
-		await ctx.plugin(client_exports$2, { initialSelection: false }).await();
+		await measureStartup("plugins", async () => {
+			await Promise.all([
+				ctx.plugin(client_exports$3).await(),
+				ctx.plugin(client_exports).await(),
+				ctx.plugin(client_exports$1).await()
+			]);
+			await ctx.plugin(client_exports$2, { initialSelection: false }).await();
+		});
 		const connection = ctx.connection;
 		const mismatch = dshCompatibilityError((await waitForSnapshot(connection.hostDescription, (snapshot$1) => snapshot$1 !== void 0, "读取 Harness 版本"))?.version, DSH_COMPATIBILITY, launcherPrefersEnglish(process.env));
 		if (mismatch !== void 0) throw new Error(mismatch);
@@ -28687,24 +28691,23 @@ var SyntaxHighlighter = class SyntaxHighlighter {
 	* @returns ready syntax renderer.
 	*/
 	static async create(theme, invalidate) {
-		const highlighter = await createHighlighterCore({
-			engine: createJavaScriptRegexEngine({
-				forgiving: true,
-				regexConstructor: (pattern) => defaultJavaScriptRegexConstructor(pattern, { lazyCompileLength: Number.POSITIVE_INFINITY })
-			}),
-			langs: COMMON_LANGUAGES.map((language) => LANGUAGE_LOADERS[language]),
-			themes: [],
-			warnings: false
+		return measureStartup("shiki", async () => {
+			const highlighter = await createHighlighterCore({
+				engine: createJavaScriptRegexEngine({ forgiving: true }),
+				langs: COMMON_LANGUAGES.map((language) => LANGUAGE_LOADERS[language]),
+				themes: [],
+				warnings: false
+			});
+			const service = new SyntaxHighlighter(highlighter, theme, invalidate);
+			for (const language of COMMON_LANGUAGES) service.loaded.add(language);
+			service.setTheme(theme);
+			for (const sample of COMMON_WARMUPS) highlighter.codeToTokens(sample.code, {
+				lang: sample.language,
+				theme: service.themeName,
+				tokenizeTimeLimit: 0
+			});
+			return service;
 		});
-		const service = new SyntaxHighlighter(highlighter, theme, invalidate);
-		for (const language of COMMON_LANGUAGES) service.loaded.add(language);
-		service.setTheme(theme);
-		for (const sample of COMMON_WARMUPS) highlighter.codeToTokens(sample.code, {
-			lang: sample.language,
-			theme: service.themeName,
-			tokenizeTimeLimit: 0
-		});
-		return service;
 	}
 	/**
 	* Replace the active token theme and invalidate bounded render caches.
@@ -30595,10 +30598,9 @@ function noticeText(message, tone) {
 */
 async function startTuiSurface(options$1) {
 	if (!internals$1.isInteractive()) throw new Error(ui("需要交互式 TTY；非交互任务请使用 dsh --profile headless", "An interactive TTY is required; use dsh --profile headless for non-interactive tasks"));
-	const settingsDocuments = await options$1.management.settings.describe();
-	setUiLocale(localeFromSettings(settingsDocuments));
 	const terminal = internals$1.createTerminal();
-	const client = await internals$1.startClient(options$1);
+	const [settingsDocuments, client] = await measureStartup("settings+client", () => Promise.all([options$1.management.settings.describe(), internals$1.startClient(options$1)]));
+	setUiLocale(localeFromSettings(settingsDocuments));
 	let stopConstructedTui = () => void 0;
 	let disposeConstructedSyntax = () => void 0;
 	try {
@@ -30630,15 +30632,34 @@ async function startTuiSurface(options$1) {
 			if (snapshot.hasMore && !snapshot.loadingOlder) current.session.loadOlder();
 		});
 		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning, initialBehavior.toolOutputLineLimit);
-		const syntax = await SyntaxHighlighter.create(initialTheme, () => {
+		let syntax;
+		disposeConstructedSyntax = () => {
+			syntax?.dispose();
+		};
+		SyntaxHighlighter.create(initialTheme, () => {
 			transcript.refreshPresentation();
 			tui.invalidate();
 			tui.requestRender(true);
-		});
-		disposeConstructedSyntax = () => {
-			syntax.dispose();
-		};
-		setCodeHighlighter((code, lang) => syntax.highlight(code, lang));
+		}).then((created) => {
+			if (stopping !== void 0) {
+				created.dispose();
+				return;
+			}
+			syntax = created;
+			disposeConstructedSyntax = () => {
+				created.dispose();
+			};
+			setCodeHighlighter((code, lang) => created.highlight(code, lang));
+			if (stopping !== void 0) {
+				created.dispose();
+				syntax = void 0;
+				setCodeHighlighter(void 0);
+				return;
+			}
+			transcript.refreshPresentation();
+			tui.invalidate();
+			tui.requestRender(true);
+		}).catch(() => {});
 		const status = new StatusBar();
 		const canvas = new Box(0, 0, background.canvas);
 		if (options$1.draft !== void 0) editor.setText(escapeTerminalText(options$1.draft));
@@ -30812,7 +30833,7 @@ async function startTuiSurface(options$1) {
 				transcript.dispose();
 				setCodeHighlighter(void 0);
 				try {
-					syntax.dispose();
+					syntax?.dispose();
 				} catch (error) {
 					failures.push(error);
 				}
@@ -30859,7 +30880,7 @@ async function startTuiSurface(options$1) {
 			},
 			applyTheme: (theme) => {
 				setTheme(theme);
-				syntax.setTheme(theme);
+				syntax?.setTheme(theme);
 				transcript.refreshPresentation();
 				tui.invalidate();
 				tui.requestRender(true);

--- a/lib/startup-trace-FL9vmf08.js
+++ b/lib/startup-trace-FL9vmf08.js
@@ -90,4 +90,52 @@ function launcherPrefersEnglish(env) {
 }
 
 //#endregion
-export { dshCompatibilityError as a, versionMessage as c, defaultPluginSpec as i, PACKAGE_NAME as n, isVersionRequest as o, PACKAGE_VERSION as r, launcherPrefersEnglish as s, DSH_COMPATIBILITY as t };
+//#region src/startup-trace.ts
+/** Optional stderr timings for SeekTTY cold-start stages. */
+/**
+* Whether `SEEKTTY_STARTUP_TRACE=1` requested stage timings.
+* @param env - process environment.
+*/
+function startupTraceEnabled(env = process.env) {
+	return env.SEEKTTY_STARTUP_TRACE === "1";
+}
+/**
+* Run one named startup stage and optionally print elapsed milliseconds.
+* @param label - stage name in the trace line.
+* @param run - synchronous or async stage body.
+* @param env - process environment.
+* @param write - stderr writer.
+*/
+function emitStartupTrace(label, started, env, write) {
+	if (startupTraceEnabled(env)) write(`seektty-startup ${label} ${Math.round(performance.now() - started)} ms\n`);
+}
+async function measureStartup(label, run, env = process.env, write = (chunk) => {
+	process.stderr.write(chunk);
+}) {
+	const started = performance.now();
+	try {
+		return await run();
+	} finally {
+		emitStartupTrace(label, started, env, write);
+	}
+}
+/**
+* Synchronous counterpart for the launcher, which cannot await.
+* @param label - stage name in the trace line.
+* @param run - stage body.
+* @param env - process environment.
+* @param write - stderr writer.
+*/
+function measureStartupSync(label, run, env = process.env, write = (chunk) => {
+	process.stderr.write(chunk);
+}) {
+	const started = performance.now();
+	try {
+		return run();
+	} finally {
+		emitStartupTrace(label, started, env, write);
+	}
+}
+
+//#endregion
+export { PACKAGE_VERSION as a, isVersionRequest as c, PACKAGE_NAME as i, launcherPrefersEnglish as l, measureStartupSync as n, defaultPluginSpec as o, DSH_COMPATIBILITY as r, dshCompatibilityError as s, measureStartup as t, versionMessage as u };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -16,6 +16,7 @@ import {
   launcherPrefersEnglish,
   versionMessage,
 } from './dsh-compat.ts'
+import { measureStartupSync } from './startup-trace.ts'
 
 const LEGACY_PACKAGE_NAME = 'deepseek-tui'
 const DEFAULT_SPEC = defaultPluginSpec(PACKAGE_VERSION)
@@ -47,15 +48,18 @@ export function launcherArgs(args: readonly string[]): { profile: string; inner:
   return { profile, inner }
 }
 
-function hasDependency(profile: string, name: string): boolean {
+function profileManifest(profile: string): ProfileManifest | undefined {
   const manifestPath = join(resolveProfileDir(profile), 'package.json')
-  if (!existsSync(manifestPath)) return false
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ProfileManifest
-  return manifest.dependencies?.[name] !== undefined
+  if (!existsSync(manifestPath)) return undefined
+  return JSON.parse(readFileSync(manifestPath, 'utf8')) as ProfileManifest
+}
+
+function hasDependency(manifest: ProfileManifest | undefined, name: string): boolean {
+  return manifest?.dependencies?.[name] !== undefined
 }
 
 export function installed(profile: string): boolean {
-  return hasDependency(profile, PACKAGE_NAME)
+  return hasDependency(profileManifest(profile), PACKAGE_NAME)
 }
 
 export function run(command: string, args: readonly string[]): number {
@@ -81,13 +85,21 @@ export function launch(
   }
   const { profile, inner } = launcherArgs(args)
   const dsh = environment.DSH_BIN?.trim() || 'dsh'
-  if (hasDependency(profile, LEGACY_PACKAGE_NAME)) {
+  const stderr = (chunk: string): void => { process.stderr.write(chunk) }
+  let manifest = measureStartupSync('launcher-manifest', () => profileManifest(profile), environment, stderr)
+  if (hasDependency(manifest, LEGACY_PACKAGE_NAME)) {
     const status = execute(dsh, ['plugin', '--profile', profile, 'remove', LEGACY_PACKAGE_NAME])
     if (status !== 0) return status
+    manifest = measureStartupSync('launcher-manifest', () => profileManifest(profile), environment, stderr)
   }
-  if (!installed(profile)) {
+  if (!hasDependency(manifest, PACKAGE_NAME)) {
     const spec = environment.SEEKTTY_SPEC?.trim() || environment.DEEPSEEK_TUI_SPEC?.trim() || DEFAULT_SPEC
-    const status = execute(dsh, ['plugin', '--profile', profile, 'add', spec])
+    const status = measureStartupSync(
+      'plugin-add',
+      () => execute(dsh, ['plugin', '--profile', profile, 'add', spec]),
+      environment,
+      stderr,
+    )
     if (status !== 0) return status
   }
   return execute(dsh, ['--profile', profile, ...inner])

--- a/src/client/client-runtime.ts
+++ b/src/client/client-runtime.ts
@@ -29,6 +29,7 @@ import {
   dshCompatibilityError,
   launcherPrefersEnglish,
 } from '../dsh-compat.ts'
+import { measureStartup } from '../startup-trace.ts'
 
 const STARTUP_TIMEOUT_MS = 20_000
 
@@ -153,10 +154,14 @@ export async function startTuiClient(
   const ctx = new Context()
   try {
     ctx.provide('connection', createConnectionHandle({ api: options.api, rpc: options.rpc, isLoopback: true }))
-    await ctx.plugin(registryPlugin).await()
-    await ctx.plugin(gatewayPlugin).await()
-    await ctx.plugin(remotesPlugin).await()
-    await ctx.plugin(runtimePlugin, { initialSelection: false }).await()
+    await measureStartup('plugins', async () => {
+      await Promise.all([
+        ctx.plugin(registryPlugin).await(),
+        ctx.plugin(gatewayPlugin).await(),
+        ctx.plugin(remotesPlugin).await(),
+      ])
+      await ctx.plugin(runtimePlugin, { initialSelection: false }).await()
+    })
     const connection = (ctx as unknown as { readonly connection: ConnectionHandle }).connection
     const description = await waitForSnapshot(
       connection.hostDescription,

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -53,6 +53,7 @@ import {
 } from './desktop-notify.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, matchesBinding } from './keymap.ts'
+import { measureStartup } from '../startup-trace.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
@@ -128,10 +129,12 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       'An interactive TTY is required; use dsh --profile headless for non-interactive tasks',
     ))
   }
-  const settingsDocuments = await options.management.settings.describe()
-  setUiLocale(localeFromSettings(settingsDocuments))
   const terminal = internals.createTerminal()
-  const client = await internals.startClient(options)
+  const [settingsDocuments, client] = await measureStartup('settings+client', () => Promise.all([
+    options.management.settings.describe(),
+    internals.startClient(options),
+  ]))
+  setUiLocale(localeFromSettings(settingsDocuments))
   let stopConstructedTui = (): void => undefined
   let disposeConstructedSyntax = (): void => undefined
   try {
@@ -173,13 +176,32 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       initialBehavior.showReasoning,
       initialBehavior.toolOutputLineLimit,
     )
-    const syntax = await SyntaxHighlighter.create(initialTheme, () => {
+    let syntax: SyntaxHighlighter | undefined
+    disposeConstructedSyntax = () => { syntax?.dispose() }
+    void SyntaxHighlighter.create(initialTheme, () => {
       transcript.refreshPresentation()
       tui.invalidate()
       tui.requestRender(true)
+    }).then(created => {
+      if (stopping !== undefined) {
+        created.dispose()
+        return
+      }
+      syntax = created
+      disposeConstructedSyntax = () => { created.dispose() }
+      setCodeHighlighter((code, lang) => created.highlight(code, lang))
+      if (stopping !== undefined) {
+        created.dispose()
+        syntax = undefined
+        setCodeHighlighter(undefined)
+        return
+      }
+      transcript.refreshPresentation()
+      tui.invalidate()
+      tui.requestRender(true)
+    }).catch(() => {
+      /* first frame already shown; highlighting stays off */
     })
-    disposeConstructedSyntax = () => { syntax.dispose() }
-    setCodeHighlighter((code, lang) => syntax.highlight(code, lang))
     const status = new StatusBar()
     const canvas = new Box(0, 0, background.canvas)
     if (options.draft !== undefined) editor.setText(escapeTerminalText(options.draft))
@@ -380,7 +402,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         overlays.dispose()
         transcript.dispose()
         setCodeHighlighter(undefined)
-        try { syntax.dispose() } catch (error) { failures.push(error) }
+        try { syntax?.dispose() } catch (error) { failures.push(error) }
         try { unsubscribeActive() } catch (error) { failures.push(error) }
         try {
           await terminal.drainInput(250, 30)
@@ -416,7 +438,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       refreshHeader: () => { refreshHeader(false) },
       applyTheme: (theme) => {
         setTheme(theme)
-        syntax.setTheme(theme)
+        syntax?.setTheme(theme)
         transcript.refreshPresentation()
         tui.invalidate()
         tui.requestRender(true)

--- a/src/client/syntax-highlighter.ts
+++ b/src/client/syntax-highlighter.ts
@@ -10,11 +10,11 @@ import {
 } from '@shikijs/core'
 import {
   createJavaScriptRegexEngine,
-  defaultJavaScriptRegexConstructor,
 } from '@shikijs/engine-javascript'
 import type { TuiSyntaxThemeColors } from '@deepseek-ai/dsh-tui-protocol'
 import { normalizeThemeColor, type ResolvedTuiTheme } from './theme-config.ts'
 import { styleTerminalText, terminalColorLevel } from './theme.ts'
+import { measureStartup } from '../startup-trace.ts'
 
 type LanguageLoader = () => Promise<{ readonly default: LanguageRegistration[] }>
 
@@ -235,28 +235,27 @@ export class SyntaxHighlighter {
    * @returns ready syntax renderer.
    */
   static async create(theme: ResolvedTuiTheme, invalidate: () => void): Promise<SyntaxHighlighter> {
-    const highlighter = await createHighlighterCore({
-      engine: createJavaScriptRegexEngine({
-        forgiving: true,
-        regexConstructor: pattern => defaultJavaScriptRegexConstructor(pattern, {
-          lazyCompileLength: Number.POSITIVE_INFINITY,
+    return measureStartup('shiki', async () => {
+      const highlighter = await createHighlighterCore({
+        engine: createJavaScriptRegexEngine({
+          forgiving: true,
         }),
-      }),
-      langs: COMMON_LANGUAGES.map(language => LANGUAGE_LOADERS[language] as LanguageInput),
-      themes: [],
-      warnings: false,
-    })
-    const service = new SyntaxHighlighter(highlighter, theme, invalidate)
-    for (const language of COMMON_LANGUAGES) service.loaded.add(language)
-    service.setTheme(theme)
-    for (const sample of COMMON_WARMUPS) {
-      highlighter.codeToTokens(sample.code, {
-        lang: sample.language,
-        theme: service.themeName,
-        tokenizeTimeLimit: 0,
+        langs: COMMON_LANGUAGES.map(language => LANGUAGE_LOADERS[language] as LanguageInput),
+        themes: [],
+        warnings: false,
       })
-    }
-    return service
+      const service = new SyntaxHighlighter(highlighter, theme, invalidate)
+      for (const language of COMMON_LANGUAGES) service.loaded.add(language)
+      service.setTheme(theme)
+      for (const sample of COMMON_WARMUPS) {
+        highlighter.codeToTokens(sample.code, {
+          lang: sample.language,
+          theme: service.themeName,
+          tokenizeTimeLimit: 0,
+        })
+      }
+      return service
+    })
   }
 
   /**

--- a/src/startup-trace.ts
+++ b/src/startup-trace.ts
@@ -1,0 +1,64 @@
+/** Optional stderr timings for SeekTTY cold-start stages. */
+
+/**
+ * Whether `SEEKTTY_STARTUP_TRACE=1` requested stage timings.
+ * @param env - process environment.
+ */
+export function startupTraceEnabled(
+  env: NodeJS.ProcessEnv | Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.SEEKTTY_STARTUP_TRACE === '1'
+}
+
+/**
+ * Run one named startup stage and optionally print elapsed milliseconds.
+ * @param label - stage name in the trace line.
+ * @param run - synchronous or async stage body.
+ * @param env - process environment.
+ * @param write - stderr writer.
+ */
+function emitStartupTrace(
+  label: string,
+  started: number,
+  env: NodeJS.ProcessEnv | Readonly<Record<string, string | undefined>>,
+  write: (chunk: string) => void,
+): void {
+  if (startupTraceEnabled(env)) {
+    write(`seektty-startup ${label} ${Math.round(performance.now() - started)} ms\n`)
+  }
+}
+
+export async function measureStartup<T>(
+  label: string,
+  run: () => T | Promise<T>,
+  env: NodeJS.ProcessEnv | Readonly<Record<string, string | undefined>> = process.env,
+  write: (chunk: string) => void = chunk => { process.stderr.write(chunk) },
+): Promise<T> {
+  const started = performance.now()
+  try {
+    return await run()
+  } finally {
+    emitStartupTrace(label, started, env, write)
+  }
+}
+
+/**
+ * Synchronous counterpart for the launcher, which cannot await.
+ * @param label - stage name in the trace line.
+ * @param run - stage body.
+ * @param env - process environment.
+ * @param write - stderr writer.
+ */
+export function measureStartupSync<T>(
+  label: string,
+  run: () => T,
+  env: NodeJS.ProcessEnv | Readonly<Record<string, string | undefined>> = process.env,
+  write: (chunk: string) => void = chunk => { process.stderr.write(chunk) },
+): T {
+  const started = performance.now()
+  try {
+    return run()
+  } finally {
+    emitStartupTrace(label, started, env, write)
+  }
+}

--- a/tests/startup-path.test.ts
+++ b/tests/startup-path.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { measureStartup, measureStartupSync, startupTraceEnabled } from '../src/startup-trace.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('startup path (task 5.1)', () => {
+  it('does not force Shiki to compile every long regex at boot', () => {
+    const source = readFileSync(resolve(root, 'src/client/syntax-highlighter.ts'), 'utf8')
+    expect(source).not.toMatch(/lazyCompileLength:\s*Number\.POSITIVE_INFINITY/u)
+  })
+
+  it('does not await syntax highlighter creation before the first TUI frame', () => {
+    const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
+    expect(source).not.toMatch(/const syntax = await SyntaxHighlighter\.create/u)
+    expect(source).toMatch(/void SyntaxHighlighter\.create/u)
+  })
+
+  it('mounts the first three client plugins in parallel before runtime', () => {
+    const source = readFileSync(resolve(root, 'src/client/client-runtime.ts'), 'utf8')
+    expect(source).toMatch(/Promise\.all\(\[[\s\S]*registryPlugin[\s\S]*gatewayPlugin[\s\S]*remotesPlugin[\s\S]*\]\)/u)
+    expect(source).toMatch(/await ctx\.plugin\(runtimePlugin/u)
+  })
+
+  it('loads settings.describe in parallel with startClient', () => {
+    const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
+    expect(source).toMatch(/Promise\.all\(\[[\s\S]*settings\.describe\(\)[\s\S]*startClient/u)
+  })
+
+  it('reads the Profile manifest once for both legacy and current plugin checks', () => {
+    const source = readFileSync(resolve(root, 'src/bin.ts'), 'utf8')
+    expect([...source.matchAll(/readFileSync\(manifestPath/gu)]).toHaveLength(1)
+  })
+})
+
+describe('SEEKTTY_STARTUP_TRACE', () => {
+  it('is off unless the env flag is 1', () => {
+    expect(startupTraceEnabled({})).toBe(false)
+    expect(startupTraceEnabled({ SEEKTTY_STARTUP_TRACE: '0' })).toBe(false)
+    expect(startupTraceEnabled({ SEEKTTY_STARTUP_TRACE: '1' })).toBe(true)
+  })
+
+  it('prints stage milliseconds to stderr when enabled', async () => {
+    const lines: string[] = []
+    const result = await measureStartup('shiki', async () => {
+      await Promise.resolve()
+      return 7
+    }, { SEEKTTY_STARTUP_TRACE: '1' }, chunk => { lines.push(chunk) })
+    expect(result).toBe(7)
+    expect(lines.join('')).toMatch(/^seektty-startup shiki \d+ ms\n$/u)
+  })
+
+  it('does not print when disabled', async () => {
+    const lines: string[] = []
+    await measureStartup('shiki', () => 1, {}, chunk => { lines.push(chunk) })
+    expect(lines).toEqual([])
+  })
+
+  it('prints the same line from the synchronous launcher helper', () => {
+    const lines: string[] = []
+    expect(measureStartupSync('launcher-manifest', () => 3, { SEEKTTY_STARTUP_TRACE: '1' }, chunk => {
+      lines.push(chunk)
+    })).toBe(3)
+    expect(lines.join('')).toMatch(/^seektty-startup launcher-manifest \d+ ms\n$/u)
+  })
+})


### PR DESCRIPTION
## Summary
- 5.1 from `docs/DEEP_OPTIMIZATION.md`: drop forced Shiki eager regex compile, paint the first frame before highlighter create, and parallelize `settings.describe()` with `startClient` plus the first three client plugins.
- Profile `package.json` is read once for the legacy and current plugin checks.
- `SEEKTTY_STARTUP_TRACE=1` prints `seektty-startup <stage> <ms> ms` on stderr.
- Stacks on #41.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/startup-path.test.ts tests/launcher.test.ts tests/package-contract.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/tsdown`
- [ ] Manual: `SEEKTTY_STARTUP_TRACE=1 deepseek --resume <id>` and confirm `shiki` / `settings+client` / `plugins` lines

Do not merge yet — remaining performance and robustness items land on stacked branches.