### PR TITLE
feat(tui): move leftover notices onto ui() in small modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21919,7 +21919,7 @@ const C1_CONTROL_STRING_INTRODUCERS = new Set([
 const SGR_PARAMETERS = /^[0-9;:]*$/u;
 function semanticColor$1(value) {
 	const match = /^#([0-9A-Fa-f]{6})$/u.exec(value);
-	if (match === null) throw new Error(`主题颜色 ${JSON.stringify(value)} 无效`);
+	if (match === null) throw new Error(ui(`主题颜色 ${JSON.stringify(value)} 无效`, `Theme color ${JSON.stringify(value)} is invalid`));
 	const digits = match[1] ?? "";
 	return { rgb: [
 		Number.parseInt(digits.slice(0, 2), 16),
@@ -22636,7 +22636,7 @@ function dangerConfirmDefaultOf(value) {
 */
 function behaviorSettings(documents) {
 	const document = documents.find((candidate) => candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE);
-	if (document === void 0) throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`);
+	if (document === void 0) throw new Error(ui(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`, `Harness did not register settings ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`));
 	return document;
 }
 /**
@@ -22857,7 +22857,7 @@ function jobElapsedMs(job, now) {
 * @param id - registry job id.
 */
 function killHostJob(jobs, id) {
-	if (jobs === void 0) throw new Error("Harness 后台任务服务未装配");
+	if (jobs === void 0) throw new Error(ui("Harness 后台任务服务未装配", "Harness background job service is not mounted"));
 	return jobs.kill(id, void 0, "user stopped the job from SeekTTY");
 }
 /**
@@ -30725,7 +30725,7 @@ function writeClipboard(text$1, options$1) {
 	const osc52Ok = Buffer.byteLength(text$1, "utf8") <= OSC52_BYTE_LIMIT;
 	if (osc52Ok) options$1.writeOsc52(osc52Sequence(text$1));
 	if (options$1.fallback === "osc52" || options$1.fallback === "off") {
-		if (!osc52Ok) throw new Error(`回复超过终端剪贴板 ${String(OSC52_BYTE_LIMIT)} 字节安全上限；请使用 /export`);
+		if (!osc52Ok) throw new Error(ui(`回复超过终端剪贴板 ${String(OSC52_BYTE_LIMIT)} 字节安全上限；请使用 /export`, `The response exceeds the ${String(OSC52_BYTE_LIMIT)}-byte terminal clipboard limit; use /export instead`));
 		return "osc52";
 	}
 	if (osc52Ok && options$1.fallback === "auto") {}
@@ -30735,7 +30735,7 @@ function writeClipboard(text$1, options$1) {
 		if (result.error === void 0 && result.status === 0) return osc52Ok ? "osc52" : candidate.method;
 	}
 	if (osc52Ok) return "osc52";
-	throw new Error(`无法写入系统剪贴板；请使用 /export。OSC 52 上限为 ${String(OSC52_BYTE_LIMIT)} 字节`);
+	throw new Error(ui(`无法写入系统剪贴板；请使用 /export。OSC 52 上限为 ${String(OSC52_BYTE_LIMIT)} 字节`, `Could not write the system clipboard; use /export. The OSC 52 limit is ${String(OSC52_BYTE_LIMIT)} bytes`));
 }
 
 //#endregion
@@ -30863,15 +30863,10 @@ function nextDesktopNotify(previous, current, primed) {
 * @param locale - current terminal locale.
 * @returns a short notification body.
 */
-function desktopNotifyBody(kind, locale) {
-	if (locale === "en") {
-		if (kind === "approval") return "SeekTTY: tool approval needed";
-		if (kind === "question") return "SeekTTY: a question is waiting";
-		return "SeekTTY: turn complete";
-	}
-	if (kind === "approval") return "SeekTTY：需要工具审批";
-	if (kind === "question") return "SeekTTY：有问题待回答";
-	return "SeekTTY：回合完成";
+function desktopNotifyBody(kind) {
+	if (kind === "approval") return ui("SeekTTY：需要工具审批", "SeekTTY: tool approval needed");
+	if (kind === "question") return ui("SeekTTY：有问题待回答", "SeekTTY: a question is waiting");
+	return ui("SeekTTY：回合完成", "SeekTTY: turn complete");
 }
 
 //#endregion
@@ -31095,7 +31090,7 @@ async function startTuiSurface(options$1) {
 			};
 			if (initialBehavior.desktopNotifications) {
 				const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed);
-				if (kind !== void 0) terminal.write(desktopNotifySequence(desktopNotifyBody(kind, uiLocale())));
+				if (kind !== void 0) terminal.write(desktopNotifySequence(desktopNotifyBody(kind)));
 			}
 			notifySnapshot = currentNotify;
 			notifyPrimed = true;
@@ -32041,7 +32036,7 @@ async function run(ctx) {
 		return;
 	}
 	const restart = ctx.get("appRestart");
-	if (restart === void 0) throw new Error("tui-runner: launcher 未提供受控重启能力");
+	if (restart === void 0) throw new Error(ui("tui-runner: launcher 未提供受控重启能力", "tui-runner: launcher did not provide controlled restart"));
 	try {
 		await restart({
 			profile: outcome.request.profile,
@@ -32056,7 +32051,7 @@ async function run(ctx) {
 			}
 		});
 	} catch (error) {
-		internals.stderr.write(`deepseek: ${translateUiText(`重启失败：${error instanceof Error ? error.message : String(error)}`)}\n`);
+		internals.stderr.write(`deepseek: ${ui(`重启失败：${error instanceof Error ? error.message : String(error)}`, `Restart failed: ${error instanceof Error ? error.message : String(error)}`)}\n`);
 		process.exitCode = 1;
 	}
 }

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -13,6 +13,7 @@ import {
   type TuiToolCardDisplay,
 } from '@deepseek-ai/dsh-tui-protocol'
 import { sanitizeKeyBindings } from './keymap.ts'
+import { ui } from './locale.ts'
 
 const TOOL_CARDS = new Set<TuiToolCardDisplay>(['collapsed', 'expanded', 'hidden'])
 const CLIPBOARD_FALLBACK = new Set<TuiClipboardFallback>(['auto', 'osc52', 'off'])
@@ -76,7 +77,10 @@ export function behaviorSettings(
   const document = documents.find(candidate =>
     candidate.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE)
   if (document === undefined) {
-    throw new Error(`Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`)
+    throw new Error(ui(
+      `Harness 未注册设置 ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`,
+      `Harness did not register settings ${TUI_BEHAVIOR_SETTINGS_NAMESPACE}`,
+    ))
   }
   return document
 }

--- a/src/client/clipboard.ts
+++ b/src/client/clipboard.ts
@@ -1,6 +1,7 @@
 /** OSC 52 clipboard writes with optional platform-command fallback. */
 
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { ui } from './locale.ts'
 import type { TuiClipboardFallback } from '@deepseek-ai/dsh-tui-protocol'
 
 /** OSC 52 payloads larger than this are refused and must use a process fallback or /export. */
@@ -75,7 +76,10 @@ export function writeClipboard(text: string, options: ClipboardWriteOptions): Cl
   if (osc52Ok) options.writeOsc52(osc52Sequence(text))
   if (options.fallback === 'osc52' || options.fallback === 'off') {
     if (!osc52Ok) {
-      throw new Error(`回复超过终端剪贴板 ${String(OSC52_BYTE_LIMIT)} 字节安全上限；请使用 /export`)
+      throw new Error(ui(
+        `回复超过终端剪贴板 ${String(OSC52_BYTE_LIMIT)} 字节安全上限；请使用 /export`,
+        `The response exceeds the ${String(OSC52_BYTE_LIMIT)}-byte terminal clipboard limit; use /export instead`,
+      ))
     }
     return 'osc52'
   }
@@ -90,5 +94,8 @@ export function writeClipboard(text: string, options: ClipboardWriteOptions): Cl
     }
   }
   if (osc52Ok) return 'osc52'
-  throw new Error(`无法写入系统剪贴板；请使用 /export。OSC 52 上限为 ${String(OSC52_BYTE_LIMIT)} 字节`)
+  throw new Error(ui(
+    `无法写入系统剪贴板；请使用 /export。OSC 52 上限为 ${String(OSC52_BYTE_LIMIT)} 字节`,
+    `Could not write the system clipboard; use /export. The OSC 52 limit is ${String(OSC52_BYTE_LIMIT)} bytes`,
+  ))
 }

--- a/src/client/desktop-notify.ts
+++ b/src/client/desktop-notify.ts
@@ -1,5 +1,7 @@
 /** Terminal BEL + OSC 9 notices for turn completion and pending interactions. */
 
+import { ui } from './locale.ts'
+
 export type DesktopNotifyKind = 'turn-complete' | 'approval' | 'question'
 
 export interface DesktopNotifySnapshot {
@@ -47,13 +49,8 @@ export function nextDesktopNotify(
  * @param locale - current terminal locale.
  * @returns a short notification body.
  */
-export function desktopNotifyBody(kind: DesktopNotifyKind, locale: 'zh' | 'en'): string {
-  if (locale === 'en') {
-    if (kind === 'approval') return 'SeekTTY: tool approval needed'
-    if (kind === 'question') return 'SeekTTY: a question is waiting'
-    return 'SeekTTY: turn complete'
-  }
-  if (kind === 'approval') return 'SeekTTY：需要工具审批'
-  if (kind === 'question') return 'SeekTTY：有问题待回答'
-  return 'SeekTTY：回合完成'
+export function desktopNotifyBody(kind: DesktopNotifyKind): string {
+  if (kind === 'approval') return ui('SeekTTY：需要工具审批', 'SeekTTY: tool approval needed')
+  if (kind === 'question') return ui('SeekTTY：有问题待回答', 'SeekTTY: a question is waiting')
+  return ui('SeekTTY：回合完成', 'SeekTTY: turn complete')
 }

--- a/src/client/job-control.ts
+++ b/src/client/job-control.ts
@@ -36,7 +36,9 @@ export function jobElapsedMs(
  * @param id - registry job id.
  */
 export function killHostJob(jobs: HostJobRegistry | undefined, id: string): JobKillResult {
-  if (jobs === undefined) throw new Error('Harness 后台任务服务未装配')
+  if (jobs === undefined) {
+    throw new Error(ui('Harness 后台任务服务未装配', 'Harness background job service is not mounted'))
+  }
   return jobs.kill(id, undefined, 'user stopped the job from SeekTTY')
 }
 

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -36,7 +36,6 @@ import {
   setUiLocale,
   translateUiText,
   ui,
-  uiLocale,
 } from './locale.ts'
 import { OverlayQueue, setDangerConfirmDefault } from './overlays.ts'
 import { SyntaxHighlighter } from './syntax-highlighter.ts'
@@ -306,7 +305,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (initialBehavior.desktopNotifications) {
         const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed)
         if (kind !== undefined) {
-          terminal.write(desktopNotifySequence(desktopNotifyBody(kind, uiLocale())))
+          terminal.write(desktopNotifySequence(desktopNotifyBody(kind)))
         }
       }
       notifySnapshot = currentNotify

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -6,6 +6,7 @@ import {
   type MarkdownTheme,
 } from '@mariozechner/pi-tui'
 import { BUILT_IN_THEMES, type ResolvedTuiTheme } from './theme-config.ts'
+import { ui } from './locale.ts'
 
 const RESET = '\u001B[0m'
 const ESC = 0x1B
@@ -42,7 +43,7 @@ interface ThemePalette {
 
 function semanticColor(value: string): SemanticColor {
   const match = /^#([0-9A-Fa-f]{6})$/u.exec(value)
-  if (match === null) throw new Error(`主题颜色 ${JSON.stringify(value)} 无效`)
+  if (match === null) throw new Error(ui(`主题颜色 ${JSON.stringify(value)} 无效`, `Theme color ${JSON.stringify(value)} is invalid`))
   const digits = match[1] ?? ''
   return {
     rgb: [

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -8,7 +8,7 @@ import { InProcessApiClient, toFetchHandler, type IApiClient } from '@deepseek-a
 import type { ClientConnectionRpc } from '@deepseek-ai/dsh-client-connection'
 import type { TuiManagementBridge, TuiSurfaceOutcome } from '@deepseek-ai/dsh-tui-protocol'
 import { startTui } from '../client/index.ts'
-import { translateUiText } from '../client/locale.ts'
+import { translateUiText, ui } from '../client/locale.ts'
 import { isActiveFiber } from './fiber-state.ts'
 import { createTuiManagementBridge } from './management.ts'
 import { TUI_STARTUP_SERVICE, type TuiStartupValues } from './startup.ts'
@@ -73,7 +73,9 @@ async function run(ctx: Context): Promise<void> {
     return
   }
   const restart = ctx.get('appRestart')
-  if (restart === undefined) throw new Error('tui-runner: launcher 未提供受控重启能力')
+  if (restart === undefined) {
+    throw new Error(ui('tui-runner: launcher 未提供受控重启能力', 'tui-runner: launcher did not provide controlled restart'))
+  }
   try {
     await restart({
       profile: outcome.request.profile,
@@ -84,7 +86,10 @@ async function run(ctx: Context): Promise<void> {
       handoff: { channel: 'seektty-v1', payload: outcome.request },
     })
   } catch (error) {
-    internals.stderr.write(`deepseek: ${translateUiText(`重启失败：${error instanceof Error ? error.message : String(error)}`)}\n`)
+    internals.stderr.write(`deepseek: ${ui(
+      `重启失败：${error instanceof Error ? error.message : String(error)}`,
+      `Restart failed: ${error instanceof Error ? error.message : String(error)}`,
+    )}\n`)
     process.exitCode = 1
   }
 }

--- a/tests/desktop-notify.test.ts
+++ b/tests/desktop-notify.test.ts
@@ -4,6 +4,7 @@ import {
   desktopNotifySequence,
   nextDesktopNotify,
 } from '../src/client/desktop-notify.ts'
+import { setUiLocale } from '../src/client/locale.ts'
 
 describe('desktop notifications', () => {
   it('emits BEL plus OSC 9 and strips control characters from the body', () => {
@@ -22,6 +23,8 @@ describe('desktop notifications', () => {
     expect(nextDesktopNotify(running, approval, true)).toBe('approval')
     expect(nextDesktopNotify(idle, question, true)).toBe('question')
     expect(nextDesktopNotify(approval, approval, true)).toBeUndefined()
-    expect(desktopNotifyBody('approval', 'en')).toContain('approval')
+    expect(desktopNotifyBody('approval')).toContain('工具审批')
+    setUiLocale('en')
+    expect(desktopNotifyBody('approval')).toContain('approval')
   })
 })

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -9,6 +9,12 @@ const GATED = [
   'bin.ts',
   'dsh-compat.ts',
   'client/overlays.ts',
+  'client/behavior.ts',
+  'client/clipboard.ts',
+  'client/desktop-notify.ts',
+  'client/job-control.ts',
+  'client/theme.ts',
+  'host/index.ts',
   'host/restart-handoff.ts',
 ]
 


### PR DESCRIPTION
## Summary
- Wrap clipboard, desktop notify, theme, behavior, job-control, and Host restart copy with `ui()`.
- Widen the AST gate to these files.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/desktop-notify.test.ts tests/clipboard.test.ts tests/behavior.test.ts`
