### PR TITLE
fix(tui): keep marketplace hits when one catalog source fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-bC3YRGeq.js";
 import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
-import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-CqTsUm3P.js";
+import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D8-O8gcm.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,4 +1,4 @@
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CqTsUm3P.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-D8-O8gcm.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-D8-O8gcm.js
+++ b/lib/plugin-marketplace-D8-O8gcm.js
@@ -263,13 +263,33 @@ var PluginMarketplace = class {
 		const cacheKey = `search:${text}:${enabled.map((source) => source.id).join(",")}`;
 		const cached = this.searchCache.get(cacheKey);
 		if (cached !== void 0) return cached;
-		const rows = await Promise.all(enabled.map((source) => {
-			if (source.kind === "npm") return this.searchNpm(text, source, signal);
-			if (source.kind === "catalog") return this.searchCatalog(text, source, signal);
-			return this.searchProvider(text, source, sources, signal);
+		const settled = await Promise.allSettled(enabled.map(async (source) => {
+			if (source.kind === "npm") return await this.searchNpm(text, source, signal);
+			if (source.kind === "catalog") return await this.searchCatalog(text, source, signal);
+			return await this.searchProvider(text, source, sources, signal);
 		}));
 		const deduped = /* @__PURE__ */ new Map();
-		for (const candidate of rows.flat()) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate);
+		for (const [index, result$1] of settled.entries()) {
+			const source = enabled[index];
+			if (source === void 0) continue;
+			if (result$1.status === "fulfilled") {
+				for (const candidate of result$1.value) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate);
+				continue;
+			}
+			const message = messageOf(result$1.reason);
+			deduped.set(`${source.id}:source-error`, {
+				id: `${source.id}:source-error`,
+				name: source.label,
+				sourceId: source.id,
+				source: sourceType(source.url),
+				spec: source.url,
+				bundle: false,
+				patchValid: false,
+				scripts: [],
+				immutable: false,
+				diagnostics: [`来源失败：${message}`]
+			});
+		}
 		const result = [...deduped.values()];
 		this.searchCache.set(cacheKey, result);
 		return result;

--- a/src/host/plugin-marketplace.ts
+++ b/src/host/plugin-marketplace.ts
@@ -371,13 +371,33 @@ export class PluginMarketplace {
     const cacheKey = `search:${text}:${enabled.map(source => source.id).join(',')}`
     const cached = this.searchCache.get(cacheKey)
     if (cached !== undefined) return cached
-    const rows = await Promise.all(enabled.map((source) => {
-      if (source.kind === 'npm') return this.searchNpm(text, source, signal)
-      if (source.kind === 'catalog') return this.searchCatalog(text, source, signal)
-      return this.searchProvider(text, source, sources, signal)
+    const settled = await Promise.allSettled(enabled.map(async (source) => {
+      if (source.kind === 'npm') return await this.searchNpm(text, source, signal)
+      if (source.kind === 'catalog') return await this.searchCatalog(text, source, signal)
+      return await this.searchProvider(text, source, sources, signal)
     }))
     const deduped = new Map<string, TuiMarketplaceCandidate>()
-    for (const candidate of rows.flat()) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate)
+    for (const [index, result] of settled.entries()) {
+      const source = enabled[index]
+      if (source === undefined) continue
+      if (result.status === 'fulfilled') {
+        for (const candidate of result.value) deduped.set(`${candidate.sourceId}:${candidate.spec}`, candidate)
+        continue
+      }
+      const message = messageOf(result.reason)
+      deduped.set(`${source.id}:source-error`, {
+        id: `${source.id}:source-error`,
+        name: source.label,
+        sourceId: source.id,
+        source: sourceType(source.url),
+        spec: source.url,
+        bundle: false,
+        patchValid: false,
+        scripts: [],
+        immutable: false,
+        diagnostics: [`来源失败：${message}`],
+      })
+    }
     const result = [...deduped.values()]
     this.searchCache.set(cacheKey, result)
     return result

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -167,6 +167,30 @@ describe('plugin marketplace search (task 5.3)', () => {
         })
       })) as typeof fetch,
     })
-    await expect(marketplace.search('demo', [source])).rejects.toThrow()
+    const rows = await marketplace.search('demo', [source])
+    expect(rows[0]?.diagnostics.join(' ')).toMatch(/aborted|timeout/iu)
+  })
+
+  it('keeps successful sources when another catalog source fails', async () => {
+    const catalog: TuiMarketplaceSource = {
+      id: 'bad-catalog',
+      kind: 'catalog',
+      label: 'Broken catalog',
+      url: 'https://example.invalid/catalog.json',
+      enabled: true,
+      builtIn: false,
+    }
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        if (url.includes('/-/v1/search')) return jsonResponse(searchBody())
+        throw new Error('catalog down')
+      }) as typeof fetch,
+    })
+    const rows = await marketplace.search('demo', [source, catalog])
+    expect(rows.some(row => row.name === 'demo-plugin')).toBe(true)
+    expect(rows.some(row => row.sourceId === 'bad-catalog' && row.diagnostics.some(item => item.includes('catalog down')))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- 6.7 from \`docs/DEEP_OPTIMIZATION.md\`: marketplace search uses \`Promise.allSettled\` so one failing catalog does not discard npm hits.
- Failed sources appear as diagnostic rows (\`来源失败：...\`).
- Stacks on #46.

## Test plan
- [x] \`./node_modules/.bin/vitest run tests/plugin-marketplace.test.ts\`
- [x] \`./node_modules/.bin/tsc --noEmit\`
- [x] \`./node_modules/.bin/tsdown\`

Do not merge yet — remaining robustness items land on stacked branches.