### PR TITLE
fix(tui): degrade invalid restart handoff instead of blocking boot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-bC3YRGeq.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DIn1PbXf.js";
 import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D8-O8gcm.js";
 import { createRequire } from "node:module";

--- a/lib/startup-DIn1PbXf.js
+++ b/lib/startup-DIn1PbXf.js
@@ -1345,10 +1345,54 @@ async function saveLanguage(settings, document, selection, env = process.env) {
 const APP_HANDOFF_ENV = "DSH_APP_HANDOFF_FILE";
 /** Maximum serialized handoff bytes; payloads carry references, never file bytes. */
 const APP_HANDOFF_MAX_BYTES = 256 * 1024;
-const PREFIX = "deepseek-handoff-";
+/** Filename prefix for launcher-owned handoff files in the process temp directory. */
+const APP_HANDOFF_PREFIX = "deepseek-handoff-";
+/** Replaceable process seams used by handoff tests. */
+const internals = {
+	tmpdir,
+	now: Date.now,
+	staleMs: 1440 * 60 * 1e3
+};
+function canonical(path) {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
 function allowedPath(path) {
-	const absolute = resolve(path);
-	return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX);
+	const absolute = canonical(path);
+	return dirname(absolute) === canonical(internals.tmpdir()) && basename(absolute).startsWith(APP_HANDOFF_PREFIX);
+}
+function degrade(reason) {
+	return {
+		kind: "degraded",
+		reason
+	};
+}
+/**
+* Remove leftover prefix files older than the stale window.
+* Called on write and consume so a child crash does not fill tmpdir.
+*/
+function sweepStaleAppHandoffs() {
+	const directory = internals.tmpdir();
+	let names;
+	try {
+		names = readdirSync(directory);
+	} catch {
+		return;
+	}
+	const cutoff = internals.now() - internals.staleMs;
+	for (const name$1 of names) {
+		if (!name$1.startsWith(APP_HANDOFF_PREFIX)) continue;
+		const path = join(directory, name$1);
+		if (!allowedPath(path)) continue;
+		try {
+			const stat = lstatSync(path);
+			if (!stat.isFile() || stat.mtimeMs > cutoff) continue;
+			unlinkSync(path);
+		} catch {}
+	}
 }
 /**
 * Persist one opaque app payload for a child process. The file is exclusive,
@@ -1359,13 +1403,14 @@ function allowedPath(path) {
 */
 function writeAppHandoff(channel, payload) {
 	if (channel.trim() === "") throw new Error("app handoff channel cannot be blank");
+	sweepStaleAppHandoffs();
 	const body = JSON.stringify({
 		version: 1,
 		channel,
 		payload
 	});
 	if (Buffer.byteLength(body) > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff payload exceeds size limit");
-	const path = join(tmpdir(), `${PREFIX}${randomUUID()}.json`);
+	const path = join(internals.tmpdir(), `${APP_HANDOFF_PREFIX}${randomUUID()}.json`);
 	writeFileSync(path, body, {
 		encoding: "utf8",
 		flag: "wx",
@@ -1375,24 +1420,29 @@ function writeAppHandoff(channel, payload) {
 }
 /**
 * Consume and delete this process's handoff when its channel matches.
-* Invalid paths, permissions, envelopes, or channels fail loud after the
-* environment value is cleared; a missing value means ordinary startup.
+* Invalid paths, permissions, envelopes, or channels degrade instead of aborting boot.
 * @param channel - expected app protocol identifier.
-* @returns parsed opaque payload, or undefined when no handoff was supplied.
+* @param env - process environment carrying {@link APP_HANDOFF_ENV}.
 */
-function consumeAppHandoff(channel) {
-	const path = process.env[APP_HANDOFF_ENV];
-	delete process.env.DSH_APP_HANDOFF_FILE;
-	if (path === void 0) return void 0;
-	if (!allowedPath(path)) throw new Error("app handoff path is outside the launcher temp boundary");
+function consumeAppHandoff(channel, env = process.env) {
+	sweepStaleAppHandoffs();
+	const path = env[APP_HANDOFF_ENV];
+	delete env[APP_HANDOFF_ENV];
+	if (path === void 0) return { kind: "missing" };
+	if (!allowedPath(path)) return degrade("app handoff path is outside the launcher temp boundary");
 	try {
 		const stat = lstatSync(path);
-		if (!stat.isFile()) throw new Error("app handoff path is not a regular file");
-		if (stat.size > APP_HANDOFF_MAX_BYTES) throw new Error("app handoff file exceeds size limit");
-		if (process.platform !== "win32" && (stat.mode & 63) !== 0) throw new Error("app handoff file permissions are not owner-only");
+		if (!stat.isFile()) return degrade("app handoff path is not a regular file");
+		if (stat.size > APP_HANDOFF_MAX_BYTES) return degrade("app handoff file exceeds size limit");
+		if (process.platform !== "win32" && (stat.mode & 63) !== 0) return degrade("app handoff file permissions are not owner-only");
 		const parsed = JSON.parse(readFileSync(path, "utf8"));
-		if (parsed === null || parsed.version !== 1 || parsed.channel !== channel || !("payload" in parsed)) throw new Error(`app handoff does not match channel ${JSON.stringify(channel)}`);
-		return parsed.payload;
+		if (parsed === null || parsed.version !== 1 || parsed.channel !== channel || !("payload" in parsed)) return degrade(`app handoff does not match channel ${JSON.stringify(channel)}`);
+		return {
+			kind: "payload",
+			payload: parsed.payload
+		};
+	} catch (error) {
+		return degrade(error instanceof Error ? error.message : String(error));
 	} finally {
 		try {
 			unlinkSync(path);
@@ -1922,6 +1972,53 @@ var ProfilePluginManager = class {
 };
 
 //#endregion
+//#region src/host/restart-handoff.ts
+function degradedNotice() {
+	return ui("重启交接无效，已按普通启动继续", "Restart handoff was invalid; continuing with a normal start");
+}
+function parseRestartHandoff(value) {
+	if (typeof value !== "object" || value === null) throw new Error("TUI 重启交接不是对象");
+	const row = value;
+	if (typeof row.profile !== "string" || typeof row.cwd !== "string" || !Array.isArray(row.attachmentPaths) || !row.attachmentPaths.every((path) => typeof path === "string")) throw new Error("TUI 重启交接缺少 Profile、工作区或附件路径");
+	if (row.attachmentPaths.length > 32) throw new Error("TUI 重启交接附件数量超过限制");
+	if (row.resume !== void 0 && typeof row.resume !== "string") throw new Error("TUI 重启交接会话 id 无效");
+	if (row.draft !== void 0 && typeof row.draft !== "string") throw new Error("TUI 重启交接草稿无效");
+	if (row.notice !== void 0 && typeof row.notice !== "string") throw new Error("TUI 重启交接提示无效");
+	return {
+		profile: row.profile,
+		cwd: resolve(row.cwd),
+		...typeof row.resume === "string" ? { resume: row.resume } : {},
+		...typeof row.draft === "string" ? { draft: row.draft } : {},
+		attachmentPaths: row.attachmentPaths,
+		...typeof row.notice === "string" ? { notice: row.notice } : {}
+	};
+}
+/**
+* Turn a consume result into a parsed handoff or a startup notice.
+* Invalid envelopes never throw; boot continues without the draft.
+*/
+function readRestartHandoff(consumed) {
+	if (consumed.kind === "missing") return {};
+	if (consumed.kind === "degraded") return { startupNotice: degradedNotice() };
+	try {
+		return { handoff: parseRestartHandoff(consumed.payload) };
+	} catch {
+		return { startupNotice: degradedNotice() };
+	}
+}
+/**
+* Drop a parsed handoff when it disagrees with this process's launcher args.
+*/
+function reconcileHandoff(pending, launch) {
+	if (pending.handoff === void 0) return pending;
+	if (pending.handoff.profile !== launch.profile || pending.handoff.cwd !== resolve(launch.cwd) || pending.handoff.resume !== launch.resume) return { startupNotice: degradedNotice() };
+	return {
+		handoff: pending.handoff,
+		...pending.handoff.notice === void 0 && pending.startupNotice === void 0 ? {} : { startupNotice: pending.handoff.notice ?? pending.startupNotice }
+	};
+}
+
+//#endregion
 //#region src/host/startup.ts
 /** Stable Cordis plugin name. */
 const name = "tui-startup";
@@ -2004,24 +2101,6 @@ Examples:
   deepseek --profile team-tui     Use the specified Harness Profile
 `));
 }
-function restartHandoff(value) {
-	if (value === void 0) return void 0;
-	if (typeof value !== "object" || value === null) throw new Error("TUI 重启交接不是对象");
-	const row = value;
-	if (typeof row.profile !== "string" || typeof row.cwd !== "string" || !Array.isArray(row.attachmentPaths) || !row.attachmentPaths.every((path) => typeof path === "string")) throw new Error("TUI 重启交接缺少 Profile、工作区或附件路径");
-	if (row.attachmentPaths.length > 32) throw new Error("TUI 重启交接附件数量超过限制");
-	if (row.resume !== void 0 && typeof row.resume !== "string") throw new Error("TUI 重启交接会话 id 无效");
-	if (row.draft !== void 0 && typeof row.draft !== "string") throw new Error("TUI 重启交接草稿无效");
-	if (row.notice !== void 0 && typeof row.notice !== "string") throw new Error("TUI 重启交接提示无效");
-	return {
-		profile: row.profile,
-		cwd: resolve(row.cwd),
-		...typeof row.resume === "string" ? { resume: row.resume } : {},
-		...typeof row.draft === "string" ? { draft: row.draft } : {},
-		attachmentPaths: row.attachmentPaths,
-		...typeof row.notice === "string" ? { notice: row.notice } : {}
-	};
-}
 /**
 * Parse TUI-owned flags and provide immutable launch values.
 * @param ctx - Host context carrying the launcher argument snapshot.
@@ -2035,14 +2114,18 @@ function apply(ctx) {
 		invokingCwd: process.cwd()
 	}));
 	ctx.provide("appRestart", restartProvider(ctx));
-	const handoff = restartHandoff(consumeAppHandoff("seektty-v1"));
+	const pendingHandoff = readRestartHandoff(consumeAppHandoff("seektty-v1"));
 	const program = tuiCommand();
 	program.action(() => {
 		const options = program.opts();
 		const task = program.args.join(" ").trim();
 		const resume = options.resume === true ? true : typeof options.resume === "string" && options.resume.trim() !== "" ? options.resume : void 0;
 		const cwd = resolve(options.cwd ?? process.cwd());
-		if (handoff !== void 0 && (handoff.profile !== profile || handoff.cwd !== cwd || handoff.resume !== resume)) throw new Error("TUI 重启交接与 launcher 参数不一致");
+		const { handoff, startupNotice } = reconcileHandoff(pendingHandoff, {
+			profile,
+			cwd,
+			...resume === void 0 ? {} : { resume }
+		});
 		ctx.provide(TUI_STARTUP_SERVICE, {
 			profile,
 			cwd,
@@ -2050,7 +2133,7 @@ function apply(ctx) {
 			...task !== "" && { task },
 			...handoff?.draft === void 0 ? {} : { draft: handoff.draft },
 			...handoff === void 0 ? {} : { attachmentPaths: handoff.attachmentPaths },
-			...handoff?.notice === void 0 ? {} : { startupNotice: handoff.notice }
+			...startupNotice === void 0 ? {} : { startupNotice }
 		});
 	});
 	parseCmdline(ctx, program);

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-bC3YRGeq.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DIn1PbXf.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/host/app-handoff.ts
+++ b/src/host/app-handoff.ts
@@ -1,7 +1,7 @@
 /** Bounded, single-use launcher handoff files for controlled process restart. */
 
 import { randomUUID } from 'node:crypto'
-import { lstatSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { lstatSync, readdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 
@@ -9,7 +9,24 @@ import { basename, dirname, join, resolve } from 'node:path'
 export const APP_HANDOFF_ENV = 'DSH_APP_HANDOFF_FILE'
 /** Maximum serialized handoff bytes; payloads carry references, never file bytes. */
 export const APP_HANDOFF_MAX_BYTES = 256 * 1024
-const PREFIX = 'deepseek-handoff-'
+/** Filename prefix for launcher-owned handoff files in the process temp directory. */
+export const APP_HANDOFF_PREFIX = 'deepseek-handoff-'
+
+/** Replaceable process seams used by handoff tests. */
+export const internals: {
+  tmpdir(): string
+  now(): number
+  staleMs: number
+} = {
+  tmpdir,
+  now: Date.now,
+  staleMs: 24 * 60 * 60 * 1_000,
+}
+
+export type ConsumeAppHandoffResult =
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'payload'; readonly payload: unknown }
+  | { readonly kind: 'degraded'; readonly reason: string }
 
 interface AppHandoffEnvelope {
   readonly version: 1
@@ -17,9 +34,47 @@ interface AppHandoffEnvelope {
   readonly payload: unknown
 }
 
+function canonical(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return resolve(path)
+  }
+}
+
 function allowedPath(path: string): boolean {
-  const absolute = resolve(path)
-  return dirname(absolute) === resolve(tmpdir()) && basename(absolute).startsWith(PREFIX)
+  const absolute = canonical(path)
+  return dirname(absolute) === canonical(internals.tmpdir())
+    && basename(absolute).startsWith(APP_HANDOFF_PREFIX)
+}
+
+function degrade(reason: string): ConsumeAppHandoffResult {
+  return { kind: 'degraded', reason }
+}
+
+/**
+ * Remove leftover prefix files older than the stale window.
+ * Called on write and consume so a child crash does not fill tmpdir.
+ */
+export function sweepStaleAppHandoffs(): void {
+  const directory = internals.tmpdir()
+  let names: string[]
+  try {
+    names = readdirSync(directory)
+  } catch {
+    return
+  }
+  const cutoff = internals.now() - internals.staleMs
+  for (const name of names) {
+    if (!name.startsWith(APP_HANDOFF_PREFIX)) continue
+    const path = join(directory, name)
+    if (!allowedPath(path)) continue
+    try {
+      const stat = lstatSync(path)
+      if (!stat.isFile() || stat.mtimeMs > cutoff) continue
+      unlinkSync(path)
+    } catch { /* best-effort tmpdir hygiene */ }
+  }
 }
 
 /**
@@ -31,37 +86,43 @@ function allowedPath(path: string): boolean {
  */
 export function writeAppHandoff(channel: string, payload: unknown): string {
   if (channel.trim() === '') throw new Error('app handoff channel cannot be blank')
+  sweepStaleAppHandoffs()
   const body = JSON.stringify({ version: 1, channel, payload } satisfies AppHandoffEnvelope)
   if (Buffer.byteLength(body) > APP_HANDOFF_MAX_BYTES) throw new Error('app handoff payload exceeds size limit')
-  const path = join(tmpdir(), `${PREFIX}${randomUUID()}.json`)
+  const path = join(internals.tmpdir(), `${APP_HANDOFF_PREFIX}${randomUUID()}.json`)
   writeFileSync(path, body, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
   return path
 }
 
 /**
  * Consume and delete this process's handoff when its channel matches.
- * Invalid paths, permissions, envelopes, or channels fail loud after the
- * environment value is cleared; a missing value means ordinary startup.
+ * Invalid paths, permissions, envelopes, or channels degrade instead of aborting boot.
  * @param channel - expected app protocol identifier.
- * @returns parsed opaque payload, or undefined when no handoff was supplied.
+ * @param env - process environment carrying {@link APP_HANDOFF_ENV}.
  */
-export function consumeAppHandoff(channel: string): unknown {
-  const path = process.env[APP_HANDOFF_ENV]
-  delete process.env.DSH_APP_HANDOFF_FILE
-  if (path === undefined) return undefined
-  if (!allowedPath(path)) throw new Error('app handoff path is outside the launcher temp boundary')
+export function consumeAppHandoff(
+  channel: string,
+  env: NodeJS.Dict<string | undefined> = process.env,
+): ConsumeAppHandoffResult {
+  sweepStaleAppHandoffs()
+  const path = env[APP_HANDOFF_ENV]
+  delete env[APP_HANDOFF_ENV]
+  if (path === undefined) return { kind: 'missing' }
+  if (!allowedPath(path)) return degrade('app handoff path is outside the launcher temp boundary')
   try {
     const stat = lstatSync(path)
-    if (!stat.isFile()) throw new Error('app handoff path is not a regular file')
-    if (stat.size > APP_HANDOFF_MAX_BYTES) throw new Error('app handoff file exceeds size limit')
+    if (!stat.isFile()) return degrade('app handoff path is not a regular file')
+    if (stat.size > APP_HANDOFF_MAX_BYTES) return degrade('app handoff file exceeds size limit')
     if (process.platform !== 'win32' && (stat.mode & 0o077) !== 0) {
-      throw new Error('app handoff file permissions are not owner-only')
+      return degrade('app handoff file permissions are not owner-only')
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<AppHandoffEnvelope> | null
     if (parsed === null || parsed.version !== 1 || parsed.channel !== channel || !('payload' in parsed)) {
-      throw new Error(`app handoff does not match channel ${JSON.stringify(channel)}`)
+      return degrade(`app handoff does not match channel ${JSON.stringify(channel)}`)
     }
-    return parsed.payload
+    return { kind: 'payload', payload: parsed.payload }
+  } catch (error) {
+    return degrade(error instanceof Error ? error.message : String(error))
   } finally {
     try { unlinkSync(path) } catch { /* single-use cleanup is best effort after a read failure */ }
   }

--- a/src/host/restart-handoff.ts
+++ b/src/host/restart-handoff.ts
@@ -1,0 +1,91 @@
+/** Parse and reconcile launcher restart handoff without blocking boot. */
+
+import { resolve } from 'node:path'
+import { ui } from '../client/locale.ts'
+import type { ConsumeAppHandoffResult } from './app-handoff.ts'
+
+/** Draft, attachments, and notice restored after a controlled restart. */
+export interface TuiRestartHandoff {
+  readonly profile: string
+  readonly cwd: string
+  readonly resume?: string
+  readonly draft?: string
+  readonly attachmentPaths: readonly string[]
+  readonly notice?: string
+}
+
+function degradedNotice(): string {
+  return ui('重启交接无效，已按普通启动继续', 'Restart handoff was invalid; continuing with a normal start')
+}
+
+function parseRestartHandoff(value: unknown): TuiRestartHandoff {
+  if (typeof value !== 'object' || value === null) throw new Error('TUI 重启交接不是对象')
+  const row = value as Record<string, unknown>
+  if (typeof row.profile !== 'string' || typeof row.cwd !== 'string'
+    || !Array.isArray(row.attachmentPaths)
+    || !row.attachmentPaths.every(path => typeof path === 'string')) {
+    throw new Error('TUI 重启交接缺少 Profile、工作区或附件路径')
+  }
+  if (row.attachmentPaths.length > 32) throw new Error('TUI 重启交接附件数量超过限制')
+  if (row.resume !== undefined && typeof row.resume !== 'string') throw new Error('TUI 重启交接会话 id 无效')
+  if (row.draft !== undefined && typeof row.draft !== 'string') throw new Error('TUI 重启交接草稿无效')
+  if (row.notice !== undefined && typeof row.notice !== 'string') throw new Error('TUI 重启交接提示无效')
+  return {
+    profile: row.profile,
+    cwd: resolve(row.cwd),
+    ...(typeof row.resume === 'string' ? { resume: row.resume } : {}),
+    ...(typeof row.draft === 'string' ? { draft: row.draft } : {}),
+    attachmentPaths: row.attachmentPaths,
+    ...(typeof row.notice === 'string' ? { notice: row.notice } : {}),
+  }
+}
+
+/**
+ * Turn a consume result into a parsed handoff or a startup notice.
+ * Invalid envelopes never throw; boot continues without the draft.
+ */
+export function readRestartHandoff(consumed: ConsumeAppHandoffResult): {
+  readonly handoff?: TuiRestartHandoff
+  readonly startupNotice?: string
+} {
+  if (consumed.kind === 'missing') return {}
+  if (consumed.kind === 'degraded') return { startupNotice: degradedNotice() }
+  try {
+    return { handoff: parseRestartHandoff(consumed.payload) }
+  } catch {
+    return { startupNotice: degradedNotice() }
+  }
+}
+
+/**
+ * Drop a parsed handoff when it disagrees with this process's launcher args.
+ */
+export function reconcileHandoff(
+  pending: { readonly handoff?: TuiRestartHandoff; readonly startupNotice?: string },
+  launch: { readonly profile: string; readonly cwd: string; readonly resume?: string | true },
+): { readonly handoff?: TuiRestartHandoff; readonly startupNotice?: string } {
+  if (pending.handoff === undefined) return pending
+  if (
+    pending.handoff.profile !== launch.profile
+    || pending.handoff.cwd !== resolve(launch.cwd)
+    || pending.handoff.resume !== launch.resume
+  ) {
+    return { startupNotice: degradedNotice() }
+  }
+  return {
+    handoff: pending.handoff,
+    ...(pending.handoff.notice === undefined && pending.startupNotice === undefined
+      ? {}
+      : { startupNotice: pending.handoff.notice ?? pending.startupNotice }),
+  }
+}
+
+/**
+ * Parse a consume result against this process's launcher arguments.
+ */
+export function applyConsumedHandoff(
+  consumed: ConsumeAppHandoffResult,
+  launch: { readonly profile: string; readonly cwd: string; readonly resume?: string | true },
+): { readonly handoff?: TuiRestartHandoff; readonly startupNotice?: string } {
+  return reconcileHandoff(readRestartHandoff(consumed), launch)
+}

--- a/src/host/startup.ts
+++ b/src/host/startup.ts
@@ -9,6 +9,7 @@ import { parseCmdline } from '@deepseek-ai/dsh-cmdline'
 import { localeFromEnvironment, setUiLocale, ui } from '../client/locale.ts'
 import { APP_HANDOFF_ENV, consumeAppHandoff, writeAppHandoff } from './app-handoff.ts'
 import { ProfilePluginManager } from './profile-plugin-manager.ts'
+import { readRestartHandoff, reconcileHandoff } from './restart-handoff.ts'
 
 /** Stable Cordis plugin name. */
 export const name = 'tui-startup'
@@ -32,15 +33,6 @@ export interface TuiStartupValues {
   readonly draft?: string
   readonly attachmentPaths?: readonly string[]
   readonly startupNotice?: string
-}
-
-interface TuiRestartHandoff {
-  readonly profile: string
-  readonly cwd: string
-  readonly resume?: string
-  readonly draft?: string
-  readonly attachmentPaths: readonly string[]
-  readonly notice?: string
 }
 
 interface TuiOptions {
@@ -172,28 +164,6 @@ Examples:
 `))
 }
 
-function restartHandoff(value: unknown): TuiRestartHandoff | undefined {
-  if (value === undefined) return undefined
-  if (typeof value !== 'object' || value === null) throw new Error('TUI 重启交接不是对象')
-  const row = value as Record<string, unknown>
-  if (typeof row.profile !== 'string' || typeof row.cwd !== 'string'
-    || !Array.isArray(row.attachmentPaths)
-    || !row.attachmentPaths.every(path => typeof path === 'string')) {
-    throw new Error('TUI 重启交接缺少 Profile、工作区或附件路径')
-  }
-  if (row.attachmentPaths.length > 32) throw new Error('TUI 重启交接附件数量超过限制')
-  if (row.resume !== undefined && typeof row.resume !== 'string') throw new Error('TUI 重启交接会话 id 无效')
-  if (row.draft !== undefined && typeof row.draft !== 'string') throw new Error('TUI 重启交接草稿无效')
-  if (row.notice !== undefined && typeof row.notice !== 'string') throw new Error('TUI 重启交接提示无效')
-  return {
-    profile: row.profile,
-    cwd: resolve(row.cwd),
-    ...(typeof row.resume === 'string' ? { resume: row.resume } : {}),
-    ...(typeof row.draft === 'string' ? { draft: row.draft } : {}),
-    attachmentPaths: row.attachmentPaths,
-    ...(typeof row.notice === 'string' ? { notice: row.notice } : {}),
-  }
-}
 
 /**
  * Parse TUI-owned flags and provide immutable launch values.
@@ -211,7 +181,7 @@ export function apply(ctx: Context): void {
     invokingCwd: process.cwd(),
   }))
   ctx.provide('appRestart', restartProvider(ctx))
-  const handoff = restartHandoff(consumeAppHandoff('seektty-v1'))
+  const pendingHandoff = readRestartHandoff(consumeAppHandoff('seektty-v1'))
   const program = tuiCommand()
   program.action(() => {
     const options = program.opts<TuiOptions>()
@@ -222,9 +192,11 @@ export function apply(ctx: Context): void {
         ? options.resume
         : undefined
     const cwd = resolve(options.cwd ?? process.cwd())
-    if (handoff !== undefined && (handoff.profile !== profile || handoff.cwd !== cwd || handoff.resume !== resume)) {
-      throw new Error('TUI 重启交接与 launcher 参数不一致')
-    }
+    const { handoff, startupNotice } = reconcileHandoff(pendingHandoff, {
+      profile,
+      cwd,
+      ...(resume === undefined ? {} : { resume }),
+    })
     ctx.provide(TUI_STARTUP_SERVICE, {
       profile,
       cwd,
@@ -232,7 +204,7 @@ export function apply(ctx: Context): void {
       ...task !== '' && { task },
       ...(handoff?.draft === undefined ? {} : { draft: handoff.draft }),
       ...(handoff === undefined ? {} : { attachmentPaths: handoff.attachmentPaths }),
-      ...(handoff?.notice === undefined ? {} : { startupNotice: handoff.notice }),
+      ...(startupNotice === undefined ? {} : { startupNotice }),
     } satisfies TuiStartupValues)
   })
   parseCmdline(ctx, program)

--- a/tests/app-handoff.test.ts
+++ b/tests/app-handoff.test.ts
@@ -1,0 +1,64 @@
+import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  APP_HANDOFF_ENV,
+  consumeAppHandoff,
+  internals,
+  sweepStaleAppHandoffs,
+  writeAppHandoff,
+} from '../src/host/app-handoff.ts'
+import { applyConsumedHandoff } from '../src/host/restart-handoff.ts'
+
+const original = { tmpdir: internals.tmpdir, now: internals.now, staleMs: internals.staleMs }
+
+afterEach(() => {
+  internals.tmpdir = original.tmpdir
+  internals.now = original.now
+  internals.staleMs = original.staleMs
+  delete process.env[APP_HANDOFF_ENV]
+})
+
+describe('app handoff (task 6.6)', () => {
+  it('treats a tmpdir symlink and its real path as the same boundary', () => {
+    const root = mkdtempSync(join(tmpdir(), 'seektty-handoff-'))
+    const real = join(root, 'real')
+    const link = join(root, 'link')
+    mkdirSync(real)
+    symlinkSync(real, link)
+    internals.tmpdir = () => real
+    const path = writeAppHandoff('seektty-v1', { ok: true }).replace(real, link)
+    process.env[APP_HANDOFF_ENV] = path
+    expect(consumeAppHandoff('seektty-v1')).toEqual({ kind: 'payload', payload: { ok: true } })
+  })
+
+  it('degrades invalid envelopes instead of throwing', () => {
+    const path = writeAppHandoff('seektty-v1', { ok: true })
+    writeFileSync(path, '{not-json')
+    chmodSync(path, 0o600)
+    process.env[APP_HANDOFF_ENV] = path
+    const result = consumeAppHandoff('seektty-v1')
+    expect(result.kind).toBe('degraded')
+    expect(process.env[APP_HANDOFF_ENV]).toBeUndefined()
+  })
+
+  it('sweeps leftover prefix files older than the stale window', () => {
+    internals.staleMs = 1_000
+    const path = writeAppHandoff('seektty-v1', { leftover: true })
+    utimesSync(path, new Date(0), new Date(0))
+    internals.now = () => 10_000
+    sweepStaleAppHandoffs()
+    process.env[APP_HANDOFF_ENV] = path
+    expect(consumeAppHandoff('seektty-v1')).toMatchObject({ kind: 'degraded' })
+  })
+
+  it('continues a normal start when the handoff does not match launcher args', () => {
+    const applied = applyConsumedHandoff(
+      { kind: 'payload', payload: { profile: 'a', cwd: '/tmp/a', attachmentPaths: [] } },
+      { profile: 'b', cwd: '/tmp/b' },
+    )
+    expect(applied.handoff).toBeUndefined()
+    expect(applied.startupNotice).toContain('普通启动')
+  })
+})


### PR DESCRIPTION
## Summary
- Compare handoff paths with `realpath` so macOS `/var` vs `/private/var` still matches.
- Invalid or mismatched handoff continues as a normal start plus a notice, instead of aborting boot.
- Sweep leftover `deepseek-handoff-*` files older than 24h on write and consume.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/app-handoff.test.ts tests/launcher.test.ts`
- [ ] Restart the TUI and confirm a draft still restores when the handoff is valid.
