### PR TITLE
feat(tui): persist diff context and cancel-first danger confirm

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21218,12 +21218,16 @@ const DEFAULT_TUI_BEHAVIOR = Object.freeze({
 	statusElapsed: true,
 	clipboardFallback: "auto",
 	toolOutputLineLimit: 200,
+	diffContextLines: 3,
+	dangerConfirmDefault: "cancel",
 	keyBindings: Object.freeze({})
 });
 /** Upper bound for persisted composer history entries. */
 const MAX_COMPOSER_HISTORY = 1e4;
 /** Upper bound for one expanded tool-output block; 0 disables folding. */
 const MAX_TOOL_OUTPUT_LINE_LIMIT = 1e4;
+/** Upper bound for unified-diff context lines around each change. */
+const MAX_DIFF_CONTEXT_LINES = 100;
 /** A stale TUI Settings writer was rejected before changing durable state. */
 var TuiSettingsConflictError = class extends Error {
 	/** Stable machine-readable conflict discriminator. */
@@ -22597,6 +22601,7 @@ const CLIPBOARD_FALLBACK = new Set([
 	"osc52",
 	"off"
 ]);
+const DANGER_CONFIRM = new Set(["cancel", "confirm"]);
 function recordOf$1(value) {
 	return typeof value === "object" && value !== null ? value : {};
 }
@@ -22616,6 +22621,13 @@ function toolOutputLineLimitOf(value) {
 }
 function clipboardFallbackOf(value) {
 	return typeof value === "string" && CLIPBOARD_FALLBACK.has(value) ? value : DEFAULT_TUI_BEHAVIOR.clipboardFallback;
+}
+function diffContextLinesOf(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_TUI_BEHAVIOR.diffContextLines;
+	return Math.min(MAX_DIFF_CONTEXT_LINES, Math.floor(value));
+}
+function dangerConfirmDefaultOf(value) {
+	return typeof value === "string" && DANGER_CONFIRM.has(value) ? value : DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault;
 }
 /**
 * Find the behavior descriptor registered by the Host bridge.
@@ -22643,6 +22655,8 @@ function normalizeBehavior(value) {
 		statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
 		clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
 		toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit),
+		diffContextLines: diffContextLinesOf(record.diffContextLines),
+		dangerConfirmDefault: dangerConfirmDefaultOf(record.dangerConfirmDefault),
 		keyBindings: sanitizeKeyBindings(record.keyBindings)
 	};
 }
@@ -23068,6 +23082,8 @@ const FIELD_LABELS = {
 	statusElapsed: ["状态栏实时耗时", "Live status elapsed time"],
 	clipboardFallback: ["剪贴板回退", "Clipboard fallback"],
 	toolOutputLineLimit: ["工具输出行数上限", "Tool output line limit"],
+	diffContextLines: ["Diff 上下文行数", "Diff context lines"],
+	dangerConfirmDefault: ["危险确认默认焦点", "Danger confirm default focus"],
 	keyBindings: ["快捷键覆盖", "Key binding overrides"]
 };
 /**
@@ -27647,6 +27663,34 @@ function saveComposerHistory(path$1, entries) {
 
 //#endregion
 //#region src/client/overlays.ts
+let dangerConfirmDefault = "cancel";
+/**
+* Apply the Settings-owned default focus for dangerous confirmations.
+* @param value - cancel keeps Enter from executing the action.
+*/
+function setDangerConfirmDefault(value) {
+	dangerConfirmDefault = value;
+}
+/**
+* Ordered confirm choices with the configured default already selected.
+* @param confirmLabel - affirmative action label.
+*/
+function dangerConfirmChoices(confirmLabel) {
+	const confirm = {
+		id: "confirm",
+		label: confirmLabel,
+		description: "我已理解上述影响"
+	};
+	const cancel = {
+		id: "cancel",
+		label: "取消",
+		description: "保持当前状态"
+	};
+	return {
+		choices: dangerConfirmDefault === "cancel" ? [cancel, confirm] : [confirm, cancel],
+		initialChoiceId: dangerConfirmDefault
+	};
+}
 function rowOf(choice, descriptionWidth) {
 	const state = choice.active === true ? "● " : choice.disabledReason === void 0 ? "  " : "× ";
 	const description = choice.disabledReason ?? choice.description;
@@ -28104,19 +28148,13 @@ var NavigationOverlay = class {
 		}));
 	}
 	async confirm(title, detail, confirmLabel = "确认") {
+		const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel);
 		return (await this.select({
 			title,
 			detail,
 			searchable: false,
-			choices: [{
-				id: "confirm",
-				label: confirmLabel,
-				description: "我已理解上述影响"
-			}, {
-				id: "cancel",
-				label: "取消",
-				description: "保持当前状态"
-			}],
+			choices,
+			initialChoiceId,
 			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
 			options: {
 				width: "95%",
@@ -28349,19 +28387,13 @@ var OverlayQueue = class {
 	* @returns true only when the affirmative action was selected.
 	*/
 	async confirm(title, detail, confirmLabel = "确认") {
+		const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel);
 		return (await this.select({
 			title,
 			detail,
 			searchable: false,
-			choices: [{
-				id: "confirm",
-				label: confirmLabel,
-				description: "我已理解上述影响"
-			}, {
-				id: "cancel",
-				label: "取消",
-				description: "保持当前状态"
-			}],
+			choices,
+			initialChoiceId,
 			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
 			options: {
 				width: "95%",
@@ -28998,6 +29030,128 @@ function foldLineBlock(text$1, limit) {
 }
 
 //#endregion
+//#region src/client/line-diff.ts
+/** Context-bounded unified hunks for transcript file diffs. */
+const MAX_LCS_CELLS = 25e4;
+function contentLines(text$1) {
+	if (text$1 === "") return [];
+	return (text$1.endsWith("\n") ? text$1.slice(0, -1) : text$1).split("\n");
+}
+function lcsEdits(oldLines, newLines) {
+	const n = oldLines.length;
+	const m = newLines.length;
+	if (n * m > MAX_LCS_CELLS) return [...oldLines.map((line, index) => ({
+		kind: "del",
+		line,
+		oldLine: index + 1,
+		newLine: 0
+	})), ...newLines.map((line, index) => ({
+		kind: "add",
+		line,
+		oldLine: 0,
+		newLine: index + 1
+	}))];
+	const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+	for (let i$1 = n - 1; i$1 >= 0; i$1 -= 1) {
+		const row = dp[i$1];
+		if (row === void 0) continue;
+		for (let j$1 = m - 1; j$1 >= 0; j$1 -= 1) row[j$1] = oldLines[i$1] === newLines[j$1] ? (dp[i$1 + 1]?.[j$1 + 1] ?? 0) + 1 : Math.max(dp[i$1 + 1]?.[j$1] ?? 0, row[j$1 + 1] ?? 0);
+	}
+	const edits = [];
+	let i = 0;
+	let j = 0;
+	let oldLine = 0;
+	let newLine = 0;
+	while (i < n && j < m) if (oldLines[i] === newLines[j]) {
+		oldLine += 1;
+		newLine += 1;
+		edits.push({
+			kind: "eq",
+			line: oldLines[i] ?? "",
+			oldLine,
+			newLine
+		});
+		i += 1;
+		j += 1;
+	} else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+		oldLine += 1;
+		edits.push({
+			kind: "del",
+			line: oldLines[i] ?? "",
+			oldLine,
+			newLine
+		});
+		i += 1;
+	} else {
+		newLine += 1;
+		edits.push({
+			kind: "add",
+			line: newLines[j] ?? "",
+			oldLine,
+			newLine
+		});
+		j += 1;
+	}
+	while (i < n) {
+		oldLine += 1;
+		edits.push({
+			kind: "del",
+			line: oldLines[i] ?? "",
+			oldLine,
+			newLine
+		});
+		i += 1;
+	}
+	while (j < m) {
+		newLine += 1;
+		edits.push({
+			kind: "add",
+			line: newLines[j] ?? "",
+			oldLine,
+			newLine
+		});
+		j += 1;
+	}
+	return edits;
+}
+function hunkHeader(oldStart, oldCount, newStart, newCount) {
+	return `@@ -${String(oldStart)},${String(oldCount)} +${String(newStart)},${String(newCount)} @@`;
+}
+/**
+* Emit unified hunks for one file, keeping `context` unchanged lines around each change.
+* @param oldText - previous file body, or null when the file is created.
+* @param newText - current file body.
+* @param context - unchanged lines to keep on each side of a change.
+*/
+function unifiedHunks(oldText, newText, context) {
+	const bounded = Math.max(0, Math.floor(context));
+	const edits = lcsEdits(oldText === null ? [] : contentLines(oldText), contentLines(newText));
+	const changeIndexes = edits.flatMap((edit$1, index) => edit$1.kind === "eq" ? [] : [index]);
+	if (changeIndexes.length === 0) return [];
+	const windows = [];
+	for (const index of changeIndexes) {
+		const start = Math.max(0, index - bounded);
+		const end = Math.min(edits.length, index + bounded + 1);
+		const last = windows.at(-1);
+		if (last !== void 0 && start <= last.end) last.end = Math.max(last.end, end);
+		else windows.push({
+			start,
+			end
+		});
+	}
+	return windows.flatMap(({ start, end }) => {
+		const slice = edits.slice(start, end);
+		const oldRows = slice.filter((edit$1) => edit$1.kind !== "add");
+		const newRows = slice.filter((edit$1) => edit$1.kind !== "del");
+		return [hunkHeader(oldRows[0]?.oldLine ?? 0, oldRows.length, newRows[0]?.newLine ?? 0, newRows.length), ...slice.map((edit$1) => {
+			if (edit$1.kind === "eq") return ` ${edit$1.line}`;
+			if (edit$1.kind === "del") return `-${edit$1.line}`;
+			return `+${edit$1.line}`;
+		})];
+	});
+}
+
+//#endregion
 //#region src/client/transcript.ts
 const PULSE_FRAME_MS = 160;
 function thinkingRow() {
@@ -29230,11 +29384,7 @@ function prettyArgs(argsRaw) {
 		return argsRaw;
 	}
 }
-function contentLines(text$1) {
-	if (text$1 === "") return [];
-	return (text$1.endsWith("\n") ? text$1.slice(0, -1) : text$1).split("\n");
-}
-function diffText(value) {
+function diffText(value, context = DEFAULT_TUI_BEHAVIOR.diffContextLines) {
 	if (!Array.isArray(value) || value.length === 0) return jsonText(value);
 	const rows = [];
 	const paths = /* @__PURE__ */ new Set();
@@ -29248,13 +29398,11 @@ function diffText(value) {
 		rows.push(`diff -- ${path$1}`);
 		rows.push(oldText === null ? "--- /dev/null" : `--- a/${path$1}`);
 		rows.push(`+++ b/${path$1}`);
-		if (oldText !== null) for (const line of contentLines(oldText)) {
-			rows.push(`-${line}`);
-			removed += 1;
-		}
-		for (const line of contentLines(newText)) {
-			rows.push(`+${line}`);
-			added += 1;
+		const hunks = unifiedHunks(oldText, newText, context);
+		for (const line of hunks) {
+			if (line.startsWith("+") && !line.startsWith("+++")) added += 1;
+			if (line.startsWith("-") && !line.startsWith("---")) removed += 1;
+			rows.push(line);
 		}
 	}
 	const visible = rows.length <= 80 ? rows : [
@@ -29351,7 +29499,7 @@ function readInvocationFallback(node) {
 	const location$1 = (Array.isArray(call.locations) ? call.locations : []).find((candidate) => typeof candidate === "object" && candidate !== null && "path" in candidate && typeof candidate.path === "string" && candidate.path !== "");
 	return location$1 === void 0 ? void 0 : invocationCode("read", { file_path: location$1.path });
 }
-function settledInvocationDetails(node) {
+function settledInvocationDetails(node, context) {
 	const call = node.callView;
 	const details = [];
 	if (call?.card === "terminal") {
@@ -29359,7 +29507,7 @@ function settledInvocationDetails(node) {
 		if (command !== void 0) details.push(command);
 	} else if (call?.card === "diff") details.push({
 		kind: "code",
-		text: diffText(call.diffs),
+		text: diffText(call.diffs, context),
 		language: "diff"
 	});
 	else if (node.call !== null) details.push(toolInvocationDetail(node.call.name, node.call.argsRaw));
@@ -29368,9 +29516,9 @@ function settledInvocationDetails(node) {
 	if (readFallback !== void 0) details.push(readFallback);
 	return details;
 }
-function viewDetails(node) {
+function viewDetails(node, context) {
 	const result = node.resultView;
-	const details = settledInvocationDetails(node);
+	const details = settledInvocationDetails(node, context);
 	if (result?.card === "terminal") {
 		if (result.output !== void 0) details.push({
 			kind: "plain",
@@ -29386,7 +29534,7 @@ function viewDetails(node) {
 		});
 	} else if (result?.card === "diff") details.push({
 		kind: "code",
-		text: diffText(result.diffs),
+		text: diffText(result.diffs, context),
 		language: "diff"
 	});
 	else if (result?.card === "generic" && result.content !== void 0) details.push(...contentDetails(result.content));
@@ -29458,7 +29606,7 @@ function viewDetails(node) {
 	});
 	return details.filter((value) => value.text !== "");
 }
-function runningViewDetails(node) {
+function runningViewDetails(node, context) {
 	const view = node.callView;
 	if (view?.card === "terminal") {
 		const command = terminalCommandDetail(view);
@@ -29466,7 +29614,7 @@ function runningViewDetails(node) {
 	}
 	if (view?.card === "diff") return [{
 		kind: "code",
-		text: diffText(view.diffs),
+		text: diffText(view.diffs, context),
 		language: "diff"
 	}];
 	return [toolInvocationDetail(node.name, node.argsRaw)];
@@ -29515,7 +29663,7 @@ function toolBlockRows(block$1, preferences, depth, cardKey) {
 	if ("kind" in block$1) {
 		const duration = block$1.callTime === null ? "" : ` · ${toolDurationText(Math.max(0, block$1.time - block$1.callTime))}`;
 		const failed = settledToolFailed(block$1);
-		const details$1 = expanded ? viewDetails(block$1) : settledInvocationDetails(block$1);
+		const details$1 = expanded ? viewDetails(block$1, preferences.diffContextLines) : settledInvocationDetails(block$1, preferences.diffContextLines);
 		return [
 			{
 				format: "plain",
@@ -29526,7 +29674,7 @@ function toolBlockRows(block$1, preferences, depth, cardKey) {
 			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
 		];
 	}
-	const details = runningViewDetails(block$1);
+	const details = runningViewDetails(block$1, preferences.diffContextLines);
 	return [
 		{
 			format: "plain",
@@ -29851,6 +29999,7 @@ var Transcript = class {
 	toolVisibility = "collapsed";
 	reasoningVisible = false;
 	toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit;
+	diffContextLines = DEFAULT_TUI_BEHAVIOR.diffContextLines;
 	emptyState = true;
 	hasMore = false;
 	loadingOlder = false;
@@ -29898,10 +30047,11 @@ var Transcript = class {
 	* @param tools - default tool-card shape.
 	* @param reasoning - whether reasoning blocks are visible at session open.
 	*/
-	applyPresentationDefaults(tools, reasoning, toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit) {
+	applyPresentationDefaults(tools, reasoning, toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit, diffContextLines = DEFAULT_TUI_BEHAVIOR.diffContextLines) {
 		this.toolVisibility = tools;
 		this.reasoningVisible = reasoning;
 		this.toolOutputLineLimit = toolOutputLineLimit;
+		this.diffContextLines = diffContextLines;
 	}
 	/** Follow new transcript output after the user submits from a historical viewport. */
 	followLatest() {
@@ -29960,6 +30110,7 @@ var Transcript = class {
 			tools: this.toolVisibility,
 			reasoning: this.reasoningVisible,
 			toolOutputLineLimit: this.toolOutputLineLimit,
+			diffContextLines: this.diffContextLines,
 			expandedTools: this.expandedTools,
 			collapsedTools: this.collapsedTools
 		};
@@ -30323,6 +30474,7 @@ var Transcript = class {
 			tools: this.toolVisibility,
 			reasoning: this.reasoningVisible,
 			toolOutputLineLimit: this.toolOutputLineLimit,
+			diffContextLines: this.diffContextLines,
 			expandedTools: this.expandedTools,
 			collapsedTools: this.collapsedTools
 		}, key)) {
@@ -30705,6 +30857,7 @@ async function startTuiSurface(options$1) {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
 		const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments));
 		applyKeyBindingOverrides(initialBehavior.keyBindings);
+		setDangerConfirmDefault(initialBehavior.dangerConfirmDefault);
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
 		stopConstructedTui = () => {
@@ -30729,7 +30882,7 @@ async function startTuiSurface(options$1) {
 			const snapshot = current.session.getSnapshot();
 			if (snapshot.hasMore && !snapshot.loadingOlder) current.session.loadOlder();
 		});
-		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning, initialBehavior.toolOutputLineLimit);
+		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning, initialBehavior.toolOutputLineLimit, initialBehavior.diffContextLines);
 		let syntax;
 		disposeConstructedSyntax = () => {
 			syntax?.dispose();
@@ -30993,6 +31146,11 @@ async function startTuiSurface(options$1) {
 			},
 			applyBehavior: (behavior) => {
 				applyKeyBindingOverrides(behavior.keyBindings);
+				setDangerConfirmDefault(behavior.dangerConfirmDefault);
+				transcript.applyPresentationDefaults(behavior.toolCards, behavior.showReasoning, behavior.toolOutputLineLimit, behavior.diffContextLines);
+				transcript.refreshPresentation();
+				tui.invalidate();
+				tui.requestRender(true);
 			},
 			setEditor: (text$1) => {
 				editor.setText(escapeTerminalText(text$1));
@@ -31472,6 +31630,8 @@ const BehaviorSettingsSchema = z$1.object({
 		"off"
 	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。"),
 	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description("展开态工具输出单块行数上限；0 表示不折叠。"),
+	diffContextLines: z$1.natural().max(MAX_DIFF_CONTEXT_LINES).default(DEFAULT_TUI_BEHAVIOR.diffContextLines).description("Diff 上下文行数。"),
+	dangerConfirmDefault: z$1.union(["cancel", "confirm"]).default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault).description("危险确认默认焦点；cancel 表示回车不执行。"),
 	keyBindings: z$1.dict(z$1.string()).default({}).description("覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。")
 });
 function settingsDocument(descriptor) {

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -3,10 +3,12 @@
 import {
   DEFAULT_TUI_BEHAVIOR,
   MAX_COMPOSER_HISTORY,
+  MAX_DIFF_CONTEXT_LINES,
   MAX_TOOL_OUTPUT_LINE_LIMIT,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   type TuiBehaviorSettings,
   type TuiClipboardFallback,
+  type TuiDangerConfirmDefault,
   type TuiSettingsDocument,
   type TuiToolCardDisplay,
 } from '@deepseek-ai/dsh-tui-protocol'
@@ -14,6 +16,7 @@ import { sanitizeKeyBindings } from './keymap.ts'
 
 const TOOL_CARDS = new Set<TuiToolCardDisplay>(['collapsed', 'expanded', 'hidden'])
 const CLIPBOARD_FALLBACK = new Set<TuiClipboardFallback>(['auto', 'osc52', 'off'])
+const DANGER_CONFIRM = new Set<TuiDangerConfirmDefault>(['cancel', 'confirm'])
 
 function recordOf(value: unknown): Readonly<Record<string, unknown>> {
   return typeof value === 'object' && value !== null ? value as Readonly<Record<string, unknown>> : {}
@@ -47,6 +50,19 @@ function clipboardFallbackOf(value: unknown): TuiClipboardFallback {
   return typeof value === 'string' && CLIPBOARD_FALLBACK.has(value as TuiClipboardFallback)
     ? value as TuiClipboardFallback
     : DEFAULT_TUI_BEHAVIOR.clipboardFallback
+}
+
+function diffContextLinesOf(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_TUI_BEHAVIOR.diffContextLines
+  }
+  return Math.min(MAX_DIFF_CONTEXT_LINES, Math.floor(value))
+}
+
+function dangerConfirmDefaultOf(value: unknown): TuiDangerConfirmDefault {
+  return typeof value === 'string' && DANGER_CONFIRM.has(value as TuiDangerConfirmDefault)
+    ? value as TuiDangerConfirmDefault
+    : DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault
 }
 
 /**
@@ -87,6 +103,8 @@ export function normalizeBehavior(value: unknown): TuiBehaviorSettings {
     statusElapsed: booleanOf(record.statusElapsed, DEFAULT_TUI_BEHAVIOR.statusElapsed),
     clipboardFallback: clipboardFallbackOf(record.clipboardFallback),
     toolOutputLineLimit: toolOutputLineLimitOf(record.toolOutputLineLimit),
+    diffContextLines: diffContextLinesOf(record.diffContextLines),
+    dangerConfirmDefault: dangerConfirmDefaultOf(record.dangerConfirmDefault),
     keyBindings: sanitizeKeyBindings(record.keyBindings),
   }
 }

--- a/src/client/line-diff.ts
+++ b/src/client/line-diff.ts
@@ -1,0 +1,123 @@
+/** Context-bounded unified hunks for transcript file diffs. */
+
+const MAX_LCS_CELLS = 250_000
+
+export function contentLines(text: string): string[] {
+  if (text === '') return []
+  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
+}
+
+interface Edit {
+  readonly kind: 'eq' | 'del' | 'add'
+  readonly line: string
+  readonly oldLine: number
+  readonly newLine: number
+}
+
+function lcsEdits(oldLines: readonly string[], newLines: readonly string[]): Edit[] {
+  const n = oldLines.length
+  const m = newLines.length
+  if (n * m > MAX_LCS_CELLS) {
+    return [
+      ...oldLines.map((line, index) => ({
+        kind: 'del' as const,
+        line,
+        oldLine: index + 1,
+        newLine: 0,
+      })),
+      ...newLines.map((line, index) => ({
+        kind: 'add' as const,
+        line,
+        oldLine: 0,
+        newLine: index + 1,
+      })),
+    ]
+  }
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array<number>(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i -= 1) {
+    const row = dp[i]
+    if (row === undefined) continue
+    for (let j = m - 1; j >= 0; j -= 1) {
+      row[j] = oldLines[i] === newLines[j]
+        ? (dp[i + 1]?.[j + 1] ?? 0) + 1
+        : Math.max(dp[i + 1]?.[j] ?? 0, row[j + 1] ?? 0)
+    }
+  }
+  const edits: Edit[] = []
+  let i = 0
+  let j = 0
+  let oldLine = 0
+  let newLine = 0
+  while (i < n && j < m) {
+    if (oldLines[i] === newLines[j]) {
+      oldLine += 1
+      newLine += 1
+      edits.push({ kind: 'eq', line: oldLines[i] ?? '', oldLine, newLine })
+      i += 1
+      j += 1
+    } else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+      oldLine += 1
+      edits.push({ kind: 'del', line: oldLines[i] ?? '', oldLine, newLine })
+      i += 1
+    } else {
+      newLine += 1
+      edits.push({ kind: 'add', line: newLines[j] ?? '', oldLine, newLine })
+      j += 1
+    }
+  }
+  while (i < n) {
+    oldLine += 1
+    edits.push({ kind: 'del', line: oldLines[i] ?? '', oldLine, newLine })
+    i += 1
+  }
+  while (j < m) {
+    newLine += 1
+    edits.push({ kind: 'add', line: newLines[j] ?? '', oldLine, newLine })
+    j += 1
+  }
+  return edits
+}
+
+function hunkHeader(oldStart: number, oldCount: number, newStart: number, newCount: number): string {
+  return `@@ -${String(oldStart)},${String(oldCount)} +${String(newStart)},${String(newCount)} @@`
+}
+
+/**
+ * Emit unified hunks for one file, keeping `context` unchanged lines around each change.
+ * @param oldText - previous file body, or null when the file is created.
+ * @param newText - current file body.
+ * @param context - unchanged lines to keep on each side of a change.
+ */
+export function unifiedHunks(oldText: string | null, newText: string, context: number): string[] {
+  const bounded = Math.max(0, Math.floor(context))
+  const edits = lcsEdits(oldText === null ? [] : contentLines(oldText), contentLines(newText))
+  const changeIndexes = edits.flatMap((edit, index) => edit.kind === 'eq' ? [] : [index])
+  if (changeIndexes.length === 0) return []
+  const windows: Array<{ start: number; end: number }> = []
+  for (const index of changeIndexes) {
+    const start = Math.max(0, index - bounded)
+    const end = Math.min(edits.length, index + bounded + 1)
+    const last = windows.at(-1)
+    if (last !== undefined && start <= last.end) last.end = Math.max(last.end, end)
+    else windows.push({ start, end })
+  }
+  return windows.flatMap(({ start, end }) => {
+    const slice = edits.slice(start, end)
+    const oldRows = slice.filter(edit => edit.kind !== 'add')
+    const newRows = slice.filter(edit => edit.kind !== 'del')
+    const lines = [
+      hunkHeader(
+        oldRows[0]?.oldLine ?? 0,
+        oldRows.length,
+        newRows[0]?.newLine ?? 0,
+        newRows.length,
+      ),
+      ...slice.map((edit) => {
+        if (edit.kind === 'eq') return ` ${edit.line}`
+        if (edit.kind === 'del') return `-${edit.line}`
+        return `+${edit.line}`
+      }),
+    ]
+    return lines
+  })
+}

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -19,6 +19,41 @@ import {
 } from '@mariozechner/pi-tui'
 import { translateUiText } from './locale.ts'
 import { color, editorTheme, escapeTerminalText, surfaceRow } from './theme.ts'
+import type { TuiDangerConfirmDefault } from '@deepseek-ai/dsh-tui-protocol'
+
+let dangerConfirmDefault: TuiDangerConfirmDefault = 'cancel'
+
+/**
+ * Apply the Settings-owned default focus for dangerous confirmations.
+ * @param value - cancel keeps Enter from executing the action.
+ */
+export function setDangerConfirmDefault(value: TuiDangerConfirmDefault): void {
+  dangerConfirmDefault = value
+}
+
+/**
+ * Ordered confirm choices with the configured default already selected.
+ * @param confirmLabel - affirmative action label.
+ */
+export function dangerConfirmChoices(confirmLabel: string): {
+  readonly choices: readonly OverlayChoice[]
+  readonly initialChoiceId: TuiDangerConfirmDefault
+} {
+  const confirm: OverlayChoice = {
+    id: 'confirm',
+    label: confirmLabel,
+    description: '我已理解上述影响',
+  }
+  const cancel: OverlayChoice = {
+    id: 'cancel',
+    label: '取消',
+    description: '保持当前状态',
+  }
+  return {
+    choices: dangerConfirmDefault === 'cancel' ? [cancel, confirm] : [confirm, cancel],
+    initialChoiceId: dangerConfirmDefault,
+  }
+}
 
 /** One row in a searchable terminal selector. */
 export interface OverlayChoice {
@@ -649,14 +684,13 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
   }
 
   async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
+    const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel)
     const selected = await this.select({
       title,
       detail,
       searchable: false,
-      choices: [
-        { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
-        { id: 'cancel', label: '取消', description: '保持当前状态' },
-      ],
+      choices,
+      initialChoiceId,
       footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })
@@ -904,14 +938,13 @@ export class OverlayQueue implements OverlayPrompts {
    * @returns true only when the affirmative action was selected.
    */
   async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
+    const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel)
     const selected = await this.select({
       title,
       detail,
       searchable: false,
-      choices: [
-        { id: 'confirm', label: confirmLabel, description: '我已理解上述影响' },
-        { id: 'cancel', label: '取消', description: '保持当前状态' },
-      ],
+      choices,
+      initialChoiceId,
       footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -216,6 +216,8 @@ const FIELD_LABELS: Readonly<Record<string, readonly [zh: string, en: string]>> 
   statusElapsed: ['状态栏实时耗时', 'Live status elapsed time'],
   clipboardFallback: ['剪贴板回退', 'Clipboard fallback'],
   toolOutputLineLimit: ['工具输出行数上限', 'Tool output line limit'],
+  diffContextLines: ['Diff 上下文行数', 'Diff context lines'],
+  dangerConfirmDefault: ['危险确认默认焦点', 'Danger confirm default focus'],
   keyBindings: ['快捷键覆盖', 'Key binding overrides'],
 }
 

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -38,7 +38,7 @@ import {
   ui,
   uiLocale,
 } from './locale.ts'
-import { OverlayQueue } from './overlays.ts'
+import { OverlayQueue, setDangerConfirmDefault } from './overlays.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
@@ -141,6 +141,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
     const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments))
     applyKeyBindingOverrides(initialBehavior.keyBindings)
+    setDangerConfirmDefault(initialBehavior.dangerConfirmDefault)
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
     stopConstructedTui = () => {
@@ -175,6 +176,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       initialBehavior.toolCards,
       initialBehavior.showReasoning,
       initialBehavior.toolOutputLineLimit,
+      initialBehavior.diffContextLines,
     )
     let syntax: SyntaxHighlighter | undefined
     disposeConstructedSyntax = () => { syntax?.dispose() }
@@ -453,6 +455,16 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       applyBehavior: (behavior) => {
         applyKeyBindingOverrides(behavior.keyBindings)
+        setDangerConfirmDefault(behavior.dangerConfirmDefault)
+        transcript.applyPresentationDefaults(
+          behavior.toolCards,
+          behavior.showReasoning,
+          behavior.toolOutputLineLimit,
+          behavior.diffContextLines,
+        )
+        transcript.refreshPresentation()
+        tui.invalidate()
+        tui.requestRender(true)
       },
       setEditor: (text) => {
         editor.setText(escapeTerminalText(text))

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -53,6 +53,7 @@ import {
 } from './theme.ts'
 import { syntaxLanguageForPath } from './syntax-highlighter.ts'
 import { foldLineBlock } from './tool-output-limit.ts'
+import { unifiedHunks } from './line-diff.ts'
 import { DEFAULT_TUI_BEHAVIOR } from '@deepseek-ai/dsh-tui-protocol'
 
 const PULSE_FRAME_MS = 160
@@ -64,6 +65,7 @@ interface TranscriptPreferences {
   readonly tools: ToolVisibility
   readonly reasoning: boolean
   readonly toolOutputLineLimit: number
+  readonly diffContextLines: number
   readonly expandedTools: ReadonlySet<string>
   readonly collapsedTools: ReadonlySet<string>
 }
@@ -391,12 +393,7 @@ function prettyArgs(argsRaw: string): string {
   try { return jsonText(JSON.parse(argsRaw)) } catch { return argsRaw }
 }
 
-function contentLines(text: string): string[] {
-  if (text === '') return []
-  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
-}
-
-function diffText(value: unknown): string {
+function diffText(value: unknown, context = DEFAULT_TUI_BEHAVIOR.diffContextLines): string {
   if (!Array.isArray(value) || value.length === 0) return jsonText(value)
   const rows: string[] = []
   const paths = new Set<string>()
@@ -412,15 +409,11 @@ function diffText(value: unknown): string {
     rows.push(`diff -- ${path}`)
     rows.push(oldText === null ? '--- /dev/null' : `--- a/${path}`)
     rows.push(`+++ b/${path}`)
-    if (oldText !== null) {
-      for (const line of contentLines(oldText)) {
-        rows.push(`-${line}`)
-        removed += 1
-      }
-    }
-    for (const line of contentLines(newText)) {
-      rows.push(`+${line}`)
-      added += 1
+    const hunks = unifiedHunks(oldText, newText, context)
+    for (const line of hunks) {
+      if (line.startsWith('+') && !line.startsWith('+++')) added += 1
+      if (line.startsWith('-') && !line.startsWith('---')) removed += 1
+      rows.push(line)
     }
   }
   const visible = rows.length <= 80
@@ -553,14 +546,14 @@ function readInvocationFallback(node: ToolResultNode): ToolDetail | undefined {
   return location === undefined ? undefined : invocationCode('read', { file_path: location.path })
 }
 
-function settledInvocationDetails(node: ToolResultNode): ToolDetail[] {
+function settledInvocationDetails(node: ToolResultNode, context: number): ToolDetail[] {
   const call = node.callView
   const details: ToolDetail[] = []
   if (call?.card === 'terminal') {
     const command = terminalCommandDetail(call)
     if (command !== undefined) details.push(command)
   } else if (call?.card === 'diff') {
-    details.push({ kind: 'code', text: diffText(call.diffs), language: 'diff' })
+    details.push({ kind: 'code', text: diffText(call.diffs, context), language: 'diff' })
   } else if (node.call !== null) {
     details.push(toolInvocationDetail(node.call.name, node.call.argsRaw))
   } else if (call?.card === 'generic' && call.rawInput !== undefined) {
@@ -571,9 +564,9 @@ function settledInvocationDetails(node: ToolResultNode): ToolDetail[] {
   return details
 }
 
-function viewDetails(node: ToolResultNode): ToolDetail[] {
+function viewDetails(node: ToolResultNode, context: number): ToolDetail[] {
   const result = node.resultView
-  const details = settledInvocationDetails(node)
+  const details = settledInvocationDetails(node, context)
   if (result?.card === 'terminal') {
     if (result.output !== undefined) details.push({ kind: 'plain', text: result.output })
     if (result.exitCode !== undefined) details.push({
@@ -585,7 +578,7 @@ function viewDetails(node: ToolResultNode): ToolDetail[] {
       text: ui(`信号 ${result.signal}`, `Signal ${result.signal}`),
     })
   } else if (result?.card === 'diff') {
-    details.push({ kind: 'code', text: diffText(result.diffs), language: 'diff' })
+    details.push({ kind: 'code', text: diffText(result.diffs, context), language: 'diff' })
   } else if (result?.card === 'generic' && result.content !== undefined) {
     details.push(...contentDetails(result.content))
   } else if (result?.card === 'read') {
@@ -648,13 +641,13 @@ function viewDetails(node: ToolResultNode): ToolDetail[] {
   return details.filter(value => value.text !== '')
 }
 
-function runningViewDetails(node: RunningToolCall): ToolDetail[] {
+function runningViewDetails(node: RunningToolCall, context: number): ToolDetail[] {
   const view = node.callView
   if (view?.card === 'terminal') {
     const command = terminalCommandDetail(view)
     return command === undefined ? [] : [command]
   }
-  if (view?.card === 'diff') return [{ kind: 'code', text: diffText(view.diffs), language: 'diff' }]
+  if (view?.card === 'diff') return [{ kind: 'code', text: diffText(view.diffs, context), language: 'diff' }]
   return [toolInvocationDetail(node.name, node.argsRaw)]
 }
 
@@ -702,7 +695,7 @@ function toolBlockRows(
   if ('kind' in block) {
     const duration = block.callTime === null ? '' : ` · ${toolDurationText(Math.max(0, block.time - block.callTime))}`
     const failed = settledToolFailed(block)
-    const details = expanded ? viewDetails(block) : settledInvocationDetails(block)
+    const details = expanded ? viewDetails(block, preferences.diffContextLines) : settledInvocationDetails(block, preferences.diffContextLines)
     return [
       {
         format: 'plain',
@@ -713,7 +706,7 @@ function toolBlockRows(
       ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
     ]
   }
-  const details = runningViewDetails(block)
+  const details = runningViewDetails(block, preferences.diffContextLines)
   return [
     {
       format: 'plain',
@@ -1109,6 +1102,7 @@ export class Transcript implements Component, Focusable {
   private toolVisibility: ToolVisibility = 'collapsed'
   private reasoningVisible = false
   private toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit
+  private diffContextLines = DEFAULT_TUI_BEHAVIOR.diffContextLines
   private emptyState = true
   private hasMore = false
   private loadingOlder = false
@@ -1166,10 +1160,12 @@ export class Transcript implements Component, Focusable {
     tools: ToolVisibility,
     reasoning: boolean,
     toolOutputLineLimit = DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit,
+    diffContextLines = DEFAULT_TUI_BEHAVIOR.diffContextLines,
   ): void {
     this.toolVisibility = tools
     this.reasoningVisible = reasoning
     this.toolOutputLineLimit = toolOutputLineLimit
+    this.diffContextLines = diffContextLines
   }
 
   /** Follow new transcript output after the user submits from a historical viewport. */
@@ -1229,6 +1225,7 @@ export class Transcript implements Component, Focusable {
       tools: this.toolVisibility,
       reasoning: this.reasoningVisible,
       toolOutputLineLimit: this.toolOutputLineLimit,
+      diffContextLines: this.diffContextLines,
       expandedTools: this.expandedTools,
       collapsedTools: this.collapsedTools,
     }
@@ -1634,6 +1631,7 @@ export class Transcript implements Component, Focusable {
       tools: this.toolVisibility,
       reasoning: this.reasoningVisible,
       toolOutputLineLimit: this.toolOutputLineLimit,
+      diffContextLines: this.diffContextLines,
       expandedTools: this.expandedTools,
       collapsedTools: this.collapsedTools,
     }, key)

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -20,6 +20,7 @@ import {
   MAX_CUSTOM_THEMES,
   MAX_TEXTMATE_RULES,
   MAX_TOOL_OUTPUT_LINE_LIMIT,
+  MAX_DIFF_CONTEXT_LINES,
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
@@ -133,6 +134,12 @@ const BehaviorSettingsSchema = z.object({
   toolOutputLineLimit: z.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT)
     .default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit)
     .description('展开态工具输出单块行数上限；0 表示不折叠。'),
+  diffContextLines: z.natural().max(MAX_DIFF_CONTEXT_LINES)
+    .default(DEFAULT_TUI_BEHAVIOR.diffContextLines)
+    .description('Diff 上下文行数。'),
+  dangerConfirmDefault: z.union(['cancel', 'confirm'])
+    .default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault)
+    .description('危险确认默认焦点；cancel 表示回车不执行。'),
   keyBindings: z.dict(z.string()).default({})
     .description('覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。'),
 })

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -114,6 +114,9 @@ export type TuiToolCardDisplay = 'collapsed' | 'expanded' | 'hidden'
 /** How `/copy` writes the system clipboard after OSC 52. */
 export type TuiClipboardFallback = 'auto' | 'osc52' | 'off'
 
+/** Which confirm-dialog choice is focused when a dangerous action opens. */
+export type TuiDangerConfirmDefault = 'cancel' | 'confirm'
+
 /** Complete behavior value owned by the SeekTTY Settings namespace. */
 export interface TuiBehaviorSettings {
   readonly toolCards: TuiToolCardDisplay
@@ -124,6 +127,8 @@ export interface TuiBehaviorSettings {
   readonly statusElapsed: boolean
   readonly clipboardFallback: TuiClipboardFallback
   readonly toolOutputLineLimit: number
+  readonly diffContextLines: number
+  readonly dangerConfirmDefault: TuiDangerConfirmDefault
   readonly keyBindings: Readonly<Record<string, string>>
 }
 
@@ -137,6 +142,8 @@ export const DEFAULT_TUI_BEHAVIOR: TuiBehaviorSettings = Object.freeze({
   statusElapsed: true,
   clipboardFallback: 'auto',
   toolOutputLineLimit: 200,
+  diffContextLines: 3,
+  dangerConfirmDefault: 'cancel',
   keyBindings: Object.freeze({}),
 })
 
@@ -145,6 +152,9 @@ export const MAX_COMPOSER_HISTORY = 10_000
 
 /** Upper bound for one expanded tool-output block; 0 disables folding. */
 export const MAX_TOOL_OUTPUT_LINE_LIMIT = 10_000
+
+/** Upper bound for unified-diff context lines around each change. */
+export const MAX_DIFF_CONTEXT_LINES = 100
 
 /** One complete, redacted registered Settings namespace. */
 export interface TuiSettingsDocument {

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -42,6 +42,8 @@ describe('seektty-behavior settings', () => {
       statusElapsed: false,
       clipboardFallback: 'osc52',
       toolOutputLineLimit: 200,
+      diffContextLines: 3,
+      dangerConfirmDefault: 'cancel',
       keyBindings: {},
     })
     expect(normalizeBehavior({
@@ -55,6 +57,13 @@ describe('seektty-behavior settings', () => {
       toolCards: 'collapsed',
       composerHistoryLimit: 10_000,
       clipboardFallback: 'auto',
+    })
+    expect(normalizeBehavior({
+      diffContextLines: 1,
+      dangerConfirmDefault: 'confirm',
+    })).toMatchObject({
+      diffContextLines: 1,
+      dangerConfirmDefault: 'confirm',
     })
   })
 

--- a/tests/danger-confirm.test.ts
+++ b/tests/danger-confirm.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  dangerConfirmChoices,
+  setDangerConfirmDefault,
+} from '../src/client/overlays.ts'
+
+afterEach(() => { setDangerConfirmDefault('cancel') })
+
+describe('danger confirm default (task 8 leftover)', () => {
+  it('focuses cancel first so Enter does not confirm', () => {
+    const { choices, initialChoiceId } = dangerConfirmChoices('删除')
+    expect(initialChoiceId).toBe('cancel')
+    expect(choices.map(choice => choice.id)).toEqual(['cancel', 'confirm'])
+    expect(choices[1]?.label).toBe('删除')
+  })
+
+  it('can restore confirm-first when the setting is confirm', () => {
+    setDangerConfirmDefault('confirm')
+    const { choices, initialChoiceId } = dangerConfirmChoices('删除')
+    expect(initialChoiceId).toBe('confirm')
+    expect(choices.map(choice => choice.id)).toEqual(['confirm', 'cancel'])
+  })
+})

--- a/tests/line-diff.test.ts
+++ b/tests/line-diff.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { unifiedHunks } from '../src/client/line-diff.ts'
+
+describe('unified hunks (task 8 leftover: diff context lines)', () => {
+  it('keeps context around a one-line change', () => {
+    const oldText = ['alpha', 'keep-one', 'old', 'keep-two', 'omega'].join('\n')
+    const newText = ['alpha', 'keep-one', 'new', 'keep-two', 'omega'].join('\n')
+    const hunks = unifiedHunks(oldText, newText, 1)
+    expect(hunks.join('\n')).toContain('@@ -2,3 +2,3 @@')
+    expect(hunks.join('\n')).toContain(' keep-one')
+    expect(hunks.join('\n')).toContain('-old')
+    expect(hunks.join('\n')).toContain('+new')
+    expect(hunks.join('\n')).toContain(' keep-two')
+    expect(hunks.join('\n')).not.toContain('alpha')
+    expect(hunks.join('\n')).not.toContain('omega')
+  })
+
+  it('treats a missing old file as all additions', () => {
+    expect(unifiedHunks(null, 'one\ntwo', 3).join('\n')).toBe([
+      '@@ -0,0 +1,2 @@',
+      '+one',
+      '+two',
+    ].join('\n'))
+  })
+})

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -637,7 +637,7 @@ describe('conversation viewport', () => {
     vi.stubEnv('COLORTERM', 'truecolor')
     const highlighter = vi.fn((code: string, _language?: string) => code.split('\n'))
     setCodeHighlighter(highlighter)
-    const transcript = new Transcript(() => 24)
+    const transcript = new Transcript(() => 40)
     transcript.cycleToolVisibility()
     transcript.update(snapshot([
       tool(


### PR DESCRIPTION
## Summary
- Add `diffContextLines` (default 3) and render unified hunks instead of whole-file -/+ dumps.
- Add `dangerConfirmDefault` (default cancel) so Enter on a dangerous prompt does not confirm.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/line-diff.test.ts tests/danger-confirm.test.ts tests/behavior.test.ts tests/transcript.test.ts`
- [ ] Open a dangerous confirm and press Enter; the action must not run.
