### PR TITLE
fix(tui): warn when Cordis fiber.state is outside the known enum

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31345,6 +31345,32 @@ function startTui(options$1) {
 }
 
 //#endregion
+//#region src/host/fiber-state.ts
+/**
+* Cordis 4.0.1 FiberState is a declaration-only const enum with no runtime export.
+* Keep the numeric map local so a Cordis reorder can be detected at boot.
+*/
+const FIBER_STATE = {
+	PENDING: 0,
+	LOADING: 1,
+	ACTIVE: 2,
+	FAILED: 3,
+	DISPOSED: 4,
+	UNLOADING: 5
+};
+const KNOWN = new Set(Object.values(FIBER_STATE));
+/**
+* True when the Host fiber is ACTIVE. Unknown numeric states warn instead of
+* failing silently.
+* @param state - `ctx.fiber.state` from Cordis.
+* @param warn - stderr-compatible writer used for the self-check.
+*/
+function isActiveFiber(state, warn = () => void 0) {
+	if (!KNOWN.has(state)) warn(`seektty: unknown Cordis fiber.state ${String(state)}\n`);
+	return state === FIBER_STATE.ACTIVE;
+}
+
+//#endregion
 //#region src/host/management.ts
 const MARKETPLACE_NAMESPACE = settingsNamespace("tui-plugin-marketplace");
 const APPEARANCE_NAMESPACE = settingsNamespace(TUI_APPEARANCE_SETTINGS_NAMESPACE);
@@ -31736,7 +31762,7 @@ const inject = [
 	TUI_STARTUP_SERVICE
 ];
 function isActive(ctx) {
-	return ctx.fiber.state === 2;
+	return isActiveFiber(ctx.fiber.state, (chunk) => internals.stderr.write(chunk));
 }
 /** Replaceable process seams used by lifecycle tests. */
 const internals = { stderr: process.stderr };

--- a/src/host/fiber-state.ts
+++ b/src/host/fiber-state.ts
@@ -1,0 +1,29 @@
+/**
+ * Cordis 4.0.1 FiberState is a declaration-only const enum with no runtime export.
+ * Keep the numeric map local so a Cordis reorder can be detected at boot.
+ */
+
+export const FIBER_STATE = {
+  PENDING: 0,
+  LOADING: 1,
+  ACTIVE: 2,
+  FAILED: 3,
+  DISPOSED: 4,
+  UNLOADING: 5,
+} as const
+
+const KNOWN = new Set<number>(Object.values(FIBER_STATE))
+
+/**
+ * True when the Host fiber is ACTIVE. Unknown numeric states warn instead of
+ * failing silently.
+ * @param state - `ctx.fiber.state` from Cordis.
+ * @param warn - stderr-compatible writer used for the self-check.
+ */
+export function isActiveFiber(
+  state: number,
+  warn: (chunk: string) => unknown = () => undefined,
+): boolean {
+  if (!KNOWN.has(state)) warn(`seektty: unknown Cordis fiber.state ${String(state)}\n`)
+  return state === FIBER_STATE.ACTIVE
+}

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -9,6 +9,7 @@ import type { ClientConnectionRpc } from '@deepseek-ai/dsh-client-connection'
 import type { TuiManagementBridge, TuiSurfaceOutcome } from '@deepseek-ai/dsh-tui-protocol'
 import { startTui } from '../client/index.ts'
 import { translateUiText } from '../client/locale.ts'
+import { isActiveFiber } from './fiber-state.ts'
 import { createTuiManagementBridge } from './management.ts'
 import { TUI_STARTUP_SERVICE, type TuiStartupValues } from './startup.ts'
 
@@ -34,8 +35,7 @@ export interface TuiSurfaceHandle {
 }
 
 function isActive(ctx: Context): boolean {
-  // FiberState is a declaration-only const enum in Cordis 4.0.1; ACTIVE is 2.
-  return ctx.fiber.state === 2
+  return isActiveFiber(ctx.fiber.state, chunk => internals.stderr.write(chunk))
 }
 
 /** Replaceable process seams used by lifecycle tests. */

--- a/tests/fiber-state.test.ts
+++ b/tests/fiber-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { FIBER_STATE, isActiveFiber } from '../src/host/fiber-state.ts'
+
+describe('Cordis fiber state (task 6.8)', () => {
+  it('treats ACTIVE as 2 and warns on an unknown numeric state', () => {
+    expect(FIBER_STATE.ACTIVE).toBe(2)
+    expect(isActiveFiber(FIBER_STATE.ACTIVE)).toBe(true)
+    expect(isActiveFiber(FIBER_STATE.FAILED)).toBe(false)
+    const warnings: string[] = []
+    expect(isActiveFiber(99, chunk => { warnings.push(chunk) })).toBe(false)
+    expect(warnings.join('')).toContain('unknown Cordis fiber.state 99')
+  })
+
+  it('keeps the Host runner on the named ACTIVE check', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const source = await readFile(new URL('../src/host/index.ts', import.meta.url), 'utf8')
+    expect(source).toContain('isActiveFiber(ctx.fiber.state')
+    expect(source).not.toMatch(/ctx\.fiber\.state === 2/u)
+  })
+})


### PR DESCRIPTION
## Summary
- Keep a local named map of Cordis 4.0.1 FiberState values (`ACTIVE === 2`).
- Warn on stderr when `ctx.fiber.state` is not in the known set, instead of failing silently.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/fiber-state.test.ts`
