### PR TITLE
feat(tui): cache Profile plugin snapshots across one pnpm add

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-CRzxAYsO.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-bC3YRGeq.js";
 import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-CqTsUm3P.js";
 import { createRequire } from "node:module";

--- a/lib/startup-bC3YRGeq.js
+++ b/lib/startup-bC3YRGeq.js
@@ -1502,6 +1502,8 @@ var ProfilePluginManager = class {
 	installAnchor;
 	invokingCwd;
 	home;
+	snapshotCache;
+	installedFactsCache = /* @__PURE__ */ new Map();
 	/** @param options - target Profile, installation resolution anchor, and invoking directory. */
 	constructor(options) {
 		this.profile = options.profile;
@@ -1525,17 +1527,25 @@ var ProfilePluginManager = class {
 	*/
 	snapshot() {
 		this.ensureProfile();
+		const stamp = this.profileStamp();
+		if (this.snapshotCache?.stamp === stamp) return this.snapshotCache.snapshot;
+		this.installedFactsCache.clear();
 		const manifest = readProfileManifest(NAME, this.dir);
 		const dependencies = { ...manifest.dependencies };
 		const bundles = [...manifest.dsh?.profile?.bundles ?? []];
 		const plugins = Object.entries(dependencies).map(([packageName, spec]) => this.inspectInstalled(packageName, spec, bundles));
-		return Object.freeze({
+		const snapshot = Object.freeze({
 			profile: this.profile,
 			dir: this.dir,
 			dependencies: Object.freeze(dependencies),
 			bundles: Object.freeze(bundles),
 			plugins: Object.freeze(plugins)
 		});
+		this.snapshotCache = {
+			stamp,
+			snapshot
+		};
+		return snapshot;
 	}
 	/**
 	* Run pnpm asynchronously inside the Profile and reconcile Bundle state.
@@ -1599,6 +1609,7 @@ var ProfilePluginManager = class {
 			if (error?.code === "ENOENT") return 127;
 			throw error;
 		});
+		this.forgetInstalled();
 		const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode);
 		const snapshot = this.snapshot();
 		const changed = initialized || !sameSnapshotState(beforeSnapshot, snapshot);
@@ -1635,6 +1646,7 @@ var ProfilePluginManager = class {
 		const spawnError = result.error ?? void 0;
 		const exitCode = spawnError === void 0 ? result.status ?? 1 : spawnError.code === "ENOENT" ? 127 : 1;
 		if (spawnError !== void 0 && spawnError.code !== "ENOENT") throw spawnError;
+		this.forgetInstalled();
 		const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode);
 		const snapshot = this.snapshot();
 		const changed = initialized || !sameSnapshotState(beforeSnapshot, snapshot);
@@ -1670,6 +1682,7 @@ var ProfilePluginManager = class {
 			}
 		};
 		writeProfileManifest(this.dir, manifest);
+		this.forgetInstalled();
 		return this.snapshot();
 	}
 	/**
@@ -1695,21 +1708,20 @@ var ProfilePluginManager = class {
 			level: plugin.active ? "error" : "warning",
 			message: `${plugin.name}: ${diagnostic}`
 		});
-		for (const bundle of snapshot.bundles) try {
-			const dir = resolveBundleDir(NAME, bundle, this.installAnchor, this.dir);
-			const patch = readInstalledManifest(dir).dsh?.bundle?.patch;
-			if (patch === void 0) diagnostics.push({
+		for (const bundle of snapshot.bundles) {
+			const facts = this.installedFacts(bundle);
+			const patch = facts.manifest?.dsh?.bundle?.patch;
+			if (facts.manifest === void 0) diagnostics.push({
+				level: "error",
+				message: facts.diagnostic ?? `${bundle} 无法读取已安装清单`
+			});
+			else if (patch === void 0) diagnostics.push({
 				level: "error",
 				message: `${bundle} 未声明 dsh.bundle.patch`
 			});
-			else if (!validPatch(dir, patch)) diagnostics.push({
+			else if (!facts.patchValid) diagnostics.push({
 				level: "error",
 				message: `${bundle} 的 Bundle patch 缺失或格式无效`
-			});
-		} catch (error) {
-			diagnostics.push({
-				level: "error",
-				message: error instanceof Error ? error.message : String(error)
 			});
 		}
 		if (diagnostics.every((item) => item.level !== "error")) diagnostics.push({
@@ -1806,30 +1818,23 @@ var ProfilePluginManager = class {
 		}
 	}
 	inspectInstalled(packageName, spec, bundles) {
+		const facts = this.installedFacts(packageName);
 		const diagnostics = [];
-		let manifest;
-		let packageDir;
-		try {
-			packageDir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir);
-			manifest = readInstalledManifest(packageDir);
-		} catch (error) {
-			diagnostics.push(error instanceof Error ? error.message : String(error));
-		}
-		const patch = manifest?.dsh?.bundle?.patch;
-		const patchValid = packageDir !== void 0 && patch !== void 0 && validPatch(packageDir, patch);
-		if (patch !== void 0 && !patchValid) diagnostics.push(`声明的 Bundle patch ${JSON.stringify(patch)} 缺失或格式无效`);
+		if (facts.diagnostic !== void 0) diagnostics.push(facts.diagnostic);
+		const patch = facts.manifest?.dsh?.bundle?.patch;
+		if (patch !== void 0 && !facts.patchValid) diagnostics.push(`声明的 Bundle patch ${JSON.stringify(patch)} 缺失或格式无效`);
 		if (bundles.includes(packageName) && patch === void 0) diagnostics.push("位于 Bundle 顺序中但未声明 dsh.bundle.patch");
 		return Object.freeze({
 			name: packageName,
 			spec: safeDependencySpec(spec),
-			...manifest?.version === void 0 ? {} : { version: manifest.version },
-			...manifest?.description === void 0 ? {} : { description: manifest.description },
+			...facts.manifest?.version === void 0 ? {} : { version: facts.manifest.version },
+			...facts.manifest?.description === void 0 ? {} : { description: facts.manifest.description },
 			source: inferSource(spec),
 			bundle: patch !== void 0,
 			active: bundles.includes(packageName),
 			...patch === void 0 ? {} : { patch },
-			patchValid,
-			scripts: Object.freeze(Object.keys(manifest?.scripts ?? {})),
+			patchValid: facts.patchValid,
+			scripts: Object.freeze(Object.keys(facts.manifest?.scripts ?? {})),
 			diagnostics: Object.freeze(diagnostics)
 		});
 	}
@@ -1865,17 +1870,43 @@ var ProfilePluginManager = class {
 				}
 			};
 			writeProfileManifest(this.dir, after);
+			this.forgetInstalled();
 		}
 		return warnings;
 	}
 	exportsPatch(packageName) {
+		const facts = this.installedFacts(packageName);
+		return facts.manifest?.dsh?.bundle?.patch !== void 0 && facts.patchValid;
+	}
+	installedFacts(packageName) {
+		const cached = this.installedFactsCache.get(packageName);
+		if (cached !== void 0) return cached;
+		let facts;
 		try {
-			const dir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir);
-			const patch = readInstalledManifest(dir).dsh?.bundle?.patch;
-			return patch !== void 0 && validPatch(dir, patch);
-		} catch {
-			return false;
+			const packageDir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir);
+			const manifest = readInstalledManifest(packageDir);
+			const patch = manifest.dsh?.bundle?.patch;
+			facts = {
+				packageDir,
+				manifest,
+				patchValid: patch !== void 0 && validPatch(packageDir, patch)
+			};
+		} catch (error) {
+			facts = {
+				patchValid: false,
+				diagnostic: error instanceof Error ? error.message : String(error)
+			};
 		}
+		this.installedFactsCache.set(packageName, facts);
+		return facts;
+	}
+	profileStamp() {
+		const path = join(this.dir, "package.json");
+		return existsSync(path) ? String(statSync(path).mtimeMs) : "missing";
+	}
+	forgetInstalled() {
+		this.snapshotCache = void 0;
+		this.installedFactsCache.clear();
 	}
 	anchorPathSpec(argument) {
 		const match = /^(?<prefix>(?:file|link):)?(?<path>\.{1,2}(?:[/\\].*)?)$/.exec(argument);

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-CRzxAYsO.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-bC3YRGeq.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/host/profile-plugin-manager.ts
+++ b/src/host/profile-plugin-manager.ts
@@ -154,6 +154,13 @@ interface InstalledManifest extends ProfileManifest {
   scripts?: Record<string, string>
 }
 
+interface InstalledFacts {
+  readonly packageDir?: string
+  readonly manifest?: InstalledManifest
+  readonly patchValid: boolean
+  readonly diagnostic?: string
+}
+
 function inferSource(spec: string): ProfilePluginSource {
   if (/^(?:git\+|github:|gitlab:|bitbucket:)|\.git(?:#|$)/i.test(spec)) return 'git'
   if (/^(?:https?:).*\.(?:tgz|tar\.gz)(?:[?#].*)?$/i.test(spec) || /\.(?:tgz|tar\.gz)$/i.test(spec)) return 'tarball'
@@ -251,6 +258,8 @@ export class ProfilePluginManager {
   private readonly installAnchor: string
   private readonly invokingCwd: string
   private readonly home: string | undefined
+  private snapshotCache: { stamp: string; snapshot: ProfilePluginSnapshot } | undefined
+  private readonly installedFactsCache = new Map<string, InstalledFacts>()
 
   /** @param options - target Profile, installation resolution anchor, and invoking directory. */
   constructor(options: ProfilePluginManagerOptions) {
@@ -277,18 +286,23 @@ export class ProfilePluginManager {
    */
   snapshot(): ProfilePluginSnapshot {
     this.ensureProfile()
+    const stamp = this.profileStamp()
+    if (this.snapshotCache?.stamp === stamp) return this.snapshotCache.snapshot
+    this.installedFactsCache.clear()
     const manifest = readProfileManifest(NAME, this.dir)
     const dependencies = { ...manifest.dependencies }
     const bundles = [...manifest.dsh?.profile?.bundles ?? []]
     const plugins = Object.entries(dependencies).map(([packageName, spec]) =>
       this.inspectInstalled(packageName, spec, bundles))
-    return Object.freeze({
+    const snapshot = Object.freeze({
       profile: this.profile,
       dir: this.dir,
       dependencies: Object.freeze(dependencies),
       bundles: Object.freeze(bundles),
       plugins: Object.freeze(plugins),
     })
+    this.snapshotCache = { stamp, snapshot }
+    return snapshot
   }
 
   /**
@@ -347,6 +361,7 @@ export class ProfilePluginManager {
       if ((error as NodeJS.ErrnoException | null)?.code === 'ENOENT') return 127
       throw error
     })
+    this.forgetInstalled()
     const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode)
     const snapshot = this.snapshot()
     const changed = initialized || !sameSnapshotState(beforeSnapshot, snapshot)
@@ -386,6 +401,7 @@ export class ProfilePluginManager {
       ? result.status ?? 1
       : (spawnError as NodeJS.ErrnoException).code === 'ENOENT' ? 127 : 1
     if (spawnError !== undefined && (spawnError as NodeJS.ErrnoException).code !== 'ENOENT') throw spawnError
+    this.forgetInstalled()
     const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode)
     const snapshot = this.snapshot()
     const changed = initialized || !sameSnapshotState(beforeSnapshot, snapshot)
@@ -421,6 +437,7 @@ export class ProfilePluginManager {
       profile: { ...manifest.dsh?.profile, bundles: [...orderedBundles] },
     }
     writeProfileManifest(this.dir, manifest)
+    this.forgetInstalled()
     return this.snapshot()
   }
 
@@ -445,14 +462,17 @@ export class ProfilePluginManager {
       }
     }
     for (const bundle of snapshot.bundles) {
-      try {
-        const dir = resolveBundleDir(NAME, bundle, this.installAnchor, this.dir)
-        const manifest = readInstalledManifest(dir)
-        const patch = manifest.dsh?.bundle?.patch
-        if (patch === undefined) diagnostics.push({ level: 'error', message: `${bundle} 未声明 dsh.bundle.patch` })
-        else if (!validPatch(dir, patch)) diagnostics.push({ level: 'error', message: `${bundle} 的 Bundle patch 缺失或格式无效` })
-      } catch (error) {
-        diagnostics.push({ level: 'error', message: error instanceof Error ? error.message : String(error) })
+      const facts = this.installedFacts(bundle)
+      const patch = facts.manifest?.dsh?.bundle?.patch
+      if (facts.manifest === undefined) {
+        diagnostics.push({
+          level: 'error',
+          message: facts.diagnostic ?? `${bundle} 无法读取已安装清单`,
+        })
+      } else if (patch === undefined) {
+        diagnostics.push({ level: 'error', message: `${bundle} 未声明 dsh.bundle.patch` })
+      } else if (!facts.patchValid) {
+        diagnostics.push({ level: 'error', message: `${bundle} 的 Bundle patch 缺失或格式无效` })
       }
     }
     if (diagnostics.every(item => item.level !== 'error')) {
@@ -549,30 +569,23 @@ export class ProfilePluginManager {
   }
 
   private inspectInstalled(packageName: string, spec: string, bundles: readonly string[]): ProfilePluginEntry {
+    const facts = this.installedFacts(packageName)
     const diagnostics: string[] = []
-    let manifest: InstalledManifest | undefined
-    let packageDir: string | undefined
-    try {
-      packageDir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir)
-      manifest = readInstalledManifest(packageDir)
-    } catch (error) {
-      diagnostics.push(error instanceof Error ? error.message : String(error))
-    }
-    const patch = manifest?.dsh?.bundle?.patch
-    const patchValid = packageDir !== undefined && patch !== undefined && validPatch(packageDir, patch)
-    if (patch !== undefined && !patchValid) diagnostics.push(`声明的 Bundle patch ${JSON.stringify(patch)} 缺失或格式无效`)
+    if (facts.diagnostic !== undefined) diagnostics.push(facts.diagnostic)
+    const patch = facts.manifest?.dsh?.bundle?.patch
+    if (patch !== undefined && !facts.patchValid) diagnostics.push(`声明的 Bundle patch ${JSON.stringify(patch)} 缺失或格式无效`)
     if (bundles.includes(packageName) && patch === undefined) diagnostics.push('位于 Bundle 顺序中但未声明 dsh.bundle.patch')
     return Object.freeze({
       name: packageName,
       spec: safeDependencySpec(spec),
-      ...(manifest?.version === undefined ? {} : { version: manifest.version }),
-      ...(manifest?.description === undefined ? {} : { description: manifest.description }),
+      ...(facts.manifest?.version === undefined ? {} : { version: facts.manifest.version }),
+      ...(facts.manifest?.description === undefined ? {} : { description: facts.manifest.description }),
       source: inferSource(spec),
       bundle: patch !== undefined,
       active: bundles.includes(packageName),
       ...(patch === undefined ? {} : { patch }),
-      patchValid,
-      scripts: Object.freeze(Object.keys(manifest?.scripts ?? {})),
+      patchValid: facts.patchValid,
+      scripts: Object.freeze(Object.keys(facts.manifest?.scripts ?? {})),
       diagnostics: Object.freeze(diagnostics),
     })
   }
@@ -605,19 +618,47 @@ export class ProfilePluginManager {
     if (changed) {
       after.dsh = { ...after.dsh, profile: { ...after.dsh?.profile, bundles } }
       writeProfileManifest(this.dir, after)
+      this.forgetInstalled()
     }
     return warnings
   }
 
   private exportsPatch(packageName: string): boolean {
+    const facts = this.installedFacts(packageName)
+    return facts.manifest?.dsh?.bundle?.patch !== undefined && facts.patchValid
+  }
+
+  private installedFacts(packageName: string): InstalledFacts {
+    const cached = this.installedFactsCache.get(packageName)
+    if (cached !== undefined) return cached
+    let facts: InstalledFacts
     try {
-      const dir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir)
-      const manifest = readInstalledManifest(dir)
+      const packageDir = resolveBundleDir(NAME, packageName, this.installAnchor, this.dir)
+      const manifest = readInstalledManifest(packageDir)
       const patch = manifest.dsh?.bundle?.patch
-      return patch !== undefined && validPatch(dir, patch)
-    } catch {
-      return false
+      facts = {
+        packageDir,
+        manifest,
+        patchValid: patch !== undefined && validPatch(packageDir, patch),
+      }
+    } catch (error) {
+      facts = {
+        patchValid: false,
+        diagnostic: error instanceof Error ? error.message : String(error),
+      }
     }
+    this.installedFactsCache.set(packageName, facts)
+    return facts
+  }
+
+  private profileStamp(): string {
+    const path = join(this.dir, 'package.json')
+    return existsSync(path) ? String(statSync(path).mtimeMs) : 'missing'
+  }
+
+  private forgetInstalled(): void {
+    this.snapshotCache = undefined
+    this.installedFactsCache.clear()
   }
 
   private anchorPathSpec(argument: string): string {

--- a/tests/profile-plugin-snapshot.test.ts
+++ b/tests/profile-plugin-snapshot.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ProfilePluginManager } from '../src/host/profile-plugin-manager.ts'
+
+describe('profile plugin snapshot (task 5.3)', () => {
+  it('reuses the same snapshot object until the Profile manifest changes', () => {
+    const home = mkdtempSync(join(tmpdir(), 'seektty-snapshot-'))
+    const manager = new ProfilePluginManager({
+      profile: 'tui',
+      installAnchor: home,
+      home,
+    })
+    const first = manager.snapshot()
+    const second = manager.snapshot()
+    expect(second).toBe(first)
+    const manifestPath = join(manager.dir, 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>
+    writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, description: 'changed' }, null, 2)}\n`)
+    const third = manager.snapshot()
+    expect(third).not.toBe(first)
+    expect(third.profile).toBe('tui')
+  })
+})


### PR DESCRIPTION
## Summary
- 5.3 from \`docs/DEEP_OPTIMIZATION.md\`: cache \`snapshot()\` by Profile manifest mtime and reuse installed package.json/YAML facts for inspect, reconcile, and doctor.
- Forget the cache after pnpm and after writing the Profile manifest so the next snapshot sees the new tree.
- Stacks on #44.

## Test plan
- [x] \`./node_modules/.bin/vitest run tests/profile-plugin-snapshot.test.ts\`
- [x] \`./node_modules/.bin/tsc --noEmit\`
- [x] \`./node_modules/.bin/tsdown\`
- [ ] Manual: \`dsh plugin add\` in a Profile and confirm /plugin still lists the new dependency

Do not merge yet — remaining robustness items land on stacked branches.