### PR TITLE
feat(tui): abort in-flight marketplace and export work from Escape

### DIFF
--- a/lib/in-process.js
+++ b/lib/in-process.js
@@ -134,10 +134,9 @@ var InProcessConnectionService = class extends Service {
 	}
 	async call(channel, endpoint, payload, signal) {
 		signal?.throwIfAborted();
-		const carrierSignal = signal ?? new AbortController().signal;
 		try {
-			const pending = this.registry.dispatch(channel, endpoint, payload, carrierSignal);
-			return signal === void 0 ? await pending : await abortable(pending, signal);
+			if (signal === void 0) return await this.registry.dispatch(channel, endpoint, payload, new AbortController().signal);
+			return await abortInProcessCall((inner) => this.registry.dispatch(channel, endpoint, payload, inner), signal);
 		} catch (error) {
 			if (signal?.aborted === true) throw abortReason(signal);
 			throw new Error(`transport failure for ${channel}/${endpoint}: handler failure: ${String(error)}`, { cause: error });
@@ -155,11 +154,28 @@ const inject = [];
 function apply(ctx) {
 	new InProcessConnectionService(ctx);
 }
-function abortable(pending, signal) {
+/**
+* Run one RPC handler under a caller AbortSignal, aborting the handler when
+* the wrapper is cancelled instead of only rejecting the outer promise.
+* @param run - handler invocation that observes the inner signal.
+* @param signal - caller cancellation signal.
+*/
+function abortInProcessCall(run, signal) {
+	const inner = new AbortController();
+	return abortable(run(AbortSignal.any([signal, inner.signal])), signal, () => {
+		if (!inner.signal.aborted) inner.abort(signal.reason);
+	});
+}
+function abortable(pending, signal, onAbort) {
 	return new Promise((resolve, reject) => {
 		const abort = () => {
+			onAbort?.();
 			reject(abortReason(signal));
 		};
+		if (signal.aborted) {
+			abort();
+			return;
+		}
 		signal.addEventListener("abort", abort, { once: true });
 		pending.then((value) => {
 			signal.removeEventListener("abort", abort);
@@ -175,4 +191,4 @@ function abortReason(signal) {
 }
 
 //#endregion
-export { InProcessConnectionService, apply, inject, name };
+export { InProcessConnectionService, abortInProcessCall, apply, inject, name };

--- a/lib/index.js
+++ b/lib/index.js
@@ -20915,9 +20915,9 @@ var HarnessTuiCapabilities = class {
 	* @param includeDescendants - whether the Host includes subagent Session artifacts.
 	* @returns saved path, byte count, media type, and scope.
 	*/
-	async exportSession(requestedPath, includeDescendants = false) {
+	async exportSession(requestedPath, includeDescendants = false, signal) {
 		const active = this.requireActive();
-		const payload = await this.managementBridge().sessionExport.download(active.sessionId, includeDescendants);
+		const payload = await this.managementBridge().sessionExport.download(active.sessionId, includeDescendants, signal);
 		const path$1 = resolve(active.workspacePath, requestedPath ?? payload.suggestedFilename);
 		return {
 			path: path$1,
@@ -24125,7 +24125,8 @@ var TuiActions = class {
 			placeholder: "可选：相对工作区或绝对路径"
 		}) : args;
 		if (requested === void 0) return;
-		const result = await this.capabilities.exportSession(requested.trim() === "" ? void 0 : requested.trim(), scope.id === "descendants");
+		const result = await this.host.overlays.runBusy("导出会话", (signal) => this.capabilities.exportSession(requested.trim() === "" ? void 0 : requested.trim(), scope.id === "descendants", signal));
+		if (result === void 0) return;
 		this.host.notice(ui(`已保存会话 ZIP（${formatByteSize(result.bytes)}）到 ${result.path}`, `Saved session ZIP (${formatByteSize(result.bytes)}) to ${result.path}`), "success");
 	}
 	async exportMarkdown(requested) {
@@ -25950,7 +25951,8 @@ Diagnostics: ${plugin.diagnostics.length === 0 ? "none" : plugin.diagnostics.map
 			if (entered === void 0 || entered.trim() === "") return;
 			text = entered.trim();
 		}
-		const candidates = await this.capabilities.managementBridge().plugins.search(text);
+		const candidates = await this.host.overlays.runBusy(`插件搜索 · ${text}`, (signal) => this.capabilities.managementBridge().plugins.search(text, signal));
+		if (candidates === void 0) return;
 		if (candidates.length === 0) {
 			this.host.notice(`未找到与 ${JSON.stringify(text)} 匹配的插件`, "info");
 			return;
@@ -25981,7 +25983,8 @@ Diagnostics: ${plugin.diagnostics.length === 0 ? "none" : plugin.diagnostics.map
 			await this.installedPlugin(installed);
 			return;
 		}
-		const candidate = await this.capabilities.managementBridge().plugins.inspect(spec);
+		const candidate = await this.host.overlays.runBusy(`检查 ${spec}`, (signal) => this.capabilities.managementBridge().plugins.inspect(spec, signal));
+		if (candidate === void 0) return;
 		await this.marketplaceCandidate(candidate);
 	}
 	async marketplaceCandidate(candidate) {
@@ -26035,7 +26038,8 @@ Warning: structural validation is not a security, trust, or quality review.`);
 			if (entered === void 0 || entered.trim() === "") return;
 			value = entered.trim();
 		}
-		const candidate = await this.capabilities.managementBridge().plugins.inspect(value);
+		const candidate = await this.host.overlays.runBusy(`检查 ${value}`, (signal) => this.capabilities.managementBridge().plugins.inspect(value, signal));
+		if (candidate === void 0) return;
 		if (candidate.source !== "git" && (!candidate.bundle || !candidate.patchValid)) throw new Error(`已拒绝安装：${candidate.diagnostics.join("；") || "未通过 dsh.bundle.patch 验证"}`);
 		await this.installCandidate(candidate);
 	}
@@ -26048,11 +26052,12 @@ pnpm 可能执行上述包脚本；Git 包只能在安装后由原生 Manager �
 Will run: pnpm add --save-exact ${candidate.spec}
 Target Profile: ${profile}
 pnpm may run the package scripts listed above; a Git package can be revalidated by the native Manager only after installation. This operation does not use the Agent sandbox.`), "理解风险并安装")) return;
-		const result = await this.capabilities.managementBridge().plugins.run([
+		const result = await this.host.overlays.runBusy(`安装 ${candidate.name}`, (signal) => this.capabilities.managementBridge().plugins.run([
 			"add",
 			"--save-exact",
 			candidate.spec
-		]);
+		], { signal }));
+		if (result === void 0) return;
 		await this.pluginOperation(`安装 ${candidate.name}`, result);
 	}
 	async pluginRemove(name$1) {
@@ -26072,7 +26077,9 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 		}
 		if (snapshot.plugins.find((candidate) => candidate.name === target) === void 0) throw new Error(`当前 Profile 未安装 ${JSON.stringify(target)}`);
 		if (!await this.host.overlays.confirm(`从 ${snapshot.profile} 移除 ${target}？`, `将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, "移除")) return;
-		await this.pluginOperation(`移除 ${target}`, await this.capabilities.managementBridge().plugins.run(["remove", target]));
+		const result = await this.host.overlays.runBusy(`移除 ${target}`, (signal) => this.capabilities.managementBridge().plugins.run(["remove", target], { signal }));
+		if (result === void 0) return;
+		await this.pluginOperation(`移除 ${target}`, result);
 	}
 	async pluginUpdate(name$1) {
 		let target = name$1.trim();
@@ -26095,7 +26102,9 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 		} else if (!snapshot.plugins.some((plugin) => plugin.name === target)) throw new Error(`当前 Profile 未安装 ${JSON.stringify(target)}`);
 		const args = target === "" ? ["update"] : ["update", target];
 		if (!await this.host.overlays.confirm(target === "" ? `更新 ${snapshot.profile} 全部依赖？` : `更新 ${target}？`, `将执行：pnpm ${args.join(" ")}。解析结果由 Profile lockfile 持久化。`, "更新")) return;
-		await this.pluginOperation(target === "" ? "更新全部插件" : `更新 ${target}`, await this.capabilities.managementBridge().plugins.run(args));
+		const result = await this.host.overlays.runBusy(target === "" ? "更新全部插件" : `更新 ${target}`, (signal) => this.capabilities.managementBridge().plugins.run(args, { signal }));
+		if (result === void 0) return;
+		await this.pluginOperation(target === "" ? "更新全部插件" : `更新 ${target}`, result);
 	}
 	async pluginOperation(label, result) {
 		if (result.exitCode !== 0) {
@@ -27953,19 +27962,23 @@ var ScrollableDetailOverlay = class {
 /** A single mounted modal with a logical page stack and one Escape owner. */
 var NavigationOverlay = class {
 	focused = false;
+	signal;
 	stack = [];
 	closed = false;
 	pendingBack;
+	controller = new AbortController();
 	constructor(tui, run$1, settle, reject, requestRender) {
 		this.tui = tui;
 		this.settle = settle;
 		this.reject = reject;
 		this.requestRender = requestRender;
+		this.signal = this.controller.signal;
 		try {
 			Promise.resolve(run$1(this)).then(() => {
 				this.finish();
 			}, (error) => {
-				this.fail(error);
+				if (this.signal.aborted) this.finish();
+				else this.fail(error);
 			});
 		} catch (error) {
 			queueMicrotask(() => {
@@ -27990,6 +28003,7 @@ var NavigationOverlay = class {
 		const current = this.current();
 		if (current === void 0) return;
 		if (matchesKey(data, Key.escape)) {
+			this.abort();
 			if (current.busy) this.pendingBack = current;
 			else this.back();
 			return;
@@ -28074,6 +28088,7 @@ var NavigationOverlay = class {
 	}
 	finish(value) {
 		if (this.closed) return;
+		this.abort();
 		this.closed = true;
 		this.pendingBack = void 0;
 		this.dismissAll();
@@ -28081,6 +28096,7 @@ var NavigationOverlay = class {
 	}
 	dispose() {
 		if (this.closed) return;
+		this.abort();
 		this.closed = true;
 		this.pendingBack = void 0;
 		this.dismissAll();
@@ -28108,6 +28124,7 @@ var NavigationOverlay = class {
 		if (this.closed || this.current() !== entry || entry.busy) return;
 		entry.busy = true;
 		Promise.resolve().then(action).catch((error) => {
+			if (this.signal.aborted) return;
 			this.fail(error);
 		}).finally(() => {
 			if (entry.active) entry.busy = false;
@@ -28140,10 +28157,18 @@ var NavigationOverlay = class {
 	}
 	fail(error) {
 		if (this.closed) return;
+		if (this.signal.aborted) {
+			this.finish();
+			return;
+		}
+		this.abort();
 		this.closed = true;
 		this.pendingBack = void 0;
 		this.dismissAll();
 		this.reject(error);
+	}
+	abort() {
+		if (!this.controller.signal.aborted) this.controller.abort();
 	}
 	disposeComponent(component) {
 		try {
@@ -28188,6 +28213,33 @@ var OverlayQueue = class {
 			const selected = await navigation.select(request);
 			navigation.finish(selected);
 		}, request.options);
+	}
+	/**
+	* Keep a modal open while work runs, aborting it on Escape.
+	* @param title - overlay title shown while busy.
+	* @param work - body that observes the session signal.
+	* @returns the work result, or undefined after cancel.
+	*/
+	runBusy(title, work) {
+		return this.navigate(async (navigation) => {
+			const page = navigation.selectPage({
+				title,
+				detail: "按 Esc 取消",
+				searchable: false,
+				choices: [{
+					id: "busy",
+					label: "进行中…",
+					disabledReason: "按 Esc 取消"
+				}]
+			}, () => void 0);
+			try {
+				navigation.finish(await work(navigation.signal));
+			} catch (error) {
+				if (navigation.signal.aborted) return;
+				throw error;
+			}
+			await page;
+		});
 	}
 	/**
 	* Open a single-line text input in FIFO order.

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -640,10 +640,15 @@ export class TuiActions {
       })
       : args
     if (requested === undefined) return
-    const result = await this.capabilities.exportSession(
-      requested.trim() === '' ? undefined : requested.trim(),
-      scope.id === 'descendants',
+    const result = await this.host.overlays.runBusy(
+      '导出会话',
+      signal => this.capabilities.exportSession(
+        requested.trim() === '' ? undefined : requested.trim(),
+        scope.id === 'descendants',
+        signal,
+      ),
     )
+    if (result === undefined) return
     this.host.notice(ui(
       `已保存会话 ZIP（${formatByteSize(result.bytes)}）到 ${result.path}`,
       `Saved session ZIP (${formatByteSize(result.bytes)}) to ${result.path}`,
@@ -2457,7 +2462,11 @@ Diagnostics: ${plugin.diagnostics.length === 0 ? 'none' : plugin.diagnostics.map
       if (entered === undefined || entered.trim() === '') return
       text = entered.trim()
     }
-    const candidates = await this.capabilities.managementBridge().plugins.search(text)
+    const candidates = await this.host.overlays.runBusy(
+      `插件搜索 · ${text}`,
+      signal => this.capabilities.managementBridge().plugins.search(text, signal),
+    )
+    if (candidates === undefined) return
     if (candidates.length === 0) {
       this.host.notice(`未找到与 ${JSON.stringify(text)} 匹配的插件`, 'info')
       return
@@ -2485,7 +2494,11 @@ Diagnostics: ${plugin.diagnostics.length === 0 ? 'none' : plugin.diagnostics.map
       await this.installedPlugin(installed)
       return
     }
-    const candidate = await this.capabilities.managementBridge().plugins.inspect(spec)
+    const candidate = await this.host.overlays.runBusy(
+      `检查 ${spec}`,
+      signal => this.capabilities.managementBridge().plugins.inspect(spec, signal),
+    )
+    if (candidate === undefined) return
     await this.marketplaceCandidate(candidate)
   }
 
@@ -2543,7 +2556,11 @@ Warning: structural validation is not a security, trust, or quality review.`,
       if (entered === undefined || entered.trim() === '') return
       value = entered.trim()
     }
-    const candidate = await this.capabilities.managementBridge().plugins.inspect(value)
+    const candidate = await this.host.overlays.runBusy(
+      `检查 ${value}`,
+      signal => this.capabilities.managementBridge().plugins.inspect(value, signal),
+    )
+    if (candidate === undefined) return
     if (candidate.source !== 'git' && (!candidate.bundle || !candidate.patchValid)) {
       throw new Error(`已拒绝安装：${candidate.diagnostics.join('；') || '未通过 dsh.bundle.patch 验证'}`)
     }
@@ -2567,7 +2584,11 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       '理解风险并安装',
     )
     if (!confirmed) return
-    const result = await this.capabilities.managementBridge().plugins.run(['add', '--save-exact', candidate.spec])
+    const result = await this.host.overlays.runBusy(
+      `安装 ${candidate.name}`,
+      signal => this.capabilities.managementBridge().plugins.run(['add', '--save-exact', candidate.spec], { signal }),
+    )
+    if (result === undefined) return
     await this.pluginOperation(`安装 ${candidate.name}`, result)
   }
 
@@ -2594,7 +2615,12 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       '移除',
     )
     if (!confirmed) return
-    await this.pluginOperation(`移除 ${target}`, await this.capabilities.managementBridge().plugins.run(['remove', target]))
+    const result = await this.host.overlays.runBusy(
+      `移除 ${target}`,
+      signal => this.capabilities.managementBridge().plugins.run(['remove', target], { signal }),
+    )
+    if (result === undefined) return
+    await this.pluginOperation(`移除 ${target}`, result)
   }
 
   private async pluginUpdate(name: string): Promise<void> {
@@ -2620,7 +2646,12 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       '更新',
     )
     if (!confirmed) return
-    await this.pluginOperation(target === '' ? '更新全部插件' : `更新 ${target}`, await this.capabilities.managementBridge().plugins.run(args))
+    const result = await this.host.overlays.runBusy(
+      target === '' ? '更新全部插件' : `更新 ${target}`,
+      signal => this.capabilities.managementBridge().plugins.run(args, { signal }),
+    )
+    if (result === undefined) return
+    await this.pluginOperation(target === '' ? '更新全部插件' : `更新 ${target}`, result)
   }
 
   private async pluginOperation(label: string, result: TuiPluginOperation): Promise<void> {

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -1386,11 +1386,13 @@ export class HarnessTuiCapabilities {
   async exportSession(
     requestedPath?: string,
     includeDescendants = false,
+    signal?: AbortSignal,
   ): Promise<TuiExportResult> {
     const active = this.requireActive()
     const payload = await this.managementBridge().sessionExport.download(
       active.sessionId,
       includeDescendants,
+      signal,
     )
     const path = resolve(active.workspacePath, requestedPath ?? payload.suggestedFilename)
     const bytes = await saveExport(path, payload.stream)

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -72,6 +72,7 @@ export interface OverlayPrompts {
 
 /** One logical overlay session whose page stack owns all back navigation. */
 export interface OverlayNavigation<TResult = void> extends OverlayPrompts {
+  readonly signal: AbortSignal
   selectPage(
     request: SelectOverlayRequest,
     onSelect: (choice: OverlayChoice) => void | Promise<void>,
@@ -534,9 +535,11 @@ class ScrollableDetailOverlay implements Component {
 /** A single mounted modal with a logical page stack and one Escape owner. */
 class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult> {
   focused = false
+  readonly signal: AbortSignal
   private readonly stack: NavigationEntry[] = []
   private closed = false
   private pendingBack: NavigationEntry | undefined
+  private readonly controller = new AbortController()
 
   constructor(
     private readonly tui: TUI,
@@ -545,10 +548,14 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     private readonly reject: (error: unknown) => void,
     private readonly requestRender: () => void,
   ) {
+    this.signal = this.controller.signal
     try {
       void Promise.resolve(run(this)).then(
         () => { this.finish() },
-        error => { this.fail(error) },
+        error => {
+          if (this.signal.aborted) this.finish()
+          else this.fail(error)
+        },
       )
     } catch (error) {
       queueMicrotask(() => { this.fail(error) })
@@ -574,6 +581,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     const current = this.current()
     if (current === undefined) return
     if (matchesKey(data, Key.escape)) {
+      this.abort()
       if (current.busy) this.pendingBack = current
       else this.back()
       return
@@ -664,6 +672,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
 
   finish(value?: TResult): void {
     if (this.closed) return
+    this.abort()
     this.closed = true
     this.pendingBack = undefined
     this.dismissAll()
@@ -672,6 +681,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
 
   dispose(): void {
     if (this.closed) return
+    this.abort()
     this.closed = true
     this.pendingBack = undefined
     this.dismissAll()
@@ -699,6 +709,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     if (this.closed || this.current() !== entry || entry.busy) return
     entry.busy = true
     void Promise.resolve().then(action).catch(error => {
+      if (this.signal.aborted) return
       this.fail(error)
     }).finally(() => {
       if (entry.active) entry.busy = false
@@ -733,10 +744,19 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
 
   private fail(error: unknown): void {
     if (this.closed) return
+    if (this.signal.aborted) {
+      this.finish()
+      return
+    }
+    this.abort()
     this.closed = true
     this.pendingBack = undefined
     this.dismissAll()
     this.reject(error)
+  }
+
+  private abort(): void {
+    if (!this.controller.signal.aborted) this.controller.abort()
   }
 
   private disposeComponent(component: DisposableComponent): void {
@@ -787,6 +807,34 @@ export class OverlayQueue implements OverlayPrompts {
       const selected = await navigation.select(request)
       navigation.finish(selected)
     }, request.options)
+  }
+
+  /**
+   * Keep a modal open while work runs, aborting it on Escape.
+   * @param title - overlay title shown while busy.
+   * @param work - body that observes the session signal.
+   * @returns the work result, or undefined after cancel.
+   */
+  runBusy<T>(title: string, work: (signal: AbortSignal) => Promise<T>): Promise<T | undefined> {
+    return this.navigate(async (navigation) => {
+      const page = navigation.selectPage({
+        title,
+        detail: '按 Esc 取消',
+        searchable: false,
+        choices: [{
+          id: 'busy',
+          label: '进行中…',
+          disabledReason: '按 Esc 取消',
+        }],
+      }, () => undefined)
+      try {
+        navigation.finish(await work(navigation.signal))
+      } catch (error) {
+        if (navigation.signal.aborted) return
+        throw error
+      }
+      await page
+    })
   }
 
   /**

--- a/src/host/in-process.ts
+++ b/src/host/in-process.ts
@@ -89,10 +89,14 @@ export class InProcessConnectionService extends Service implements InProcessConn
     signal?: AbortSignal,
   ): Promise<RpcResult<unknown>> {
     signal?.throwIfAborted()
-    const carrierSignal = signal ?? new AbortController().signal
     try {
-      const pending = this.registry.dispatch(channel, endpoint, payload, carrierSignal)
-      return signal === undefined ? await pending : await abortable(pending, signal)
+      if (signal === undefined) {
+        return await this.registry.dispatch(channel, endpoint, payload, new AbortController().signal)
+      }
+      return await abortInProcessCall(
+        inner => this.registry.dispatch(channel, endpoint, payload, inner),
+        signal,
+      )
     } catch (error) {
       if (signal?.aborted === true) throw abortReason(signal)
       throw new Error(
@@ -117,9 +121,38 @@ export function apply(ctx: Context): void {
   new InProcessConnectionService(ctx)
 }
 
-function abortable<T>(pending: Promise<T>, signal: AbortSignal): Promise<T> {
+/**
+ * Run one RPC handler under a caller AbortSignal, aborting the handler when
+ * the wrapper is cancelled instead of only rejecting the outer promise.
+ * @param run - handler invocation that observes the inner signal.
+ * @param signal - caller cancellation signal.
+ */
+export function abortInProcessCall<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  const inner = new AbortController()
+  const combined = AbortSignal.any([signal, inner.signal])
+  const pending = run(combined)
+  return abortable(pending, signal, () => {
+    if (!inner.signal.aborted) inner.abort(signal.reason)
+  })
+}
+
+function abortable<T>(
+  pending: Promise<T>,
+  signal: AbortSignal,
+  onAbort?: () => void,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const abort = (): void => { reject(abortReason(signal)) }
+    const abort = (): void => {
+      onAbort?.()
+      reject(abortReason(signal))
+    }
+    if (signal.aborted) {
+      abort()
+      return
+    }
     signal.addEventListener('abort', abort, { once: true })
     pending.then(
       (value) => {

--- a/tests/in-process-abort.test.ts
+++ b/tests/in-process-abort.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { abortInProcessCall } from '../src/host/in-process.ts'
+
+describe('in-process abort (task 5.4)', () => {
+  it('aborts the handler signal instead of only rejecting the wrapper', async () => {
+    const controller = new AbortController()
+    let handlerAborted = false
+    const pending = abortInProcessCall(async (signal) => {
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          handlerAborted = true
+          reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'))
+        }, { once: true })
+      })
+    }, controller.signal)
+    controller.abort(new Error('stop'))
+    await expect(pending).rejects.toThrow('stop')
+    expect(handlerAborted).toBe(true)
+  })
+})

--- a/tests/overlay-abort.test.ts
+++ b/tests/overlay-abort.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('overlay abort wiring (task 5.4)', () => {
+  it('passes overlay signals into marketplace search, inspect, run, and session export', () => {
+    const actions = readFileSync(resolve(root, 'src/client/actions.ts'), 'utf8')
+    const capabilities = readFileSync(resolve(root, 'src/client/capabilities.ts'), 'utf8')
+    expect(actions).toMatch(/plugins\.search\([^)]*signal/u)
+    expect(actions).toMatch(/plugins\.inspect\([^)]*signal/u)
+    expect(actions).toMatch(/plugins\.run\([\s\S]*signal/u)
+    expect(capabilities).toMatch(/sessionExport\.download\([\s\S]*signal/u)
+  })
+})

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -142,4 +142,42 @@ describe('overlay navigation', () => {
     harness.component().handleInput('\n')
     await expect(submitted).resolves.toBe('hello\nx')
   })
+
+  it('aborts the navigation signal when Escape closes a busy session', async () => {
+    const harness = overlayHarness()
+    let signal: AbortSignal | undefined
+    const session = harness.overlays.navigate(async (navigation) => {
+      signal = navigation.signal
+      await navigation.selectPage({
+        title: 'busy work',
+        choices: [{ id: 'go', label: 'start' }],
+      }, async () => {
+        await new Promise<void>((resolve, reject) => {
+          navigation.signal.addEventListener('abort', () => { reject(new Error('aborted')) }, { once: true })
+        })
+      })
+    })
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('busy work')
+    })
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(signal?.aborted).toBe(false)
+    })
+    harness.component().handleInput(ESCAPE)
+    await expect(session).resolves.toBeUndefined()
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('returns undefined from runBusy when Escape aborts the work', async () => {
+    const harness = overlayHarness()
+    const pending = harness.overlays.runBusy('searching', signal => new Promise<string>((_resolve, reject) => {
+      signal.addEventListener('abort', () => { reject(new Error('aborted')) }, { once: true })
+    }))
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('searching')
+    })
+    harness.component().handleInput(ESCAPE)
+    await expect(pending).resolves.toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- 5.4 from \`docs/DEEP_OPTIMIZATION.md\`: overlay sessions expose \`signal\`; Esc aborts it. \`runBusy\` keeps a cancelable modal open during work.
- \`/plugin search|inspect|run\` and session ZIP export pass that signal. in-process RPC aborts the handler signal instead of only rejecting the wrapper promise.
- Stacks on #45.

## Test plan
- [x] \`./node_modules/.bin/vitest run tests/overlays-navigation.test.ts tests/in-process-abort.test.ts tests/overlay-abort.test.ts\`
- [x] \`./node_modules/.bin/tsc --noEmit\`
- [x] \`./node_modules/.bin/tsdown\`
- [ ] Manual: start \`/plugin search\`, press Esc, confirm the Host stops fetching

Do not merge yet — remaining items land on stacked branches.