### PR TITLE
feat(tui): describe one Settings namespace without repeating full dumps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23930,7 +23930,7 @@ var TuiActions = class {
 	async settingsConflict(error) {
 		let actual = error.actual;
 		try {
-			const document = (await this.capabilities.managementBridge().settings.describe()).find((candidate) => candidate.namespace === error.namespace);
+			const document = (await this.capabilities.managementBridge().settings.describe(error.namespace))[0];
 			if (document !== void 0) actual = document.revision;
 		} catch (refreshError) {
 			this.host.notice(`设置冲突后重新读取失败：${capabilityError(refreshError)}`, "error");
@@ -24541,7 +24541,7 @@ var TuiActions = class {
 	}
 	async language(args, overlays = this.host.overlays, suppliedDocument) {
 		const settings = this.capabilities.managementBridge().settings;
-		const document = suppliedDocument ?? localeSettings(await settings.describe());
+		const document = suppliedDocument ?? localeSettings(await settings.describe(LOCALE_SETTINGS_NAMESPACE));
 		const requested = args.toLowerCase();
 		let selection = requested === "" ? void 0 : new Map([
 			["auto", "auto"],
@@ -24644,7 +24644,7 @@ var TuiActions = class {
 	}
 	async themeCenter() {
 		const bridge = this.capabilities.managementBridge().settings;
-		const appearance = appearanceFromSettings(appearanceSettings(await bridge.describe()));
+		const appearance = appearanceFromSettings(appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE)));
 		const activeCodeTheme = resolveCodeTheme(appearance);
 		const choices = [
 			{
@@ -24715,7 +24715,7 @@ var TuiActions = class {
 	}
 	async activateTheme(target) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		const resolved = resolveTheme(appearance, target);
 		if (target === appearance.theme && appearance.codeTheme === "auto") {
@@ -24731,7 +24731,7 @@ var TuiActions = class {
 			await this.activateTheme(value);
 			return;
 		}
-		const appearance = appearanceFromSettings(appearanceSettings(await this.capabilities.managementBridge().settings.describe()));
+		const appearance = appearanceFromSettings(appearanceSettings(await this.capabilities.managementBridge().settings.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE)));
 		const requested = value.startsWith("custom:") ? value.slice(7) : value;
 		const folded = requested.toLowerCase();
 		const theme = appearance.customThemes.find((candidate) => candidate.id === requested || candidate.name.toLowerCase() === folded);
@@ -24740,7 +24740,7 @@ var TuiActions = class {
 	}
 	async themeCode(value) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		let target;
 		if (value !== "") if (value === "auto" || value === "dark" || value === "light") target = value;
@@ -24822,7 +24822,7 @@ var TuiActions = class {
 	}
 	async themePalette(requestedName) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		const enteredName = requestedName === "" ? await this.promptThemeName() : requestedName;
 		if (enteredName === void 0) return;
@@ -24847,7 +24847,7 @@ var TuiActions = class {
 	}
 	async themeImport(args) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		const [first = "", ...rest] = commandArguments(args);
 		const looksLikePath = /^(?:[./~]|file:)/u.test(first) || /\.jsonc?$/iu.test(first);
@@ -24872,7 +24872,7 @@ var TuiActions = class {
 		await this.previewAndSaveTheme(document, convertVsCodeTheme(loaded, identity.id, identity.name), void 0, "code");
 	}
 	async themeExport(args) {
-		const appearance = appearanceFromSettings(appearanceSettings(await this.capabilities.managementBridge().settings.describe()));
+		const appearance = appearanceFromSettings(appearanceSettings(await this.capabilities.managementBridge().settings.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE)));
 		const [first = "", ...rest] = commandArguments(args);
 		const looksLikePath = /^(?:[./~]|file:)/u.test(first) || /\.jsonc?$/iu.test(first);
 		const requested = looksLikePath ? "" : first;
@@ -24909,7 +24909,7 @@ var TuiActions = class {
 	}
 	async themeEdit(requested) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		let source;
 		if (requested !== "") {
@@ -25117,7 +25117,7 @@ var TuiActions = class {
 	}
 	async themeDelete(requested) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const document = appearanceSettings(await bridge.describe());
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
 		const appearance = appearanceFromSettings(document);
 		if (appearance.customThemes.length === 0) throw new Error("没有可删除的自定义主题");
 		let theme = requested === "" ? void 0 : appearance.customThemes.find((candidate) => candidate.id === requested || candidate.name.toLowerCase() === requested.toLowerCase());
@@ -25374,7 +25374,7 @@ var TuiActions = class {
 	}
 	async keymap(args) {
 		const settings = this.capabilities.managementBridge().settings;
-		const document = behaviorSettings(await settings.describe());
+		const document = behaviorSettings(await settings.describe(TUI_BEHAVIOR_SETTINGS_NAMESPACE));
 		const current = behaviorFromSettings(document);
 		applyKeyBindingOverrides(current.keyBindings);
 		const { first, rest } = argumentPair(args);
@@ -25441,7 +25441,7 @@ var TuiActions = class {
 	}
 	async settingsNamespace(navigation, namespace, initialChoiceId) {
 		const bridge = this.capabilities.managementBridge().settings;
-		const initialDocument = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
+		const initialDocument = (await bridge.describe(namespace))[0];
 		if (initialDocument === void 0) throw new Error(`Settings 命名空间 ${JSON.stringify(namespace)} 不存在`);
 		let document = initialDocument;
 		let fields = settingsFields(document);
@@ -25467,7 +25467,7 @@ var TuiActions = class {
 				const field = fields.find((candidate) => JSON.stringify(candidate.path) === selected.id);
 				if (field !== void 0) await this.editSetting(navigation, document, field);
 			}
-			const refreshed = (await bridge.describe()).find((candidate) => candidate.namespace === namespace);
+			const refreshed = (await bridge.describe(namespace))[0];
 			if (refreshed === void 0) {
 				this.host.notice(`Settings 命名空间 ${namespace} 已不可用`, "warning");
 				navigation.back();
@@ -31362,6 +31362,33 @@ function settingsDocument(descriptor) {
 		secrets: descriptor.secrets ?? []
 	};
 }
+/**
+* Cache a full Settings describe() so one() and namespaced reads do not reserialize
+* every namespace on the Host event loop.
+* @param load - redacted descriptors from Harness Settings.
+*/
+function createSettingsDescribeCache(load) {
+	let cached;
+	const all = () => {
+		cached ??= load();
+		return cached;
+	};
+	const one = (namespace) => {
+		const document = all().find((row) => row.namespace === namespace);
+		if (document === void 0) throw new Error(`设置命名空间 ${JSON.stringify(namespace)} 已卸载`);
+		return document;
+	};
+	return {
+		describe(namespace) {
+			if (namespace === void 0) return all();
+			return [one(namespace)];
+		},
+		one,
+		invalidate() {
+			cached = void 0;
+		}
+	};
+}
 function redactInstallerOutput(value) {
 	let redacted = value.replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, "$1***@").replace(/(https?:\/\/)[^\s/@]+@/giu, "$1***@").replace(/((?:_authToken|authorization|password|token)\s*[=:]\s*)[^\s]+/giu, "$1***");
 	for (const [key, secret] of Object.entries(process.env)) {
@@ -31424,14 +31451,9 @@ function createTuiManagementBridge(ctx, cwd) {
 		resolveCredential: async (ref) => (await credentials.resolve(credentialRef(ref)))?.value,
 		...providers === void 0 ? {} : { providers }
 	});
-	const describe = () => settings.describe({ redactSecrets: true }).map(settingsDocument);
-	const one = (namespace) => {
-		const document = describe().find((row) => row.namespace === namespace);
-		if (document === void 0) throw new Error(`设置命名空间 ${JSON.stringify(namespace)} 已卸载`);
-		return document;
-	};
+	const documents = createSettingsDescribeCache(() => settings.describe({ redactSecrets: true }).map(settingsDocument));
 	const sourceSnapshot = () => {
-		const document = one(MARKETPLACE_NAMESPACE);
+		const document = documents.one(MARKETPLACE_NAMESPACE);
 		const stored = document.value.sources.map((source) => validateCatalogSource({
 			id: source.id,
 			kind: "catalog",
@@ -31488,10 +31510,11 @@ function createTuiManagementBridge(ctx, cwd) {
 			};
 		} },
 		settings: {
-			describe: () => Promise.resolve(describe()),
+			describe: (namespace) => Promise.resolve(documents.describe(namespace)),
 			mutate: async (namespace, ops, expectedRevision) => {
 				await mutateSettings(settings, namespace, ops, expectedRevision);
-				return one(namespace);
+				documents.invalidate();
+				return documents.one(namespace);
 			},
 			credentialInfo: (ref) => credentials.describe(credentialRef(ref)),
 			setCredential: async (ref, value) => {
@@ -31545,6 +31568,7 @@ function createTuiManagementBridge(ctx, cwd) {
 					path: ["sources"],
 					value: catalog
 				}], expectedRevision);
+				documents.invalidate();
 				return sourceSnapshot();
 			},
 			search: async (query, signal) => {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -435,8 +435,7 @@ export class TuiActions {
   private async settingsConflict(error: TuiSettingsConflictError): Promise<void> {
     let actual = error.actual
     try {
-      const document = (await this.capabilities.managementBridge().settings.describe())
-        .find(candidate => candidate.namespace === error.namespace)
+      const document = (await this.capabilities.managementBridge().settings.describe(error.namespace))[0]
       if (document !== undefined) actual = document.revision
     } catch (refreshError) {
       this.host.notice(`设置冲突后重新读取失败：${capabilityError(refreshError)}`, 'error')
@@ -1058,7 +1057,7 @@ export class TuiActions {
     suppliedDocument?: TuiSettingsDocument,
   ): Promise<void> {
     const settings = this.capabilities.managementBridge().settings
-    const document = suppliedDocument ?? localeSettings(await settings.describe())
+    const document = suppliedDocument ?? localeSettings(await settings.describe(LOCALE_SETTINGS_NAMESPACE))
     const requested = args.toLowerCase()
     const aliases = new Map<string, TuiLanguageSelection>([
       ['auto', 'auto'],
@@ -1164,7 +1163,7 @@ export class TuiActions {
 
   private async themeCenter(): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const activeCodeTheme = resolveCodeTheme(appearance)
     const choices: OverlayChoice[] = [
@@ -1211,7 +1210,7 @@ export class TuiActions {
 
   private async activateTheme(target: TuiThemeId): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const resolved = resolveTheme(appearance, target)
     if (target === appearance.theme && appearance.codeTheme === 'auto') {
@@ -1228,7 +1227,7 @@ export class TuiActions {
       await this.activateTheme(value)
       return
     }
-    const document = appearanceSettings(await this.capabilities.managementBridge().settings.describe())
+    const document = appearanceSettings(await this.capabilities.managementBridge().settings.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const requested = value.startsWith('custom:') ? value.slice('custom:'.length) : value
     const folded = requested.toLowerCase()
@@ -1240,7 +1239,7 @@ export class TuiActions {
 
   private async themeCode(value: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     let target: TuiCodeThemeId | undefined
     if (value !== '') {
@@ -1324,7 +1323,7 @@ export class TuiActions {
 
   private async themePalette(requestedName: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const enteredName = requestedName === '' ? await this.promptThemeName() : requestedName
     if (enteredName === undefined) return
@@ -1345,7 +1344,7 @@ export class TuiActions {
 
   private async themeImport(args: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const [first = '', ...rest] = commandArguments(args)
     const looksLikePath = /^(?:[./~]|file:)/u.test(first) || /\.jsonc?$/iu.test(first)
@@ -1371,7 +1370,7 @@ export class TuiActions {
   }
 
   private async themeExport(args: string): Promise<void> {
-    const document = appearanceSettings(await this.capabilities.managementBridge().settings.describe())
+    const document = appearanceSettings(await this.capabilities.managementBridge().settings.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     const [first = '', ...rest] = commandArguments(args)
     const looksLikePath = /^(?:[./~]|file:)/u.test(first) || /\.jsonc?$/iu.test(first)
@@ -1417,7 +1416,7 @@ export class TuiActions {
 
   private async themeEdit(requested: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     let source: ResolvedTuiTheme | undefined
     if (requested !== '') {
@@ -1594,7 +1593,7 @@ export class TuiActions {
 
   private async themeDelete(requested: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe())
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
     const appearance = appearanceFromSettings(document)
     if (appearance.customThemes.length === 0) throw new Error('没有可删除的自定义主题')
     let theme = requested === '' ? undefined : appearance.customThemes.find(candidate =>
@@ -1865,7 +1864,7 @@ export class TuiActions {
 
   private async keymap(args: string): Promise<void> {
     const settings = this.capabilities.managementBridge().settings
-    const document = behaviorSettings(await settings.describe())
+    const document = behaviorSettings(await settings.describe(TUI_BEHAVIOR_SETTINGS_NAMESPACE))
     const current = behaviorFromSettings(document)
     applyKeyBindingOverrides(current.keyBindings)
     const { first, rest } = argumentPair(args)
@@ -1971,7 +1970,7 @@ export class TuiActions {
     initialChoiceId?: string,
   ): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const initialDocument = (await bridge.describe()).find(candidate => candidate.namespace === namespace)
+    const initialDocument = (await bridge.describe(namespace))[0]
     if (initialDocument === undefined) throw new Error(`Settings 命名空间 ${JSON.stringify(namespace)} 不存在`)
     let document: TuiSettingsDocument = initialDocument
     let fields = settingsFields(document)
@@ -2001,7 +2000,7 @@ export class TuiActions {
         const field = fields.find(candidate => JSON.stringify(candidate.path) === selected.id)
         if (field !== undefined) await this.editSetting(navigation, document, field)
       }
-      const refreshed = (await bridge.describe()).find(candidate => candidate.namespace === namespace)
+      const refreshed = (await bridge.describe(namespace))[0]
       if (refreshed === undefined) {
         this.host.notice(`Settings 命名空间 ${namespace} 已不可用`, 'warning')
         navigation.back()

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -162,6 +162,40 @@ function settingsDocument(descriptor: SettingsDescriptor): TuiSettingsDocument {
   }
 }
 
+/**
+ * Cache a full Settings describe() so one() and namespaced reads do not reserialize
+ * every namespace on the Host event loop.
+ * @param load - redacted descriptors from Harness Settings.
+ */
+export function createSettingsDescribeCache(
+  load: () => readonly TuiSettingsDocument[],
+): {
+  describe(namespace?: string): readonly TuiSettingsDocument[]
+  one(namespace: string): TuiSettingsDocument
+  invalidate(): void
+} {
+  let cached: readonly TuiSettingsDocument[] | undefined
+  const all = (): readonly TuiSettingsDocument[] => {
+    cached ??= load()
+    return cached
+  }
+  const one = (namespace: string): TuiSettingsDocument => {
+    const document = all().find(row => row.namespace === namespace)
+    if (document === undefined) throw new Error(`设置命名空间 ${JSON.stringify(namespace)} 已卸载`)
+    return document
+  }
+  return {
+    describe(namespace?: string): readonly TuiSettingsDocument[] {
+      if (namespace === undefined) return all()
+      return [one(namespace)]
+    },
+    one,
+    invalidate(): void {
+      cached = undefined
+    },
+  }
+}
+
 function redactInstallerOutput(value: string): string {
   let redacted = value
     .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, '$1***@')
@@ -245,15 +279,11 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
     ...(providers === undefined ? {} : { providers }),
   })
 
-  const describe = (): readonly TuiSettingsDocument[] =>
-    settings.describe({ redactSecrets: true }).map(settingsDocument)
-  const one = (namespace: string): TuiSettingsDocument => {
-    const document = describe().find(row => row.namespace === namespace)
-    if (document === undefined) throw new Error(`设置命名空间 ${JSON.stringify(namespace)} 已卸载`)
-    return document
-  }
+  const documents = createSettingsDescribeCache(
+    () => settings.describe({ redactSecrets: true }).map(settingsDocument),
+  )
   const sourceSnapshot = (): TuiMarketplaceSources => {
-    const document = one(MARKETPLACE_NAMESPACE)
+    const document = documents.one(MARKETPLACE_NAMESPACE)
     const value = document.value as MarketplaceSettings
     const stored = value.sources.map(source => validateCatalogSource({
       id: source.id,
@@ -316,10 +346,11 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
       },
     },
     settings: {
-      describe: () => Promise.resolve(describe()),
+      describe: namespace => Promise.resolve(documents.describe(namespace)),
       mutate: async (namespace, ops, expectedRevision) => {
         await mutateSettings(settings, namespace, ops, expectedRevision)
-        return one(namespace)
+        documents.invalidate()
+        return documents.one(namespace)
       },
       credentialInfo: ref => credentials.describe(credentialRef(ref)),
       setCredential: async (ref, value) => {
@@ -371,6 +402,7 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
         const conflict = catalog.find(source => reserved.has(source.id))
         if (conflict !== undefined) throw new Error(`Catalog Source ${conflict.id} 与内置或 Provider Source 冲突`)
         await mutateSettings(settings, MARKETPLACE_NAMESPACE, [{ op: 'set', path: ['sources'], value: catalog }], expectedRevision)
+        documents.invalidate()
         return sourceSnapshot()
       },
       search: async (query, signal) => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -305,7 +305,7 @@ export interface TuiManagementBridge {
     download(sessionId: string, includeDescendants: boolean, signal?: AbortSignal): Promise<TuiSessionExport>
   }
   readonly settings: {
-    describe(): Promise<readonly TuiSettingsDocument[]>
+    describe(namespace?: string): Promise<readonly TuiSettingsDocument[]>
     mutate(namespace: string, ops: readonly TuiSettingsPathOp[], expectedRevision: number): Promise<TuiSettingsDocument>
     credentialInfo(ref: string): Promise<TuiCredentialInfo>
     setCredential(ref: string, value: string): Promise<TuiCredentialInfo>

--- a/tests/settings-describe.test.ts
+++ b/tests/settings-describe.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createSettingsDescribeCache } from '../src/host/management.ts'
+import type { TuiSettingsDocument } from '../src/protocol.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+function document(namespace: string): TuiSettingsDocument {
+  return {
+    namespace,
+    schema: {},
+    value: { namespace },
+    revision: 1,
+    applies: 'live',
+    secrets: [],
+  }
+}
+
+describe('settings describe (task 5.3)', () => {
+  it('exposes an optional namespace on the management bridge', () => {
+    const source = readFileSync(resolve(root, 'src/protocol.ts'), 'utf8')
+    expect(source).toMatch(/describe\(namespace\?: string\): Promise<readonly TuiSettingsDocument\[\]>/u)
+  })
+
+  it('loads every namespace once then serves one() from that snapshot', () => {
+    let loads = 0
+    const cache = createSettingsDescribeCache(() => {
+      loads += 1
+      return [document('seektty-appearance'), document('seektty-behavior')]
+    })
+    expect(cache.one('seektty-appearance').namespace).toBe('seektty-appearance')
+    expect(cache.one('seektty-behavior').value).toEqual({ namespace: 'seektty-behavior' })
+    expect(cache.describe().map(row => row.namespace)).toEqual(['seektty-appearance', 'seektty-behavior'])
+    expect(loads).toBe(1)
+  })
+
+  it('filters describe(namespace) without a second load', () => {
+    let loads = 0
+    const cache = createSettingsDescribeCache(() => {
+      loads += 1
+      return [document('seektty-appearance'), document('seektty-behavior')]
+    })
+    expect(cache.describe('seektty-behavior')).toEqual([document('seektty-behavior')])
+    expect(loads).toBe(1)
+  })
+
+  it('reloads after invalidate so mutate cannot serve a stale revision', () => {
+    let revision = 1
+    const cache = createSettingsDescribeCache(() => [
+      { ...document('seektty-appearance'), revision },
+    ])
+    expect(cache.one('seektty-appearance').revision).toBe(1)
+    revision = 2
+    cache.invalidate()
+    expect(cache.one('seektty-appearance').revision).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- 5.3 from `docs/DEEP_OPTIMIZATION.md`: \`TuiManagementBridge.settings.describe(namespace?)\` can return one namespace.
- Host caches the redacted full describe until mutate/saveSources, so \`one()\` and repeated theme/locale/behavior reads do not reserialize every namespace.
- Stacks on #43.

## Test plan
- [x] \`./node_modules/.bin/vitest run tests/settings-describe.test.ts tests/actions-theme.test.ts tests/actions-settings-navigation.test.ts\`
- [x] \`./node_modules/.bin/tsc --noEmit\`
- [x] \`./node_modules/.bin/tsdown\`
- [ ] Manual: change a theme, then open another settings namespace without a stall

Do not merge yet — remaining host performance items land on stacked branches.