### PR TITLE
feat(tui): gate leftover Chinese copy behind ui/launcherCopy

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_VERSION, c as isVersionRequest, i as PACKAGE_NAME, l as launcherPrefersEnglish, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as versionMessage } from "./startup-trace-FL9vmf08.js";
+import { a as PACKAGE_VERSION, c as isVersionRequest, d as versionMessage, i as PACKAGE_NAME, l as launcherCopy, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
 import { join } from "node:path";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -16,14 +16,14 @@ function launcherArgs(args) {
 		const argument = args[index];
 		if (argument === "--profile") {
 			const value = args[index + 1];
-			if (value === void 0 || value.trim() === "") throw new Error("--profile 需要一个 Profile 名称");
+			if (value === void 0 || value.trim() === "") throw new Error(launcherCopy("--profile 需要一个 Profile 名称", "--profile requires a Profile name", launcherPrefersEnglish(process.env)));
 			profile = value;
 			index += 1;
 			continue;
 		}
 		if (argument?.startsWith("--profile=") === true) {
 			const value = argument.slice(10);
-			if (value === "") throw new Error("--profile 需要一个 Profile 名称");
+			if (value === "") throw new Error(launcherCopy("--profile 需要一个 Profile 名称", "--profile requires a Profile name", launcherPrefersEnglish(process.env)));
 			profile = value;
 			continue;
 		}
@@ -48,7 +48,7 @@ function installed(profile) {
 function run(command, args) {
 	const result = spawnSync(command, [...args], { stdio: "inherit" });
 	if (result.error !== void 0) throw result.error;
-	if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`);
+	if (result.signal !== null) throw new Error(launcherCopy(`${command} 被信号 ${result.signal} 终止`, `${command} was terminated by signal ${result.signal}`, launcherPrefersEnglish(process.env)));
 	return result.status ?? 1;
 }
 function launch(args, environment = process.env, execute = run, write = (chunk) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
-import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DIn1PbXf.js";
-import { l as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup } from "./startup-trace-FL9vmf08.js";
+import { a as languageSelection, c as saveLanguage, d as ui, f as uiLocale, l as setUiLocale, o as localeFromSettings, s as localeSettings, t as TUI_STARTUP_SERVICE, u as translateUiText } from "./startup-DznulVSj.js";
+import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-D8-O8gcm.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -27679,12 +27679,12 @@ function dangerConfirmChoices(confirmLabel) {
 	const confirm = {
 		id: "confirm",
 		label: confirmLabel,
-		description: "我已理解上述影响"
+		description: ui("我已理解上述影响", "I understand the impact")
 	};
 	const cancel = {
 		id: "cancel",
-		label: "取消",
-		description: "保持当前状态"
+		label: ui("取消", "Cancel"),
+		description: ui("保持当前状态", "Keep current state")
 	};
 	return {
 		choices: dangerConfirmDefault === "cancel" ? [cancel, confirm] : [confirm, cancel],
@@ -27777,11 +27777,11 @@ var SearchSelectOverlay = class {
 		if (this.request.detail !== void 0) lines.push(...wrappedDetail(this.request.detail, safeWidth));
 		if (this.request.searchable !== false) {
 			this.input.focused = this.focused;
-			lines.push(`${color.muted(translateUiText("搜索 "))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`);
+			lines.push(`${color.muted(ui("搜索 ", "Search "))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`);
 		}
 		lines.push(...this.list.render(safeWidth));
 		if (this.notice !== "") lines.push(color.warning(truncateToWidth(this.notice, safeWidth, "…")));
-		lines.push(color.muted(translateUiText(this.request.footer ?? "↑↓ 选择 · Enter 确认 · Esc 返回/关闭")));
+		lines.push(color.muted(translateUiText(this.request.footer ?? ui("↑↓ 选择 · Enter 确认 · Esc 返回/关闭", "↑↓ Select · Enter confirm · Esc back/close"))));
 		return modalFrame(this.request.title, lines, width);
 	}
 	handleInput(data) {
@@ -27852,7 +27852,7 @@ var TextInputOverlay = class {
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			this.input.render(safeWidth)[0] ?? color.muted(translateUiText(this.request.placeholder ?? "")),
-			color.muted(translateUiText("Enter 确认 · Esc 返回/关闭"))
+			color.muted(ui("Enter 确认 · Esc 返回/关闭", "Enter confirm · Esc back/close"))
 		], width);
 	}
 	handleInput(data) {
@@ -27883,7 +27883,7 @@ var MultilineEditorOverlay = class {
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			...body,
-			color.muted(translateUiText("Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭"))
+			color.muted(ui("Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭", "Enter newline · Ctrl+Enter submit · Esc back/close"))
 		], width);
 	}
 	handleInput(data) {
@@ -27916,11 +27916,11 @@ var SecretInputOverlay = class {
 		const safeWidth = frameContentWidth(width);
 		const length = Array.from(this.input.getValue()).length;
 		const cursor = this.focused ? CURSOR_MARKER : "";
-		const masked = length === 0 ? `${cursor}${color.muted(translateUiText(this.request.placeholder ?? "输入新 Secret"))}` : `${"•".repeat(Math.min(length, 32))}${cursor}▌`;
+		const masked = length === 0 ? `${cursor}${color.muted(translateUiText(this.request.placeholder ?? "") || ui("输入新 Secret", "Enter a new secret"))}` : `${"•".repeat(Math.min(length, 32))}${cursor}▌`;
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
 			truncateToWidth(masked, safeWidth, "…"),
-			color.muted(translateUiText("输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭"))
+			color.muted(ui("输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭", "Input is never displayed or logged · Enter save · Esc back/close"))
 		], width);
 	}
 	handleInput(data) {
@@ -27963,9 +27963,9 @@ var MultiSelectOverlay = class {
 		this.input.focused = this.focused;
 		return modalFrame(this.request.title, [
 			...this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth),
-			`${color.muted(translateUiText("搜索 "))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`,
+			`${color.muted(ui("搜索 ", "Search "))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`,
 			...this.list.render(safeWidth),
-			color.muted(translateUiText(this.request.footer ?? "↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭"))
+			color.muted(translateUiText(this.request.footer ?? ui("↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭", "↑↓ Select · Space toggle · Enter submit · Esc back/close")))
 		], width);
 	}
 	handleInput(data) {
@@ -28027,13 +28027,13 @@ var ScrollableDetailOverlay = class {
 	render(width) {
 		const safeWidth = frameContentWidth(width);
 		const content = escapeTerminalText(this.request.content);
-		const lines = wrapTextWithAnsi(content === "" ? translateUiText("(无详情)") : content, safeWidth).map((line) => color.muted(line));
+		const lines = wrapTextWithAnsi(content === "" ? ui("(无详情)", "(No details)") : content, safeWidth).map((line) => color.muted(line));
 		this.lineCount = lines.length;
 		const maxOffset = Math.max(0, this.lineCount - this.viewportRows);
 		this.offset = Math.min(this.offset, maxOffset);
 		const end = Math.min(this.lineCount, this.offset + this.viewportRows);
-		const position = `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`;
-		return modalFrame(this.request.title, [...lines.slice(this.offset, end), color.muted(translateUiText(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`))], width);
+		const position = ui(`${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`, `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} lines`);
+		return modalFrame(this.request.title, [...lines.slice(this.offset, end), color.muted(translateUiText(this.request.footer ?? ui(`${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`, `${position} · ↑↓ scroll · PgUp/PgDn page · Home/End · Enter/q close · Esc back`)))], width);
 	}
 	handleInput(data) {
 		if (matchesKey(data, Key.enter) || data === "q") {
@@ -28120,7 +28120,7 @@ var NavigationOverlay = class {
 	replaceSelectPage(request, onSelect) {
 		if (this.closed) return;
 		const entry = this.current();
-		if (entry === void 0) throw new Error("没有可替换的 overlay 页面");
+		if (entry === void 0) throw new Error(ui("没有可替换的 overlay 页面", "No overlay page to replace"));
 		this.disposeComponent(entry.component);
 		entry.component = new SearchSelectOverlay(request, (choice) => {
 			this.dispatch(entry, () => onSelect(choice));
@@ -28147,7 +28147,7 @@ var NavigationOverlay = class {
 			submit();
 		}));
 	}
-	async confirm(title, detail, confirmLabel = "确认") {
+	async confirm(title, detail, confirmLabel = ui("确认", "Confirm")) {
 		const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel);
 		return (await this.select({
 			title,
@@ -28155,7 +28155,7 @@ var NavigationOverlay = class {
 			searchable: false,
 			choices,
 			initialChoiceId,
-			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
+			footer: ui("↑↓ 选择 · Enter 确认 · Esc 返回/关闭", "↑↓ Select · Enter confirm · Esc back/close"),
 			options: {
 				width: "95%",
 				maxHeight: "90%",
@@ -28308,12 +28308,12 @@ var OverlayQueue = class {
 		return this.navigate(async (navigation) => {
 			const page = navigation.selectPage({
 				title,
-				detail: "按 Esc 取消",
+				detail: ui("按 Esc 取消", "Press Esc to cancel"),
 				searchable: false,
 				choices: [{
 					id: "busy",
-					label: "进行中…",
-					disabledReason: "按 Esc 取消"
+					label: ui("进行中…", "In progress…"),
+					disabledReason: ui("按 Esc 取消", "Press Esc to cancel")
 				}]
 			}, () => void 0);
 			try {
@@ -28386,7 +28386,7 @@ var OverlayQueue = class {
 	* @param confirmLabel - affirmative action label.
 	* @returns true only when the affirmative action was selected.
 	*/
-	async confirm(title, detail, confirmLabel = "确认") {
+	async confirm(title, detail, confirmLabel = ui("确认", "Confirm")) {
 		const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel);
 		return (await this.select({
 			title,
@@ -28394,7 +28394,7 @@ var OverlayQueue = class {
 			searchable: false,
 			choices,
 			initialChoiceId,
-			footer: "↑↓ 选择 · Enter 确认 · Esc 返回/关闭",
+			footer: ui("↑↓ 选择 · Enter 确认 · Esc 返回/关闭", "↑↓ Select · Enter confirm · Esc back/close"),
 			options: {
 				width: "95%",
 				maxHeight: "90%",

--- a/lib/startup-DznulVSj.js
+++ b/lib/startup-DznulVSj.js
@@ -1977,13 +1977,13 @@ function degradedNotice() {
 	return ui("重启交接无效，已按普通启动继续", "Restart handoff was invalid; continuing with a normal start");
 }
 function parseRestartHandoff(value) {
-	if (typeof value !== "object" || value === null) throw new Error("TUI 重启交接不是对象");
+	if (typeof value !== "object" || value === null) throw new Error(ui("TUI 重启交接不是对象", "TUI restart handoff is not an object"));
 	const row = value;
-	if (typeof row.profile !== "string" || typeof row.cwd !== "string" || !Array.isArray(row.attachmentPaths) || !row.attachmentPaths.every((path) => typeof path === "string")) throw new Error("TUI 重启交接缺少 Profile、工作区或附件路径");
-	if (row.attachmentPaths.length > 32) throw new Error("TUI 重启交接附件数量超过限制");
-	if (row.resume !== void 0 && typeof row.resume !== "string") throw new Error("TUI 重启交接会话 id 无效");
-	if (row.draft !== void 0 && typeof row.draft !== "string") throw new Error("TUI 重启交接草稿无效");
-	if (row.notice !== void 0 && typeof row.notice !== "string") throw new Error("TUI 重启交接提示无效");
+	if (typeof row.profile !== "string" || typeof row.cwd !== "string" || !Array.isArray(row.attachmentPaths) || !row.attachmentPaths.every((path) => typeof path === "string")) throw new Error(ui("TUI 重启交接缺少 Profile、工作区或附件路径", "TUI restart handoff is missing the Profile, workspace, or attachment paths"));
+	if (row.attachmentPaths.length > 32) throw new Error(ui("TUI 重启交接附件数量超过限制", "TUI restart handoff exceeds the attachment limit"));
+	if (row.resume !== void 0 && typeof row.resume !== "string") throw new Error(ui("TUI 重启交接会话 id 无效", "TUI restart handoff has an invalid session ID"));
+	if (row.draft !== void 0 && typeof row.draft !== "string") throw new Error(ui("TUI 重启交接草稿无效", "TUI restart handoff has an invalid draft"));
+	if (row.notice !== void 0 && typeof row.notice !== "string") throw new Error(ui("TUI 重启交接提示无效", "TUI restart handoff has an invalid notice"));
 	return {
 		profile: row.profile,
 		cwd: resolve(row.cwd),

--- a/lib/startup-trace-QEGhP-_i.js
+++ b/lib/startup-trace-QEGhP-_i.js
@@ -88,6 +88,15 @@ function launcherPrefersEnglish(env) {
 	const locale = env.LC_ALL || env.LC_MESSAGES || env.LANG || "";
 	return /^en([_.]|$)/iu.test(locale);
 }
+/**
+* Launcher-safe bilingual copy. Must not import locale.ts.
+* @param zh - Chinese text.
+* @param en - English text.
+* @param english - POSIX-derived language choice.
+*/
+function launcherCopy(zh, en, english) {
+	return english ? en : zh;
+}
 
 //#endregion
 //#region src/startup-trace.ts
@@ -138,4 +147,4 @@ function measureStartupSync(label, run, env = process.env, write = (chunk) => {
 }
 
 //#endregion
-export { PACKAGE_VERSION as a, isVersionRequest as c, PACKAGE_NAME as i, launcherPrefersEnglish as l, measureStartupSync as n, defaultPluginSpec as o, DSH_COMPATIBILITY as r, dshCompatibilityError as s, measureStartup as t, versionMessage as u };
+export { PACKAGE_VERSION as a, isVersionRequest as c, versionMessage as d, PACKAGE_NAME as i, launcherCopy as l, measureStartupSync as n, defaultPluginSpec as o, DSH_COMPATIBILITY as r, dshCompatibilityError as s, measureStartup as t, launcherPrefersEnglish as u };

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,3 +1,3 @@
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DIn1PbXf.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DznulVSj.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -13,6 +13,7 @@ import {
   PACKAGE_VERSION,
   defaultPluginSpec,
   isVersionRequest,
+  launcherCopy,
   launcherPrefersEnglish,
   versionMessage,
 } from './dsh-compat.ts'
@@ -32,14 +33,26 @@ export function launcherArgs(args: readonly string[]): { profile: string; inner:
     const argument = args[index]
     if (argument === '--profile') {
       const value = args[index + 1]
-      if (value === undefined || value.trim() === '') throw new Error('--profile 需要一个 Profile 名称')
+      if (value === undefined || value.trim() === '') {
+        throw new Error(launcherCopy(
+          '--profile 需要一个 Profile 名称',
+          '--profile requires a Profile name',
+          launcherPrefersEnglish(process.env),
+        ))
+      }
       profile = value
       index += 1
       continue
     }
     if (argument?.startsWith('--profile=') === true) {
       const value = argument.slice('--profile='.length)
-      if (value === '') throw new Error('--profile 需要一个 Profile 名称')
+      if (value === '') {
+        throw new Error(launcherCopy(
+          '--profile 需要一个 Profile 名称',
+          '--profile requires a Profile name',
+          launcherPrefersEnglish(process.env),
+        ))
+      }
       profile = value
       continue
     }
@@ -65,7 +78,13 @@ export function installed(profile: string): boolean {
 export function run(command: string, args: readonly string[]): number {
   const result = spawnSync(command, [...args], { stdio: 'inherit' })
   if (result.error !== undefined) throw result.error
-  if (result.signal !== null) throw new Error(`${command} 被信号 ${result.signal} 终止`)
+  if (result.signal !== null) {
+    throw new Error(launcherCopy(
+      `${command} 被信号 ${result.signal} 终止`,
+      `${command} was terminated by signal ${result.signal}`,
+      launcherPrefersEnglish(process.env),
+    ))
+  }
   return result.status ?? 1
 }
 

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -17,7 +17,7 @@ import {
   type SelectItem,
   type TUI,
 } from '@mariozechner/pi-tui'
-import { translateUiText } from './locale.ts'
+import { translateUiText, ui } from './locale.ts'
 import { color, editorTheme, escapeTerminalText, surfaceRow } from './theme.ts'
 import type { TuiDangerConfirmDefault } from '@deepseek-ai/dsh-tui-protocol'
 
@@ -42,12 +42,12 @@ export function dangerConfirmChoices(confirmLabel: string): {
   const confirm: OverlayChoice = {
     id: 'confirm',
     label: confirmLabel,
-    description: '我已理解上述影响',
+    description: ui('我已理解上述影响', 'I understand the impact'),
   }
   const cancel: OverlayChoice = {
     id: 'cancel',
-    label: '取消',
-    description: '保持当前状态',
+    label: ui('取消', 'Cancel'),
+    description: ui('保持当前状态', 'Keep current state'),
   }
   return {
     choices: dangerConfirmDefault === 'cancel' ? [cancel, confirm] : [confirm, cancel],
@@ -248,11 +248,14 @@ class SearchSelectOverlay implements Component {
     }
     if (this.request.searchable !== false) {
       this.input.focused = this.focused
-      lines.push(`${color.muted(translateUiText('搜索 '))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ''}`)
+      lines.push(`${color.muted(ui('搜索 ', 'Search '))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ''}`)
     }
     lines.push(...this.list.render(safeWidth))
     if (this.notice !== '') lines.push(color.warning(truncateToWidth(this.notice, safeWidth, '…')))
-    lines.push(color.muted(translateUiText(this.request.footer ?? '↑↓ 选择 · Enter 确认 · Esc 返回/关闭')))
+    lines.push(color.muted(translateUiText(this.request.footer ?? ui(
+      '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
+      '↑↓ Select · Enter confirm · Esc back/close',
+    ))))
     return modalFrame(this.request.title, lines, width)
   }
 
@@ -333,7 +336,7 @@ class TextInputOverlay implements Component {
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
       this.input.render(safeWidth)[0] ?? color.muted(translateUiText(this.request.placeholder ?? '')),
-      color.muted(translateUiText('Enter 确认 · Esc 返回/关闭')),
+      color.muted(ui('Enter 确认 · Esc 返回/关闭', 'Enter confirm · Esc back/close')),
     ], width)
   }
 
@@ -368,7 +371,7 @@ class MultilineEditorOverlay implements Component {
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
       ...body,
-      color.muted(translateUiText('Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭')),
+      color.muted(ui('Enter 换行 · Ctrl+Enter 提交 · Esc 返回/关闭', 'Enter newline · Ctrl+Enter submit · Esc back/close')),
     ], width)
   }
 
@@ -404,14 +407,17 @@ class SecretInputOverlay implements Component {
     const length = Array.from(this.input.getValue()).length
     const cursor = this.focused ? CURSOR_MARKER : ''
     const masked = length === 0
-      ? `${cursor}${color.muted(translateUiText(this.request.placeholder ?? '输入新 Secret'))}`
+      ? `${cursor}${color.muted(translateUiText(this.request.placeholder ?? '') || ui('输入新 Secret', 'Enter a new secret'))}`
       : `${'•'.repeat(Math.min(length, 32))}${cursor}▌`
     return modalFrame(this.request.title, [
       ...(this.request.detail === undefined
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
       truncateToWidth(masked, safeWidth, '…'),
-      color.muted(translateUiText('输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭')),
+      color.muted(ui(
+        '输入内容不会回显或写入日志 · Enter 保存 · Esc 返回/关闭',
+        'Input is never displayed or logged · Enter save · Esc back/close',
+      )),
     ], width)
   }
 
@@ -462,9 +468,12 @@ class MultiSelectOverlay implements Component {
       ...(this.request.detail === undefined
         ? []
         : wrappedDetail(this.request.detail, safeWidth)),
-      `${color.muted(translateUiText('搜索 '))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ''}`,
+      `${color.muted(ui('搜索 ', 'Search '))}${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ''}`,
       ...this.list.render(safeWidth),
-      color.muted(translateUiText(this.request.footer ?? '↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭')),
+      color.muted(translateUiText(this.request.footer ?? ui(
+        '↑↓ 选择 · Space 勾选 · Enter 提交 · Esc 返回/关闭',
+        '↑↓ Select · Space toggle · Enter submit · Esc back/close',
+      ))),
     ], width)
   }
 
@@ -539,16 +548,22 @@ class ScrollableDetailOverlay implements Component {
   render(width: number): string[] {
     const safeWidth = frameContentWidth(width)
     const content = escapeTerminalText(this.request.content)
-    const lines = wrapTextWithAnsi(content === '' ? translateUiText('(无详情)') : content, safeWidth)
+    const lines = wrapTextWithAnsi(content === '' ? ui('(无详情)', '(No details)') : content, safeWidth)
       .map(line => color.muted(line))
     this.lineCount = lines.length
     const maxOffset = Math.max(0, this.lineCount - this.viewportRows)
     this.offset = Math.min(this.offset, maxOffset)
     const end = Math.min(this.lineCount, this.offset + this.viewportRows)
-    const position = `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`
+    const position = ui(
+      `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} 行`,
+      `${String(this.offset + 1)}-${String(end)}/${String(this.lineCount)} lines`,
+    )
     return modalFrame(this.request.title, [
       ...lines.slice(this.offset, end),
-      color.muted(translateUiText(this.request.footer ?? `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`)),
+      color.muted(translateUiText(this.request.footer ?? ui(
+        `${position} · ↑↓ 滚动 · PgUp/PgDn 翻页 · Home/End · Enter/q 关闭 · Esc 返回`,
+        `${position} · ↑↓ scroll · PgUp/PgDn page · Home/End · Enter/q close · Esc back`,
+      ))),
     ], width)
   }
 
@@ -651,7 +666,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
   ): void {
     if (this.closed) return
     const entry = this.current()
-    if (entry === undefined) throw new Error('没有可替换的 overlay 页面')
+    if (entry === undefined) throw new Error(ui('没有可替换的 overlay 页面', 'No overlay page to replace'))
     this.disposeComponent(entry.component)
     entry.component = new SearchSelectOverlay(request, choice => {
       this.dispatch(entry, () => onSelect(choice))
@@ -683,7 +698,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     await this.prompt<void>(submit => new ScrollableDetailOverlay(request, () => { submit() }))
   }
 
-  async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
+  async confirm(title: string, detail: string, confirmLabel = ui('确认', 'Confirm')): Promise<boolean> {
     const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel)
     const selected = await this.select({
       title,
@@ -691,7 +706,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
       searchable: false,
       choices,
       initialChoiceId,
-      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
+      footer: ui('↑↓ 选择 · Enter 确认 · Esc 返回/关闭', '↑↓ Select · Enter confirm · Esc back/close'),
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })
     return selected?.id === 'confirm'
@@ -853,12 +868,12 @@ export class OverlayQueue implements OverlayPrompts {
     return this.navigate(async (navigation) => {
       const page = navigation.selectPage({
         title,
-        detail: '按 Esc 取消',
+        detail: ui('按 Esc 取消', 'Press Esc to cancel'),
         searchable: false,
         choices: [{
           id: 'busy',
-          label: '进行中…',
-          disabledReason: '按 Esc 取消',
+          label: ui('进行中…', 'In progress…'),
+          disabledReason: ui('按 Esc 取消', 'Press Esc to cancel'),
         }],
       }, () => undefined)
       try {
@@ -937,7 +952,7 @@ export class OverlayQueue implements OverlayPrompts {
    * @param confirmLabel - affirmative action label.
    * @returns true only when the affirmative action was selected.
    */
-  async confirm(title: string, detail: string, confirmLabel = '确认'): Promise<boolean> {
+  async confirm(title: string, detail: string, confirmLabel = ui('确认', 'Confirm')): Promise<boolean> {
     const { choices, initialChoiceId } = dangerConfirmChoices(confirmLabel)
     const selected = await this.select({
       title,
@@ -945,7 +960,7 @@ export class OverlayQueue implements OverlayPrompts {
       searchable: false,
       choices,
       initialChoiceId,
-      footer: '↑↓ 选择 · Enter 确认 · Esc 返回/关闭',
+      footer: ui('↑↓ 选择 · Enter 确认 · Esc 返回/关闭', '↑↓ Select · Enter confirm · Esc back/close'),
       options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
     })
     return selected?.id === 'confirm'

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -131,3 +131,13 @@ export function launcherPrefersEnglish(env: NodeJS.ProcessEnv): boolean {
   const locale = env.LC_ALL || env.LC_MESSAGES || env.LANG || ''
   return /^en([_.]|$)/iu.test(locale)
 }
+
+/**
+ * Launcher-safe bilingual copy. Must not import locale.ts.
+ * @param zh - Chinese text.
+ * @param en - English text.
+ * @param english - POSIX-derived language choice.
+ */
+export function launcherCopy(zh: string, en: string, english: boolean): string {
+  return english ? en : zh
+}

--- a/src/host/restart-handoff.ts
+++ b/src/host/restart-handoff.ts
@@ -19,17 +19,17 @@ function degradedNotice(): string {
 }
 
 function parseRestartHandoff(value: unknown): TuiRestartHandoff {
-  if (typeof value !== 'object' || value === null) throw new Error('TUI 重启交接不是对象')
+  if (typeof value !== 'object' || value === null) throw new Error(ui('TUI 重启交接不是对象', 'TUI restart handoff is not an object'))
   const row = value as Record<string, unknown>
   if (typeof row.profile !== 'string' || typeof row.cwd !== 'string'
     || !Array.isArray(row.attachmentPaths)
     || !row.attachmentPaths.every(path => typeof path === 'string')) {
-    throw new Error('TUI 重启交接缺少 Profile、工作区或附件路径')
+    throw new Error(ui('TUI 重启交接缺少 Profile、工作区或附件路径', 'TUI restart handoff is missing the Profile, workspace, or attachment paths'))
   }
-  if (row.attachmentPaths.length > 32) throw new Error('TUI 重启交接附件数量超过限制')
-  if (row.resume !== undefined && typeof row.resume !== 'string') throw new Error('TUI 重启交接会话 id 无效')
-  if (row.draft !== undefined && typeof row.draft !== 'string') throw new Error('TUI 重启交接草稿无效')
-  if (row.notice !== undefined && typeof row.notice !== 'string') throw new Error('TUI 重启交接提示无效')
+  if (row.attachmentPaths.length > 32) throw new Error(ui('TUI 重启交接附件数量超过限制', 'TUI restart handoff exceeds the attachment limit'))
+  if (row.resume !== undefined && typeof row.resume !== 'string') throw new Error(ui('TUI 重启交接会话 id 无效', 'TUI restart handoff has an invalid session ID'))
+  if (row.draft !== undefined && typeof row.draft !== 'string') throw new Error(ui('TUI 重启交接草稿无效', 'TUI restart handoff has an invalid draft'))
+  if (row.notice !== undefined && typeof row.notice !== 'string') throw new Error(ui('TUI 重启交接提示无效', 'TUI restart handoff has an invalid notice'))
   return {
     profile: row.profile,
     cwd: resolve(row.cwd),

--- a/tests/dsh-compat.test.ts
+++ b/tests/dsh-compat.test.ts
@@ -4,6 +4,7 @@ import {
   defaultPluginSpec,
   dshCompatibilityError,
   isVersionRequest,
+  launcherCopy,
   versionMessage,
 } from '../src/dsh-compat.ts'
 
@@ -18,6 +19,8 @@ describe('dsh version and compatibility', () => {
       version: '1.0.0',
       compatibility: { minimum: '0.1.0-rc.6', tested: '0.1.0-rc.6' },
     }, true)).toContain('Requires dsh >= 0.1.0-rc.6')
+    expect(launcherCopy('--profile 需要一个 Profile 名称', '--profile requires a Profile name', true))
+      .toBe('--profile requires a Profile name')
   })
 
   it('rejects dsh older than the declared minimum', () => {

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -1,0 +1,90 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import ts from 'typescript'
+
+const SRC = join(import.meta.dirname, '../src')
+const HAN = /[\u4e00-\u9fff]/u
+const GATED = [
+  'bin.ts',
+  'dsh-compat.ts',
+  'client/overlays.ts',
+  'host/restart-handoff.ts',
+]
+
+function walk(directory: string): string[] {
+  return readdirSync(directory).flatMap((name) => {
+    const path = join(directory, name)
+    return statSync(path).isDirectory() ? walk(path) : path.endsWith('.ts') ? [path] : []
+  })
+}
+
+function callName(node: ts.CallExpression): string | undefined {
+  const expression = node.expression
+  if (ts.isIdentifier(expression)) return expression.text
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text
+  return undefined
+}
+
+function insideAllowedCall(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node
+  while (current !== undefined) {
+    const parent: ts.Node | undefined = current.parent as ts.Node | undefined
+    if (parent === undefined) return false
+    if (ts.isCallExpression(parent)) {
+      const name = callName(parent)
+      if ((name === 'ui' || name === 'launcherCopy') && parent.arguments[0] === current) return true
+    }
+    if (ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name) && parent.name.text === 'zh') {
+      return true
+    }
+    current = parent
+  }
+  return false
+}
+
+function englishTernary(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node.parent as ts.Node | undefined
+  while (current !== undefined) {
+    if (ts.isConditionalExpression(current)) return true
+    current = current.parent as ts.Node | undefined
+  }
+  return false
+}
+
+function chineseLiterals(path: string): readonly string[] {
+  const source = ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const found: string[] = []
+  const visit = (node: ts.Node): void => {
+    const text = ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)
+      ? node.text
+      : ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)
+        ? node.text
+        : undefined
+    if (text !== undefined && HAN.test(text) && !insideAllowedCall(node)) {
+      if (relative(SRC, path) === 'dsh-compat.ts' && englishTernary(node)) {
+        ts.forEachChild(node, visit)
+        return
+      }
+      found.push(`${relative(SRC, path)}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}:${text.slice(0, 60)}`)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+  return found
+}
+
+describe('i18n AST gate (task 7)', () => {
+  it('keeps Chinese literals in gated files as ui/launcherCopy first arguments', () => {
+    const gated = new Set(GATED.map(file => join(SRC, file)))
+    const files = walk(SRC).filter(path => gated.has(path))
+    expect(files).toHaveLength(GATED.length)
+    expect(files.flatMap(chineseLiterals)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Add `launcherCopy` for bin.ts (must not import locale.ts) and wrap overlay/restart-handoff leftovers with `ui()`.
- AST test asserts Chinese literals in gated files are only `ui`/`launcherCopy` first arguments (or `zh:` / dsh-compat ternaries).

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/locale.test.ts tests/launcher.test.ts tests/overlays-navigation.test.ts`
- [ ] `LANG=en_US.UTF-8 deepseek --profile` missing value prints English.