### PR TITLE
feat(tui): cache transcript rows by chat node during streaming

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29154,6 +29154,11 @@ function unifiedHunks(oldText, newText, context) {
 //#endregion
 //#region src/client/transcript.ts
 const PULSE_FRAME_MS = 160;
+/** Replaceable counters used by incremental-render tests. */
+const internals$2 = {
+	markdownCreated: 0,
+	componentRenders: 0
+};
 function thinkingRow() {
 	return {
 		format: "plain",
@@ -29778,6 +29783,18 @@ function grouped(rows) {
 		gapBefore: true
 	} : row);
 }
+function nodeFingerprint(node, preferences) {
+	return JSON.stringify({
+		kind: node.kind,
+		data: node.data,
+		tools: preferences.tools,
+		reasoning: preferences.reasoning,
+		toolOutputLineLimit: preferences.toolOutputLineLimit,
+		diffContextLines: preferences.diffContextLines,
+		expanded: preferences.expandedTools.has(node.key),
+		collapsed: preferences.collapsedTools.has(node.key)
+	});
+}
 function nonnegativeNumber(value) {
 	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : void 0;
 }
@@ -30015,6 +30032,8 @@ var Transcript = class {
 	toolCursor = 0;
 	expandedTools = /* @__PURE__ */ new Set();
 	collapsedTools = /* @__PURE__ */ new Set();
+	nodeCache = /* @__PURE__ */ new Map();
+	lineCache = /* @__PURE__ */ new WeakMap();
 	focused = false;
 	/**
 	* @param viewportRows - current terminal-dependent transcript height.
@@ -30078,6 +30097,7 @@ var Transcript = class {
 		this.sessionId = void 0;
 		this.pendingImages.clear();
 		this.imageComponents.clear();
+		this.nodeCache.clear();
 		this.emptyState = true;
 		this.hasMore = false;
 		this.loadingOlder = false;
@@ -30102,6 +30122,7 @@ var Transcript = class {
 			this.expandedTools.clear();
 			this.collapsedTools.clear();
 			this.toolCursor = 0;
+			this.nodeCache.clear();
 		}
 		this.imageLoader = imageLoader;
 		this.hasMore = snapshot.hasMore;
@@ -30118,15 +30139,57 @@ var Transcript = class {
 			const node = snapshot.chat.nodes.get(key);
 			return node === void 0 || node.visibility !== "visible" ? [] : [node];
 		});
-		const rows = visibleNodes.flatMap((node) => chatNodeRows(node, preferences));
+		const rows = [];
+		const components = [];
+		const keep = /* @__PURE__ */ new Set();
+		const take = (key, fingerprint, build) => {
+			keep.add(key);
+			const hit = this.nodeCache.get(key);
+			if (hit !== void 0 && hit.fingerprint === fingerprint) {
+				rows.push(...hit.rows);
+				components.push(...hit.components);
+				return;
+			}
+			const built = build();
+			const created = built.map((row) => this.component(row));
+			this.nodeCache.set(key, {
+				fingerprint,
+				rows: built,
+				components: created
+			});
+			rows.push(...built);
+			components.push(...created);
+		};
+		for (const node of visibleNodes) take(node.key, nodeFingerprint(node, preferences), () => chatNodeRows(node, preferences));
 		if (snapshot.partial !== null && !visibleNodes.some((node) => node.kind === "assistant-step")) {
-			const partialRows = snapshot.partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences));
-			rows.push(...grouped([...partialRows.length === 0 ? [thinkingRow()] : [], ...partialRows]));
+			const partial = snapshot.partial;
+			take("__partial__", JSON.stringify({
+				partial,
+				tools: preferences.tools,
+				reasoning: preferences.reasoning,
+				toolOutputLineLimit: preferences.toolOutputLineLimit,
+				diffContextLines: preferences.diffContextLines
+			}), () => {
+				const partialRows = partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences));
+				return grouped([...partialRows.length === 0 ? [thinkingRow()] : [], ...partialRows]);
+			});
 		}
-		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) rows.push(...snapshot.runningCalls.flatMap((call) => grouped(toolBlockRows(call, preferences, 0, call.callId))));
+		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) for (const call of snapshot.runningCalls) take(`__running__:${call.callId}`, JSON.stringify({
+			call,
+			tools: preferences.tools,
+			reasoning: preferences.reasoning,
+			toolOutputLineLimit: preferences.toolOutputLineLimit,
+			diffContextLines: preferences.diffContextLines,
+			expanded: preferences.expandedTools.has(call.callId),
+			collapsed: preferences.collapsedTools.has(call.callId)
+		}), () => grouped(toolBlockRows(call, preferences, 0, call.callId)));
 		this.emptyState = rows.length === 0;
-		if (this.emptyState) rows.push(...this.emptySessionRows());
-		this.replace(rows);
+		if (this.emptyState) take("__empty__", JSON.stringify({
+			cursor: this.exampleCursor,
+			session: this.sessionId
+		}), () => this.emptySessionRows());
+		for (const key of [...this.nodeCache.keys()]) if (!keep.has(key)) this.nodeCache.delete(key);
+		this.commit(rows, components);
 		const keys = this.toolKeys();
 		if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1);
 	}
@@ -30159,6 +30222,7 @@ var Transcript = class {
 		const scrollOffset = this.scrollOffset;
 		const turnCursor = this.turnCursor;
 		const snapshot = this.snapshot;
+		this.nodeCache.clear();
 		if (snapshot === void 0) this.replace([{
 			format: "plain",
 			text: color.muted(translateUiText(this.emptyMessage))
@@ -30169,7 +30233,10 @@ var Transcript = class {
 		this.requestRender();
 	}
 	invalidate() {
-		for (const component of this.components) component.invalidate();
+		for (const [index, component] of this.components.entries()) {
+			const row = this.rows[index];
+			if (row?.pulse !== void 0 || row?.liveDurationSince !== void 0) component.invalidate();
+		}
 	}
 	/** Stop pending attachment presentation updates during terminal teardown. */
 	dispose() {
@@ -30201,7 +30268,17 @@ var Transcript = class {
 			if (lines.length > 0 && this.rows[index]?.gapBefore === true) lines.push("");
 			if (this.rows[index]?.userTurn === true) anchors.push(lines.length);
 			const row = this.rows[index];
-			const rendered = component.render(contentWidth);
+			const pulsing = row?.pulse !== void 0 || row?.liveDurationSince !== void 0;
+			const cached = pulsing ? void 0 : this.lineCache.get(component);
+			const rendered = cached !== void 0 && cached.width === contentWidth ? cached.lines : (() => {
+				internals$2.componentRenders += 1;
+				const lines$1 = component.render(contentWidth);
+				if (!pulsing) this.lineCache.set(component, {
+					width: contentWidth,
+					lines: lines$1
+				});
+				return lines$1;
+			})();
 			const escaped = row?.format === "image" ? rendered : rendered.map(escapeTerminalText);
 			lines.push(...escaped);
 		}
@@ -30505,13 +30582,19 @@ var Transcript = class {
 		];
 	}
 	replace(rows) {
+		this.commit(rows, rows.map((row) => this.component(row)));
+	}
+	commit(rows, components) {
 		this.rows = rows;
 		this.turnCursor = void 0;
-		this.components = rows.map((row) => this.component(row));
+		this.components = [...components];
 		this.syncPulseAnimation(rows.some((row) => row.liveDurationSince !== void 0 || row.pulse !== void 0 && terminalColorLevel() !== 0));
 	}
 	component(row) {
-		if (row.format === "markdown") return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme);
+		if (row.format === "markdown") {
+			internals$2.markdownCreated += 1;
+			return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme);
+		}
 		if (row.format === "plain") return row.pulse === void 0 ? new Text(escapeTerminalText(row.text), 0, 0) : new PulsingRow(row.text, row.pulse, () => this.pulseFrame, row.liveDurationSince);
 		if (row.format === "code") return new CodeRow(row);
 		const cacheKey = `${this.sessionId ?? "none"}:${row.key}`;
@@ -30540,7 +30623,13 @@ var Transcript = class {
 		}).finally(() => {
 			if (generation !== this.imageGeneration) return;
 			this.pendingImages.delete(cacheKey);
-			this.components = this.rows.map((current) => this.component(current));
+			const image = this.imageComponents.get(cacheKey);
+			if (image === void 0) {
+				this.requestRender();
+				return;
+			}
+			this.components = this.rows.map((current, index) => current.format === "image" && `${this.sessionId ?? "none"}:${current.key}` === cacheKey ? image : this.components[index] ?? this.component(current));
+			for (const entry of this.nodeCache.values()) for (const [index, current] of entry.rows.entries()) if (current.format === "image" && `${this.sessionId ?? "none"}:${current.key}` === cacheKey) entry.components[index] = image;
 			this.requestRender();
 		});
 		return fallback;

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -58,6 +58,12 @@ import { DEFAULT_TUI_BEHAVIOR } from '@deepseek-ai/dsh-tui-protocol'
 
 const PULSE_FRAME_MS = 160
 
+/** Replaceable counters used by incremental-render tests. */
+export const internals = {
+  markdownCreated: 0,
+  componentRenders: 0,
+}
+
 /** User-visible tool-card posture; display only, never a model/runtime mutation. */
 export type ToolVisibility = 'collapsed' | 'expanded' | 'hidden'
 
@@ -851,6 +857,22 @@ function grouped(rows: readonly TranscriptRow[]): TranscriptRow[] {
   return rows.map((row, index) => index === 0 ? { ...row, gapBefore: true } : row)
 }
 
+function nodeFingerprint(
+  node: ChatConversationViewNode,
+  preferences: TranscriptPreferences,
+): string {
+  return JSON.stringify({
+    kind: node.kind,
+    data: node.data,
+    tools: preferences.tools,
+    reasoning: preferences.reasoning,
+    toolOutputLineLimit: preferences.toolOutputLineLimit,
+    diffContextLines: preferences.diffContextLines,
+    expanded: preferences.expandedTools.has(node.key),
+    collapsed: preferences.collapsedTools.has(node.key),
+  })
+}
+
 function nonnegativeNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
 }
@@ -1118,6 +1140,12 @@ export class Transcript implements Component, Focusable {
   private toolCursor = 0
   private readonly expandedTools = new Set<string>()
   private readonly collapsedTools = new Set<string>()
+  private readonly nodeCache = new Map<string, {
+    fingerprint: string
+    rows: TranscriptRow[]
+    components: Component[]
+  }>()
+  private readonly lineCache = new WeakMap<Component, { width: number; lines: readonly string[] }>()
   focused = false
 
   /**
@@ -1195,6 +1223,7 @@ export class Transcript implements Component, Focusable {
     this.sessionId = undefined
     this.pendingImages.clear()
     this.imageComponents.clear()
+    this.nodeCache.clear()
     this.emptyState = true
     this.hasMore = false
     this.loadingOlder = false
@@ -1217,6 +1246,7 @@ export class Transcript implements Component, Focusable {
       this.expandedTools.clear()
       this.collapsedTools.clear()
       this.toolCursor = 0
+      this.nodeCache.clear()
     }
     this.imageLoader = imageLoader
     this.hasMore = snapshot.hasMore
@@ -1233,22 +1263,66 @@ export class Transcript implements Component, Focusable {
       const node = snapshot.chat.nodes.get(key)
       return node === undefined || node.visibility !== 'visible' ? [] : [node]
     })
-    const rows: TranscriptRow[] = visibleNodes.flatMap(node => chatNodeRows(node, preferences))
+    const rows: TranscriptRow[] = []
+    const components: Component[] = []
+    const keep = new Set<string>()
+    const take = (key: string, fingerprint: string, build: () => TranscriptRow[]): void => {
+      keep.add(key)
+      const hit = this.nodeCache.get(key)
+      if (hit !== undefined && hit.fingerprint === fingerprint) {
+        rows.push(...hit.rows)
+        components.push(...hit.components)
+        return
+      }
+      const built = build()
+      const created = built.map(row => this.component(row))
+      this.nodeCache.set(key, { fingerprint, rows: built, components: created })
+      rows.push(...built)
+      components.push(...created)
+    }
+    for (const node of visibleNodes) {
+      take(node.key, nodeFingerprint(node, preferences), () => chatNodeRows(node, preferences))
+    }
     if (snapshot.partial !== null && !visibleNodes.some(node => node.kind === 'assistant-step')) {
-      const partialRows = snapshot.partial.blocks.flatMap(block => assistantBlockRows(block, preferences))
-      rows.push(...grouped([
-        ...(partialRows.length === 0
-          ? [thinkingRow()]
-          : []),
-        ...partialRows,
-      ]))
+      const partial = snapshot.partial
+      take('__partial__', JSON.stringify({
+        partial,
+        tools: preferences.tools,
+        reasoning: preferences.reasoning,
+        toolOutputLineLimit: preferences.toolOutputLineLimit,
+        diffContextLines: preferences.diffContextLines,
+      }), () => {
+        const partialRows = partial.blocks.flatMap(block => assistantBlockRows(block, preferences))
+        return grouped([
+          ...(partialRows.length === 0 ? [thinkingRow()] : []),
+          ...partialRows,
+        ])
+      })
     }
     if (preferences.tools !== 'hidden' && !visibleNodes.some(node => node.kind === 'tool-call')) {
-      rows.push(...snapshot.runningCalls.flatMap(call => grouped(toolBlockRows(call, preferences, 0, call.callId))))
+      for (const call of snapshot.runningCalls) {
+        take(`__running__:${call.callId}`, JSON.stringify({
+          call,
+          tools: preferences.tools,
+          reasoning: preferences.reasoning,
+          toolOutputLineLimit: preferences.toolOutputLineLimit,
+          diffContextLines: preferences.diffContextLines,
+          expanded: preferences.expandedTools.has(call.callId),
+          collapsed: preferences.collapsedTools.has(call.callId),
+        }), () => grouped(toolBlockRows(call, preferences, 0, call.callId)))
+      }
     }
     this.emptyState = rows.length === 0
-    if (this.emptyState) rows.push(...this.emptySessionRows())
-    this.replace(rows)
+    if (this.emptyState) {
+      take('__empty__', JSON.stringify({
+        cursor: this.exampleCursor,
+        session: this.sessionId,
+      }), () => this.emptySessionRows())
+    }
+    for (const key of [...this.nodeCache.keys()]) {
+      if (!keep.has(key)) this.nodeCache.delete(key)
+    }
+    this.commit(rows, components)
     const keys = this.toolKeys()
     if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1)
   }
@@ -1277,6 +1351,7 @@ export class Transcript implements Component, Focusable {
     const scrollOffset = this.scrollOffset
     const turnCursor = this.turnCursor
     const snapshot = this.snapshot
+    this.nodeCache.clear()
     if (snapshot === undefined) {
       this.replace([{ format: 'plain', text: color.muted(translateUiText(this.emptyMessage)) }])
     } else {
@@ -1288,7 +1363,10 @@ export class Transcript implements Component, Focusable {
   }
 
   invalidate(): void {
-    for (const component of this.components) component.invalidate()
+    for (const [index, component] of this.components.entries()) {
+      const row = this.rows[index]
+      if (row?.pulse !== undefined || row?.liveDurationSince !== undefined) component.invalidate()
+    }
   }
 
   /** Stop pending attachment presentation updates during terminal teardown. */
@@ -1326,7 +1404,16 @@ export class Transcript implements Component, Focusable {
         anchors.push(lines.length)
       }
       const row = this.rows[index]
-      const rendered = component.render(contentWidth)
+      const pulsing = row?.pulse !== undefined || row?.liveDurationSince !== undefined
+      const cached = pulsing ? undefined : this.lineCache.get(component)
+      const rendered = cached !== undefined && cached.width === contentWidth
+        ? cached.lines
+        : (() => {
+          internals.componentRenders += 1
+          const lines = component.render(contentWidth)
+          if (!pulsing) this.lineCache.set(component, { width: contentWidth, lines })
+          return lines
+        })()
       const escaped = row?.format === 'image'
         ? rendered
         : rendered.map(escapeTerminalText)
@@ -1665,15 +1752,22 @@ export class Transcript implements Component, Focusable {
   }
 
   private replace(rows: readonly TranscriptRow[]): void {
+    this.commit(rows, rows.map(row => this.component(row)))
+  }
+
+  private commit(rows: readonly TranscriptRow[], components: readonly Component[]): void {
     this.rows = rows
     this.turnCursor = undefined
-    this.components = rows.map(row => this.component(row))
+    this.components = [...components]
     this.syncPulseAnimation(rows.some(row => row.liveDurationSince !== undefined
       || (row.pulse !== undefined && terminalColorLevel() !== 0)))
   }
 
   private component(row: TranscriptRow): Component {
-    if (row.format === 'markdown') return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme)
+    if (row.format === 'markdown') {
+      internals.markdownCreated += 1
+      return new Markdown(escapeTerminalText(row.text), 0, 0, markdownTheme)
+    }
     if (row.format === 'plain') {
       return row.pulse === undefined
         ? new Text(escapeTerminalText(row.text), 0, 0)
@@ -1716,7 +1810,22 @@ export class Transcript implements Component, Focusable {
     }).finally(() => {
       if (generation !== this.imageGeneration) return
       this.pendingImages.delete(cacheKey)
-      this.components = this.rows.map(current => this.component(current))
+      const image = this.imageComponents.get(cacheKey)
+      if (image === undefined) {
+        this.requestRender()
+        return
+      }
+      this.components = this.rows.map((current, index) =>
+        current.format === 'image' && `${this.sessionId ?? 'none'}:${current.key}` === cacheKey
+          ? image
+          : this.components[index] ?? this.component(current))
+      for (const entry of this.nodeCache.values()) {
+        for (const [index, current] of entry.rows.entries()) {
+          if (current.format === 'image' && `${this.sessionId ?? 'none'}:${current.key}` === cacheKey) {
+            entry.components[index] = image
+          }
+        }
+      }
       this.requestRender()
     })
     return fallback

--- a/tests/transcript-cache.test.ts
+++ b/tests/transcript-cache.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ChatConversationViewNode,
+  ConversationSnapshot,
+} from '@deepseek-ai/dsh-client-runtime/node-client'
+import { internals, Transcript } from '../src/client/transcript.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import { setCodeHighlighter, setTheme } from '../src/client/theme.ts'
+import { BUILT_IN_THEMES } from '../src/client/theme-config.ts'
+
+function chatNode(key: string, data: unknown): ChatConversationViewNode {
+  return {
+    key,
+    kind: 'fixture',
+    id: key,
+    target: 'chat',
+    anchorSeq: 1,
+    location: { kind: 'session' },
+    visibility: 'visible',
+    data,
+  }
+}
+
+const assistant = (key: string, text: string): ChatConversationViewNode => chatNode(key, {
+  kind: 'assistant',
+  seq: 2,
+  time: 2,
+  turn: 1,
+  step: 1,
+  blocks: [{ kind: 'text', text }],
+})
+
+function snapshot(nodes: readonly ChatConversationViewNode[]): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  return {
+    sessionId: 'session',
+    views: { get: () => undefined },
+    chat: {
+      order: nodes.map(node => node.key),
+      nodes: { get: (key: string) => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls: [],
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: false,
+    loadingOlder: false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+afterEach(() => {
+  internals.markdownCreated = 0
+  internals.componentRenders = 0
+  setCodeHighlighter()
+  setTheme(BUILT_IN_THEMES.dark)
+  setUiLocale('zh')
+  vi.unstubAllEnvs()
+})
+
+describe('transcript node cache (task 5.2)', () => {
+  it('rebuilds only the streaming node in a 5000-line session', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const nodes = Array.from({ length: 250 }, (_, index) =>
+      assistant(`a${String(index)}`, Array.from({ length: 20 }, () => `line-${String(index)}`).join('\n')))
+    const transcript = new Transcript(() => Number.POSITIVE_INFINITY)
+    transcript.update(snapshot(nodes))
+    expect(internals.markdownCreated).toBe(250)
+    const created = internals.markdownCreated
+    const last = nodes.at(-1)
+    if (last === undefined) throw new Error('expected a last assistant node')
+    transcript.update(snapshot([
+      ...nodes.slice(0, -1),
+      assistant(last.key, `${(last.data as { blocks: readonly { text: string }[] }).blocks[0]?.text ?? ''}\nstreamed`),
+    ]))
+    expect(internals.markdownCreated - created).toBe(1)
+  })
+
+  it('reuses unchanged component output across pulse frames', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const nodes = Array.from({ length: 40 }, (_, index) =>
+      assistant(`a${String(index)}`, 'stable body'))
+    const transcript = new Transcript(() => Number.POSITIVE_INFINITY)
+    transcript.update(snapshot(nodes))
+    transcript.render(80)
+    const first = internals.componentRenders
+    expect(first).toBeGreaterThan(0)
+    transcript.render(80)
+    expect(internals.componentRenders).toBe(first)
+  })
+})


### PR DESCRIPTION
## Summary
- Cache rendered rows and components per chat node key so a streaming update rebuilds only the changed node.
- Reuse non-pulsing `component.render` output across pulse frames.
- Benchmark construction: 250 assistants × 20 lines (5000 lines); streaming the last node creates one Markdown component.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/transcript-cache.test.ts tests/transcript.test.ts`
