### PR TITLE
feat(tui): stop marketplace search from downloading tarballs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-CRzxAYsO.js";
 import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
-import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-CVMll_8y.js";
+import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-CqTsUm3P.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,4 +1,4 @@
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CVMll_8y.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CqTsUm3P.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-CqTsUm3P.js
+++ b/lib/plugin-marketplace-CqTsUm3P.js
@@ -1,11 +1,13 @@
 import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { gunzipSync } from "node:zlib";
+import { promisify } from "node:util";
+import { gunzip } from "node:zlib";
 import { entryListSchema } from "@deepseek-ai/cordis-plugin-include";
 import { load } from "js-yaml";
 
 //#region src/host/plugin-marketplace.ts
+const gunzip$1 = promisify(gunzip);
 const MAX_INDEX_BYTES = 2 * 1024 * 1024;
 const MAX_TARBALL_BYTES = 16 * 1024 * 1024;
 const MAX_INFLATED_BYTES = 64 * 1024 * 1024;
@@ -13,6 +15,8 @@ const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
 const MAX_PATCH_BYTES = 2 * 1024 * 1024;
 const MAX_TAR_ENTRIES = 8192;
 const MAX_SEARCH_RESULTS = 12;
+const DEFAULT_FETCH_TIMEOUT_MS = 15e3;
+const TARBALL_PENDING = "尚未下载 tarball；选中后才会校验 Bundle patch";
 const SENSITIVE_QUERY_KEY = new RegExp(String.raw`(?:^|[-_])(?:access[-_]?token|api[-_]?key|auth|authorization|credential|password|secret|signature|token)(?:$|[-_])`, "i");
 function sourceType(spec) {
 	if (/^(?:git\+|github:|gitlab:|bitbucket:)|\.git(?:#|$)/i.test(spec)) return "git";
@@ -23,10 +27,11 @@ function sourceType(spec) {
 function messageOf(error) {
 	return error instanceof Error ? error.message : String(error);
 }
-function requestInit(headers, signal) {
+function requestInit(headers, timeoutMs, signal) {
+	const timeout = AbortSignal.timeout(timeoutMs);
 	return {
 		headers,
-		...signal === void 0 ? {} : { signal }
+		signal: signal === void 0 ? timeout : AbortSignal.any([timeout, signal])
 	};
 }
 /**
@@ -120,8 +125,8 @@ function paxPath(body) {
 	}
 	return found;
 }
-function tarEntries(compressed) {
-	const bytes = compressed[0] === 31 && compressed[1] === 139 ? gunzipSync(compressed, { maxOutputLength: MAX_INFLATED_BYTES }) : compressed;
+async function tarEntries(compressed) {
+	const bytes = compressed[0] === 31 && compressed[1] === 139 ? await gunzip$1(compressed, { maxOutputLength: MAX_INFLATED_BYTES }) : compressed;
 	if (bytes.byteLength > MAX_INFLATED_BYTES) throw new Error("tarball 解压后超过限制");
 	const entries = /* @__PURE__ */ new Map();
 	let offset = 0;
@@ -179,8 +184,8 @@ function packageCandidate(manifest, patchBytes, facts) {
 		diagnostics
 	};
 }
-function manifestFromTarball(bytes, facts) {
-	const entries = tarEntries(bytes);
+async function manifestFromTarball(bytes, facts) {
+	const entries = await tarEntries(bytes);
 	const manifestBytes = entries.get("package/package.json") ?? entries.get("package.json");
 	if (manifestBytes === void 0) throw new Error("tarball 不含 package.json");
 	const parsed = parseJson(manifestBytes, "package.json");
@@ -189,6 +194,23 @@ function manifestFromTarball(bytes, facts) {
 	const patch = manifest.dsh?.bundle?.patch;
 	const normalized = patch === void 0 ? void 0 : safePatchPath(patch);
 	return packageCandidate(manifest, normalized === void 0 ? void 0 : entries.get(`package/${normalized}`) ?? entries.get(normalized), facts);
+}
+function pendingSearchCandidate(facts) {
+	return {
+		id: facts.id,
+		name: facts.name,
+		...facts.version === void 0 ? {} : { version: facts.version },
+		...facts.description === void 0 ? {} : { description: facts.description },
+		...facts.publisher === void 0 ? {} : { publisher: facts.publisher },
+		sourceId: facts.sourceId,
+		source: facts.source,
+		spec: facts.spec,
+		bundle: false,
+		patchValid: false,
+		scripts: [],
+		immutable: facts.immutable,
+		diagnostics: [TARBALL_PENDING]
+	};
 }
 function parseNpmSpec(spec) {
 	const value = spec.startsWith("npm:") ? spec.slice(4) : spec;
@@ -210,31 +232,22 @@ function parseNpmSpec(spec) {
 function publisherOf(manifest) {
 	return manifest._npmUser?.name ?? manifest.maintainers?.find((row) => row.name !== void 0)?.name;
 }
-async function mapLimited(items, limit, work) {
-	const results = [];
-	let cursor = 0;
-	const worker = async () => {
-		for (;;) {
-			const index = cursor++;
-			if (index >= items.length) return;
-			results[index] = await work(items[index]);
-		}
-	};
-	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-	return results;
-}
 /** Marketplace discovery service. It validates package bytes but never installs or executes them. */
 var PluginMarketplace = class {
 	cwd;
 	resolveCredential;
 	fetcher;
 	providers;
+	timeoutMs;
+	searchCache = /* @__PURE__ */ new Map();
+	inspectCache = /* @__PURE__ */ new Map();
 	/** @param options - workspace base, Host credential resolver, and replaceable fetch seam. */
 	constructor(options) {
 		this.cwd = options.cwd;
 		this.resolveCredential = options.resolveCredential;
 		this.fetcher = options.fetch ?? fetch;
 		this.providers = options.providers;
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
 	}
 	/**
 	* Search every enabled Provider and validate returned candidates.
@@ -247,6 +260,9 @@ var PluginMarketplace = class {
 		const text = query.trim();
 		if (text === "") throw new Error("插件搜索词不能为空");
 		const enabled = sources.filter((source) => source.enabled);
+		const cacheKey = `search:${text}:${enabled.map((source) => source.id).join(",")}`;
+		const cached = this.searchCache.get(cacheKey);
+		if (cached !== void 0) return cached;
 		const rows = await Promise.all(enabled.map((source) => {
 			if (source.kind === "npm") return this.searchNpm(text, source, signal);
 			if (source.kind === "catalog") return this.searchCatalog(text, source, signal);
@@ -254,7 +270,9 @@ var PluginMarketplace = class {
 		}));
 		const deduped = /* @__PURE__ */ new Map();
 		for (const candidate of rows.flat()) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate);
-		return [...deduped.values()];
+		const result = [...deduped.values()];
+		this.searchCache.set(cacheKey, result);
+		return result;
 	}
 	/**
 	* Inspect one npm, tarball, local, or Git spec without installing it.
@@ -266,6 +284,13 @@ var PluginMarketplace = class {
 	async inspect(spec, sources, signal) {
 		const value = spec.trim();
 		if (value === "") throw new Error("插件 spec 不能为空");
+		const cached = this.inspectCache.get(value);
+		if (cached !== void 0) return cached;
+		const candidate = await this.inspectUncached(value, sources, signal);
+		this.inspectCache.set(value, candidate);
+		return candidate;
+	}
+	async inspectUncached(value, sources, signal) {
 		assertCredentialFreeUrl(value, "插件 spec");
 		const type = sourceType(value);
 		if (type === "git") {
@@ -285,7 +310,7 @@ var PluginMarketplace = class {
 		}
 		if (type === "local") return this.inspectLocal(value);
 		if (type === "tarball") {
-			if (/^https?:/i.test(value)) return manifestFromTarball(await readBounded(await this.fetcher(value, requestInit({}, signal)), MAX_TARBALL_BYTES, "插件 tarball"), {
+			if (/^https?:/i.test(value)) return manifestFromTarball(await readBounded(await this.fetcher(value, requestInit({}, this.timeoutMs, signal)), MAX_TARBALL_BYTES, "插件 tarball"), {
 				id: `direct:${value}`,
 				sourceId: "direct",
 				source: "tarball",
@@ -310,38 +335,35 @@ var PluginMarketplace = class {
 		const url = new URL("-/v1/search", source.url.endsWith("/") ? source.url : `${source.url}/`);
 		url.searchParams.set("text", `${query} keywords:dsh`);
 		url.searchParams.set("size", String(MAX_SEARCH_RESULTS));
-		const body = parseJson(await readBounded(await this.fetcher(url, requestInit(await this.headers(source, url), signal)), MAX_INDEX_BYTES, `npm Source ${source.label}`), "npm 搜索响应");
-		return mapLimited((typeof body === "object" && body !== null && Array.isArray(body.objects) ? body.objects : []).flatMap((row) => {
+		const body = parseJson(await readBounded(await this.fetcher(url, requestInit(await this.headers(source, url), this.timeoutMs, signal)), MAX_INDEX_BYTES, `npm Source ${source.label}`), "npm 搜索响应");
+		return (typeof body === "object" && body !== null && Array.isArray(body.objects) ? body.objects : []).flatMap((row) => {
 			if (typeof row !== "object" || row === null) return [];
 			const pkg = row.package;
 			if (typeof pkg !== "object" || pkg === null) return [];
 			const name = pkg.name;
+			if (typeof name !== "string") return [];
 			const version = pkg.version;
-			return typeof name === "string" ? [`${name}${typeof version === "string" ? `@${version}` : ""}`] : [];
-		}).slice(0, MAX_SEARCH_RESULTS), 4, async (spec) => {
-			try {
-				return await this.inspectNpm(spec, source, signal);
-			} catch (error) {
-				return {
-					id: `${source.id}:${spec}`,
-					name: parseNpmSpec(spec).name,
-					sourceId: source.id,
-					source: "npm",
-					spec,
-					bundle: false,
-					patchValid: false,
-					scripts: [],
-					immutable: spec.includes("@"),
-					diagnostics: [`验证失败：${messageOf(error)}`]
-				};
-			}
-		});
+			const description = pkg.description;
+			const publisher = pkg.publisher?.username;
+			const spec = `${name}${typeof version === "string" ? `@${version}` : ""}`;
+			return [pendingSearchCandidate({
+				id: `${source.id}:${spec}`,
+				name,
+				...typeof version === "string" ? { version } : {},
+				...typeof description === "string" ? { description } : {},
+				...typeof publisher === "string" ? { publisher } : {},
+				sourceId: source.id,
+				source: "npm",
+				spec,
+				immutable: typeof version === "string"
+			})];
+		}).slice(0, MAX_SEARCH_RESULTS);
 	}
 	async inspectNpm(spec, source, signal) {
 		const parsed = parseNpmSpec(spec);
 		const registry = source.url.endsWith("/") ? source.url : `${source.url}/`;
 		const metadataUrl = new URL(encodeURIComponent(parsed.name), registry);
-		const metadata = parseJson(await readBounded(await this.fetcher(metadataUrl, requestInit(await this.headers(source, metadataUrl), signal)), MAX_INDEX_BYTES, `npm 包 ${parsed.name}`), "npm 包元数据");
+		const metadata = parseJson(await readBounded(await this.fetcher(metadataUrl, requestInit(await this.headers(source, metadataUrl), this.timeoutMs, signal)), MAX_INDEX_BYTES, `npm 包 ${parsed.name}`), "npm 包元数据");
 		if (typeof metadata !== "object" || metadata === null) throw new Error("npm 元数据不是对象");
 		const record = metadata;
 		const version = parsed.version ?? record["dist-tags"]?.latest;
@@ -352,10 +374,10 @@ var PluginMarketplace = class {
 		if (typeof tarball !== "string") throw new Error(`${parsed.name}@${version} 缺少 dist.tarball`);
 		const tarballUrl = new URL(tarball);
 		if (!["http:", "https:"].includes(tarballUrl.protocol)) throw new Error("npm dist.tarball 必须使用 HTTP(S)");
-		const tarResponse = await this.fetcher(tarballUrl, requestInit(await this.headers(source, tarballUrl), signal));
+		const tarResponse = await this.fetcher(tarballUrl, requestInit(await this.headers(source, tarballUrl), this.timeoutMs, signal));
 		const exactSpec = `${parsed.name}@${version}`;
 		const publisher = publisherOf(manifest);
-		const candidate = manifestFromTarball(await readBounded(tarResponse, MAX_TARBALL_BYTES, `${exactSpec} tarball`), {
+		const candidate = await manifestFromTarball(await readBounded(tarResponse, MAX_TARBALL_BYTES, `${exactSpec} tarball`), {
 			id: `${source.id}:${exactSpec}`,
 			sourceId: source.id,
 			source: "npm",
@@ -369,7 +391,7 @@ var PluginMarketplace = class {
 			...candidate.description === void 0 && manifest.description !== void 0 ? { description: manifest.description } : {}
 		};
 	}
-	inspectLocal(spec) {
+	async inspectLocal(spec) {
 		const fileUrl = spec.startsWith("file://");
 		const prefix = /^(?:file:|link:)/.exec(spec)?.[0] ?? "";
 		const raw = prefix === "" ? spec : spec.slice(prefix.length);
@@ -378,7 +400,7 @@ var PluginMarketplace = class {
 		const stat = statSync(path);
 		if (stat.isFile()) {
 			const finalSpec$1 = fileUrl ? spec : prefix === "" ? path : `${prefix}${path}`;
-			return manifestFromTarball(readLocalBounded(path, MAX_TARBALL_BYTES, "本地插件 tarball"), {
+			return await manifestFromTarball(readLocalBounded(path, MAX_TARBALL_BYTES, "本地插件 tarball"), {
 				id: `local:${path}`,
 				sourceId: "local",
 				source: "tarball",
@@ -412,10 +434,10 @@ var PluginMarketplace = class {
 	}
 	async searchCatalog(query, source, signal) {
 		const localPath = source.url.startsWith("file:") ? fileURLToPath(source.url) : resolve(this.cwd, source.url);
-		const body = parseJson(/^https?:/i.test(source.url) ? await readBounded(await this.fetcher(source.url, requestInit(await this.headers(source, source.url), signal)), MAX_INDEX_BYTES, `Catalog ${source.label}`) : readLocalBounded(localPath, MAX_INDEX_BYTES, `Catalog ${source.label}`), `Catalog ${source.label}`);
+		const body = parseJson(/^https?:/i.test(source.url) ? await readBounded(await this.fetcher(source.url, requestInit(await this.headers(source, source.url), this.timeoutMs, signal)), MAX_INDEX_BYTES, `Catalog ${source.label}`) : readLocalBounded(localPath, MAX_INDEX_BYTES, `Catalog ${source.label}`), `Catalog ${source.label}`);
 		const entries = Array.isArray(body) ? body : typeof body === "object" && body !== null && Array.isArray(body.plugins) ? body.plugins : [];
 		const lowered = query.toLocaleLowerCase();
-		return mapLimited(entries.flatMap((entry) => {
+		return entries.flatMap((entry) => {
 			if (typeof entry !== "object" || entry === null) return [];
 			const candidate = entry;
 			if (typeof candidate.spec !== "string" && typeof candidate.name !== "string") return [];
@@ -426,72 +448,29 @@ var PluginMarketplace = class {
 				...candidate.description === void 0 ? {} : { description: candidate.description },
 				...candidate.publisher === void 0 ? {} : { publisher: candidate.publisher }
 			}];
-		}).slice(0, MAX_SEARCH_RESULTS), 4, async (entry) => {
-			const spec = entry.spec;
-			try {
-				const candidate = await this.inspect(spec, [source, {
-					id: "npm",
-					kind: "npm",
-					label: "npm Registry",
-					url: "https://registry.npmjs.org/",
-					enabled: true,
-					builtIn: true
-				}], signal);
-				return {
-					...candidate,
-					id: `${source.id}:${candidate.spec}`,
-					sourceId: source.id,
-					...candidate.description === void 0 && entry.description !== void 0 ? { description: entry.description } : {},
-					...candidate.publisher === void 0 && entry.publisher !== void 0 ? { publisher: entry.publisher } : {}
-				};
-			} catch (error) {
-				return {
-					id: `${source.id}:${spec}`,
-					name: entry.name,
-					...entry.description === void 0 ? {} : { description: entry.description },
-					...entry.publisher === void 0 ? {} : { publisher: entry.publisher },
-					sourceId: source.id,
-					source: sourceType(spec),
-					spec,
-					bundle: false,
-					patchValid: false,
-					scripts: [],
-					immutable: false,
-					diagnostics: [`验证失败：${messageOf(error)}`]
-				};
-			}
-		});
+		}).slice(0, MAX_SEARCH_RESULTS).map((entry) => pendingSearchCandidate({
+			id: `${source.id}:${entry.spec}`,
+			name: entry.name,
+			sourceId: source.id,
+			source: sourceType(entry.spec),
+			spec: entry.spec,
+			...entry.description === void 0 ? {} : { description: entry.description },
+			...entry.publisher === void 0 ? {} : { publisher: entry.publisher },
+			immutable: false
+		}));
 	}
-	async searchProvider(query, source, sources, signal) {
+	async searchProvider(query, source, _sources, signal) {
 		if (this.providers === void 0) throw new Error(`Source Provider ${JSON.stringify(source.kind)} 未装配`);
-		return mapLimited(await this.providers.search(query, source, signal), 4, async (entry) => {
-			try {
-				const candidate = await this.inspect(entry.spec, sources, signal);
-				return {
-					...candidate,
-					id: `${source.id}:${candidate.spec}`,
-					sourceId: source.id,
-					...entry.name === void 0 ? {} : { name: entry.name },
-					...candidate.description === void 0 && entry.description !== void 0 ? { description: entry.description } : {},
-					...candidate.publisher === void 0 && entry.publisher !== void 0 ? { publisher: entry.publisher } : {}
-				};
-			} catch (error) {
-				return {
-					id: `${source.id}:${entry.spec}`,
-					name: entry.name ?? entry.spec,
-					...entry.description === void 0 ? {} : { description: entry.description },
-					...entry.publisher === void 0 ? {} : { publisher: entry.publisher },
-					sourceId: source.id,
-					source: sourceType(entry.spec),
-					spec: entry.spec,
-					bundle: false,
-					patchValid: false,
-					scripts: [],
-					immutable: false,
-					diagnostics: [`Provider 候选验证失败：${messageOf(error)}`]
-				};
-			}
-		});
+		return (await this.providers.search(query, source, signal)).map((entry) => pendingSearchCandidate({
+			id: `${source.id}:${entry.spec}`,
+			name: entry.name ?? entry.spec,
+			sourceId: source.id,
+			source: sourceType(entry.spec),
+			spec: entry.spec,
+			...entry.description === void 0 ? {} : { description: entry.description },
+			...entry.publisher === void 0 ? {} : { publisher: entry.publisher },
+			immutable: false
+		}));
 	}
 };
 

--- a/src/host/plugin-marketplace.ts
+++ b/src/host/plugin-marketplace.ts
@@ -3,7 +3,8 @@
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { isAbsolute, join, posix, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { gunzipSync } from 'node:zlib'
+import { promisify } from 'node:util'
+import { gunzip as gunzipCallback } from 'node:zlib'
 import { entryListSchema } from '@deepseek-ai/cordis-plugin-include'
 import { load } from 'js-yaml'
 import type {
@@ -13,6 +14,7 @@ import type {
 } from '@deepseek-ai/dsh-tui-protocol'
 import type { TuiMarketplaceProviderRegistry } from './marketplace-provider.ts'
 
+const gunzip = promisify(gunzipCallback)
 const MAX_INDEX_BYTES = 2 * 1024 * 1024
 const MAX_TARBALL_BYTES = 16 * 1024 * 1024
 const MAX_INFLATED_BYTES = 64 * 1024 * 1024
@@ -20,6 +22,8 @@ const MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 const MAX_PATCH_BYTES = 2 * 1024 * 1024
 const MAX_TAR_ENTRIES = 8_192
 const MAX_SEARCH_RESULTS = 12
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000
+const TARBALL_PENDING = '尚未下载 tarball；选中后才会校验 Bundle patch'
 const SENSITIVE_QUERY_KEY = new RegExp(
   String.raw`(?:^|[-_])(?:access[-_]?token|api[-_]?key|auth|authorization|credential|password|secret|signature|token)(?:$|[-_])`,
   'i',
@@ -53,6 +57,7 @@ interface MarketplaceOptions {
   readonly resolveCredential: (ref: string) => Promise<string | undefined>
   readonly fetch?: typeof fetch
   readonly providers?: Pick<TuiMarketplaceProviderRegistry, 'search'>
+  readonly timeoutMs?: number
 }
 
 function sourceType(spec: string): TuiPluginEntry['source'] {
@@ -66,10 +71,15 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function requestInit(headers: Record<string, string>, signal: AbortSignal | undefined): RequestInit {
+function requestInit(
+  headers: Record<string, string>,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): RequestInit {
+  const timeout = AbortSignal.timeout(timeoutMs)
   return {
     headers,
-    ...(signal === undefined ? {} : { signal }),
+    signal: signal === undefined ? timeout : AbortSignal.any([timeout, signal]),
   }
 }
 
@@ -178,10 +188,10 @@ function paxPath(body: string): string | undefined {
   return found
 }
 
-function tarEntries(compressed: Uint8Array): ReadonlyMap<string, Uint8Array> {
+async function tarEntries(compressed: Uint8Array): Promise<ReadonlyMap<string, Uint8Array>> {
   const gzip = compressed[0] === 0x1f && compressed[1] === 0x8b
   const bytes = gzip
-    ? gunzipSync(compressed, { maxOutputLength: MAX_INFLATED_BYTES })
+    ? await gunzip(compressed, { maxOutputLength: MAX_INFLATED_BYTES })
     : compressed
   if (bytes.byteLength > MAX_INFLATED_BYTES) throw new Error('tarball 解压后超过限制')
   const entries = new Map<string, Uint8Array>()
@@ -258,8 +268,11 @@ function packageCandidate(
   }
 }
 
-function manifestFromTarball(bytes: Uint8Array, facts: Parameters<typeof packageCandidate>[2]): TuiMarketplaceCandidate {
-  const entries = tarEntries(bytes)
+async function manifestFromTarball(
+  bytes: Uint8Array,
+  facts: Parameters<typeof packageCandidate>[2],
+): Promise<TuiMarketplaceCandidate> {
+  const entries = await tarEntries(bytes)
   const manifestBytes = entries.get('package/package.json') ?? entries.get('package.json')
   if (manifestBytes === undefined) throw new Error('tarball 不含 package.json')
   const parsed = parseJson(manifestBytes, 'package.json')
@@ -273,6 +286,34 @@ function manifestFromTarball(bytes: Uint8Array, facts: Parameters<typeof package
     ? undefined
     : entries.get(`package/${normalized}`) ?? entries.get(normalized)
   return packageCandidate(manifest, patchBytes, facts)
+}
+
+function pendingSearchCandidate(facts: {
+  readonly id: string
+  readonly name: string
+  readonly sourceId: string
+  readonly source: TuiPluginEntry['source']
+  readonly spec: string
+  readonly version?: string
+  readonly description?: string
+  readonly publisher?: string
+  readonly immutable: boolean
+}): TuiMarketplaceCandidate {
+  return {
+    id: facts.id,
+    name: facts.name,
+    ...(facts.version === undefined ? {} : { version: facts.version }),
+    ...(facts.description === undefined ? {} : { description: facts.description }),
+    ...(facts.publisher === undefined ? {} : { publisher: facts.publisher }),
+    sourceId: facts.sourceId,
+    source: facts.source,
+    spec: facts.spec,
+    bundle: false,
+    patchValid: false,
+    scripts: [],
+    immutable: facts.immutable,
+    diagnostics: [TARBALL_PENDING],
+  }
 }
 
 function parseNpmSpec(spec: string): { name: string; version?: string } {
@@ -293,26 +334,15 @@ function publisherOf(manifest: PackageManifest): string | undefined {
   return manifest._npmUser?.name ?? manifest.maintainers?.find(row => row.name !== undefined)?.name
 }
 
-async function mapLimited<T, R>(items: readonly T[], limit: number, work: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = []
-  let cursor = 0
-  const worker = async (): Promise<void> => {
-    for (;;) {
-      const index = cursor++
-      if (index >= items.length) return
-      results[index] = await work(items[index] as T)
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
-  return results
-}
-
 /** Marketplace discovery service. It validates package bytes but never installs or executes them. */
 export class PluginMarketplace {
   private readonly cwd: string
   private readonly resolveCredential: MarketplaceOptions['resolveCredential']
   private readonly fetcher: typeof fetch
   private readonly providers: MarketplaceOptions['providers']
+  private readonly timeoutMs: number
+  private readonly searchCache = new Map<string, readonly TuiMarketplaceCandidate[]>()
+  private readonly inspectCache = new Map<string, TuiMarketplaceCandidate>()
 
   /** @param options - workspace base, Host credential resolver, and replaceable fetch seam. */
   constructor(options: MarketplaceOptions) {
@@ -320,6 +350,7 @@ export class PluginMarketplace {
     this.resolveCredential = options.resolveCredential
     this.fetcher = options.fetch ?? fetch
     this.providers = options.providers
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
   }
 
   /**
@@ -337,6 +368,9 @@ export class PluginMarketplace {
     const text = query.trim()
     if (text === '') throw new Error('插件搜索词不能为空')
     const enabled = sources.filter(source => source.enabled)
+    const cacheKey = `search:${text}:${enabled.map(source => source.id).join(',')}`
+    const cached = this.searchCache.get(cacheKey)
+    if (cached !== undefined) return cached
     const rows = await Promise.all(enabled.map((source) => {
       if (source.kind === 'npm') return this.searchNpm(text, source, signal)
       if (source.kind === 'catalog') return this.searchCatalog(text, source, signal)
@@ -344,7 +378,9 @@ export class PluginMarketplace {
     }))
     const deduped = new Map<string, TuiMarketplaceCandidate>()
     for (const candidate of rows.flat()) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate)
-    return [...deduped.values()]
+    const result = [...deduped.values()]
+    this.searchCache.set(cacheKey, result)
+    return result
   }
 
   /**
@@ -361,6 +397,18 @@ export class PluginMarketplace {
   ): Promise<TuiMarketplaceCandidate> {
     const value = spec.trim()
     if (value === '') throw new Error('插件 spec 不能为空')
+    const cached = this.inspectCache.get(value)
+    if (cached !== undefined) return cached
+    const candidate = await this.inspectUncached(value, sources, signal)
+    this.inspectCache.set(value, candidate)
+    return candidate
+  }
+
+  private async inspectUncached(
+    value: string,
+    sources: readonly TuiMarketplaceSource[],
+    signal?: AbortSignal,
+  ): Promise<TuiMarketplaceCandidate> {
     assertCredentialFreeUrl(value, '插件 spec')
     const type = sourceType(value)
     if (type === 'git') {
@@ -384,7 +432,7 @@ export class PluginMarketplace {
     if (type === 'local') return this.inspectLocal(value)
     if (type === 'tarball') {
       if (/^https?:/i.test(value)) {
-        const response = await this.fetcher(value, requestInit({}, signal))
+        const response = await this.fetcher(value, requestInit({}, this.timeoutMs, signal))
         return manifestFromTarball(await readBounded(response, MAX_TARBALL_BYTES, '插件 tarball'), {
           id: `direct:${value}`, sourceId: 'direct', source: 'tarball', spec: value, immutable: false,
         })
@@ -414,39 +462,33 @@ export class PluginMarketplace {
     const url = new URL('-/v1/search', source.url.endsWith('/') ? source.url : `${source.url}/`)
     url.searchParams.set('text', `${query} keywords:dsh`)
     url.searchParams.set('size', String(MAX_SEARCH_RESULTS))
-    const response = await this.fetcher(url, requestInit(await this.headers(source, url), signal))
+    const response = await this.fetcher(url, requestInit(await this.headers(source, url), this.timeoutMs, signal))
     const body = parseJson(await readBounded(response, MAX_INDEX_BYTES, `npm Source ${source.label}`), 'npm 搜索响应')
     const objects = typeof body === 'object' && body !== null && Array.isArray((body as { objects?: unknown }).objects)
       ? (body as { objects: unknown[] }).objects
       : []
-    const specs = objects.flatMap((row) => {
+    return objects.flatMap((row): TuiMarketplaceCandidate[] => {
       if (typeof row !== 'object' || row === null) return []
       const pkg = (row as { package?: unknown }).package
       if (typeof pkg !== 'object' || pkg === null) return []
       const name = (pkg as { name?: unknown }).name
+      if (typeof name !== 'string') return []
       const version = (pkg as { version?: unknown }).version
-      return typeof name === 'string'
-        ? [`${name}${typeof version === 'string' ? `@${version}` : ''}`]
-        : []
+      const description = (pkg as { description?: unknown }).description
+      const publisher = (pkg as { publisher?: { username?: string } }).publisher?.username
+      const spec = `${name}${typeof version === 'string' ? `@${version}` : ''}`
+      return [pendingSearchCandidate({
+        id: `${source.id}:${spec}`,
+        name,
+        ...(typeof version === 'string' ? { version } : {}),
+        ...(typeof description === 'string' ? { description } : {}),
+        ...(typeof publisher === 'string' ? { publisher } : {}),
+        sourceId: source.id,
+        source: 'npm',
+        spec,
+        immutable: typeof version === 'string',
+      })]
     }).slice(0, MAX_SEARCH_RESULTS)
-    return mapLimited(specs, 4, async (spec) => {
-      try {
-        return await this.inspectNpm(spec, source, signal)
-      } catch (error) {
-        return {
-          id: `${source.id}:${spec}`,
-          name: parseNpmSpec(spec).name,
-          sourceId: source.id,
-          source: 'npm' as const,
-          spec,
-          bundle: false,
-          patchValid: false,
-          scripts: [],
-          immutable: spec.includes('@'),
-          diagnostics: [`验证失败：${messageOf(error)}`],
-        }
-      }
-    })
   }
 
   private async inspectNpm(
@@ -457,7 +499,7 @@ export class PluginMarketplace {
     const parsed = parseNpmSpec(spec)
     const registry = source.url.endsWith('/') ? source.url : `${source.url}/`
     const metadataUrl = new URL(encodeURIComponent(parsed.name), registry)
-    const response = await this.fetcher(metadataUrl, requestInit(await this.headers(source, metadataUrl), signal))
+    const response = await this.fetcher(metadataUrl, requestInit(await this.headers(source, metadataUrl), this.timeoutMs, signal))
     const metadata = parseJson(await readBounded(response, MAX_INDEX_BYTES, `npm 包 ${parsed.name}`), 'npm 包元数据')
     if (typeof metadata !== 'object' || metadata === null) throw new Error('npm 元数据不是对象')
     const record = metadata as { versions?: Record<string, PackageManifest>; 'dist-tags'?: Record<string, string> }
@@ -469,10 +511,10 @@ export class PluginMarketplace {
     if (typeof tarball !== 'string') throw new Error(`${parsed.name}@${version} 缺少 dist.tarball`)
     const tarballUrl = new URL(tarball)
     if (!['http:', 'https:'].includes(tarballUrl.protocol)) throw new Error('npm dist.tarball 必须使用 HTTP(S)')
-    const tarResponse = await this.fetcher(tarballUrl, requestInit(await this.headers(source, tarballUrl), signal))
+    const tarResponse = await this.fetcher(tarballUrl, requestInit(await this.headers(source, tarballUrl), this.timeoutMs, signal))
     const exactSpec = `${parsed.name}@${version}`
     const publisher = publisherOf(manifest)
-    const candidate = manifestFromTarball(await readBounded(tarResponse, MAX_TARBALL_BYTES, `${exactSpec} tarball`), {
+    const candidate = await manifestFromTarball(await readBounded(tarResponse, MAX_TARBALL_BYTES, `${exactSpec} tarball`), {
       id: `${source.id}:${exactSpec}`,
       sourceId: source.id,
       source: 'npm',
@@ -491,7 +533,7 @@ export class PluginMarketplace {
     }
   }
 
-  private inspectLocal(spec: string): TuiMarketplaceCandidate {
+  private async inspectLocal(spec: string): Promise<TuiMarketplaceCandidate> {
     const fileUrl = spec.startsWith('file://')
     const prefix = /^(?:file:|link:)/.exec(spec)?.[0] ?? ''
     const raw = prefix === '' ? spec : spec.slice(prefix.length)
@@ -500,7 +542,7 @@ export class PluginMarketplace {
     const stat = statSync(path)
     if (stat.isFile()) {
       const finalSpec = fileUrl ? spec : prefix === '' ? path : `${prefix}${path}`
-      return manifestFromTarball(readLocalBounded(path, MAX_TARBALL_BYTES, '本地插件 tarball'), {
+      return await manifestFromTarball(readLocalBounded(path, MAX_TARBALL_BYTES, '本地插件 tarball'), {
         id: `local:${path}`, sourceId: 'local', source: 'tarball', spec: finalSpec, immutable: false,
       })
     }
@@ -537,7 +579,7 @@ export class PluginMarketplace {
     const localPath = source.url.startsWith('file:') ? fileURLToPath(source.url) : resolve(this.cwd, source.url)
     const bytes = /^https?:/i.test(source.url)
       ? await readBounded(
-        await this.fetcher(source.url, requestInit(await this.headers(source, source.url), signal)),
+        await this.fetcher(source.url, requestInit(await this.headers(source, source.url), this.timeoutMs, signal)),
         MAX_INDEX_BYTES,
         `Catalog ${source.label}`,
       )
@@ -562,77 +604,35 @@ export class PluginMarketplace {
         ...(candidate.publisher === undefined ? {} : { publisher: candidate.publisher }),
       }]
     }).slice(0, MAX_SEARCH_RESULTS)
-    return mapLimited(candidates, 4, async (entry) => {
-      const spec = entry.spec
-      try {
-        const candidate = await this.inspect(spec, [source, {
-          id: 'npm', kind: 'npm', label: 'npm Registry', url: 'https://registry.npmjs.org/', enabled: true, builtIn: true,
-        }], signal)
-        return {
-          ...candidate,
-          id: `${source.id}:${candidate.spec}`,
-          sourceId: source.id,
-          ...(candidate.description === undefined && entry.description !== undefined ? { description: entry.description } : {}),
-          ...(candidate.publisher === undefined && entry.publisher !== undefined ? { publisher: entry.publisher } : {}),
-        }
-      } catch (error) {
-        return {
-          id: `${source.id}:${spec}`,
-          name: entry.name,
-          ...(entry.description === undefined ? {} : { description: entry.description }),
-          ...(entry.publisher === undefined ? {} : { publisher: entry.publisher }),
-          sourceId: source.id,
-          source: sourceType(spec),
-          spec,
-          bundle: false,
-          patchValid: false,
-          scripts: [],
-          immutable: false,
-          diagnostics: [`验证失败：${messageOf(error)}`],
-        }
-      }
-    })
+    return candidates.map(entry => pendingSearchCandidate({
+      id: `${source.id}:${entry.spec}`,
+      name: entry.name,
+      sourceId: source.id,
+      source: sourceType(entry.spec),
+      spec: entry.spec,
+      ...(entry.description === undefined ? {} : { description: entry.description }),
+      ...(entry.publisher === undefined ? {} : { publisher: entry.publisher }),
+      immutable: false,
+    }))
   }
 
   private async searchProvider(
     query: string,
     source: TuiMarketplaceSource,
-    sources: readonly TuiMarketplaceSource[],
+    _sources: readonly TuiMarketplaceSource[],
     signal?: AbortSignal,
   ): Promise<readonly TuiMarketplaceCandidate[]> {
     if (this.providers === undefined) throw new Error(`Source Provider ${JSON.stringify(source.kind)} 未装配`)
     const discoveries = await this.providers.search(query, source, signal)
-    return mapLimited(discoveries, 4, async (entry) => {
-      try {
-        const candidate = await this.inspect(entry.spec, sources, signal)
-        return {
-          ...candidate,
-          id: `${source.id}:${candidate.spec}`,
-          sourceId: source.id,
-          ...(entry.name === undefined ? {} : { name: entry.name }),
-          ...(candidate.description === undefined && entry.description !== undefined
-            ? { description: entry.description }
-            : {}),
-          ...(candidate.publisher === undefined && entry.publisher !== undefined
-            ? { publisher: entry.publisher }
-            : {}),
-        }
-      } catch (error) {
-        return {
-          id: `${source.id}:${entry.spec}`,
-          name: entry.name ?? entry.spec,
-          ...(entry.description === undefined ? {} : { description: entry.description }),
-          ...(entry.publisher === undefined ? {} : { publisher: entry.publisher }),
-          sourceId: source.id,
-          source: sourceType(entry.spec),
-          spec: entry.spec,
-          bundle: false,
-          patchValid: false,
-          scripts: [],
-          immutable: false,
-          diagnostics: [`Provider 候选验证失败：${messageOf(error)}`],
-        }
-      }
-    })
+    return discoveries.map(entry => pendingSearchCandidate({
+      id: `${source.id}:${entry.spec}`,
+      name: entry.name ?? entry.spec,
+      sourceId: source.id,
+      source: sourceType(entry.spec),
+      spec: entry.spec,
+      ...(entry.description === undefined ? {} : { description: entry.description }),
+      ...(entry.publisher === undefined ? {} : { publisher: entry.publisher }),
+      immutable: false,
+    }))
   }
 }

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,0 +1,172 @@
+import { gzipSync } from 'node:zlib'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PluginMarketplace } from '../src/host/plugin-marketplace.ts'
+import type { TuiMarketplaceSource } from '../src/protocol.ts'
+
+const root = resolve(import.meta.dirname, '..')
+const source: TuiMarketplaceSource = {
+  id: 'npm',
+  kind: 'npm',
+  label: 'npm Registry',
+  url: 'https://registry.npmjs.org/',
+  enabled: true,
+  builtIn: true,
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+function tarFile(path: string, content: string): Uint8Array {
+  const data = Buffer.from(content)
+  const header = Buffer.alloc(512)
+  header.write(path)
+  header.write(`${data.byteLength.toString(8).padStart(11, '0')}\0`, 124)
+  header[156] = 0x30
+  header.write('ustar\0', 257)
+  header.write('        ', 148)
+  let sum = 0
+  for (const byte of header) sum += byte
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148)
+  const padded = Math.ceil(data.byteLength / 512) * 512
+  const block = Buffer.alloc(padded)
+  data.copy(block)
+  return Buffer.concat([header, block, Buffer.alloc(1024)])
+}
+
+const tarball = gzipSync(tarFile('package/package.json', JSON.stringify({
+  name: 'demo-plugin',
+  version: '1.2.3',
+  description: 'from tarball',
+})))
+
+function searchBody(): unknown {
+  return {
+    objects: [{
+      package: {
+        name: 'demo-plugin',
+        version: '1.2.3',
+        description: 'from search',
+        publisher: { username: 'alice' },
+      },
+    }],
+  }
+}
+
+function metadataBody(): unknown {
+  return {
+    'dist-tags': { latest: '1.2.3' },
+    versions: {
+      '1.2.3': {
+        name: 'demo-plugin',
+        version: '1.2.3',
+        description: 'from metadata',
+        dist: { tarball: 'https://registry.npmjs.org/demo-plugin/-/demo-plugin-1.2.3.tgz' },
+        maintainers: [{ name: 'alice' }],
+      },
+    },
+  }
+}
+
+describe('plugin marketplace search (task 5.3)', () => {
+  it('does not use synchronous gunzip', () => {
+    const sourceText = readFileSync(resolve(root, 'src/host/plugin-marketplace.ts'), 'utf8')
+    expect(sourceText).not.toMatch(/gunzipSync/u)
+    expect(sourceText).toMatch(/AbortSignal\.timeout/u)
+  })
+
+  it('searches npm from registry metadata without downloading tarballs', async () => {
+    const urls: string[] = []
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        urls.push(url)
+        if (url.includes('/-/v1/search')) return jsonResponse(searchBody())
+        throw new Error(`unexpected fetch ${url}`)
+      }) as typeof fetch,
+    })
+    const rows = await marketplace.search('demo', [source])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.name).toBe('demo-plugin')
+    expect(rows[0]?.version).toBe('1.2.3')
+    expect(rows[0]?.description).toBe('from search')
+    expect(urls.every(url => !url.endsWith('.tgz'))).toBe(true)
+  })
+
+  it('reuses a cached search instead of hitting the registry again', async () => {
+    let searches = 0
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        if (url.includes('/-/v1/search')) {
+          searches += 1
+          return jsonResponse(searchBody())
+        }
+        throw new Error(`unexpected fetch ${url}`)
+      }) as typeof fetch,
+    })
+    await marketplace.search('demo', [source])
+    await marketplace.search('demo', [source])
+    expect(searches).toBe(1)
+  })
+
+  it('downloads the tarball only when inspect is called', async () => {
+    const urls: string[] = []
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        urls.push(url)
+        if (url.includes('/demo-plugin') && url.endsWith('.tgz')) {
+          return new Response(tarball, { status: 200 })
+        }
+        if (url.includes('demo-plugin')) return jsonResponse(metadataBody())
+        throw new Error(`unexpected fetch ${url}`)
+      }) as typeof fetch,
+    })
+    const candidate = await marketplace.inspect('demo-plugin@1.2.3', [source])
+    expect(candidate.description).toBe('from tarball')
+    expect(urls.some(url => url.endsWith('.tgz'))).toBe(true)
+  })
+
+  it('reuses a cached inspect instead of re-downloading the tarball', async () => {
+    let tarballs = 0
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        if (url.endsWith('.tgz')) {
+          tarballs += 1
+          return new Response(tarball, { status: 200 })
+        }
+        if (url.includes('demo-plugin')) return jsonResponse(metadataBody())
+        throw new Error(`unexpected fetch ${url}`)
+      }) as typeof fetch,
+    })
+    await marketplace.inspect('demo-plugin@1.2.3', [source])
+    await marketplace.inspect('demo-plugin@1.2.3', [source])
+    expect(tarballs).toBe(1)
+  })
+
+  it('aborts a hung registry request with the marketplace timeout', async () => {
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      timeoutMs: 20,
+      fetch: (async (_input, init) => new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(init.signal?.reason ?? new Error('aborted'))
+        })
+      })) as typeof fetch,
+    })
+    await expect(marketplace.search('demo', [source])).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- 5.3 from `docs/DEEP_OPTIMIZATION.md`: `/plugin search` returns registry/catalog metadata instead of downloading and `gunzipSync`-ing every candidate tarball.
- Tarball Bundle checks run on `inspect` when the user selects a row. Search and inspect results are cached in memory by query/spec.
- Marketplace HTTP uses `AbortSignal.timeout` (15s, composable with a caller signal). Gunzip is async.
- Stacks on #42.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/plugin-marketplace.test.ts tests/package-contract.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/tsdown`
- [ ] Manual: `/plugin search` stays responsive; selecting a row still shows patch diagnostics

Do not merge yet — remaining host performance items land on stacked branches.