### PR TITLE
feat(tui): structure /trajectory request details instead of dumping JSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,9 +64,9 @@ var __export = (all) => {
 * Matches if all query characters appear in order (not necessarily consecutive).
 * Lower score = better match.
 */
-function fuzzyMatch(query, text) {
+function fuzzyMatch(query, text$1) {
 	const queryLower = query.toLowerCase();
-	const textLower = text.toLowerCase();
+	const textLower = text$1.toLowerCase();
 	const matchQuery = (normalizedQuery) => {
 		if (normalizedQuery.length === 0) return {
 			matches: true,
@@ -127,11 +127,11 @@ function fuzzyFilter(items, query, getText) {
 	if (tokens.length === 0) return items;
 	const results = [];
 	for (const item of items) {
-		const text = getText(item);
+		const text$1 = getText(item);
 		let totalScore = 0;
 		let allMatch = true;
 		for (const token of tokens) {
-			const match = fuzzyMatch(token, text);
+			const match = fuzzyMatch(token, text$1);
 			if (match.matches) totalScore += match.score;
 			else {
 				allMatch = false;
@@ -175,31 +175,31 @@ function buildFdPathQuery(query) {
 	if (hasTrailingSeparator) pattern += separatorPattern;
 	return pattern;
 }
-function findLastDelimiter(text) {
-	for (let i = text.length - 1; i >= 0; i -= 1) if (PATH_DELIMITERS.has(text[i] ?? "")) return i;
+function findLastDelimiter(text$1) {
+	for (let i = text$1.length - 1; i >= 0; i -= 1) if (PATH_DELIMITERS.has(text$1[i] ?? "")) return i;
 	return -1;
 }
-function findUnclosedQuoteStart(text) {
+function findUnclosedQuoteStart(text$1) {
 	let inQuotes = false;
 	let quoteStart = -1;
-	for (let i = 0; i < text.length; i += 1) if (text[i] === "\"") {
+	for (let i = 0; i < text$1.length; i += 1) if (text$1[i] === "\"") {
 		inQuotes = !inQuotes;
 		if (inQuotes) quoteStart = i;
 	}
 	return inQuotes ? quoteStart : null;
 }
-function isTokenStart(text, index) {
-	return index === 0 || PATH_DELIMITERS.has(text[index - 1] ?? "");
+function isTokenStart(text$1, index) {
+	return index === 0 || PATH_DELIMITERS.has(text$1[index - 1] ?? "");
 }
-function extractQuotedPrefix(text) {
-	const quoteStart = findUnclosedQuoteStart(text);
+function extractQuotedPrefix(text$1) {
+	const quoteStart = findUnclosedQuoteStart(text$1);
 	if (quoteStart === null) return null;
-	if (quoteStart > 0 && text[quoteStart - 1] === "@") {
-		if (!isTokenStart(text, quoteStart - 1)) return null;
-		return text.slice(quoteStart - 1);
+	if (quoteStart > 0 && text$1[quoteStart - 1] === "@") {
+		if (!isTokenStart(text$1, quoteStart - 1)) return null;
+		return text$1.slice(quoteStart - 1);
 	}
-	if (!isTokenStart(text, quoteStart)) return null;
-	return text.slice(quoteStart);
+	if (!isTokenStart(text$1, quoteStart)) return null;
+	return text$1.slice(quoteStart);
 }
 function parsePathPrefix(prefix) {
 	if (prefix.startsWith("@\"")) return {
@@ -428,22 +428,22 @@ var CombinedAutocompleteProvider = class {
 			cursorCol: beforePrefix.length + cursorOffset
 		};
 	}
-	extractAtPrefix(text) {
-		const quotedPrefix = extractQuotedPrefix(text);
+	extractAtPrefix(text$1) {
+		const quotedPrefix = extractQuotedPrefix(text$1);
 		if (quotedPrefix?.startsWith("@\"")) return quotedPrefix;
-		const lastDelimiterIndex = findLastDelimiter(text);
+		const lastDelimiterIndex = findLastDelimiter(text$1);
 		const tokenStart = lastDelimiterIndex === -1 ? 0 : lastDelimiterIndex + 1;
-		if (text[tokenStart] === "@") return text.slice(tokenStart);
+		if (text$1[tokenStart] === "@") return text$1.slice(tokenStart);
 		return null;
 	}
-	extractPathPrefix(text, forceExtract = false) {
-		const quotedPrefix = extractQuotedPrefix(text);
+	extractPathPrefix(text$1, forceExtract = false) {
+		const quotedPrefix = extractQuotedPrefix(text$1);
 		if (quotedPrefix) return quotedPrefix;
-		const lastDelimiterIndex = findLastDelimiter(text);
-		const pathPrefix = lastDelimiterIndex === -1 ? text : text.slice(lastDelimiterIndex + 1);
+		const lastDelimiterIndex = findLastDelimiter(text$1);
+		const pathPrefix = lastDelimiterIndex === -1 ? text$1 : text$1.slice(lastDelimiterIndex + 1);
 		if (forceExtract) return pathPrefix;
 		if (pathPrefix.includes("/") || pathPrefix.startsWith(".") || pathPrefix.startsWith("~/")) return pathPrefix;
-		if (pathPrefix === "" && text.endsWith(" ")) return pathPrefix;
+		if (pathPrefix === "" && text$1.endsWith(" ")) return pathPrefix;
 		return null;
 	}
 	expandHomePath(path$1) {
@@ -1321,24 +1321,24 @@ function isPrintableAscii(str) {
 	}
 	return true;
 }
-function truncateFragmentToWidth(text, maxWidth) {
-	if (maxWidth <= 0 || text.length === 0) return {
+function truncateFragmentToWidth(text$1, maxWidth) {
+	if (maxWidth <= 0 || text$1.length === 0) return {
 		text: "",
 		width: 0
 	};
-	if (isPrintableAscii(text)) {
-		const clipped = text.slice(0, maxWidth);
+	if (isPrintableAscii(text$1)) {
+		const clipped = text$1.slice(0, maxWidth);
 		return {
 			text: clipped,
 			width: clipped.length
 		};
 	}
-	const hasAnsi = text.includes("\x1B");
-	const hasTabs = text.includes("	");
+	const hasAnsi = text$1.includes("\x1B");
+	const hasTabs = text$1.includes("	");
 	if (!hasAnsi && !hasTabs) {
 		let result$1 = "";
 		let width$1 = 0;
-		for (const { segment } of segmenter$1.segment(text)) {
+		for (const { segment } of segmenter$1.segment(text$1)) {
 			const w = graphemeWidth(segment);
 			if (width$1 + w > maxWidth) break;
 			result$1 += segment;
@@ -1353,14 +1353,14 @@ function truncateFragmentToWidth(text, maxWidth) {
 	let width = 0;
 	let i = 0;
 	let pendingAnsi = "";
-	while (i < text.length) {
-		const ansi$1 = extractAnsiCode(text, i);
+	while (i < text$1.length) {
+		const ansi$1 = extractAnsiCode(text$1, i);
 		if (ansi$1) {
 			pendingAnsi += ansi$1.code;
 			i += ansi$1.length;
 			continue;
 		}
-		if (text[i] === "	") {
+		if (text$1[i] === "	") {
 			if (width + 3 > maxWidth) break;
 			if (pendingAnsi) {
 				result += pendingAnsi;
@@ -1372,11 +1372,11 @@ function truncateFragmentToWidth(text, maxWidth) {
 			continue;
 		}
 		let end = i;
-		while (end < text.length && text[end] !== "	") {
-			if (extractAnsiCode(text, end)) break;
+		while (end < text$1.length && text$1[end] !== "	") {
+			if (extractAnsiCode(text$1, end)) break;
 			end++;
 		}
-		for (const { segment } of segmenter$1.segment(text.slice(i, end))) {
+		for (const { segment } of segmenter$1.segment(text$1.slice(i, end))) {
 			const w = graphemeWidth(segment);
 			if (width + w > maxWidth) return {
 				text: result,
@@ -1700,10 +1700,10 @@ var AnsiCodeTracker = class {
 		return result;
 	}
 };
-function updateTrackerFromText(text, tracker) {
+function updateTrackerFromText(text$1, tracker) {
 	let i = 0;
-	while (i < text.length) {
-		const ansiResult = extractAnsiCode(text, i);
+	while (i < text$1.length) {
+		const ansiResult = extractAnsiCode(text$1, i);
 		if (ansiResult) {
 			tracker.process(ansiResult.code);
 			i += ansiResult.length;
@@ -1713,20 +1713,20 @@ function updateTrackerFromText(text, tracker) {
 /**
 * Split text into words while keeping ANSI codes attached.
 */
-function splitIntoTokensWithAnsi(text) {
+function splitIntoTokensWithAnsi(text$1) {
 	const tokens = [];
 	let current = "";
 	let pendingAnsi = "";
 	let inWhitespace = false;
 	let i = 0;
-	while (i < text.length) {
-		const ansiResult = extractAnsiCode(text, i);
+	while (i < text$1.length) {
+		const ansiResult = extractAnsiCode(text$1, i);
 		if (ansiResult) {
 			pendingAnsi += ansiResult.code;
 			i += ansiResult.length;
 			continue;
 		}
-		const char = text[i];
+		const char = text$1[i];
 		const charIsSpace = char === " ";
 		if (charIsSpace !== inWhitespace && current) {
 			tokens.push(current);
@@ -1755,9 +1755,9 @@ function splitIntoTokensWithAnsi(text) {
 * @param width - Maximum visible width per line
 * @returns Array of wrapped lines (NOT padded to width)
 */
-function wrapTextWithAnsi(text, width) {
-	if (!text) return [""];
-	const inputLines = text.split("\n");
+function wrapTextWithAnsi(text$1, width) {
+	if (!text$1) return [""];
+	const inputLines = text$1.split("\n");
 	const result = [];
 	const tracker = new AnsiCodeTracker();
 	for (const inputLine of inputLines) {
@@ -1900,21 +1900,21 @@ function applyBackgroundToLine(line, width, bgFn) {
 * @param pad - If true, pad result with spaces to exactly maxWidth (default: false)
 * @returns Truncated text, optionally padded to exactly maxWidth
 */
-function truncateToWidth(text, maxWidth, ellipsis = "...", pad = false) {
+function truncateToWidth(text$1, maxWidth, ellipsis = "...", pad = false) {
 	if (maxWidth <= 0) return "";
-	if (text.length === 0) return pad ? " ".repeat(maxWidth) : "";
+	if (text$1.length === 0) return pad ? " ".repeat(maxWidth) : "";
 	const ellipsisWidth = visibleWidth(ellipsis);
 	if (ellipsisWidth >= maxWidth) {
-		const textWidth = visibleWidth(text);
-		if (textWidth <= maxWidth) return pad ? text + " ".repeat(maxWidth - textWidth) : text;
+		const textWidth = visibleWidth(text$1);
+		if (textWidth <= maxWidth) return pad ? text$1 + " ".repeat(maxWidth - textWidth) : text$1;
 		const clippedEllipsis = truncateFragmentToWidth(ellipsis, maxWidth);
 		if (clippedEllipsis.width === 0) return pad ? " ".repeat(maxWidth) : "";
 		return finalizeTruncatedResult("", 0, clippedEllipsis.text, clippedEllipsis.width, maxWidth, pad);
 	}
-	if (isPrintableAscii(text)) {
-		if (text.length <= maxWidth) return pad ? text + " ".repeat(maxWidth - text.length) : text;
+	if (isPrintableAscii(text$1)) {
+		if (text$1.length <= maxWidth) return pad ? text$1 + " ".repeat(maxWidth - text$1.length) : text$1;
 		const targetWidth$1 = maxWidth - ellipsisWidth;
-		return finalizeTruncatedResult(text.slice(0, targetWidth$1), targetWidth$1, ellipsis, ellipsisWidth, maxWidth, pad);
+		return finalizeTruncatedResult(text$1.slice(0, targetWidth$1), targetWidth$1, ellipsis, ellipsisWidth, maxWidth, pad);
 	}
 	const targetWidth = maxWidth - ellipsisWidth;
 	let result = "";
@@ -1924,10 +1924,10 @@ function truncateToWidth(text, maxWidth, ellipsis = "...", pad = false) {
 	let keepContiguousPrefix = true;
 	let overflowed = false;
 	let exhaustedInput = false;
-	const hasAnsi = text.includes("\x1B");
-	const hasTabs = text.includes("	");
+	const hasAnsi = text$1.includes("\x1B");
+	const hasTabs = text$1.includes("	");
 	if (!hasAnsi && !hasTabs) {
-		for (const { segment } of segmenter$1.segment(text)) {
+		for (const { segment } of segmenter$1.segment(text$1)) {
 			const width = graphemeWidth(segment);
 			if (keepContiguousPrefix && keptWidth + width <= targetWidth) {
 				result += segment;
@@ -1942,14 +1942,14 @@ function truncateToWidth(text, maxWidth, ellipsis = "...", pad = false) {
 		exhaustedInput = !overflowed;
 	} else {
 		let i = 0;
-		while (i < text.length) {
-			const ansi$1 = extractAnsiCode(text, i);
+		while (i < text$1.length) {
+			const ansi$1 = extractAnsiCode(text$1, i);
 			if (ansi$1) {
 				pendingAnsi += ansi$1.code;
 				i += ansi$1.length;
 				continue;
 			}
-			if (text[i] === "	") {
+			if (text$1[i] === "	") {
 				if (keepContiguousPrefix && keptWidth + 3 <= targetWidth) {
 					if (pendingAnsi) {
 						result += pendingAnsi;
@@ -1970,11 +1970,11 @@ function truncateToWidth(text, maxWidth, ellipsis = "...", pad = false) {
 				continue;
 			}
 			let end = i;
-			while (end < text.length && text[end] !== "	") {
-				if (extractAnsiCode(text, end)) break;
+			while (end < text$1.length && text$1[end] !== "	") {
+				if (extractAnsiCode(text$1, end)) break;
 				end++;
 			}
-			for (const { segment } of segmenter$1.segment(text.slice(i, end))) {
+			for (const { segment } of segmenter$1.segment(text$1.slice(i, end))) {
 				const width = graphemeWidth(segment);
 				if (keepContiguousPrefix && keptWidth + width <= targetWidth) {
 					if (pendingAnsi) {
@@ -1996,9 +1996,9 @@ function truncateToWidth(text, maxWidth, ellipsis = "...", pad = false) {
 			if (overflowed) break;
 			i = end;
 		}
-		exhaustedInput = i >= text.length;
+		exhaustedInput = i >= text$1.length;
 	}
-	if (!overflowed && exhaustedInput) return pad ? text + " ".repeat(Math.max(0, maxWidth - visibleSoFar)) : text;
+	if (!overflowed && exhaustedInput) return pad ? text$1 + " ".repeat(Math.max(0, maxWidth - visibleSoFar)) : text$1;
 	return finalizeTruncatedResult(result, keptWidth, ellipsis, ellipsisWidth, maxWidth, pad);
 }
 /**
@@ -3089,14 +3089,14 @@ var Text = class {
 	cachedText;
 	cachedWidth;
 	cachedLines;
-	constructor(text = "", paddingX = 1, paddingY = 1, customBgFn) {
-		this.text = text;
+	constructor(text$1 = "", paddingX = 1, paddingY = 1, customBgFn) {
+		this.text = text$1;
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.customBgFn = customBgFn;
 	}
-	setText(text) {
-		this.text = text;
+	setText(text$1) {
+		this.text = text$1;
 		this.cachedText = void 0;
 		this.cachedWidth = void 0;
 		this.cachedLines = void 0;
@@ -3171,12 +3171,12 @@ var KillRing = class {
 	* @param opts.prepend - If accumulating, prepend (backward deletion) or append (forward deletion)
 	* @param opts.accumulate - Merge with the most recent entry instead of creating a new one
 	*/
-	push(text, opts) {
-		if (!text) return;
+	push(text$1, opts) {
+		if (!text$1) return;
 		if (opts.accumulate && this.ring.length > 0) {
 			const last = this.ring.pop();
-			this.ring.push(opts.prepend ? text + last : last + text);
-		} else this.ring.push(text);
+			this.ring.push(opts.prepend ? text$1 + last : last + text$1);
+		} else this.ring.push(text$1);
 	}
 	/** Get most recent entry without modifying the ring. */
 	peek() {
@@ -3455,8 +3455,8 @@ function renderImage(base64Data, imageDimensions, options$1 = {}) {
 * @param text - The visible text to display
 * @param url - The URL to link to
 */
-function hyperlink(text, url) {
-	return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+function hyperlink(text$1, url) {
+	return `\x1b]8;;${url}\x1b\\${text$1}\x1b]8;;\x1b\\`;
 }
 function imageFallback(mimeType, dimensions, filename) {
 	const parts = [];
@@ -4282,7 +4282,7 @@ var UndoStack = class {
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
-const normalizeToSingleLine = (text) => text.replace(/[\r\n]+/g, " ").trim();
+const normalizeToSingleLine = (text$1) => text$1.replace(/[\r\n]+/g, " ").trim();
 const clamp$1 = (value, min, max) => Math.max(min, Math.min(value, max));
 var SelectList = class {
 	items = [];
@@ -4422,10 +4422,10 @@ function isPasteMarker(segment) {
 *
 * Only markers whose numeric ID exists in `validIds` are merged.
 */
-function segmentWithMarkers(text, validIds) {
-	if (validIds.size === 0 || !text.includes("[paste #")) return baseSegmenter.segment(text);
+function segmentWithMarkers(text$1, validIds) {
+	if (validIds.size === 0 || !text$1.includes("[paste #")) return baseSegmenter.segment(text$1);
 	const markers = [];
-	for (const m of text.matchAll(PASTE_MARKER_REGEX)) {
+	for (const m of text$1.matchAll(PASTE_MARKER_REGEX)) {
 		const id = Number.parseInt(m[1], 10);
 		if (!validIds.has(id)) continue;
 		markers.push({
@@ -4433,8 +4433,8 @@ function segmentWithMarkers(text, validIds) {
 			end: m.index + m[0].length
 		});
 	}
-	if (markers.length === 0) return baseSegmenter.segment(text);
-	const baseSegments = baseSegmenter.segment(text);
+	if (markers.length === 0) return baseSegmenter.segment(text$1);
+	const baseSegments = baseSegmenter.segment(text$1);
 	const result = [];
 	let markerIdx = 0;
 	for (const seg of baseSegments) {
@@ -4442,11 +4442,11 @@ function segmentWithMarkers(text, validIds) {
 		const marker = markerIdx < markers.length ? markers[markerIdx] : null;
 		if (marker && seg.index >= marker.start && seg.index < marker.end) {
 			if (seg.index === marker.start) {
-				const markerText = text.slice(marker.start, marker.end);
+				const markerText = text$1.slice(marker.start, marker.end);
 				result.push({
 					segment: markerText,
 					index: marker.start,
-					input: text
+					input: text$1
 				});
 			}
 		} else result.push(seg);
@@ -4595,8 +4595,8 @@ var Editor = class {
 		return new Set(this.pastes.keys());
 	}
 	/** Segment text with paste-marker awareness, only merging markers with valid IDs. */
-	segment(text) {
-		return segmentWithMarkers(text, this.validPasteIds());
+	segment(text$1) {
+		return segmentWithMarkers(text$1, this.validPasteIds());
 	}
 	getPaddingX() {
 		return this.paddingX;
@@ -4626,8 +4626,8 @@ var Editor = class {
 	* Add a prompt to history for up/down arrow navigation.
 	* Called after successful submission.
 	*/
-	addToHistory(text) {
-		const trimmed = text.trim();
+	addToHistory(text$1) {
+		const trimmed = text$1.trim();
 		if (!trimmed) return;
 		if (this.history.length > 0 && this.history[0] === trimmed) return;
 		this.history.unshift(trimmed);
@@ -4655,8 +4655,8 @@ var Editor = class {
 		else this.setTextInternal(this.history[this.historyIndex] || "");
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
-	setTextInternal(text) {
-		const lines = text.split("\n");
+	setTextInternal(text$1) {
+		const lines = text$1.split("\n");
 		this.state.lines = lines.length === 0 ? [""] : lines;
 		this.state.cursorLine = this.state.lines.length - 1;
 		this.setCursorCol(this.state.lines[this.state.cursorLine]?.length || 0);
@@ -4989,8 +4989,8 @@ var Editor = class {
 	getText() {
 		return this.state.lines.join("\n");
 	}
-	expandPasteMarkers(text) {
-		let result = text;
+	expandPasteMarkers(text$1) {
+		let result = text$1;
 		for (const [pasteId, pasteContent] of this.pastes) {
 			const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+\\d+ lines|\\d+ chars))?\\]`, "g");
 			result = result.replace(markerRegex, () => pasteContent);
@@ -5013,11 +5013,11 @@ var Editor = class {
 			col: this.state.cursorCol
 		};
 	}
-	setText(text) {
+	setText(text$1) {
 		this.cancelAutocomplete();
 		this.lastAction = null;
 		this.historyIndex = -1;
-		const normalized = this.normalizeText(text);
+		const normalized = this.normalizeText(text$1);
 		if (this.getText() !== normalized) this.pushUndoSnapshot();
 		this.setTextInternal(normalized);
 	}
@@ -5026,30 +5026,30 @@ var Editor = class {
 	* Used for programmatic insertion (e.g., clipboard image markers).
 	* This is atomic for undo - single undo restores entire pre-insert state.
 	*/
-	insertTextAtCursor(text) {
-		if (!text) return;
+	insertTextAtCursor(text$1) {
+		if (!text$1) return;
 		this.cancelAutocomplete();
 		this.pushUndoSnapshot();
 		this.lastAction = null;
 		this.historyIndex = -1;
-		this.insertTextAtCursorInternal(text);
+		this.insertTextAtCursorInternal(text$1);
 	}
 	/**
 	* Normalize text for editor storage:
 	* - Normalize line endings (\r\n and \r -> \n)
 	* - Expand tabs to 4 spaces
 	*/
-	normalizeText(text) {
-		return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\t/g, "    ");
+	normalizeText(text$1) {
+		return text$1.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\t/g, "    ");
 	}
 	/**
 	* Internal text insertion at cursor. Handles single and multi-line text.
 	* Does not push undo snapshots or trigger autocomplete - caller is responsible.
 	* Normalizes line endings and calls onChange once at the end.
 	*/
-	insertTextAtCursorInternal(text) {
-		if (!text) return;
-		const normalized = this.normalizeText(text);
+	insertTextAtCursorInternal(text$1) {
+		if (!text$1) return;
+		const normalized = this.normalizeText(text$1);
 		const insertedLines = normalized.split("\n");
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.state.cursorCol);
@@ -5569,8 +5569,8 @@ var Editor = class {
 	yank() {
 		if (this.killRing.length === 0) return;
 		this.pushUndoSnapshot();
-		const text = this.killRing.peek();
-		this.insertYankedText(text);
+		const text$1 = this.killRing.peek();
+		this.insertYankedText(text$1);
 		this.lastAction = "yank";
 	}
 	/**
@@ -5582,22 +5582,22 @@ var Editor = class {
 		this.pushUndoSnapshot();
 		this.deleteYankedText();
 		this.killRing.rotate();
-		const text = this.killRing.peek();
-		this.insertYankedText(text);
+		const text$1 = this.killRing.peek();
+		this.insertYankedText(text$1);
 		this.lastAction = "yank";
 	}
 	/**
 	* Insert text at cursor position (used by yank operations).
 	*/
-	insertYankedText(text) {
+	insertYankedText(text$1) {
 		this.historyIndex = -1;
-		const lines = text.split("\n");
+		const lines = text$1.split("\n");
 		if (lines.length === 1) {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const before = currentLine.slice(0, this.state.cursorCol);
 			const after = currentLine.slice(this.state.cursorCol);
-			this.state.lines[this.state.cursorLine] = before + text + after;
-			this.setCursorCol(this.state.cursorCol + text.length);
+			this.state.lines[this.state.cursorLine] = before + text$1 + after;
+			this.setCursorCol(this.state.cursorCol + text$1.length);
 		} else {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const before = currentLine.slice(0, this.state.cursorCol);
@@ -6152,11 +6152,11 @@ var Input = class {
 		this.value = this.value.slice(0, this.cursor) + this.value.slice(deleteTo);
 	}
 	yank() {
-		const text = this.killRing.peek();
-		if (!text) return;
+		const text$1 = this.killRing.peek();
+		if (!text$1) return;
 		this.pushUndo();
-		this.value = this.value.slice(0, this.cursor) + text + this.value.slice(this.cursor);
-		this.cursor += text.length;
+		this.value = this.value.slice(0, this.cursor) + text$1 + this.value.slice(this.cursor);
+		this.cursor += text$1.length;
 		this.lastAction = "yank";
 	}
 	yankPop() {
@@ -6166,9 +6166,9 @@ var Input = class {
 		this.value = this.value.slice(0, this.cursor - prevText.length) + this.value.slice(this.cursor);
 		this.cursor -= prevText.length;
 		this.killRing.rotate();
-		const text = this.killRing.peek() || "";
-		this.value = this.value.slice(0, this.cursor) + text + this.value.slice(this.cursor);
-		this.cursor += text.length;
+		const text$1 = this.killRing.peek() || "";
+		this.value = this.value.slice(0, this.cursor) + text$1 + this.value.slice(this.cursor);
+		this.cursor += text$1.length;
 		this.lastAction = "yank";
 	}
 	pushUndo() {
@@ -6555,24 +6555,24 @@ function findClosingBracket(str, b) {
 function outputLink(cap, link2, raw, lexer2, rules) {
 	const href = link2.href;
 	const title = link2.title || null;
-	const text = cap[1].replace(rules.other.outputLinkReplace, "$1");
+	const text$1 = cap[1].replace(rules.other.outputLinkReplace, "$1");
 	lexer2.state.inLink = true;
 	const token = {
 		type: cap[0].charAt(0) === "!" ? "image" : "link",
 		raw,
 		href,
 		title,
-		text,
-		tokens: lexer2.inlineTokens(text)
+		text: text$1,
+		tokens: lexer2.inlineTokens(text$1)
 	};
 	lexer2.state.inLink = false;
 	return token;
 }
-function indentCodeCompensation(raw, text, rules) {
+function indentCodeCompensation(raw, text$1, rules) {
 	const matchIndentToCode = raw.match(rules.other.indentCodeCompensation);
-	if (matchIndentToCode === null) return text;
+	if (matchIndentToCode === null) return text$1;
 	const indentToCode = matchIndentToCode[1];
-	return text.split("\n").map((node) => {
+	return text$1.split("\n").map((node) => {
 		const matchIndentInNode = node.match(rules.other.beginningSpace);
 		if (matchIndentInNode === null) return node;
 		const [indentInNode] = matchIndentInNode;
@@ -6597,12 +6597,12 @@ var _Tokenizer = class {
 	code(src) {
 		const cap = this.rules.block.code.exec(src);
 		if (cap) {
-			const text = cap[0].replace(this.rules.other.codeRemoveIndent, "");
+			const text$1 = cap[0].replace(this.rules.other.codeRemoveIndent, "");
 			return {
 				type: "code",
 				raw: cap[0],
 				codeBlockStyle: "indented",
-				text: !this.options.pedantic ? rtrim(text, "\n") : text
+				text: !this.options.pedantic ? rtrim(text$1, "\n") : text$1
 			};
 		}
 	}
@@ -6610,30 +6610,30 @@ var _Tokenizer = class {
 		const cap = this.rules.block.fences.exec(src);
 		if (cap) {
 			const raw = cap[0];
-			const text = indentCodeCompensation(raw, cap[3] || "", this.rules);
+			const text$1 = indentCodeCompensation(raw, cap[3] || "", this.rules);
 			return {
 				type: "code",
 				raw,
 				lang: cap[2] ? cap[2].trim().replace(this.rules.inline.anyPunctuation, "$1") : cap[2],
-				text
+				text: text$1
 			};
 		}
 	}
 	heading(src) {
 		const cap = this.rules.block.heading.exec(src);
 		if (cap) {
-			let text = cap[2].trim();
-			if (this.rules.other.endingHash.test(text)) {
-				const trimmed = rtrim(text, "#");
-				if (this.options.pedantic) text = trimmed.trim();
-				else if (!trimmed || this.rules.other.endingSpaceChar.test(trimmed)) text = trimmed.trim();
+			let text$1 = cap[2].trim();
+			if (this.rules.other.endingHash.test(text$1)) {
+				const trimmed = rtrim(text$1, "#");
+				if (this.options.pedantic) text$1 = trimmed.trim();
+				else if (!trimmed || this.rules.other.endingSpaceChar.test(trimmed)) text$1 = trimmed.trim();
 			}
 			return {
 				type: "heading",
 				raw: cap[0],
 				depth: cap[1].length,
-				text,
-				tokens: this.lexer.inline(text)
+				text: text$1,
+				tokens: this.lexer.inline(text$1)
 			};
 		}
 	}
@@ -6649,7 +6649,7 @@ var _Tokenizer = class {
 		if (cap) {
 			let lines = rtrim(cap[0], "\n").split("\n");
 			let raw = "";
-			let text = "";
+			let text$1 = "";
 			const tokens = [];
 			while (lines.length > 0) {
 				let inBlockquote = false;
@@ -6665,7 +6665,7 @@ var _Tokenizer = class {
 				const currentText = currentRaw.replace(this.rules.other.blockquoteSetextReplace, "\n    $1").replace(this.rules.other.blockquoteSetextReplace2, "");
 				raw = raw ? `${raw}
 ${currentRaw}` : currentRaw;
-				text = text ? `${text}
+				text$1 = text$1 ? `${text$1}
 ${currentText}` : currentText;
 				const top = this.lexer.state.top;
 				this.lexer.state.top = true;
@@ -6680,7 +6680,7 @@ ${currentText}` : currentText;
 					const newToken = this.blockquote(newText);
 					tokens[tokens.length - 1] = newToken;
 					raw = raw.substring(0, raw.length - oldToken.raw.length) + newToken.raw;
-					text = text.substring(0, text.length - oldToken.text.length) + newToken.text;
+					text$1 = text$1.substring(0, text$1.length - oldToken.text.length) + newToken.text;
 					break;
 				} else if (lastToken?.type === "list") {
 					const oldToken = lastToken;
@@ -6688,7 +6688,7 @@ ${currentText}` : currentText;
 					const newToken = this.list(newText);
 					tokens[tokens.length - 1] = newToken;
 					raw = raw.substring(0, raw.length - lastToken.raw.length) + newToken.raw;
-					text = text.substring(0, text.length - oldToken.raw.length) + newToken.raw;
+					text$1 = text$1.substring(0, text$1.length - oldToken.raw.length) + newToken.raw;
 					lines = newText.substring(tokens.at(-1).raw.length).split("\n");
 					continue;
 				}
@@ -6697,7 +6697,7 @@ ${currentText}` : currentText;
 				type: "blockquote",
 				raw,
 				tokens,
-				text
+				text: text$1
 			};
 		}
 	}
@@ -6894,12 +6894,12 @@ ${currentText}` : currentText;
 	paragraph(src) {
 		const cap = this.rules.block.paragraph.exec(src);
 		if (cap) {
-			const text = cap[1].charAt(cap[1].length - 1) === "\n" ? cap[1].slice(0, -1) : cap[1];
+			const text$1 = cap[1].charAt(cap[1].length - 1) === "\n" ? cap[1].slice(0, -1) : cap[1];
 			return {
 				type: "paragraph",
 				raw: cap[0],
-				text,
-				tokens: this.lexer.inline(text)
+				text: text$1,
+				tokens: this.lexer.inline(text$1)
 			};
 		}
 	}
@@ -6978,11 +6978,11 @@ ${currentText}` : currentText;
 		if ((cap = this.rules.inline.reflink.exec(src)) || (cap = this.rules.inline.nolink.exec(src))) {
 			const link2 = links[(cap[2] || cap[1]).replace(this.rules.other.multipleSpaceGlobal, " ").toLowerCase()];
 			if (!link2) {
-				const text = cap[0].charAt(0);
+				const text$1 = cap[0].charAt(0);
 				return {
 					type: "text",
-					raw: text,
-					text
+					raw: text$1,
+					text: text$1
 				};
 			}
 			return outputLink(cap, link2, cap[0], this.lexer, this.rules);
@@ -7025,12 +7025,12 @@ ${currentText}` : currentText;
 						tokens: this.lexer.inlineTokens(text2)
 					};
 				}
-				const text = raw.slice(2, -2);
+				const text$1 = raw.slice(2, -2);
 				return {
 					type: "strong",
 					raw,
-					text,
-					tokens: this.lexer.inlineTokens(text)
+					text: text$1,
+					tokens: this.lexer.inlineTokens(text$1)
 				};
 			}
 		}
@@ -7038,14 +7038,14 @@ ${currentText}` : currentText;
 	codespan(src) {
 		const cap = this.rules.inline.code.exec(src);
 		if (cap) {
-			let text = cap[2].replace(this.rules.other.newLineCharGlobal, " ");
-			const hasNonSpaceChars = this.rules.other.nonSpaceChar.test(text);
-			const hasSpaceCharsOnBothEnds = this.rules.other.startingSpaceChar.test(text) && this.rules.other.endingSpaceChar.test(text);
-			if (hasNonSpaceChars && hasSpaceCharsOnBothEnds) text = text.substring(1, text.length - 1);
+			let text$1 = cap[2].replace(this.rules.other.newLineCharGlobal, " ");
+			const hasNonSpaceChars = this.rules.other.nonSpaceChar.test(text$1);
+			const hasSpaceCharsOnBothEnds = this.rules.other.startingSpaceChar.test(text$1) && this.rules.other.endingSpaceChar.test(text$1);
+			if (hasNonSpaceChars && hasSpaceCharsOnBothEnds) text$1 = text$1.substring(1, text$1.length - 1);
 			return {
 				type: "codespan",
 				raw: cap[0],
-				text
+				text: text$1
 			};
 		}
 	}
@@ -7068,23 +7068,23 @@ ${currentText}` : currentText;
 	autolink(src) {
 		const cap = this.rules.inline.autolink.exec(src);
 		if (cap) {
-			let text, href;
+			let text$1, href;
 			if (cap[2] === "@") {
-				text = cap[1];
-				href = "mailto:" + text;
+				text$1 = cap[1];
+				href = "mailto:" + text$1;
 			} else {
-				text = cap[1];
-				href = text;
+				text$1 = cap[1];
+				href = text$1;
 			}
 			return {
 				type: "link",
 				raw: cap[0],
-				text,
+				text: text$1,
 				href,
 				tokens: [{
 					type: "text",
-					raw: text,
-					text
+					raw: text$1,
+					text: text$1
 				}]
 			};
 		}
@@ -7092,29 +7092,29 @@ ${currentText}` : currentText;
 	url(src) {
 		let cap;
 		if (cap = this.rules.inline.url.exec(src)) {
-			let text, href;
+			let text$1, href;
 			if (cap[2] === "@") {
-				text = cap[0];
-				href = "mailto:" + text;
+				text$1 = cap[0];
+				href = "mailto:" + text$1;
 			} else {
 				let prevCapZero;
 				do {
 					prevCapZero = cap[0];
 					cap[0] = this.rules.inline._backpedal.exec(cap[0])?.[0] ?? "";
 				} while (prevCapZero !== cap[0]);
-				text = cap[0];
+				text$1 = cap[0];
 				if (cap[1] === "www.") href = "http://" + cap[0];
 				else href = cap[0];
 			}
 			return {
 				type: "link",
 				raw: cap[0],
-				text,
+				text: text$1,
 				href,
 				tokens: [{
 					type: "text",
-					raw: text,
-					text
+					raw: text$1,
+					text: text$1
 				}]
 			};
 		}
@@ -7459,9 +7459,9 @@ var _Renderer = class {
 	space(token) {
 		return "";
 	}
-	code({ text, lang, escaped }) {
+	code({ text: text$1, lang, escaped }) {
 		const langString = (lang || "").match(other.notSpaceStart)?.[0];
-		const code = text.replace(other.endingNewline, "") + "\n";
+		const code = text$1.replace(other.endingNewline, "") + "\n";
 		if (!langString) return "<pre><code>" + (escaped ? code : escape2(code, true)) + "</code></pre>\n";
 		return "<pre><code class=\"language-" + escape2(langString) + "\">" + (escaped ? code : escape2(code, true)) + "</code></pre>\n";
 	}
@@ -7470,8 +7470,8 @@ var _Renderer = class {
 ${this.parser.parse(tokens)}</blockquote>
 `;
 	}
-	html({ text }) {
-		return text;
+	html({ text: text$1 }) {
+		return text$1;
 	}
 	heading({ tokens, depth }) {
 		return `<h${depth}>${this.parser.parseInline(tokens)}</h${depth}>
@@ -7536,9 +7536,9 @@ ${this.parser.parse(tokens)}</blockquote>
 		if (body) body = `<tbody>${body}</tbody>`;
 		return "<table>\n<thead>\n" + header + "</thead>\n" + body + "</table>\n";
 	}
-	tablerow({ text }) {
+	tablerow({ text: text$1 }) {
 		return `<tr>
-${text}</tr>
+${text$1}</tr>
 `;
 	}
 	tablecell(token) {
@@ -7556,8 +7556,8 @@ ${text}</tr>
 	em({ tokens }) {
 		return `<em>${this.parser.parseInline(tokens)}</em>`;
 	}
-	codespan({ text }) {
-		return `<code>${escape2(text, true)}</code>`;
+	codespan({ text: text$1 }) {
+		return `<code>${escape2(text$1, true)}</code>`;
 	}
 	br(token) {
 		return "<br>";
@@ -7566,21 +7566,21 @@ ${text}</tr>
 		return `<del>${this.parser.parseInline(tokens)}</del>`;
 	}
 	link({ href, title, tokens }) {
-		const text = this.parser.parseInline(tokens);
+		const text$1 = this.parser.parseInline(tokens);
 		const cleanHref = cleanUrl(href);
-		if (cleanHref === null) return text;
+		if (cleanHref === null) return text$1;
 		href = cleanHref;
 		let out = "<a href=\"" + href + "\"";
 		if (title) out += " title=\"" + escape2(title) + "\"";
-		out += ">" + text + "</a>";
+		out += ">" + text$1 + "</a>";
 		return out;
 	}
-	image({ href, title, text, tokens }) {
-		if (tokens) text = this.parser.parseInline(tokens, this.parser.textRenderer);
+	image({ href, title, text: text$1, tokens }) {
+		if (tokens) text$1 = this.parser.parseInline(tokens, this.parser.textRenderer);
 		const cleanHref = cleanUrl(href);
-		if (cleanHref === null) return escape2(text);
+		if (cleanHref === null) return escape2(text$1);
 		href = cleanHref;
-		let out = `<img src="${href}" alt="${text}"`;
+		let out = `<img src="${href}" alt="${text$1}"`;
 		if (title) out += ` title="${escape2(title)}"`;
 		out += ">";
 		return out;
@@ -7590,29 +7590,29 @@ ${text}</tr>
 	}
 };
 var _TextRenderer = class {
-	strong({ text }) {
-		return text;
+	strong({ text: text$1 }) {
+		return text$1;
 	}
-	em({ text }) {
-		return text;
+	em({ text: text$1 }) {
+		return text$1;
 	}
-	codespan({ text }) {
-		return text;
+	codespan({ text: text$1 }) {
+		return text$1;
 	}
-	del({ text }) {
-		return text;
+	del({ text: text$1 }) {
+		return text$1;
 	}
-	html({ text }) {
-		return text;
+	html({ text: text$1 }) {
+		return text$1;
 	}
-	text({ text }) {
-		return text;
+	text({ text: text$1 }) {
+		return text$1;
 	}
-	link({ text }) {
-		return "" + text;
+	link({ text: text$1 }) {
+		return "" + text$1;
 	}
-	image({ text }) {
-		return "" + text;
+	image({ text: text$1 }) {
+		return "" + text$1;
 	}
 	br() {
 		return "";
@@ -8101,12 +8101,12 @@ var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
 		const match = STRICT_STRIKETHROUGH_REGEX.exec(src);
 		if (!match) return;
-		const text = match[2];
+		const text$1 = match[2];
 		return {
 			type: "del",
 			raw: match[0],
-			text,
-			tokens: this.lexer.inlineTokens(text)
+			text: text$1,
+			tokens: this.lexer.inlineTokens(text$1)
 		};
 	}
 };
@@ -8122,15 +8122,15 @@ var Markdown = class {
 	cachedText;
 	cachedWidth;
 	cachedLines;
-	constructor(text, paddingX, paddingY, theme, defaultTextStyle) {
-		this.text = text;
+	constructor(text$1, paddingX, paddingY, theme, defaultTextStyle) {
+		this.text = text$1;
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.theme = theme;
 		this.defaultTextStyle = defaultTextStyle;
 	}
-	setText(text) {
-		this.text = text;
+	setText(text$1) {
+		this.text = text$1;
 		this.invalidate();
 	}
 	invalidate() {
@@ -8199,9 +8199,9 @@ var Markdown = class {
 	* NOTE: Background color is NOT applied here - it's applied at the padding stage
 	* to ensure it extends to the full line width.
 	*/
-	applyDefaultStyle(text) {
-		if (!this.defaultTextStyle) return text;
-		let styled = text;
+	applyDefaultStyle(text$1) {
+		if (!this.defaultTextStyle) return text$1;
+		let styled = text$1;
 		if (this.defaultTextStyle.color) styled = this.defaultTextStyle.color(styled);
 		if (this.defaultTextStyle.bold) styled = this.theme.bold(styled);
 		if (this.defaultTextStyle.italic) styled = this.theme.italic(styled);
@@ -8231,7 +8231,7 @@ var Markdown = class {
 	}
 	getDefaultInlineStyleContext() {
 		return {
-			applyText: (text) => this.applyDefaultStyle(text),
+			applyText: (text$1) => this.applyDefaultStyle(text$1),
 			stylePrefix: this.getDefaultStylePrefix()
 		};
 	}
@@ -8242,8 +8242,8 @@ var Markdown = class {
 				const headingLevel = token.depth;
 				const headingPrefix = `${"#".repeat(headingLevel)} `;
 				let headingStyleFn;
-				if (headingLevel === 1) headingStyleFn = (text) => this.theme.heading(this.theme.bold(this.theme.underline(text)));
-				else headingStyleFn = (text) => this.theme.heading(this.theme.bold(text));
+				if (headingLevel === 1) headingStyleFn = (text$1) => this.theme.heading(this.theme.bold(this.theme.underline(text$1)));
+				else headingStyleFn = (text$1) => this.theme.heading(this.theme.bold(text$1));
 				const headingStyleContext = {
 					applyText: headingStyleFn,
 					stylePrefix: this.getStylePrefix(headingStyleFn)
@@ -8296,7 +8296,7 @@ var Markdown = class {
 				break;
 			}
 			case "blockquote": {
-				const quoteStyle = (text) => this.theme.quote(this.theme.italic(text));
+				const quoteStyle = (text$1) => this.theme.quote(this.theme.italic(text$1));
 				const quoteStylePrefix = this.getStylePrefix(quoteStyle);
 				const applyQuoteStyle = (line) => {
 					if (!quoteStylePrefix) return quoteStyle(line);
@@ -8304,7 +8304,7 @@ var Markdown = class {
 				};
 				const quoteContentWidth = Math.max(1, width - 2);
 				const quoteInlineStyleContext = {
-					applyText: (text) => text,
+					applyText: (text$1) => text$1,
 					stylePrefix: quoteStylePrefix
 				};
 				const quoteTokens = token.tokens || [];
@@ -8340,8 +8340,8 @@ var Markdown = class {
 		let result = "";
 		const resolvedStyleContext = styleContext ?? this.getDefaultInlineStyleContext();
 		const { applyText, stylePrefix } = resolvedStyleContext;
-		const applyTextWithNewlines = (text) => {
-			return text.split("\n").map((segment) => applyText(segment)).join("\n");
+		const applyTextWithNewlines = (text$1) => {
+			return text$1.split("\n").map((segment) => applyText(segment)).join("\n");
 		};
 		for (const token of tokens) switch (token.type) {
 			case "text":
@@ -8426,11 +8426,11 @@ var Markdown = class {
 			const nestedLines = this.renderList(token, parentDepth + 1, styleContext, width);
 			lines.push(...nestedLines);
 		} else if (token.type === "text") {
-			const text = token.tokens && token.tokens.length > 0 ? this.renderInlineTokens(token.tokens, styleContext) : token.text || "";
-			lines.push(text);
+			const text$1 = token.tokens && token.tokens.length > 0 ? this.renderInlineTokens(token.tokens, styleContext) : token.text || "";
+			lines.push(text$1);
 		} else if (token.type === "paragraph") {
-			const text = this.renderInlineTokens(token.tokens || [], styleContext);
-			lines.push(text);
+			const text$1 = this.renderInlineTokens(token.tokens || [], styleContext);
+			lines.push(text$1);
 		} else if (token.type === "code") {
 			const indent = this.theme.codeBlockIndent ?? "  ";
 			const codeWidth = Math.max(1, contentWidth - visibleWidth(indent));
@@ -8454,16 +8454,16 @@ var Markdown = class {
 				}
 			}
 		} else {
-			const text = this.renderInlineTokens([token], styleContext);
-			if (text) lines.push(text);
+			const text$1 = this.renderInlineTokens([token], styleContext);
+			if (text$1) lines.push(text$1);
 		}
 		return lines;
 	}
 	/**
 	* Get the visible width of the longest word in a string.
 	*/
-	getLongestWordWidth(text, maxWidth) {
-		const words = text.split(/\s+/).filter((word) => word.length > 0);
+	getLongestWordWidth(text$1, maxWidth) {
+		const words = text$1.split(/\s+/).filter((word) => word.length > 0);
 		let longest = 0;
 		for (const word of words) longest = Math.max(longest, visibleWidth(word));
 		if (maxWidth === void 0) return longest;
@@ -8475,8 +8475,8 @@ var Markdown = class {
 	* Delegates to wrapTextWithAnsi() so ANSI codes + long tokens are handled
 	* consistently with the rest of the renderer.
 	*/
-	wrapCellText(text, maxWidth) {
-		return wrapTextWithAnsi(text, Math.max(1, maxWidth));
+	wrapCellText(text$1, maxWidth) {
+		return wrapTextWithAnsi(text$1, Math.max(1, maxWidth));
 	}
 	/**
 	* Render a table with width-aware cell wrapping.
@@ -8555,14 +8555,14 @@ var Markdown = class {
 		const topBorderCells = columnWidths.map((w) => "─".repeat(w));
 		lines.push(`┌─${topBorderCells.join("─┬─")}─┐`);
 		const headerCellLines = token.header.map((cell, i) => {
-			const text = this.renderInlineTokens(cell.tokens || [], styleContext);
-			return this.wrapCellText(text, columnWidths[i]);
+			const text$1 = this.renderInlineTokens(cell.tokens || [], styleContext);
+			return this.wrapCellText(text$1, columnWidths[i]);
 		});
 		const headerLineCount = Math.max(...headerCellLines.map((c) => c.length));
 		for (let lineIdx = 0; lineIdx < headerLineCount; lineIdx++) {
 			const rowParts = headerCellLines.map((cellLines, colIdx) => {
-				const text = cellLines[lineIdx] || "";
-				const padded$1 = text + " ".repeat(Math.max(0, columnWidths[colIdx] - visibleWidth(text)));
+				const text$1 = cellLines[lineIdx] || "";
+				const padded$1 = text$1 + " ".repeat(Math.max(0, columnWidths[colIdx] - visibleWidth(text$1)));
 				return this.theme.bold(padded$1);
 			});
 			lines.push(`│ ${rowParts.join(" │ ")} │`);
@@ -8571,14 +8571,14 @@ var Markdown = class {
 		lines.push(separatorLine);
 		for (let rowIndex = 0; rowIndex < token.rows.length; rowIndex++) {
 			const rowCellLines = token.rows[rowIndex].map((cell, i) => {
-				const text = this.renderInlineTokens(cell.tokens || [], styleContext);
-				return this.wrapCellText(text, columnWidths[i]);
+				const text$1 = this.renderInlineTokens(cell.tokens || [], styleContext);
+				return this.wrapCellText(text$1, columnWidths[i]);
 			});
 			const rowLineCount = Math.max(...rowCellLines.map((c) => c.length));
 			for (let lineIdx = 0; lineIdx < rowLineCount; lineIdx++) {
 				const rowParts = rowCellLines.map((cellLines, colIdx) => {
-					const text = cellLines[lineIdx] || "";
-					return text + " ".repeat(Math.max(0, columnWidths[colIdx] - visibleWidth(text)));
+					const text$1 = cellLines[lineIdx] || "";
+					return text$1 + " ".repeat(Math.max(0, columnWidths[colIdx] - visibleWidth(text$1)));
 				});
 				lines.push(`│ ${rowParts.join(" │ ")} │`);
 			}
@@ -9824,11 +9824,11 @@ const READ_SAMPLE_SOURCE = [
 	"// A windowed read keeps the file line numbers in the gutter.",
 	"const marker = \"fixture read sample\""
 ];
-const READ_SAMPLE_LINES = READ_SAMPLE_SOURCE.map((text, index) => ({
+const READ_SAMPLE_LINES = READ_SAMPLE_SOURCE.map((text$1, index) => ({
 	number: READ_SAMPLE_FIRST_LINE + index,
-	text
+	text: text$1
 }));
-const READ_SAMPLE_TEXT = READ_SAMPLE_SOURCE.map((text, index) => `${READ_SAMPLE_FIRST_LINE + index}: ${text}`).join("\n");
+const READ_SAMPLE_TEXT = READ_SAMPLE_SOURCE.map((text$1, index) => `${READ_SAMPLE_FIRST_LINE + index}: ${text$1}`).join("\n");
 
 //#endregion
 //#region vendor/client-connection/api-path.js
@@ -16513,8 +16513,8 @@ function compactSummary(match, checkpoint) {
 	if (match?.event.type === "compaction/summary") {
 		const data = match.event.data;
 		if (Array.isArray(data.summary)) {
-			const text = data.summary.map((block$1) => block$1.type === "text" ? block$1.text : "").join("");
-			summary = text.trim() === "" ? null : text;
+			const text$1 = data.summary.map((block$1) => block$1.type === "text" ? block$1.text : "").join("");
+			summary = text$1.trim() === "" ? null : text$1;
 		}
 		shadowedItemCount = Array.isArray(data.shadowedSeqs) && data.shadowedSeqs.every((seq) => Number.isSafeInteger(seq) && seq >= 0) ? data.shadowedSeqs.length : null;
 		shadowedTokenCount = Number.isSafeInteger(data.shadowedTokenCount) && data.shadowedTokenCount >= 0 ? data.shadowedTokenCount : null;
@@ -19529,11 +19529,11 @@ const FENCE = /^```[^\n]*\n([\s\S]*?)^```/mu;
 * @param text - complete assistant text.
 * @returns the block body without fences, or undefined when none exist.
 */
-function lastFencedCode(text) {
+function lastFencedCode(text$1) {
 	let match;
 	let last;
 	const pattern = new RegExp(FENCE.source, "gmu");
-	while ((match = pattern.exec(text)) !== null) last = match[1]?.replace(/\n$/u, "");
+	while ((match = pattern.exec(text$1)) !== null) last = match[1]?.replace(/\n$/u, "");
 	return last === void 0 || last.trim() === "" ? void 0 : last;
 }
 /**
@@ -19543,12 +19543,12 @@ function lastFencedCode(text) {
 */
 function copyTargets(entries) {
 	return [...entries].reverse().flatMap((entry) => {
-		const text = entry.text.trim();
-		if (text === "") return [];
+		const text$1 = entry.text.trim();
+		if (text$1 === "") return [];
 		return [{
 			id: entry.id,
-			preview: text.replace(/\s+/gu, " ").slice(0, 160),
-			text
+			preview: text$1.replace(/\s+/gu, " ").slice(0, 160),
+			text: text$1
 		}];
 	});
 }
@@ -19564,9 +19564,9 @@ function contentBlockText$1(block$1) {
 	return `[${typeof value.type === "string" ? value.type : "content"}]`;
 }
 function userSection(heading$1, content) {
-	const text = content.map(contentBlockText$1).join("\n").trim();
-	if (text === "") return void 0;
-	return `## ${heading$1}\n\n${text}`;
+	const text$1 = content.map(contentBlockText$1).join("\n").trim();
+	if (text$1 === "") return void 0;
+	return `## ${heading$1}\n\n${text$1}`;
 }
 function assistantSection(node) {
 	const parts = [];
@@ -20023,13 +20023,13 @@ async function saveExport(path$1, stream) {
 		if (!complete) await unlink(path$1).catch(() => void 0);
 	}
 }
-async function saveTextExport(path$1, text) {
+async function saveTextExport(path$1, text$1) {
 	await mkdir(dirname(path$1), { recursive: true });
 	const file = await open(path$1, "wx");
 	let complete = false;
 	try {
-		const bytes = Buffer.byteLength(text, "utf8");
-		await file.write(Buffer.from(text, "utf8"));
+		const bytes = Buffer.byteLength(text$1, "utf8");
+		await file.write(Buffer.from(text$1, "utf8"));
 		await file.sync();
 		complete = true;
 		return bytes;
@@ -20407,8 +20407,8 @@ var HarnessTuiCapabilities = class {
 	* TUI decorator supplies terminal-native input and message-rating choices.
 	* @param text - human-authored session feedback.
 	*/
-	async recordSessionFeedback(text) {
-		const normalized = text.trim();
+	async recordSessionFeedback(text$1) {
+		const normalized = text$1.trim();
 		if (normalized === "") throw new Error("会话反馈不能为空");
 		const result = await this.requireActive().session.command(`/feedback ${normalized}`);
 		if (!result.ok) throw new Error(`提交会话反馈失败：${result.error.message}`);
@@ -20613,10 +20613,10 @@ var HarnessTuiCapabilities = class {
 	* @param text - current editor text.
 	* @returns the official multimodal prompt content array.
 	*/
-	promptContent(text) {
-		return [...text === "" ? [] : [{
+	promptContent(text$1) {
+		return [...text$1 === "" ? [] : [{
 			type: "text",
-			text
+			text: text$1
 		}], ...this.attachments.map((item) => ({
 			type: "image",
 			mediaType: item.mediaType,
@@ -20842,11 +20842,11 @@ var HarnessTuiCapabilities = class {
 		const feedback = new Map(items.map((item) => [item.messageId, item]));
 		return active.session.getSnapshot().nodes.flatMap((node) => {
 			if (node.kind !== "assistant" || node.messageId === void 0) return [];
-			const text = assistantText(node);
+			const text$1 = assistantText(node);
 			const item = feedback.get(node.messageId);
 			return [{
 				message: node,
-				preview: text.replace(/\s+/gu, " ").slice(0, 160) || "[无文本回复]",
+				preview: text$1.replace(/\s+/gu, " ").slice(0, 160) || "[无文本回复]",
 				...item === void 0 ? {} : { feedback: item }
 			}];
 		}).reverse();
@@ -20892,8 +20892,8 @@ var HarnessTuiCapabilities = class {
 	lastAssistantText() {
 		const node = this.requireActive().session.getSnapshot().nodes.findLast((candidate) => candidate.kind === "assistant");
 		if (node?.kind !== "assistant") return void 0;
-		const text = assistantText(node);
-		return text === "" ? void 0 : text;
+		const text$1 = assistantText(node);
+		return text$1 === "" ? void 0 : text$1;
 	}
 	/**
 	* Read every loaded Assistant reply as copy-picker rows, newest first.
@@ -20902,10 +20902,10 @@ var HarnessTuiCapabilities = class {
 	assistantCopyTargets() {
 		return copyTargets(this.requireActive().session.getSnapshot().nodes.flatMap((node) => {
 			if (node.kind !== "assistant") return [];
-			const text = assistantText(node);
-			return text === "" ? [] : [{
+			const text$1 = assistantText(node);
+			return text$1 === "" ? [] : [{
 				id: String(node.seq),
-				text
+				text: text$1
 			}];
 		}));
 	}
@@ -21610,26 +21610,26 @@ function generatedSyntax(background$1, foreground, muted, accents) {
 function candidateTheme(id, name$1, colors, tone) {
 	const ordered = [...colors].sort((left, right) => luminance(left) - luminance(right));
 	const canvas = tone === "dark" ? ordered[0] ?? "#000000" : ordered.at(-1) ?? "#FFFFFF";
-	const text = ensureContrast(ordered.filter((color$1) => color$1 !== canvas).sort((left, right) => themeContrast(right, canvas) - themeContrast(left, canvas))[0] ?? (tone === "dark" ? "#FFFFFF" : "#000000"), canvas, 4.5);
-	const accents = accentColors(colors, canvas, text);
-	const brand = accents[0] ?? text;
+	const text$1 = ensureContrast(ordered.filter((color$1) => color$1 !== canvas).sort((left, right) => themeContrast(right, canvas) - themeContrast(left, canvas))[0] ?? (tone === "dark" ? "#FFFFFF" : "#000000"), canvas, 4.5);
+	const accents = accentColors(colors, canvas, text$1);
+	const brand = accents[0] ?? text$1;
 	const brandHue = oklchOf(brand).hue;
 	const accent = accents.find((color$1) => hueDistance(oklchOf(color$1).hue, brandHue) >= 35) ?? accents[1] ?? brand;
-	const surface = mix(canvas, text, tone === "dark" ? .075 : .045);
+	const surface = mix(canvas, text$1, tone === "dark" ? .075 : .045);
 	const selection = mix(canvas, brand, tone === "dark" ? .28 : .18);
-	const muted = ensureContrast(mix(text, canvas, .42), canvas, 3);
-	const border = ensureContrast(mix(text, canvas, .68), canvas, 1.5);
+	const muted = ensureContrast(mix(text$1, canvas, .42), canvas, 3);
+	const border = ensureContrast(mix(text$1, canvas, .68), canvas, 1.5);
 	const success = statusColor(colors, 150, "#2FBF8F", canvas);
 	const warning = statusColor(colors, 75, "#D99B3D", canvas);
 	const danger = statusColor(colors, 20, "#E66476", canvas);
-	const syntaxAccents = accentColors(colors, surface, text);
+	const syntaxAccents = accentColors(colors, surface, text$1);
 	const theme = {
 		id,
 		name: name$1,
 		tone,
 		source: "palette",
 		colors: {
-			text,
+			text: text$1,
 			muted,
 			border,
 			brand,
@@ -21641,13 +21641,13 @@ function candidateTheme(id, name$1, colors, tone) {
 			surface,
 			selection
 		},
-		syntax: generatedSyntax(surface, text, muted, syntaxAccents),
+		syntax: generatedSyntax(surface, text$1, muted, syntaxAccents),
 		tokenColors: []
 	};
 	const paletteContrast = colors.reduce((sum, color$1) => sum + themeContrast(color$1, canvas), 0) / colors.length;
 	return {
 		theme,
-		score: themeContrast(text, canvas) * 2 + themeContrast(brand, canvas) + paletteContrast
+		score: themeContrast(text$1, canvas) * 2 + themeContrast(brand, canvas) + paletteContrast
 	};
 }
 /**
@@ -21965,20 +21965,20 @@ function runtimePalette(theme) {
 let selectedTheme = BUILT_IN_THEMES.dark;
 let palette = runtimePalette(selectedTheme);
 let codeHighlighter;
-function controlStringEnd(text, start) {
-	for (let index = start; index < text.length; index += 1) {
-		const code = text.charCodeAt(index);
+function controlStringEnd(text$1, start) {
+	for (let index = start; index < text$1.length; index += 1) {
+		const code = text$1.charCodeAt(index);
 		if (code === 7 || code === ST) return index + 1;
-		if (code === ESC && text.charCodeAt(index + 1) === 92) return index + 2;
+		if (code === ESC && text$1.charCodeAt(index + 1) === 92) return index + 2;
 	}
-	return text.length;
+	return text$1.length;
 }
-function csiEnd(text, start) {
-	for (let index = start; index < text.length; index += 1) {
-		const code = text.charCodeAt(index);
+function csiEnd(text$1, start) {
+	for (let index = start; index < text$1.length; index += 1) {
+		const code = text$1.charCodeAt(index);
 		if (code >= 64 && code <= 126) return index + 1;
 	}
-	return text.length;
+	return text$1.length;
 }
 /**
 * Escape untrusted terminal text while retaining harmless SGR foreground/style sequences.
@@ -21989,28 +21989,28 @@ function csiEnd(text, start) {
 * @param text - terminal-bound text from Harness, extensions, files, or user metadata.
 * @returns text safe to compose into a terminal frame.
 */
-function escapeTerminalText(text) {
+function escapeTerminalText(text$1) {
 	let escaped = "";
-	for (let index = 0; index < text.length;) {
-		const code = text.charCodeAt(index);
+	for (let index = 0; index < text$1.length;) {
+		const code = text$1.charCodeAt(index);
 		if (code === ESC) {
-			const next = text.charCodeAt(index + 1);
+			const next = text$1.charCodeAt(index + 1);
 			if (next === 91) {
-				const end = csiEnd(text, index + 2);
-				const final = text.charCodeAt(end - 1);
-				const parameters = text.slice(index + 2, Math.max(index + 2, end - 1));
-				if (final === 109 && SGR_PARAMETERS.test(parameters)) escaped += text.slice(index, end);
+				const end = csiEnd(text$1, index + 2);
+				const final = text$1.charCodeAt(end - 1);
+				const parameters = text$1.slice(index + 2, Math.max(index + 2, end - 1));
+				if (final === 109 && SGR_PARAMETERS.test(parameters)) escaped += text$1.slice(index, end);
 				index = end;
 				continue;
 			}
 			if (CONTROL_STRING_INTRODUCERS.has(next)) {
-				index = controlStringEnd(text, index + 2);
+				index = controlStringEnd(text$1, index + 2);
 				continue;
 			}
 			if (next >= 32 && next <= 47) {
 				let end = index + 2;
-				while (text.charCodeAt(end) >= 32 && text.charCodeAt(end) <= 47) end += 1;
-				if (text.charCodeAt(end) >= 48 && text.charCodeAt(end) <= 126) end += 1;
+				while (text$1.charCodeAt(end) >= 32 && text$1.charCodeAt(end) <= 47) end += 1;
+				if (text$1.charCodeAt(end) >= 48 && text$1.charCodeAt(end) <= 126) end += 1;
 				index = end;
 				continue;
 			}
@@ -22018,18 +22018,18 @@ function escapeTerminalText(text) {
 			continue;
 		}
 		if (code === CSI) {
-			index = csiEnd(text, index + 1);
+			index = csiEnd(text$1, index + 1);
 			continue;
 		}
 		if (C1_CONTROL_STRING_INTRODUCERS.has(code)) {
-			index = controlStringEnd(text, index + 1);
+			index = controlStringEnd(text$1, index + 1);
 			continue;
 		}
 		if (code >= 0 && code <= 31 && code !== 9 && code !== 10 || code >= 127 && code <= 159) {
 			index += 1;
 			continue;
 		}
-		escaped += text.charAt(index);
+		escaped += text$1.charAt(index);
 		index += 1;
 	}
 	return escaped;
@@ -22130,20 +22130,20 @@ function backgroundSequence(entry, level) {
 	const [red, green, blue] = entry.rgb;
 	return `\u001B[48;2;${String(red)};${String(green)};${String(blue)}m`;
 }
-function paint(entry, text) {
-	const safeText = escapeTerminalText(text);
+function paint(entry, text$1) {
+	const safeText = escapeTerminalText(text$1);
 	const level = terminalColorLevel();
 	if (level === 0) return safeText;
 	return `${foregroundSequence(entry, level)}${safeText}${RESET}`;
 }
-function layer(background$1, text, foreground = palette.text) {
+function layer(background$1, text$1, foreground = palette.text) {
 	const level = terminalColorLevel();
-	if (level === 0) return text;
+	if (level === 0) return text$1;
 	const prefix = `${backgroundSequence(background$1, level)}${foregroundSequence(foreground, level)}`;
-	return `${prefix}${text.replace(/\u001B\[(?:0)?m/gu, `${RESET}${prefix}`)}${RESET}`;
+	return `${prefix}${text$1.replace(/\u001B\[(?:0)?m/gu, `${RESET}${prefix}`)}${RESET}`;
 }
-function ansi(code, text) {
-	const safeText = escapeTerminalText(text);
+function ansi(code, text$1) {
+	const safeText = escapeTerminalText(text$1);
 	return terminalColorLevel() === 0 ? safeText : `\u001B[${String(code)}m${safeText}${RESET}`;
 }
 /**
@@ -22152,8 +22152,8 @@ function ansi(code, text) {
 * @param style - foreground/background colors and portable code-token styles.
 * @returns escaped terminal text with capability-aware SGR sequences.
 */
-function styleTerminalText(text, style) {
-	const safeText = escapeTerminalText(text);
+function styleTerminalText(text$1, style) {
+	const safeText = escapeTerminalText(text$1);
 	const level = terminalColorLevel();
 	if (level === 0 || safeText === "") return safeText;
 	const sequences = [];
@@ -22194,24 +22194,24 @@ function highlightCodeLines(code, language) {
 }
 /** Product semantic foregrounds; no component owns raw color values. */
 const color = {
-	brand: (text) => paint(palette.brand, text),
-	accent: (text) => paint(palette.accent, text),
-	pulse: (text, frame) => {
+	brand: (text$1) => paint(palette.brand, text$1),
+	accent: (text$1) => paint(palette.accent, text$1),
+	pulse: (text$1, frame) => {
 		const values = palette.pulse;
-		return paint(values[(Math.floor(frame) % values.length + values.length) % values.length] ?? palette.brand, text);
+		return paint(values[(Math.floor(frame) % values.length + values.length) % values.length] ?? palette.brand, text$1);
 	},
-	muted: (text) => paint(palette.muted, text),
-	border: (text) => paint(palette.border, text),
-	success: (text) => paint(palette.success, text),
-	warning: (text) => paint(palette.warning, text),
-	danger: (text) => paint(palette.danger, text)
+	muted: (text$1) => paint(palette.muted, text$1),
+	border: (text$1) => paint(palette.border, text$1),
+	success: (text$1) => paint(palette.success, text$1),
+	warning: (text$1) => paint(palette.warning, text$1),
+	danger: (text$1) => paint(palette.danger, text$1)
 };
 /** Background layers shared by the full frame, panels, and selected rows. */
 const background = {
-	canvas: (text) => layer(palette.canvas, text),
-	surface: (text) => layer(palette.surface, text),
-	selection: (text) => layer(palette.selection, text),
-	code: (text) => layer(palette.codeBackground, text, palette.codeForeground)
+	canvas: (text$1) => layer(palette.canvas, text$1),
+	surface: (text$1) => layer(palette.surface, text$1),
+	selection: (text$1) => layer(palette.selection, text$1),
+	code: (text$1) => layer(palette.codeBackground, text$1, palette.codeForeground)
 };
 /**
 * Fill a complete panel row with the active surface background.
@@ -22219,8 +22219,8 @@ const background = {
 * @param width - target terminal cells.
 * @returns one padded surface row.
 */
-function surfaceRow(text, width) {
-	return background.surface(`${text}${" ".repeat(Math.max(0, width - visibleWidth(text)))}`);
+function surfaceRow(text$1, width) {
+	return background.surface(`${text$1}${" ".repeat(Math.max(0, width - visibleWidth(text$1)))}`);
 }
 /** Shared editor/select-list theme used by the main composer and overlays. */
 const editorTheme = {
@@ -22236,19 +22236,19 @@ const editorTheme = {
 /** Markdown/GFM theme using semantic colors and a continuous code background. */
 const markdownTheme = {
 	heading: color.brand,
-	link: (text) => ansi(4, color.accent(text)),
+	link: (text$1) => ansi(4, color.accent(text$1)),
 	linkUrl: color.muted,
-	code: (text) => background.code(color.accent(text)),
+	code: (text$1) => background.code(color.accent(text$1)),
 	codeBlock: background.code,
 	codeBlockBorder: color.muted,
 	quote: color.muted,
 	quoteBorder: color.brand,
 	hr: color.muted,
 	listBullet: color.accent,
-	bold: (text) => ansi(1, text),
-	italic: (text) => ansi(3, text),
-	strikethrough: (text) => ansi(9, text),
-	underline: (text) => ansi(4, text),
+	bold: (text$1) => ansi(1, text$1),
+	italic: (text$1) => ansi(3, text$1),
+	strikethrough: (text$1) => ansi(9, text$1),
+	underline: (text$1) => ansi(4, text$1),
 	highlightCode: highlightCodeLines
 };
 
@@ -22775,6 +22775,52 @@ var SessionToolAllowlist = class {
 };
 
 //#endregion
+//#region src/client/trajectory-detail.ts
+function text(value) {
+	return typeof value === "string" && value.trim() !== "" ? value : void 0;
+}
+function millis(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : void 0;
+}
+/**
+* Format the main fields of one Trajectory request instead of dumping JSON.
+* @param request - Trajectory request record from the projection snapshot.
+*/
+function trajectoryRequestDetail(request) {
+	if (typeof request !== "object" || request === null) return String(request);
+	const row = request;
+	const config = typeof row.requestConfig === "object" && row.requestConfig !== null ? row.requestConfig : {};
+	const started = millis(row.startedAt);
+	const completed = row.completedAt === null ? void 0 : millis(row.completedAt);
+	const duration = started !== void 0 && completed !== void 0 ? Math.max(0, completed - started) : void 0;
+	const usage = typeof row.usage === "object" && row.usage !== null ? row.usage : void 0;
+	const lines = [
+		`${ui("用途", "Purpose")}: ${text(row.purpose) ?? ui("未知", "unknown")}`,
+		`${ui("状态", "Status")}: ${text(row.status) ?? ui("未知", "unknown")}`,
+		`${ui("Provider", "Provider")}: ${text(config.provider) ?? ui("未知", "unknown")}`,
+		`${ui("模型", "Model")}: ${text(config.model) ?? ui("未知", "unknown")}`,
+		...text(config.reasoningEffort) === void 0 ? [] : [`${ui("推理强度", "Reasoning effort")}: ${text(config.reasoningEffort)}`],
+		...started === void 0 ? [] : [`${ui("开始", "Started")}: ${new Date(started).toISOString()}`],
+		...completed === void 0 ? [`${ui("结束", "Completed")}: ${ui("运行中", "running")}`] : [`${ui("结束", "Completed")}: ${new Date(completed).toISOString()}`],
+		...duration === void 0 ? [] : [`${ui("耗时", "Duration")}: ${String(duration)} ms`]
+	];
+	if (usage !== void 0) {
+		const parts = [
+			"input",
+			"output",
+			"cacheRead",
+			"cacheWrite",
+			"reasoning"
+		].flatMap((key) => {
+			const amount = millis(usage[key]);
+			return amount === void 0 ? [] : [`${key} ${String(amount)}`];
+		});
+		if (parts.length > 0) lines.push(`${ui("用量", "Usage")}: ${parts.join(" · ")}`);
+	}
+	return lines.join("\n");
+}
+
+//#endregion
 //#region src/client/job-control.ts
 /**
 * Whether the user can still request cancellation.
@@ -22965,15 +23011,15 @@ function settingsFields(document) {
 * @param text - unmasked editor value.
 * @returns JSON-compatible value for a Settings path mutation.
 */
-function parseSettingsValue(field, text) {
+function parseSettingsValue(field, text$1) {
 	switch (field.control) {
 		case "number": {
-			const value = Number(text);
+			const value = Number(text$1);
 			if (!Number.isFinite(value)) throw new Error(ui(`${field.label} 必须是有限数字`, `${field.label} must be a finite number`));
 			return value;
 		}
 		case "json": try {
-			return JSON.parse(text);
+			return JSON.parse(text$1);
 		} catch (error) {
 			throw new Error(ui(`${field.label} 需要有效 JSON：${error instanceof Error ? error.message : String(error)}`, `${field.label} requires valid JSON: ${error instanceof Error ? error.message : String(error)}`));
 		}
@@ -22981,7 +23027,7 @@ function parseSettingsValue(field, text) {
 		case "enum": throw new Error(ui(`${field.label} 应通过选择器写入`, `${field.label} must be changed with the selector`));
 		case "credential-ref":
 		case "secret":
-		case "text": return text;
+		case "text": return text$1;
 	}
 }
 /**
@@ -23232,9 +23278,9 @@ function objectRecord(value, label) {
 function optionalRecord(value, label) {
 	return value === void 0 ? {} : objectRecord(value, label);
 }
-function parseJsonc(text, path$1) {
+function parseJsonc(text$1, path$1) {
 	const errors = [];
-	const value = parse(text, errors, {
+	const value = parse(text$1, errors, {
 		allowTrailingComma: true,
 		disallowComments: false
 	});
@@ -23284,12 +23330,12 @@ async function loadThemeRecord(path$1, active, budget) {
 		throw new Error(`VS Code 主题 include 存在循环：${chain}`);
 	}
 	if (active.length >= MAX_INCLUDE_DEPTH) throw new Error(`VS Code 主题 include 超过 ${String(MAX_INCLUDE_DEPTH)} 层`);
-	const text = await readFile(canonical, "utf8");
-	const bytes = Buffer.byteLength(text);
+	const text$1 = await readFile(canonical, "utf8");
+	const bytes = Buffer.byteLength(text$1);
 	if (bytes > MAX_THEME_FILE_BYTES) throw new Error(`VS Code 主题文件超过 ${String(MAX_THEME_FILE_BYTES)} 字节`);
 	budget.bytes += bytes;
 	if (budget.bytes > MAX_THEME_TOTAL_BYTES) throw new Error(`VS Code 主题 include 总大小超过 ${String(MAX_THEME_TOTAL_BYTES)} 字节`);
-	const current = parseJsonc(text, canonical);
+	const current = parseJsonc(text$1, canonical);
 	let base = EMPTY_THEME;
 	if (current.include !== void 0) {
 		const include = typeof current.include === "string" ? current.include.trim() : "";
@@ -23561,13 +23607,13 @@ function serializeThemeExport(theme) {
 * @param text - serialized JSON.
 * @returns written byte count.
 */
-async function writeThemeExport(path$1, text) {
+async function writeThemeExport(path$1, text$1) {
 	await mkdir(dirname(path$1), { recursive: true });
 	const file = await open(path$1, "wx");
 	let complete = false;
 	try {
-		const bytes = Buffer.byteLength(text, "utf8");
-		await file.write(Buffer.from(text, "utf8"));
+		const bytes = Buffer.byteLength(text$1, "utf8");
+		await file.write(Buffer.from(text$1, "utf8"));
 		await file.sync();
 		complete = true;
 		return bytes;
@@ -23712,7 +23758,7 @@ function resolvedCustomTheme(theme) {
 	};
 }
 function themePreviewText(theme, warnings) {
-	const codeBlock = (text, language) => highlightCodeLines(text, language).map((line) => background.code(`${line}${" ".repeat(Math.max(0, 42 - visibleWidth(line)))}`)).join("\n");
+	const codeBlock = (text$1, language) => highlightCodeLines(text$1, language).map((line) => background.code(`${line}${" ".repeat(Math.max(0, 42 - visibleWidth(line)))}`)).join("\n");
 	return [
 		`${color.brand("deepseek")} · ${color.accent(theme.name)} · ${theme.tone === "dark" ? ui("暗色", "Dark") : ui("亮色", "Light")}`,
 		`${markdownTheme.heading(ui("Markdown 标题", "Markdown heading"))}  ${markdownTheme.bold(ui("粗体", "Bold"))}  ${markdownTheme.code("inline code")}`,
@@ -24153,15 +24199,15 @@ var TuiActions = class {
 		this.copyLastResponse();
 	}
 	copyLastResponse() {
-		const text = this.capabilities.lastAssistantText();
-		if (text === void 0) throw new Error("当前会话没有可复制的 DeepSeek 文本回复");
-		this.host.copy(text);
-		this.host.notice(`已复制最后一条回复（${text.length} 个字符）`, "success");
+		const text$1 = this.capabilities.lastAssistantText();
+		if (text$1 === void 0) throw new Error("当前会话没有可复制的 DeepSeek 文本回复");
+		this.host.copy(text$1);
+		this.host.notice(`已复制最后一条回复（${text$1.length} 个字符）`, "success");
 	}
 	copyCode() {
-		const text = this.capabilities.lastAssistantText();
-		if (text === void 0) throw new Error("当前会话没有可复制的 DeepSeek 文本回复");
-		const code = lastFencedCode(text);
+		const text$1 = this.capabilities.lastAssistantText();
+		if (text$1 === void 0) throw new Error("当前会话没有可复制的 DeepSeek 文本回复");
+		const code = lastFencedCode(text$1);
 		if (code === void 0) throw new Error("最后一条回复没有可复制的代码块");
 		this.host.copy(code);
 		this.host.notice(`已复制最后一段代码（${code.length} 个字符）`, "success");
@@ -25290,15 +25336,15 @@ var TuiActions = class {
 		if (action.id === "steer") await this.capabilities.updateQueue(row.id, { kind: "steer" });
 		if (action.id === "remove") await this.capabilities.updateQueue(row.id, { kind: "remove" });
 		if (action.id === "edit" && row.text !== null) {
-			const text = await nav.multilineInput({
+			const text$1 = await nav.multilineInput({
 				title: "编辑排队消息",
 				initialValue: row.text
 			});
-			if (text !== void 0) await this.capabilities.updateQueue(row.id, {
+			if (text$1 !== void 0) await this.capabilities.updateQueue(row.id, {
 				kind: "edit",
 				content: [{
 					type: "text",
-					text
+					text: text$1
 				}]
 			});
 		}
@@ -25314,11 +25360,11 @@ var TuiActions = class {
 		if (active === void 0) return;
 		for (const row of movable) await this.capabilities.updateQueue(row.id, { kind: "remove" });
 		for (const row of ordered) {
-			const text = row.text;
-			if (text === null) continue;
+			const text$1 = row.text;
+			if (text$1 === null) continue;
 			const result = await active.session.prompt([{
 				type: "text",
-				text
+				text: text$1
 			}], "queue");
 			if (!result.ok) throw new Error(`重排队列失败：${result.error.message}`);
 		}
@@ -25718,13 +25764,13 @@ var TuiActions = class {
 			value = secret;
 		} else {
 			const initialValue = field.control === "json" ? JSON.stringify(field.value, null, 2) : typeof field.value === "string" ? field.value : "";
-			const text = await overlays.input({
+			const text$1 = await overlays.input({
 				title: `修改 ${field.label}`,
 				...field.description === void 0 ? {} : { detail: field.description },
 				initialValue
 			});
-			if (text === void 0) return void 0;
-			value = parseSettingsValue(field, text);
+			if (text$1 === void 0) return void 0;
+			value = parseSettingsValue(field, text$1);
 		}
 		return this.capabilities.managementBridge().settings.mutate(document.namespace, [{
 			op: "set",
@@ -25942,23 +25988,23 @@ Diagnostics: ${plugin.diagnostics.length === 0 ? "none" : plugin.diagnostics.map
 		if (selected?.id === "remove") await this.pluginRemove(plugin.name);
 	}
 	async pluginSearch(query) {
-		let text = query.trim();
-		if (text === "") {
+		let text$1 = query.trim();
+		if (text$1 === "") {
 			const entered = await this.host.overlays.input({
 				title: "搜索插件",
 				placeholder: "名称、描述或 Catalog 关键词"
 			});
 			if (entered === void 0 || entered.trim() === "") return;
-			text = entered.trim();
+			text$1 = entered.trim();
 		}
-		const candidates = await this.host.overlays.runBusy(`插件搜索 · ${text}`, (signal) => this.capabilities.managementBridge().plugins.search(text, signal));
+		const candidates = await this.host.overlays.runBusy(`插件搜索 · ${text$1}`, (signal) => this.capabilities.managementBridge().plugins.search(text$1, signal));
 		if (candidates === void 0) return;
 		if (candidates.length === 0) {
-			this.host.notice(`未找到与 ${JSON.stringify(text)} 匹配的插件`, "info");
+			this.host.notice(`未找到与 ${JSON.stringify(text$1)} 匹配的插件`, "info");
 			return;
 		}
 		const selected = await this.host.overlays.select({
-			title: `插件搜索 · ${text}`,
+			title: `插件搜索 · ${text$1}`,
 			detail: "“验证通过”只表示包结构兼容，不表示官方、审核过、安全或可信",
 			choices: candidates.map((candidate$1) => ({
 				id: candidate$1.id,
@@ -26797,7 +26843,7 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		const value = selected.id.startsWith("request:") ? trajectory.requests[Number(selected.id.slice(8))] : trajectory.runningCalls.find((call) => `call:${call.callId}` === selected.id);
 		await this.host.overlays.detail({
 			title: selected.label,
-			content: detailText(value),
+			content: selected.id.startsWith("request:") ? trajectoryRequestDetail(value) : detailText(value),
 			options: {
 				width: "95%",
 				maxHeight: "90%",
@@ -26828,12 +26874,12 @@ ${source.credentialRef === void 0 ? "无 Credential Ref" : `Credential Ref：${s
 		});
 		if (kind === void 0) return;
 		if (kind.id === "session") {
-			const text = await this.host.overlays.input({
+			const text$1 = await this.host.overlays.input({
 				title: "会话反馈",
 				placeholder: "输入对当前会话的反馈"
 			});
-			if (text === void 0 || text.trim() === "") return;
-			await this.capabilities.recordSessionFeedback(text);
+			if (text$1 === void 0 || text$1.trim() === "") return;
+			await this.capabilities.recordSessionFeedback(text$1);
 			this.host.notice("已记录会话反馈", "success");
 			return;
 		}
@@ -27267,11 +27313,11 @@ function formatElapsed(milliseconds) {
 
 //#endregion
 //#region src/client/chrome.ts
-function fit(text, width) {
-	return truncateToWidth(text, Math.max(1, width), "…");
+function fit(text$1, width) {
+	return truncateToWidth(text$1, Math.max(1, width), "…");
 }
-function padded(text, width) {
-	const clipped = fit(text, width);
+function padded(text$1, width) {
+	const clipped = fit(text$1, width);
 	return `${clipped}${" ".repeat(Math.max(0, width - visibleWidth(clipped)))}`;
 }
 function columns(left, right, width) {
@@ -27341,8 +27387,8 @@ function isHorizontalRule(line) {
 	const plain = line.replace(/\u001B\[[0-9;:]*m/gu, "");
 	return /^(?:─+|─── [↑↓] \d+ more ─*)$/u.test(plain);
 }
-function isBlankMultiline(text) {
-	return /[\r\n]/u.test(text) && text.trim() === "";
+function isBlankMultiline(text$1) {
+	return /[\r\n]/u.test(text$1) && text$1.trim() === "";
 }
 /**
 * Keep the composer and shortcut row visible while the editor or autocomplete grows.
@@ -27511,8 +27557,8 @@ var PromptEditor = class extends Editor {
 	setEmpty() {
 		this.facts = void 0;
 	}
-	setText(text) {
-		super.setText(isBlankMultiline(text) ? "" : text);
+	setText(text$1) {
+		super.setText(isBlankMultiline(text$1) ? "" : text$1);
 	}
 	handleInput(data) {
 		super.handleInput(data);
@@ -27566,9 +27612,9 @@ function asEntries(value) {
 * @param limit - maximum stored entries; 0 disables persistence.
 * @returns the updated newest-first list.
 */
-function rememberComposerHistory(entries, text, limit) {
+function rememberComposerHistory(entries, text$1, limit) {
 	if (limit <= 0) return [];
-	const trimmed = text.trim();
+	const trimmed = text$1.trim();
 	if (trimmed === "") return [...entries];
 	return (entries[0] === trimmed ? [...entries] : [trimmed, ...entries]).slice(0, limit);
 }
@@ -28933,15 +28979,15 @@ function scrollOffsetToReveal(lineCount, viewportRows, lineIndex) {
 * @param text - one tool-output block.
 * @param limit - line cap; 0 or negative means unlimited.
 */
-function foldLineBlock(text, limit) {
+function foldLineBlock(text$1, limit) {
 	if (!Number.isFinite(limit) || limit <= 0) return {
-		text,
+		text: text$1,
 		omitted: 0
 	};
 	const cap = Math.floor(limit);
-	const lines = text.split("\n");
+	const lines = text$1.split("\n");
 	if (lines.length <= cap) return {
-		text,
+		text: text$1,
 		omitted: 0
 	};
 	const omitted = lines.length - cap;
@@ -28962,8 +29008,8 @@ function thinkingRow() {
 	};
 }
 var PulsingRow = class {
-	constructor(text, mode, frame, liveDurationSince) {
-		this.text = text;
+	constructor(text$1, mode, frame, liveDurationSince) {
+		this.text = text$1;
 		this.mode = mode;
 		this.frame = frame;
 		this.liveDurationSince = liveDurationSince;
@@ -29051,14 +29097,14 @@ function planCommandText(node) {
 	if (node.name !== "plan") return void 0;
 	if (node.outcome === null) return color.warning(ui("正在切换计划模式", "Switching plan mode"));
 	if (node.outcome.kind !== "success") return color.danger(ui(`计划模式切换失败${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`, `Failed to switch plan mode${node.outcome.text === void 0 ? "" : `\n${node.outcome.text}`}`));
-	const text = node.outcome.text ?? "";
+	const text$1 = node.outcome.text ?? "";
 	if (node.args?.trim() === "off") {
-		if (text.includes("entry cancelled")) return color.success(ui("已取消进入计划模式", "Plan-mode entry cancelled"));
-		if (text.includes("already inactive")) return color.muted(ui("计划模式未开启", "Plan mode is not active"));
-		if (text.startsWith("Leaving ")) return color.success(ui("计划模式将在下一步关闭", "Plan mode will stop on the next step"));
+		if (text$1.includes("entry cancelled")) return color.success(ui("已取消进入计划模式", "Plan-mode entry cancelled"));
+		if (text$1.includes("already inactive")) return color.muted(ui("计划模式未开启", "Plan mode is not active"));
+		if (text$1.startsWith("Leaving ")) return color.success(ui("计划模式将在下一步关闭", "Plan mode will stop on the next step"));
 		return color.success(ui("计划模式已关闭", "Plan mode disabled"));
 	}
-	return color.success(text.startsWith("Entering ") ? ui("计划模式将在下一步开启", "Plan mode will start on the next step") : ui("计划模式已开启", "Plan mode enabled"));
+	return color.success(text$1.startsWith("Entering ") ? ui("计划模式将在下一步开启", "Plan mode will start on the next step") : ui("计划模式已开启", "Plan mode enabled"));
 }
 function goalCommandText(node) {
 	if (node.name !== "goal") return void 0;
@@ -29184,9 +29230,9 @@ function prettyArgs(argsRaw) {
 		return argsRaw;
 	}
 }
-function contentLines(text) {
-	if (text === "") return [];
-	return (text.endsWith("\n") ? text.slice(0, -1) : text).split("\n");
+function contentLines(text$1) {
+	if (text$1 === "") return [];
+	return (text$1.endsWith("\n") ? text$1.slice(0, -1) : text$1).split("\n");
 }
 function diffText(value) {
 	if (!Array.isArray(value) || value.length === 0) return jsonText(value);
@@ -29760,10 +29806,10 @@ function chatNodeRows(node, preferences) {
 			});
 			return grouped(rows);
 		}
-		const text = nodeText(node.data, preferences);
-		return text === "" ? [] : grouped([{
+		const text$1 = nodeText(node.data, preferences);
+		return text$1 === "" ? [] : grouped([{
 			format: "plain",
-			text
+			text: text$1
 		}]);
 	}
 	const commandInputText = node.kind === "command-input" ? textProperty(node.data) : void 0;
@@ -30425,8 +30471,8 @@ function defaultSpawn$1(command, args, input) {
 * @param text - UTF-8 text to place on the clipboard.
 * @returns the complete OSC 52 sequence.
 */
-function osc52Sequence(text) {
-	return `\u001B]52;c;${Buffer.from(text, "utf8").toString("base64")}\u0007`;
+function osc52Sequence(text$1) {
+	return `\u001B]52;c;${Buffer.from(text$1, "utf8").toString("base64")}\u0007`;
 }
 /**
 * Write text to the terminal clipboard, then to a platform clipboard tool when allowed.
@@ -30434,9 +30480,9 @@ function osc52Sequence(text) {
 * @param options - fallback policy and I/O seams.
 * @returns which writer succeeded.
 */
-function writeClipboard(text, options$1) {
-	const osc52Ok = Buffer.byteLength(text, "utf8") <= OSC52_BYTE_LIMIT;
-	if (osc52Ok) options$1.writeOsc52(osc52Sequence(text));
+function writeClipboard(text$1, options$1) {
+	const osc52Ok = Buffer.byteLength(text$1, "utf8") <= OSC52_BYTE_LIMIT;
+	if (osc52Ok) options$1.writeOsc52(osc52Sequence(text$1));
 	if (options$1.fallback === "osc52" || options$1.fallback === "off") {
 		if (!osc52Ok) throw new Error(`回复超过终端剪贴板 ${String(OSC52_BYTE_LIMIT)} 字节安全上限；请使用 /export`);
 		return "osc52";
@@ -30444,7 +30490,7 @@ function writeClipboard(text, options$1) {
 	if (osc52Ok && options$1.fallback === "auto") {}
 	const spawn$2 = options$1.spawn ?? defaultSpawn$1;
 	for (const candidate of FALLBACKS[options$1.platform] ?? []) {
-		const result = spawn$2(candidate.command, candidate.args, text);
+		const result = spawn$2(candidate.command, candidate.args, text$1);
 		if (result.error === void 0 && result.status === 0) return osc52Ok ? "osc52" : candidate.method;
 	}
 	if (osc52Ok) return "osc52";
@@ -30635,12 +30681,12 @@ function pastedImagePath(data) {
 	return IMAGE_PATH_SUFFIX.test(suffixTarget) ? candidate : void 0;
 }
 function noticeText(message, tone) {
-	const text = translateUiText(message);
+	const text$1 = translateUiText(message);
 	switch (tone) {
-		case "success": return color.success(text);
-		case "warning": return color.warning(text);
-		case "error": return color.danger(text);
-		case "info": return color.brand(text);
+		case "success": return color.success(text$1);
+		case "warning": return color.warning(text$1);
+		case "error": return color.danger(text$1);
+		case "info": return color.brand(text$1);
 	}
 }
 /**
@@ -30948,13 +30994,13 @@ async function startTuiSurface(options$1) {
 			applyBehavior: (behavior) => {
 				applyKeyBindingOverrides(behavior.keyBindings);
 			},
-			setEditor: (text) => {
-				editor.setText(escapeTerminalText(text));
+			setEditor: (text$1) => {
+				editor.setText(escapeTerminalText(text$1));
 				focusEditor();
 				renderWhileOpen();
 			},
-			copy: (text) => {
-				writeClipboard(text, {
+			copy: (text$1) => {
+				writeClipboard(text$1, {
 					fallback: initialBehavior.clipboardFallback,
 					platform: process.platform,
 					writeOsc52: (sequence) => {
@@ -31017,19 +31063,19 @@ async function startTuiSurface(options$1) {
 		editor.setAutocompleteProvider(new HarnessAutocompleteProvider(capabilities, (message) => {
 			setNotice(`命令目录：${message}`, "error");
 		}));
-		const sendPrompt = async (text, mode = "queue") => {
+		const sendPrompt = async (text$1, mode = "queue") => {
 			const current = capabilities.active();
 			if (current === void 0) {
 				setNotice("当前没有打开的会话", "error");
-				if (text !== "" && editor.getText() === "") editor.setText(text);
+				if (text$1 !== "" && editor.getText() === "") editor.setText(text$1);
 				return false;
 			}
-			const content = capabilities.promptContent(text);
+			const content = capabilities.promptContent(text$1);
 			if (content.length === 0) return false;
 			const result = await current.session.prompt(content, mode);
 			if (!result.ok) {
 				setNotice(`${mode === "steer" ? "引导" : "发送"}失败：${result.error.message}`, "error");
-				if (text !== "" && editor.getText() === "") editor.setText(text);
+				if (text$1 !== "" && editor.getText() === "") editor.setText(text$1);
 				return false;
 			}
 			capabilities.clearAttachments();
@@ -31070,19 +31116,19 @@ async function startTuiSurface(options$1) {
 			}
 		};
 		editor.onSubmit = (raw) => {
-			const text = raw.trim();
-			if (text === "" && capabilities.draftAttachments().length === 0) return;
+			const text$1 = raw.trim();
+			if (text$1 === "" && capabilities.draftAttachments().length === 0) return;
 			transcript.followLatest();
-			if (text !== "") {
-				editor.addToHistory(text);
-				composerHistory = rememberComposerHistory(composerHistory, text, historyLimit);
+			if (text$1 !== "") {
+				editor.addToHistory(text$1);
+				composerHistory = rememberComposerHistory(composerHistory, text$1, historyLimit);
 				if (historyLimit > 0) try {
 					saveComposerHistory(historyPath, composerHistory);
 				} catch {}
 			}
 			editor.setText("");
-			if (text.startsWith("/")) dispatchCommand(text);
-			else sendPrompt(text);
+			if (text$1.startsWith("/")) dispatchCommand(text$1);
+			else sendPrompt(text$1);
 		};
 		const attachPastedImage = (path$1, fallbackText) => {
 			capabilities.addAttachment(path$1).then((attachment) => {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -37,6 +37,7 @@ import {
 } from './keymap.ts'
 import { pluginFailureDetail } from './error-advice.ts'
 import { SessionToolAllowlist } from './session-tool-allowlist.ts'
+import { trajectoryRequestDetail } from './trajectory-detail.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
 import { moveIndex } from './queue-order.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
@@ -3283,7 +3284,7 @@ ${source.credentialRef === undefined ? '无 Credential Ref' : `Credential Ref：
       : trajectory.runningCalls.find(call => `call:${call.callId}` === selected.id)
     await this.host.overlays.detail({
       title: selected.label,
-      content: detailText(value),
+      content: selected.id.startsWith('request:') ? trajectoryRequestDetail(value) : detailText(value),
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })
   }

--- a/src/client/trajectory-detail.ts
+++ b/src/client/trajectory-detail.ts
@@ -1,0 +1,54 @@
+/** Structured /trajectory request inspector text. */
+
+import { ui } from './locale.ts'
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+function millis(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Format the main fields of one Trajectory request instead of dumping JSON.
+ * @param request - Trajectory request record from the projection snapshot.
+ */
+export function trajectoryRequestDetail(request: unknown): string {
+  if (typeof request !== 'object' || request === null) return String(request)
+  const row = request as Readonly<Record<string, unknown>>
+  const config = typeof row.requestConfig === 'object' && row.requestConfig !== null
+    ? row.requestConfig as Readonly<Record<string, unknown>>
+    : {}
+  const started = millis(row.startedAt)
+  const completed = row.completedAt === null ? undefined : millis(row.completedAt)
+  const duration = started !== undefined && completed !== undefined
+    ? Math.max(0, completed - started)
+    : undefined
+  const usage = typeof row.usage === 'object' && row.usage !== null
+    ? row.usage as Readonly<Record<string, unknown>>
+    : undefined
+  const lines = [
+    `${ui('用途', 'Purpose')}: ${text(row.purpose) ?? ui('未知', 'unknown')}`,
+    `${ui('状态', 'Status')}: ${text(row.status) ?? ui('未知', 'unknown')}`,
+    `${ui('Provider', 'Provider')}: ${text(config.provider) ?? ui('未知', 'unknown')}`,
+    `${ui('模型', 'Model')}: ${text(config.model) ?? ui('未知', 'unknown')}`,
+    ...text(config.reasoningEffort) === undefined
+      ? []
+      : [`${ui('推理强度', 'Reasoning effort')}: ${text(config.reasoningEffort)}`],
+    ...started === undefined ? [] : [`${ui('开始', 'Started')}: ${new Date(started).toISOString()}`],
+    ...completed === undefined
+      ? [`${ui('结束', 'Completed')}: ${ui('运行中', 'running')}`]
+      : [`${ui('结束', 'Completed')}: ${new Date(completed).toISOString()}`],
+    ...duration === undefined ? [] : [`${ui('耗时', 'Duration')}: ${String(duration)} ms`],
+  ]
+  if (usage !== undefined) {
+    const parts = ['input', 'output', 'cacheRead', 'cacheWrite', 'reasoning']
+      .flatMap((key) => {
+        const amount = millis(usage[key])
+        return amount === undefined ? [] : [`${key} ${String(amount)}`]
+      })
+    if (parts.length > 0) lines.push(`${ui('用量', 'Usage')}: ${parts.join(' · ')}`)
+  }
+  return lines.join('\n')
+}

--- a/tests/trajectory-detail.test.ts
+++ b/tests/trajectory-detail.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setUiLocale } from '../src/client/locale.ts'
+import { trajectoryRequestDetail } from '../src/client/trajectory-detail.ts'
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('trajectory request detail (task 6.4)', () => {
+  it('prints main request fields instead of JSON', () => {
+    const text = trajectoryRequestDetail({
+      purpose: 'assistant',
+      status: 'completed',
+      startedAt: Date.parse('2026-01-01T00:00:00.000Z'),
+      completedAt: Date.parse('2026-01-01T00:00:01.250Z'),
+      requestConfig: { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' },
+      usage: { input: 12, output: 34 },
+      prompt: { tools: [{ name: 'shell' }] },
+    })
+    expect(text).toContain('用途: assistant')
+    expect(text).toContain('Provider: deepseek')
+    expect(text).toContain('模型: deepseek-chat')
+    expect(text).toContain('耗时: 1250 ms')
+    expect(text).toContain('用量: input 12 · output 34')
+    expect(text).not.toContain('"prompt"')
+    expect(text).not.toContain('shell')
+  })
+
+  it('marks an in-flight request as running', () => {
+    const text = trajectoryRequestDetail({
+      purpose: 'assistant',
+      status: 'running',
+      startedAt: 1,
+      completedAt: null,
+      requestConfig: { provider: 'deepseek', model: 'deepseek-chat' },
+    })
+    expect(text).toContain('结束: 运行中')
+  })
+})


### PR DESCRIPTION
## Summary
- `/trajectory` request inspector shows purpose, status, provider, model, timing, and usage.
- Full JSON dump is kept for running tool-call records.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/trajectory-detail.test.ts`
- [ ] Open `/trajectory`, select a completed request, confirm the overlay is structured fields not JSON.
