### PR TITLE
fix(tui): keep the plugin marketplace open when a catalog row is invalid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26215,7 +26215,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			choices: [...snapshot.sources.map((source$1) => ({
 				id: `source:${source$1.id}`,
 				label: `${source$1.enabled ? "● " : "○ "}${source$1.label}`,
-				description: `${source$1.kind} · ${source$1.url}${source$1.credentialRef === void 0 ? "" : ` · Credential ${source$1.credentialRef}`}${source$1.builtIn ? " · 内置" : ""}`
+				description: `${source$1.kind} · ${source$1.url}${source$1.credentialRef === void 0 ? "" : ` · Credential ${source$1.credentialRef}`}${source$1.builtIn ? " · 内置" : ""}${source$1.diagnostic === void 0 ? "" : ` · ${source$1.diagnostic}`}`
 			})), {
 				id: "__add__",
 				label: "添加插件目录…"

--- a/lib/index.js
+++ b/lib/index.js
@@ -31466,6 +31466,66 @@ function validateCatalogSource(source) {
 		credentialRef: source.credentialRef ?? ""
 	};
 }
+function degradedCatalogSource(raw, index, diagnostic) {
+	const record = typeof raw === "object" && raw !== null ? raw : {};
+	const id = typeof record.id === "string" && record.id.trim() !== "" ? record.id.trim() : `invalid-${String(index)}`;
+	const label = typeof record.label === "string" && record.label.trim() !== "" ? record.label.trim() : id;
+	const url = typeof record.url === "string" ? record.url : "";
+	return {
+		id,
+		kind: "catalog",
+		label: `${label}（无效）`,
+		url,
+		enabled: false,
+		builtIn: false,
+		diagnostic
+	};
+}
+/**
+* Read stored catalog rows, disabling invalid ones instead of locking the marketplace.
+* @param stored - Settings-persisted catalog rows.
+* @param reservedIds - built-in and Provider source ids that must stay unique.
+*/
+function catalogSourcesFromStored(stored, reservedIds) {
+	const seen = new Set(reservedIds);
+	const sources = [];
+	for (const [index, raw] of stored.entries()) {
+		const record = typeof raw === "object" && raw !== null ? raw : {};
+		const rawId = typeof record.id === "string" ? record.id : "";
+		if (rawId !== "" && seen.has(rawId)) {
+			sources.push(degradedCatalogSource(raw, index, `Catalog Source ${rawId} 与内置或 Provider Source 冲突`));
+			continue;
+		}
+		try {
+			const storedSource = validateCatalogSource({
+				id: typeof record.id === "string" ? record.id : "",
+				kind: "catalog",
+				label: typeof record.label === "string" ? record.label : "",
+				url: typeof record.url === "string" ? record.url : "",
+				enabled: record.enabled !== false,
+				...typeof record.credentialRef === "string" && record.credentialRef !== "" ? { credentialRef: record.credentialRef } : {},
+				builtIn: false
+			});
+			if (seen.has(storedSource.id)) {
+				sources.push(degradedCatalogSource(raw, index, `Catalog Source ${storedSource.id} 与内置或 Provider Source 冲突`));
+				continue;
+			}
+			seen.add(storedSource.id);
+			sources.push({
+				id: storedSource.id,
+				kind: "catalog",
+				label: storedSource.label,
+				url: storedSource.url,
+				enabled: storedSource.enabled,
+				...storedSource.credentialRef === "" ? {} : { credentialRef: storedSource.credentialRef },
+				builtIn: false
+			});
+		} catch (error) {
+			sources.push(degradedCatalogSource(raw, index, error instanceof Error ? error.message : String(error)));
+		}
+	}
+	return sources;
+}
 function tuiProfile(summary) {
 	if (!summary.compatible || summary.bundles.includes(TUI_BUNDLE)) return summary;
 	return {
@@ -31506,35 +31566,14 @@ function createTuiManagementBridge(ctx, cwd) {
 	const documents = createSettingsDescribeCache(() => settings.describe({ redactSecrets: true }).map(settingsDocument));
 	const sourceSnapshot = () => {
 		const document = documents.one(MARKETPLACE_NAMESPACE);
-		const stored = document.value.sources.map((source) => validateCatalogSource({
-			id: source.id,
-			kind: "catalog",
-			label: source.label,
-			url: source.url,
-			enabled: source.enabled,
-			...source.credentialRef === "" ? {} : { credentialRef: source.credentialRef },
-			builtIn: false
-		}));
-		const providerSources = providers?.sources() ?? [];
-		const sourceIds = new Set([NPM_SOURCE.id, ...providerSources.map((source) => source.id)]);
-		for (const source of stored) {
-			if (sourceIds.has(source.id)) throw new Error(`Catalog Source ${source.id} 与内置或 Provider Source 冲突`);
-			sourceIds.add(source.id);
-		}
+		const value = document.value;
+		const stored = catalogSourcesFromStored(value.sources, new Set([NPM_SOURCE.id, ...(providers?.sources() ?? []).map((source) => source.id)]));
 		return {
 			revision: document.revision,
 			sources: [
 				NPM_SOURCE,
-				...providerSources,
-				...stored.map((source) => ({
-					id: source.id,
-					kind: "catalog",
-					label: source.label,
-					url: source.url,
-					enabled: source.enabled,
-					...source.credentialRef === "" ? {} : { credentialRef: source.credentialRef },
-					builtIn: false
-				}))
+				...providers?.sources() ?? [],
+				...stored
 			]
 		};
 	};

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -2759,7 +2759,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
         ...snapshot.sources.map(source => ({
           id: `source:${source.id}`,
           label: `${source.enabled ? '● ' : '○ '}${source.label}`,
-          description: `${source.kind} · ${source.url}${source.credentialRef === undefined ? '' : ` · Credential ${source.credentialRef}`}${source.builtIn ? ' · 内置' : ''}`,
+          description: `${source.kind} · ${source.url}${source.credentialRef === undefined ? '' : ` · Credential ${source.credentialRef}`}${source.builtIn ? ' · 内置' : ''}${source.diagnostic === undefined ? '' : ` · ${source.diagnostic}`}`,
         })),
         { id: '__add__', label: '添加插件目录…' },
       ],

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -230,6 +230,73 @@ function validateCatalogSource(source: TuiMarketplaceSource): StoredCatalogSourc
   }
 }
 
+function degradedCatalogSource(raw: unknown, index: number, diagnostic: string): TuiMarketplaceSource {
+  const record = typeof raw === 'object' && raw !== null ? raw as Partial<StoredCatalogSource> : {}
+  const id = typeof record.id === 'string' && record.id.trim() !== '' ? record.id.trim() : `invalid-${String(index)}`
+  const label = typeof record.label === 'string' && record.label.trim() !== '' ? record.label.trim() : id
+  const url = typeof record.url === 'string' ? record.url : ''
+  return {
+    id,
+    kind: 'catalog',
+    label: `${label}（无效）`,
+    url,
+    enabled: false,
+    builtIn: false,
+    diagnostic,
+  }
+}
+
+/**
+ * Read stored catalog rows, disabling invalid ones instead of locking the marketplace.
+ * @param stored - Settings-persisted catalog rows.
+ * @param reservedIds - built-in and Provider source ids that must stay unique.
+ */
+export function catalogSourcesFromStored(
+  stored: readonly unknown[],
+  reservedIds: ReadonlySet<string>,
+): readonly TuiMarketplaceSource[] {
+  const seen = new Set(reservedIds)
+  const sources: TuiMarketplaceSource[] = []
+  for (const [index, raw] of stored.entries()) {
+    const record = typeof raw === 'object' && raw !== null ? raw as Partial<StoredCatalogSource> : {}
+    const rawId = typeof record.id === 'string' ? record.id : ''
+    if (rawId !== '' && seen.has(rawId)) {
+      sources.push(degradedCatalogSource(raw, index, `Catalog Source ${rawId} 与内置或 Provider Source 冲突`))
+      continue
+    }
+    try {
+      const storedSource = validateCatalogSource({
+        id: typeof record.id === 'string' ? record.id : '',
+        kind: 'catalog',
+        label: typeof record.label === 'string' ? record.label : '',
+        url: typeof record.url === 'string' ? record.url : '',
+        enabled: record.enabled !== false,
+        ...(typeof record.credentialRef === 'string' && record.credentialRef !== ''
+          ? { credentialRef: record.credentialRef }
+          : {}),
+        builtIn: false,
+      })
+      if (seen.has(storedSource.id)) {
+        sources.push(degradedCatalogSource(raw, index, `Catalog Source ${storedSource.id} 与内置或 Provider Source 冲突`))
+        continue
+      }
+      seen.add(storedSource.id)
+      sources.push({
+        id: storedSource.id,
+        kind: 'catalog',
+        label: storedSource.label,
+        url: storedSource.url,
+        enabled: storedSource.enabled,
+        ...(storedSource.credentialRef === '' ? {} : { credentialRef: storedSource.credentialRef }),
+        builtIn: false,
+      })
+    } catch (error) {
+      sources.push(degradedCatalogSource(raw, index, error instanceof Error ? error.message : String(error)))
+    }
+  }
+  return sources
+}
+
 function tuiProfile(summary: TuiProfileSummary): TuiProfileSummary {
   if (!summary.compatible || summary.bundles.includes(TUI_BUNDLE)) return summary
   return {
@@ -285,35 +352,16 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
   const sourceSnapshot = (): TuiMarketplaceSources => {
     const document = documents.one(MARKETPLACE_NAMESPACE)
     const value = document.value as MarketplaceSettings
-    const stored = value.sources.map(source => validateCatalogSource({
-      id: source.id,
-      kind: 'catalog',
-      label: source.label,
-      url: source.url,
-      enabled: source.enabled,
-      ...(source.credentialRef === '' ? {} : { credentialRef: source.credentialRef }),
-      builtIn: false,
-    }))
-    const providerSources = providers?.sources() ?? []
-    const sourceIds = new Set([NPM_SOURCE.id, ...providerSources.map(source => source.id)])
-    for (const source of stored) {
-      if (sourceIds.has(source.id)) throw new Error(`Catalog Source ${source.id} 与内置或 Provider Source 冲突`)
-      sourceIds.add(source.id)
-    }
+    const stored = catalogSourcesFromStored(
+      value.sources,
+      new Set([NPM_SOURCE.id, ...(providers?.sources() ?? []).map(source => source.id)]),
+    )
     return {
       revision: document.revision,
       sources: [
         NPM_SOURCE,
-        ...providerSources,
-        ...stored.map(source => ({
-          id: source.id,
-          kind: 'catalog' as const,
-          label: source.label,
-          url: source.url,
-          enabled: source.enabled,
-          ...(source.credentialRef === '' ? {} : { credentialRef: source.credentialRef }),
-          builtIn: false,
-        })),
+        ...(providers?.sources() ?? []),
+        ...stored,
       ],
     }
   }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -260,6 +260,8 @@ export interface TuiMarketplaceSource {
   readonly enabled: boolean
   readonly credentialRef?: string
   readonly builtIn: boolean
+  /** Present when a stored catalog row failed validation and was kept disabled. */
+  readonly diagnostic?: string
 }
 
 /** Marketplace source list with the native Settings revision that produced it. */

--- a/tests/catalog-sources.test.ts
+++ b/tests/catalog-sources.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { catalogSourcesFromStored } from '../src/host/management.ts'
+
+describe('catalog sources (task 6.5)', () => {
+  it('keeps valid catalog rows', () => {
+    const rows = catalogSourcesFromStored([{
+      id: 'private',
+      label: 'Private',
+      url: 'https://example.com/catalog.json',
+      enabled: true,
+      credentialRef: '',
+    }], new Set(['npm']))
+    expect(rows).toEqual([{
+      id: 'private',
+      kind: 'catalog',
+      label: 'Private',
+      url: 'https://example.com/catalog.json',
+      enabled: true,
+      builtIn: false,
+    }])
+  })
+
+  it('degrades a stored row with an embedded credential instead of throwing', () => {
+    const rows = catalogSourcesFromStored([{
+      id: 'leaky',
+      label: 'Leaky',
+      url: 'https://user:secret@example.com/catalog.json',
+      enabled: true,
+      credentialRef: '',
+    }], new Set(['npm']))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.enabled).toBe(false)
+    expect(rows[0]?.diagnostic).toMatch(/Credential|凭证|Secret/u)
+  })
+
+  it('degrades a row that collides with a reserved source id', () => {
+    const rows = catalogSourcesFromStored([{
+      id: 'npm',
+      label: 'Collision',
+      url: 'https://example.com/catalog.json',
+      enabled: true,
+      credentialRef: '',
+    }], new Set(['npm']))
+    expect(rows[0]?.enabled).toBe(false)
+    expect(rows[0]?.diagnostic).toMatch(/冲突/u)
+  })
+})


### PR DESCRIPTION
## Summary
- Invalid or conflicting catalog source rows stay listed as disabled diagnostics instead of crashing `/plugin`.
- `/plugin source` appends the stored diagnostic so the operator can see why a row was skipped.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/catalog-sources.test.ts`
- [ ] Confirm a malformed catalog row does not close the marketplace overlay.
