### PR TITLE
feat(tui): wrap leftover theme validation copy with ui()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21283,7 +21283,7 @@ const SYNTAX_COLOR_KEYS = [
 ];
 const BUILT_IN_DARK = Object.freeze({
 	id: "dark",
-	name: "DeepSeek 暗色",
+	name: ui("DeepSeek 暗色", "DeepSeek dark"),
 	tone: "dark",
 	syntaxTone: "dark",
 	source: "builtin",
@@ -21323,7 +21323,7 @@ const BUILT_IN_DARK = Object.freeze({
 });
 const BUILT_IN_LIGHT = Object.freeze({
 	id: "light",
-	name: "DeepSeek 亮色",
+	name: ui("DeepSeek 亮色", "DeepSeek light"),
 	tone: "light",
 	syntaxTone: "light",
 	source: "builtin",
@@ -21445,7 +21445,7 @@ function hexOf(rgb$1) {
 */
 function normalizeThemeColor(value) {
 	const parsed = parseRgba(value);
-	if (parsed === void 0 || parsed.alpha !== 1) throw new Error(`颜色 ${JSON.stringify(value)} 必须是无透明度的 HEX 或 RGB`);
+	if (parsed === void 0 || parsed.alpha !== 1) throw new Error(ui(`颜色 ${JSON.stringify(value)} 必须是无透明度的 HEX 或 RGB`, `Color ${JSON.stringify(value)} must be opaque HEX or RGB`));
 	return hexOf(parsed);
 }
 /**
@@ -21456,7 +21456,7 @@ function normalizeThemeColor(value) {
 */
 function normalizeThemeColorOn(value, background$1) {
 	const parsed = parseRgba(value);
-	if (parsed === void 0) throw new Error(`颜色 ${JSON.stringify(value)} 不是有效的 HEX 或 RGB`);
+	if (parsed === void 0) throw new Error(ui(`颜色 ${JSON.stringify(value)} 不是有效的 HEX 或 RGB`, `Color ${JSON.stringify(value)} is not valid HEX or RGB`));
 	if (parsed.alpha === 1) return hexOf(parsed);
 	const base = rgbOf(normalizeThemeColor(background$1));
 	return hexOf({
@@ -21467,7 +21467,7 @@ function normalizeThemeColorOn(value, background$1) {
 }
 function rgbOf(color$1) {
 	const parsed = parseRgba(color$1);
-	if (parsed === void 0) throw new Error(`颜色 ${JSON.stringify(color$1)} 无效`);
+	if (parsed === void 0) throw new Error(ui(`颜色 ${JSON.stringify(color$1)} 无效`, `Color ${JSON.stringify(color$1)} is invalid`));
 	return parsed;
 }
 function linearChannel(channel) {
@@ -21664,8 +21664,8 @@ function parseThemePalette(input) {
 	const matches$1 = input.match(/#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)/giu) ?? [];
 	const colors = [...new Set(matches$1.map(normalizeThemeColor))];
 	const residue = matches$1.reduce((value, match) => value.replace(match, " "), input).replace(/[\s,;|]+/gu, "");
-	if (residue !== "") throw new Error(`无法识别的配色内容 ${JSON.stringify(residue.slice(0, 40))}`);
-	if (colors.length < 3 || colors.length > 16) throw new Error("配色需要 3–16 个不重复的 HEX/RGB 颜色");
+	if (residue !== "") throw new Error(ui(`无法识别的配色内容 ${JSON.stringify(residue.slice(0, 40))}`, `Unrecognized palette text ${JSON.stringify(residue.slice(0, 40))}`));
+	if (colors.length < 3 || colors.length > 16) throw new Error(ui("配色需要 3–16 个不重复的 HEX/RGB 颜色", "A palette requires 3–16 unique HEX/RGB colors"));
 	return colors;
 }
 /**
@@ -21701,12 +21701,12 @@ function themeIdFromName(name$1) {
 	return `theme-${(hash >>> 0).toString(16).padStart(8, "0")}`;
 }
 function recordOf$2(value, label) {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} 必须是对象`);
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(ui(`${label} 必须是对象`, `${label} must be an object`));
 	return value;
 }
 function stringOf(record, key, label) {
 	const value = record[key];
-	if (typeof value !== "string") throw new Error(`${label}.${key} 必须是字符串`);
+	if (typeof value !== "string") throw new Error(ui(`${label}.${key} 必须是字符串`, `${label}.${key} must be a string`));
 	return value;
 }
 function colorRecord(value, keys, label) {
@@ -21721,26 +21721,26 @@ const TOKEN_FONT_STYLES = new Set([
 ]);
 function textMateRules$1(value) {
 	if (value === void 0) return [];
-	if (!Array.isArray(value) || value.length > MAX_TEXTMATE_RULES) throw new Error(`customThemes[].tokenColors 最多包含 ${String(MAX_TEXTMATE_RULES)} 条规则`);
+	if (!Array.isArray(value) || value.length > MAX_TEXTMATE_RULES) throw new Error(ui(`customThemes[].tokenColors 最多包含 ${String(MAX_TEXTMATE_RULES)} 条规则`, `customThemes[].tokenColors can contain at most ${String(MAX_TEXTMATE_RULES)} rules`));
 	return value.map((entry, index) => {
 		const label = `customThemes[].tokenColors[${String(index)}]`;
 		const record = recordOf$2(entry, label);
-		if (!Array.isArray(record.scope) || record.scope.length === 0 || record.scope.length > 64) throw new Error(`${label}.scope 必须包含 1–64 个 TextMate scope`);
+		if (!Array.isArray(record.scope) || record.scope.length === 0 || record.scope.length > 64) throw new Error(ui(`${label}.scope 必须包含 1–64 个 TextMate scope`, `${label}.scope must contain 1–64 TextMate scopes`));
 		const scope = [...new Set(record.scope.map((item) => {
-			if (typeof item !== "string" || item === "" || item.length > 256 || /[\u0000-\u001F\u007F-\u009F]/u.test(item)) throw new Error(`${label}.scope 包含无效值`);
+			if (typeof item !== "string" || item === "" || item.length > 256 || /[\u0000-\u001F\u007F-\u009F]/u.test(item)) throw new Error(ui(`${label}.scope 包含无效值`, `${label}.scope contains an invalid value`));
 			return item;
 		}))];
 		const foreground = record.foreground === void 0 ? void 0 : normalizeThemeColor(stringOf(record, "foreground", label));
 		const background$1 = record.background === void 0 ? void 0 : normalizeThemeColor(stringOf(record, "background", label));
 		let fontStyle;
 		if (record.fontStyle !== void 0) {
-			if (!Array.isArray(record.fontStyle)) throw new Error(`${label}.fontStyle 必须是数组`);
+			if (!Array.isArray(record.fontStyle)) throw new Error(ui(`${label}.fontStyle 必须是数组`, `${label}.fontStyle must be an array`));
 			fontStyle = [...new Set(record.fontStyle.map((style) => {
-				if (typeof style !== "string" || !TOKEN_FONT_STYLES.has(style)) throw new Error(`${label}.fontStyle 包含不支持的样式`);
+				if (typeof style !== "string" || !TOKEN_FONT_STYLES.has(style)) throw new Error(ui(`${label}.fontStyle 包含不支持的样式`, `${label}.fontStyle contains an unsupported style`));
 				return style;
 			}))];
 		}
-		if (foreground === void 0 && background$1 === void 0 && fontStyle === void 0) throw new Error(`${label} 没有颜色或代码字体样式`);
+		if (foreground === void 0 && background$1 === void 0 && fontStyle === void 0) throw new Error(ui(`${label} 没有颜色或代码字体样式`, `${label} has no color or code font style`));
 		return {
 			scope,
 			...foreground === void 0 ? {} : { foreground },
@@ -21760,11 +21760,11 @@ function normalizeCustomTheme(value) {
 	const name$1 = stringOf(record, "name", "customThemes[]").trim();
 	const tone = stringOf(record, "tone", "customThemes[]");
 	const source = stringOf(record, "source", "customThemes[]");
-	if (!/^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/u.test(id)) throw new Error(`自定义主题 id ${JSON.stringify(id)} 无效`);
-	if (name$1 === "" || name$1.length > 80) throw new Error("自定义主题名称必须为 1–80 个字符");
-	if (/[\u0000-\u001F\u007F-\u009F]/u.test(name$1)) throw new Error("自定义主题名称不能包含终端控制字符");
-	if (tone !== "dark" && tone !== "light") throw new Error(`自定义主题 tone ${JSON.stringify(tone)} 无效`);
-	if (source !== "manual" && source !== "palette" && source !== "vscode") throw new Error(`自定义主题 source ${JSON.stringify(source)} 无效`);
+	if (!/^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/u.test(id)) throw new Error(ui(`自定义主题 id ${JSON.stringify(id)} 无效`, `Custom theme id ${JSON.stringify(id)} is invalid`));
+	if (name$1 === "" || name$1.length > 80) throw new Error(ui("自定义主题名称必须为 1–80 个字符", "Custom theme name must contain 1–80 characters"));
+	if (/[\u0000-\u001F\u007F-\u009F]/u.test(name$1)) throw new Error(ui("自定义主题名称不能包含终端控制字符", "Custom theme name cannot contain terminal control characters"));
+	if (tone !== "dark" && tone !== "light") throw new Error(ui(`自定义主题 tone ${JSON.stringify(tone)} 无效`, `Custom theme tone ${JSON.stringify(tone)} is invalid`));
+	if (source !== "manual" && source !== "palette" && source !== "vscode") throw new Error(ui(`自定义主题 source ${JSON.stringify(source)} 无效`, `Custom theme source ${JSON.stringify(source)} is invalid`));
 	return {
 		id,
 		name: name$1,
@@ -21783,25 +21783,25 @@ function normalizeCustomTheme(value) {
 function normalizeAppearance(value) {
 	const record = recordOf$2(value, "SeekTTY appearance");
 	const rawTheme = stringOf(record, "theme", "SeekTTY appearance");
-	if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) throw new Error(`SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`);
+	if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) throw new Error(ui(`SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`, `SeekTTY theme ${JSON.stringify(rawTheme)} is not supported`));
 	const rawThemes = record.customThemes ?? [];
-	if (!Array.isArray(rawThemes) || rawThemes.length > MAX_CUSTOM_THEMES) throw new Error(`SeekTTY 最多保存 ${String(MAX_CUSTOM_THEMES)} 个自定义主题`);
+	if (!Array.isArray(rawThemes) || rawThemes.length > MAX_CUSTOM_THEMES) throw new Error(ui(`SeekTTY 最多保存 ${String(MAX_CUSTOM_THEMES)} 个自定义主题`, `SeekTTY can store at most ${String(MAX_CUSTOM_THEMES)} custom themes`));
 	const customThemes = rawThemes.map(normalizeCustomTheme);
 	const ids = /* @__PURE__ */ new Set();
 	const names = /* @__PURE__ */ new Set();
 	for (const theme$1 of customThemes) {
 		const foldedName = theme$1.name.toLowerCase();
-		if (ids.has(theme$1.id)) throw new Error(`自定义主题 id ${JSON.stringify(theme$1.id)} 重复`);
-		if (names.has(foldedName)) throw new Error(`自定义主题名称 ${JSON.stringify(theme$1.name)} 重复`);
+		if (ids.has(theme$1.id)) throw new Error(ui(`自定义主题 id ${JSON.stringify(theme$1.id)} 重复`, `Custom theme id ${JSON.stringify(theme$1.id)} is duplicated`));
+		if (names.has(foldedName)) throw new Error(ui(`自定义主题名称 ${JSON.stringify(theme$1.name)} 重复`, `Custom theme name ${JSON.stringify(theme$1.name)} is duplicated`));
 		ids.add(theme$1.id);
 		names.add(foldedName);
 	}
 	const theme = rawTheme;
-	if (theme.startsWith("custom:") && !ids.has(theme.slice(7))) throw new Error(`当前自定义主题 ${JSON.stringify(theme)} 不存在`);
+	if (theme.startsWith("custom:") && !ids.has(theme.slice(7))) throw new Error(ui(`当前自定义主题 ${JSON.stringify(theme)} 不存在`, `The current custom theme ${JSON.stringify(theme)} does not exist`));
 	const rawCodeTheme = record.codeTheme === void 0 ? DEFAULT_TUI_CODE_THEME : stringOf(record, "codeTheme", "SeekTTY appearance");
-	if (!/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawCodeTheme)) throw new Error(`SeekTTY 代码主题 ${JSON.stringify(rawCodeTheme)} 不受支持`);
+	if (!/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawCodeTheme)) throw new Error(ui(`SeekTTY 代码主题 ${JSON.stringify(rawCodeTheme)} 不受支持`, `SeekTTY code theme ${JSON.stringify(rawCodeTheme)} is not supported`));
 	const codeTheme = rawCodeTheme;
-	if (codeTheme.startsWith("custom:") && !ids.has(codeTheme.slice(7))) throw new Error(`当前自定义代码主题 ${JSON.stringify(codeTheme)} 不存在`);
+	if (codeTheme.startsWith("custom:") && !ids.has(codeTheme.slice(7))) throw new Error(ui(`当前自定义代码主题 ${JSON.stringify(codeTheme)} 不存在`, `The current custom code theme ${JSON.stringify(codeTheme)} does not exist`));
 	return {
 		theme,
 		codeTheme,
@@ -21818,7 +21818,7 @@ function resolveTheme(appearance, requested = appearance.theme) {
 	if (requested === "dark" || requested === "light") return BUILT_IN_THEMES[requested];
 	const id = requested.slice(7);
 	const theme = appearance.customThemes.find((candidate) => candidate.id === id);
-	if (theme === void 0) throw new Error(`自定义主题 ${JSON.stringify(id)} 不存在`);
+	if (theme === void 0) throw new Error(ui(`自定义主题 ${JSON.stringify(id)} 不存在`, `Custom theme ${JSON.stringify(id)} does not exist`));
 	return {
 		...theme,
 		id: requested,
@@ -21864,13 +21864,13 @@ function resolveAppearanceTheme(appearance) {
 */
 function themeContrastWarnings(theme) {
 	const warnings = [];
-	if (themeContrast(theme.colors.text, theme.colors.canvas) < 4.5) warnings.push("正文与画布对比度低于 4.5:1");
-	if (themeContrast(theme.colors.muted, theme.colors.canvas) < 3) warnings.push("弱化文字与画布对比度低于 3:1");
-	if (themeContrast(theme.syntax.foreground, theme.syntax.background) < 4.5) warnings.push("代码正文与代码背景对比度低于 4.5:1");
+	if (themeContrast(theme.colors.text, theme.colors.canvas) < 4.5) warnings.push(ui("正文与画布对比度低于 4.5:1", "Text-to-canvas contrast is below 4.5:1"));
+	if (themeContrast(theme.colors.muted, theme.colors.canvas) < 3) warnings.push(ui("弱化文字与画布对比度低于 3:1", "Muted-text-to-canvas contrast is below 3:1"));
+	if (themeContrast(theme.syntax.foreground, theme.syntax.background) < 4.5) warnings.push(ui("代码正文与代码背景对比度低于 4.5:1", "Code-text-to-background contrast is below 4.5:1"));
 	const lowTokens = SYNTAX_COLOR_KEYS.filter((key) => key !== "background" && key !== "foreground").filter((key) => themeContrast(theme.syntax[key], theme.syntax.background) < 3);
-	if (lowTokens.length > 0) warnings.push(`代码颜色对比度偏低：${lowTokens.join("、")}`);
+	if (lowTokens.length > 0) warnings.push(ui(`代码颜色对比度偏低：${lowTokens.join("、")}`, `Low code-color contrast: ${lowTokens.join(", ")}`));
 	const lowImported = theme.tokenColors.filter((rule) => rule.foreground !== void 0 && themeContrast(rule.foreground, rule.background ?? theme.syntax.background) < 3).length;
-	if (lowImported > 0) warnings.push(`${String(lowImported)} 条导入的 TextMate 规则对比度低于 3:1`);
+	if (lowImported > 0) warnings.push(ui(`${String(lowImported)} 条导入的 TextMate 规则对比度低于 3:1`, `${String(lowImported)} imported TextMate rule(s) have contrast below 3:1`));
 	return warnings;
 }
 /**
@@ -23334,7 +23334,7 @@ const MAX_THEME_FILE_BYTES = 2 * 1024 * 1024;
 const MAX_THEME_TOTAL_BYTES = 8 * 1024 * 1024;
 const MAX_INCLUDE_DEPTH = 16;
 function objectRecord(value, label) {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} 必须是对象`);
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(ui(`${label} 必须是对象`, `${label} must be an object`));
 	return value;
 }
 function optionalRecord(value, label) {
@@ -23347,13 +23347,13 @@ function parseJsonc(text$1, path$1) {
 		disallowComments: false
 	});
 	const first = errors[0];
-	if (first !== void 0) throw new Error(`${path$1} 的 JSONC 无效：${printParseErrorCode(first.error)}（offset ${String(first.offset)}）`);
+	if (first !== void 0) throw new Error(ui(`${path$1} 的 JSONC 无效：${printParseErrorCode(first.error)}（offset ${String(first.offset)}）`, `${path$1} has invalid JSONC: ${printParseErrorCode(first.error)} (offset ${String(first.offset)})`));
 	return objectRecord(value, path$1);
 }
 function sourcePath(input) {
 	const trimmed = input.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/u, "$1$2");
-	if (trimmed === "") throw new Error("VS Code 主题文件路径不能为空");
-	if (/^https?:/iu.test(trimmed)) throw new Error("只支持本地 VS Code 主题文件，不读取远程 URL");
+	if (trimmed === "") throw new Error(ui("VS Code 主题文件路径不能为空", "VS Code theme path cannot be empty"));
+	if (/^https?:/iu.test(trimmed)) throw new Error(ui("只支持本地 VS Code 主题文件，不读取远程 URL", "Only local VS Code theme files are supported; remote URLs are not fetched"));
 	if (trimmed.startsWith("file:")) return fileURLToPath(trimmed);
 	if (trimmed === "~") return homedir();
 	if (trimmed.startsWith("~/")) return resolve(homedir(), trimmed.slice(2));
@@ -23363,7 +23363,7 @@ function mergeTheme(base, current, path$1) {
 	const colors = optionalRecord(current.colors, `${path$1}.colors`);
 	const semanticTokenColors = optionalRecord(current.semanticTokenColors, `${path$1}.semanticTokenColors`);
 	const rawTokenColors = current.tokenColors ?? [];
-	if (!Array.isArray(rawTokenColors)) throw new Error(`${path$1}.tokenColors 必须是数组`);
+	if (!Array.isArray(rawTokenColors)) throw new Error(ui(`${path$1}.tokenColors 必须是数组`, `${path$1}.tokenColors must be an array`));
 	const name$1 = typeof current.name === "string" ? current.name : base.name;
 	const type = typeof current.type === "string" ? current.type : base.type;
 	return {
@@ -23389,19 +23389,19 @@ async function loadThemeRecord(path$1, active, budget) {
 	const canonical = await realpath(path$1);
 	if (active.includes(canonical)) {
 		const chain = [...active, canonical].map((item) => basename(item)).join(" → ");
-		throw new Error(`VS Code 主题 include 存在循环：${chain}`);
+		throw new Error(ui(`VS Code 主题 include 存在循环：${chain}`, `VS Code theme include cycle: ${chain}`));
 	}
-	if (active.length >= MAX_INCLUDE_DEPTH) throw new Error(`VS Code 主题 include 超过 ${String(MAX_INCLUDE_DEPTH)} 层`);
+	if (active.length >= MAX_INCLUDE_DEPTH) throw new Error(ui(`VS Code 主题 include 超过 ${String(MAX_INCLUDE_DEPTH)} 层`, `VS Code theme include exceeds ${String(MAX_INCLUDE_DEPTH)} levels`));
 	const text$1 = await readFile(canonical, "utf8");
 	const bytes = Buffer.byteLength(text$1);
-	if (bytes > MAX_THEME_FILE_BYTES) throw new Error(`VS Code 主题文件超过 ${String(MAX_THEME_FILE_BYTES)} 字节`);
+	if (bytes > MAX_THEME_FILE_BYTES) throw new Error(ui(`VS Code 主题文件超过 ${String(MAX_THEME_FILE_BYTES)} 字节`, `VS Code theme file exceeds ${String(MAX_THEME_FILE_BYTES)} bytes`));
 	budget.bytes += bytes;
-	if (budget.bytes > MAX_THEME_TOTAL_BYTES) throw new Error(`VS Code 主题 include 总大小超过 ${String(MAX_THEME_TOTAL_BYTES)} 字节`);
+	if (budget.bytes > MAX_THEME_TOTAL_BYTES) throw new Error(ui(`VS Code 主题 include 总大小超过 ${String(MAX_THEME_TOTAL_BYTES)} 字节`, `VS Code theme include total size exceeds ${String(MAX_THEME_TOTAL_BYTES)} bytes`));
 	const current = parseJsonc(text$1, canonical);
 	let base = EMPTY_THEME;
 	if (current.include !== void 0) {
 		const include = typeof current.include === "string" ? current.include.trim() : "";
-		if (include === "" || isAbsolute(include) || /^[a-z][a-z0-9+.-]*:/iu.test(include)) throw new Error(`${canonical}.include 必须是相对文件路径`);
+		if (include === "" || isAbsolute(include) || /^[a-z][a-z0-9+.-]*:/iu.test(include)) throw new Error(ui(`${canonical}.include 必须是相对文件路径`, `${canonical}.include must be a relative file path`));
 		base = (await loadThemeRecord(resolve(dirname(canonical), include), [...active, canonical], budget)).value;
 	}
 	return {
@@ -23473,7 +23473,7 @@ function fontStyles(value) {
 	return [...new Set(value.toLowerCase().split(/\s+/u).filter((item) => FONT_STYLES.has(item)))];
 }
 function textMateRules(value, background$1) {
-	if (value.tokenColors.length > MAX_TEXTMATE_RULES) throw new Error(`VS Code 主题最多导入 ${String(MAX_TEXTMATE_RULES)} 条 TextMate 规则`);
+	if (value.tokenColors.length > MAX_TEXTMATE_RULES) throw new Error(ui(`VS Code 主题最多导入 ${String(MAX_TEXTMATE_RULES)} 条 TextMate 规则`, `A VS Code theme can import at most ${String(MAX_TEXTMATE_RULES)} TextMate rules`));
 	return value.tokenColors.flatMap((entry) => {
 		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return [];
 		const record = entry;

--- a/src/client/theme-config.ts
+++ b/src/client/theme-config.ts
@@ -15,6 +15,7 @@ import {
   type TuiThemeUiColors,
   type TuiTokenFontStyle,
 } from '@deepseek-ai/dsh-tui-protocol'
+import { ui } from './locale.ts'
 
 interface Rgb {
   readonly red: number
@@ -70,7 +71,7 @@ const SYNTAX_COLOR_KEYS = [
 
 const BUILT_IN_DARK: ResolvedTuiTheme = Object.freeze({
   id: 'dark',
-  name: 'DeepSeek 暗色',
+  name: ui('DeepSeek 暗色', 'DeepSeek dark'),
   tone: 'dark',
   syntaxTone: 'dark',
   source: 'builtin',
@@ -91,7 +92,7 @@ const BUILT_IN_DARK: ResolvedTuiTheme = Object.freeze({
 
 const BUILT_IN_LIGHT: ResolvedTuiTheme = Object.freeze({
   id: 'light',
-  name: 'DeepSeek 亮色',
+  name: ui('DeepSeek 亮色', 'DeepSeek light'),
   tone: 'light',
   syntaxTone: 'light',
   source: 'builtin',
@@ -202,7 +203,10 @@ function hexOf(rgb: Rgb): string {
 export function normalizeThemeColor(value: string): string {
   const parsed = parseRgba(value)
   if (parsed === undefined || parsed.alpha !== 1) {
-    throw new Error(`颜色 ${JSON.stringify(value)} 必须是无透明度的 HEX 或 RGB`)
+    throw new Error(ui(
+      `颜色 ${JSON.stringify(value)} 必须是无透明度的 HEX 或 RGB`,
+      `Color ${JSON.stringify(value)} must be opaque HEX or RGB`,
+    ))
   }
   return hexOf(parsed)
 }
@@ -215,7 +219,12 @@ export function normalizeThemeColor(value: string): string {
  */
 export function normalizeThemeColorOn(value: string, background: string): string {
   const parsed = parseRgba(value)
-  if (parsed === undefined) throw new Error(`颜色 ${JSON.stringify(value)} 不是有效的 HEX 或 RGB`)
+  if (parsed === undefined) {
+    throw new Error(ui(
+      `颜色 ${JSON.stringify(value)} 不是有效的 HEX 或 RGB`,
+      `Color ${JSON.stringify(value)} is not valid HEX or RGB`,
+    ))
+  }
   if (parsed.alpha === 1) return hexOf(parsed)
   const base = rgbOf(normalizeThemeColor(background))
   return hexOf({
@@ -227,7 +236,9 @@ export function normalizeThemeColorOn(value: string, background: string): string
 
 function rgbOf(color: string): Rgb {
   const parsed = parseRgba(color)
-  if (parsed === undefined) throw new Error(`颜色 ${JSON.stringify(color)} 无效`)
+  if (parsed === undefined) {
+    throw new Error(ui(`颜色 ${JSON.stringify(color)} 无效`, `Color ${JSON.stringify(color)} is invalid`))
+  }
   return parsed
 }
 
@@ -443,8 +454,15 @@ export function parseThemePalette(input: string): readonly string[] {
   const colors = [...new Set(matches.map(normalizeThemeColor))]
   const residue = matches.reduce((value, match) => value.replace(match, ' '), input)
     .replace(/[\s,;|]+/gu, '')
-  if (residue !== '') throw new Error(`无法识别的配色内容 ${JSON.stringify(residue.slice(0, 40))}`)
-  if (colors.length < 3 || colors.length > 16) throw new Error('配色需要 3–16 个不重复的 HEX/RGB 颜色')
+  if (residue !== '') {
+    throw new Error(ui(
+      `无法识别的配色内容 ${JSON.stringify(residue.slice(0, 40))}`,
+      `Unrecognized palette text ${JSON.stringify(residue.slice(0, 40))}`,
+    ))
+  }
+  if (colors.length < 3 || colors.length > 16) {
+    throw new Error(ui('配色需要 3–16 个不重复的 HEX/RGB 颜色', 'A palette requires 3–16 unique HEX/RGB colors'))
+  }
   return colors
 }
 
@@ -487,13 +505,17 @@ export function themeIdFromName(name: string): string {
 }
 
 function recordOf(value: unknown, label: string): Readonly<Record<string, unknown>> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} 必须是对象`)
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(ui(`${label} 必须是对象`, `${label} must be an object`))
+  }
   return value as Readonly<Record<string, unknown>>
 }
 
 function stringOf(record: Readonly<Record<string, unknown>>, key: string, label: string): string {
   const value = record[key]
-  if (typeof value !== 'string') throw new Error(`${label}.${key} 必须是字符串`)
+  if (typeof value !== 'string') {
+    throw new Error(ui(`${label}.${key} 必须是字符串`, `${label}.${key} must be a string`))
+  }
   return value
 }
 
@@ -511,17 +533,23 @@ const TOKEN_FONT_STYLES = new Set<TuiTokenFontStyle>(['bold', 'italic', 'underli
 function textMateRules(value: unknown): readonly TuiTextMateRule[] {
   if (value === undefined) return []
   if (!Array.isArray(value) || value.length > MAX_TEXTMATE_RULES) {
-    throw new Error(`customThemes[].tokenColors 最多包含 ${String(MAX_TEXTMATE_RULES)} 条规则`)
+    throw new Error(ui(
+      `customThemes[].tokenColors 最多包含 ${String(MAX_TEXTMATE_RULES)} 条规则`,
+      `customThemes[].tokenColors can contain at most ${String(MAX_TEXTMATE_RULES)} rules`,
+    ))
   }
   return value.map((entry, index): TuiTextMateRule => {
     const label = `customThemes[].tokenColors[${String(index)}]`
     const record = recordOf(entry, label)
     if (!Array.isArray(record.scope) || record.scope.length === 0 || record.scope.length > 64) {
-      throw new Error(`${label}.scope 必须包含 1–64 个 TextMate scope`)
+      throw new Error(ui(
+        `${label}.scope 必须包含 1–64 个 TextMate scope`,
+        `${label}.scope must contain 1–64 TextMate scopes`,
+      ))
     }
     const scope = [...new Set(record.scope.map((item) => {
       if (typeof item !== 'string' || item === '' || item.length > 256 || /[\u0000-\u001F\u007F-\u009F]/u.test(item)) {
-        throw new Error(`${label}.scope 包含无效值`)
+        throw new Error(ui(`${label}.scope 包含无效值`, `${label}.scope contains an invalid value`))
       }
       return item
     }))]
@@ -533,16 +561,18 @@ function textMateRules(value: unknown): readonly TuiTextMateRule[] {
       : normalizeThemeColor(stringOf(record, 'background', label))
     let fontStyle: readonly TuiTokenFontStyle[] | undefined
     if (record.fontStyle !== undefined) {
-      if (!Array.isArray(record.fontStyle)) throw new Error(`${label}.fontStyle 必须是数组`)
+      if (!Array.isArray(record.fontStyle)) {
+        throw new Error(ui(`${label}.fontStyle 必须是数组`, `${label}.fontStyle must be an array`))
+      }
       fontStyle = [...new Set(record.fontStyle.map((style) => {
         if (typeof style !== 'string' || !TOKEN_FONT_STYLES.has(style as TuiTokenFontStyle)) {
-          throw new Error(`${label}.fontStyle 包含不支持的样式`)
+          throw new Error(ui(`${label}.fontStyle 包含不支持的样式`, `${label}.fontStyle contains an unsupported style`))
         }
         return style as TuiTokenFontStyle
       }))]
     }
     if (foreground === undefined && background === undefined && fontStyle === undefined) {
-      throw new Error(`${label} 没有颜色或代码字体样式`)
+      throw new Error(ui(`${label} 没有颜色或代码字体样式`, `${label} has no color or code font style`))
     }
     return {
       scope,
@@ -564,12 +594,23 @@ export function normalizeCustomTheme(value: unknown): TuiCustomTheme {
   const name = stringOf(record, 'name', 'customThemes[]').trim()
   const tone = stringOf(record, 'tone', 'customThemes[]')
   const source = stringOf(record, 'source', 'customThemes[]')
-  if (!/^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/u.test(id)) throw new Error(`自定义主题 id ${JSON.stringify(id)} 无效`)
-  if (name === '' || name.length > 80) throw new Error('自定义主题名称必须为 1–80 个字符')
-  if (/[\u0000-\u001F\u007F-\u009F]/u.test(name)) throw new Error('自定义主题名称不能包含终端控制字符')
-  if (tone !== 'dark' && tone !== 'light') throw new Error(`自定义主题 tone ${JSON.stringify(tone)} 无效`)
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/u.test(id)) {
+    throw new Error(ui(`自定义主题 id ${JSON.stringify(id)} 无效`, `Custom theme id ${JSON.stringify(id)} is invalid`))
+  }
+  if (name === '' || name.length > 80) {
+    throw new Error(ui('自定义主题名称必须为 1–80 个字符', 'Custom theme name must contain 1–80 characters'))
+  }
+  if (/[\u0000-\u001F\u007F-\u009F]/u.test(name)) {
+    throw new Error(ui('自定义主题名称不能包含终端控制字符', 'Custom theme name cannot contain terminal control characters'))
+  }
+  if (tone !== 'dark' && tone !== 'light') {
+    throw new Error(ui(`自定义主题 tone ${JSON.stringify(tone)} 无效`, `Custom theme tone ${JSON.stringify(tone)} is invalid`))
+  }
   if (source !== 'manual' && source !== 'palette' && source !== 'vscode') {
-    throw new Error(`自定义主题 source ${JSON.stringify(source)} 无效`)
+    throw new Error(ui(
+      `自定义主题 source ${JSON.stringify(source)} 无效`,
+      `Custom theme source ${JSON.stringify(source)} is invalid`,
+    ))
   }
   return {
     id,
@@ -591,35 +632,60 @@ export function normalizeAppearance(value: unknown): TuiAppearanceSettings {
   const record = recordOf(value, 'SeekTTY appearance')
   const rawTheme = stringOf(record, 'theme', 'SeekTTY appearance')
   if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) {
-    throw new Error(`SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`)
+    throw new Error(ui(
+      `SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`,
+      `SeekTTY theme ${JSON.stringify(rawTheme)} is not supported`,
+    ))
   }
   const rawThemes = record.customThemes ?? []
   if (!Array.isArray(rawThemes) || rawThemes.length > MAX_CUSTOM_THEMES) {
-    throw new Error(`SeekTTY 最多保存 ${String(MAX_CUSTOM_THEMES)} 个自定义主题`)
+    throw new Error(ui(
+      `SeekTTY 最多保存 ${String(MAX_CUSTOM_THEMES)} 个自定义主题`,
+      `SeekTTY can store at most ${String(MAX_CUSTOM_THEMES)} custom themes`,
+    ))
   }
   const customThemes = rawThemes.map(normalizeCustomTheme)
   const ids = new Set<string>()
   const names = new Set<string>()
   for (const theme of customThemes) {
     const foldedName = theme.name.toLowerCase()
-    if (ids.has(theme.id)) throw new Error(`自定义主题 id ${JSON.stringify(theme.id)} 重复`)
-    if (names.has(foldedName)) throw new Error(`自定义主题名称 ${JSON.stringify(theme.name)} 重复`)
+    if (ids.has(theme.id)) {
+      throw new Error(ui(
+        `自定义主题 id ${JSON.stringify(theme.id)} 重复`,
+        `Custom theme id ${JSON.stringify(theme.id)} is duplicated`,
+      ))
+    }
+    if (names.has(foldedName)) {
+      throw new Error(ui(
+        `自定义主题名称 ${JSON.stringify(theme.name)} 重复`,
+        `Custom theme name ${JSON.stringify(theme.name)} is duplicated`,
+      ))
+    }
     ids.add(theme.id)
     names.add(foldedName)
   }
   const theme = rawTheme as TuiThemeId
   if (theme.startsWith('custom:') && !ids.has(theme.slice('custom:'.length))) {
-    throw new Error(`当前自定义主题 ${JSON.stringify(theme)} 不存在`)
+    throw new Error(ui(
+      `当前自定义主题 ${JSON.stringify(theme)} 不存在`,
+      `The current custom theme ${JSON.stringify(theme)} does not exist`,
+    ))
   }
   const rawCodeTheme = record.codeTheme === undefined
     ? DEFAULT_TUI_CODE_THEME
     : stringOf(record, 'codeTheme', 'SeekTTY appearance')
   if (!/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawCodeTheme)) {
-    throw new Error(`SeekTTY 代码主题 ${JSON.stringify(rawCodeTheme)} 不受支持`)
+    throw new Error(ui(
+      `SeekTTY 代码主题 ${JSON.stringify(rawCodeTheme)} 不受支持`,
+      `SeekTTY code theme ${JSON.stringify(rawCodeTheme)} is not supported`,
+    ))
   }
   const codeTheme = rawCodeTheme as TuiCodeThemeId
   if (codeTheme.startsWith('custom:') && !ids.has(codeTheme.slice('custom:'.length))) {
-    throw new Error(`当前自定义代码主题 ${JSON.stringify(codeTheme)} 不存在`)
+    throw new Error(ui(
+      `当前自定义代码主题 ${JSON.stringify(codeTheme)} 不存在`,
+      `The current custom code theme ${JSON.stringify(codeTheme)} does not exist`,
+    ))
   }
   return { theme, codeTheme, customThemes }
 }
@@ -637,7 +703,9 @@ export function resolveTheme(
   if (requested === 'dark' || requested === 'light') return BUILT_IN_THEMES[requested]
   const id = requested.slice('custom:'.length)
   const theme = appearance.customThemes.find(candidate => candidate.id === id)
-  if (theme === undefined) throw new Error(`自定义主题 ${JSON.stringify(id)} 不存在`)
+  if (theme === undefined) {
+    throw new Error(ui(`自定义主题 ${JSON.stringify(id)} 不存在`, `Custom theme ${JSON.stringify(id)} does not exist`))
+  }
   return { ...theme, id: requested, syntaxTone: theme.tone }
 }
 
@@ -691,16 +759,29 @@ export function resolveAppearanceTheme(appearance: TuiAppearanceSettings): Resol
  */
 export function themeContrastWarnings(theme: ResolvedTuiTheme | TuiCustomTheme): readonly string[] {
   const warnings: string[] = []
-  if (themeContrast(theme.colors.text, theme.colors.canvas) < 4.5) warnings.push('正文与画布对比度低于 4.5:1')
-  if (themeContrast(theme.colors.muted, theme.colors.canvas) < 3) warnings.push('弱化文字与画布对比度低于 3:1')
-  if (themeContrast(theme.syntax.foreground, theme.syntax.background) < 4.5) warnings.push('代码正文与代码背景对比度低于 4.5:1')
+  if (themeContrast(theme.colors.text, theme.colors.canvas) < 4.5) {
+    warnings.push(ui('正文与画布对比度低于 4.5:1', 'Text-to-canvas contrast is below 4.5:1'))
+  }
+  if (themeContrast(theme.colors.muted, theme.colors.canvas) < 3) {
+    warnings.push(ui('弱化文字与画布对比度低于 3:1', 'Muted-text-to-canvas contrast is below 3:1'))
+  }
+  if (themeContrast(theme.syntax.foreground, theme.syntax.background) < 4.5) {
+    warnings.push(ui('代码正文与代码背景对比度低于 4.5:1', 'Code-text-to-background contrast is below 4.5:1'))
+  }
   const lowTokens = SYNTAX_COLOR_KEYS
     .filter(key => key !== 'background' && key !== 'foreground')
     .filter(key => themeContrast(theme.syntax[key], theme.syntax.background) < 3)
-  if (lowTokens.length > 0) warnings.push(`代码颜色对比度偏低：${lowTokens.join('、')}`)
+  if (lowTokens.length > 0) {
+    warnings.push(ui(`代码颜色对比度偏低：${lowTokens.join('、')}`, `Low code-color contrast: ${lowTokens.join(', ')}`))
+  }
   const lowImported = theme.tokenColors.filter(rule => rule.foreground !== undefined
     && themeContrast(rule.foreground, rule.background ?? theme.syntax.background) < 3).length
-  if (lowImported > 0) warnings.push(`${String(lowImported)} 条导入的 TextMate 规则对比度低于 3:1`)
+  if (lowImported > 0) {
+    warnings.push(ui(
+      `${String(lowImported)} 条导入的 TextMate 规则对比度低于 3:1`,
+      `${String(lowImported)} imported TextMate rule(s) have contrast below 3:1`,
+    ))
+  }
   return warnings
 }
 

--- a/src/client/theme-import.ts
+++ b/src/client/theme-import.ts
@@ -20,6 +20,7 @@ import {
   normalizeThemeColor,
   normalizeThemeColorOn,
 } from './theme-config.ts'
+import { ui } from './locale.ts'
 
 const MAX_THEME_FILE_BYTES = 2 * 1024 * 1024
 const MAX_THEME_TOTAL_BYTES = 8 * 1024 * 1024
@@ -41,7 +42,9 @@ export interface LoadedVsCodeTheme {
 }
 
 function objectRecord(value: unknown, label: string): Readonly<Record<string, unknown>> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} 必须是对象`)
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(ui(`${label} 必须是对象`, `${label} must be an object`))
+  }
   return value as Readonly<Record<string, unknown>>
 }
 
@@ -54,15 +57,23 @@ function parseJsonc(text: string, path: string): Readonly<Record<string, unknown
   const value: unknown = parse(text, errors, { allowTrailingComma: true, disallowComments: false })
   const first = errors[0]
   if (first !== undefined) {
-    throw new Error(`${path} 的 JSONC 无效：${printParseErrorCode(first.error)}（offset ${String(first.offset)}）`)
+    throw new Error(ui(
+      `${path} 的 JSONC 无效：${printParseErrorCode(first.error)}（offset ${String(first.offset)}）`,
+      `${path} has invalid JSONC: ${printParseErrorCode(first.error)} (offset ${String(first.offset)})`,
+    ))
   }
   return objectRecord(value, path)
 }
 
 function sourcePath(input: string): string {
   const trimmed = input.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/u, '$1$2')
-  if (trimmed === '') throw new Error('VS Code 主题文件路径不能为空')
-  if (/^https?:/iu.test(trimmed)) throw new Error('只支持本地 VS Code 主题文件，不读取远程 URL')
+  if (trimmed === '') throw new Error(ui('VS Code 主题文件路径不能为空', 'VS Code theme path cannot be empty'))
+  if (/^https?:/iu.test(trimmed)) {
+    throw new Error(ui(
+      '只支持本地 VS Code 主题文件，不读取远程 URL',
+      'Only local VS Code theme files are supported; remote URLs are not fetched',
+    ))
+  }
   if (trimmed.startsWith('file:')) return fileURLToPath(trimmed)
   if (trimmed === '~') return homedir()
   if (trimmed.startsWith('~/')) return resolve(homedir(), trimmed.slice(2))
@@ -73,7 +84,9 @@ function mergeTheme(base: LoadedThemeRecord, current: Readonly<Record<string, un
   const colors = optionalRecord(current.colors, `${path}.colors`)
   const semanticTokenColors = optionalRecord(current.semanticTokenColors, `${path}.semanticTokenColors`)
   const rawTokenColors = current.tokenColors ?? []
-  if (!Array.isArray(rawTokenColors)) throw new Error(`${path}.tokenColors 必须是数组`)
+  if (!Array.isArray(rawTokenColors)) {
+    throw new Error(ui(`${path}.tokenColors 必须是数组`, `${path}.tokenColors must be an array`))
+  }
   const name = typeof current.name === 'string' ? current.name : base.name
   const type = typeof current.type === 'string' ? current.type : base.type
   return {
@@ -99,20 +112,38 @@ async function loadThemeRecord(
   const canonical = await realpath(path)
   if (active.includes(canonical)) {
     const chain = [...active, canonical].map(item => basename(item)).join(' → ')
-    throw new Error(`VS Code 主题 include 存在循环：${chain}`)
+    throw new Error(ui(`VS Code 主题 include 存在循环：${chain}`, `VS Code theme include cycle: ${chain}`))
   }
-  if (active.length >= MAX_INCLUDE_DEPTH) throw new Error(`VS Code 主题 include 超过 ${String(MAX_INCLUDE_DEPTH)} 层`)
+  if (active.length >= MAX_INCLUDE_DEPTH) {
+    throw new Error(ui(
+      `VS Code 主题 include 超过 ${String(MAX_INCLUDE_DEPTH)} 层`,
+      `VS Code theme include exceeds ${String(MAX_INCLUDE_DEPTH)} levels`,
+    ))
+  }
   const text = await readFile(canonical, 'utf8')
   const bytes = Buffer.byteLength(text)
-  if (bytes > MAX_THEME_FILE_BYTES) throw new Error(`VS Code 主题文件超过 ${String(MAX_THEME_FILE_BYTES)} 字节`)
+  if (bytes > MAX_THEME_FILE_BYTES) {
+    throw new Error(ui(
+      `VS Code 主题文件超过 ${String(MAX_THEME_FILE_BYTES)} 字节`,
+      `VS Code theme file exceeds ${String(MAX_THEME_FILE_BYTES)} bytes`,
+    ))
+  }
   budget.bytes += bytes
-  if (budget.bytes > MAX_THEME_TOTAL_BYTES) throw new Error(`VS Code 主题 include 总大小超过 ${String(MAX_THEME_TOTAL_BYTES)} 字节`)
+  if (budget.bytes > MAX_THEME_TOTAL_BYTES) {
+    throw new Error(ui(
+      `VS Code 主题 include 总大小超过 ${String(MAX_THEME_TOTAL_BYTES)} 字节`,
+      `VS Code theme include total size exceeds ${String(MAX_THEME_TOTAL_BYTES)} bytes`,
+    ))
+  }
   const current = parseJsonc(text, canonical)
   let base = EMPTY_THEME
   if (current.include !== undefined) {
     const include = typeof current.include === 'string' ? current.include.trim() : ''
     if (include === '' || isAbsolute(include) || /^[a-z][a-z0-9+.-]*:/iu.test(include)) {
-      throw new Error(`${canonical}.include 必须是相对文件路径`)
+      throw new Error(ui(
+        `${canonical}.include 必须是相对文件路径`,
+        `${canonical}.include must be a relative file path`,
+      ))
     }
     const included = await loadThemeRecord(resolve(dirname(canonical), include), [...active, canonical], budget)
     base = included.value
@@ -188,7 +219,10 @@ function fontStyles(value: unknown): readonly TuiTokenFontStyle[] | undefined {
 
 function textMateRules(value: LoadedThemeRecord, background: string): readonly TuiTextMateRule[] {
   if (value.tokenColors.length > MAX_TEXTMATE_RULES) {
-    throw new Error(`VS Code 主题最多导入 ${String(MAX_TEXTMATE_RULES)} 条 TextMate 规则`)
+    throw new Error(ui(
+      `VS Code 主题最多导入 ${String(MAX_TEXTMATE_RULES)} 条 TextMate 规则`,
+      `A VS Code theme can import at most ${String(MAX_TEXTMATE_RULES)} TextMate rules`,
+    ))
   }
   return value.tokenColors.flatMap((entry): TuiTextMateRule[] => {
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return []

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -31,6 +31,8 @@ const GATED = [
   'host/marketplace-provider.ts',
   'host/profile-plugin-manager.ts',
   'host/management.ts',
+  'client/theme-config.ts',
+  'client/theme-import.ts',
 ]
 
 function walk(directory: string): string[] {


### PR DESCRIPTION
## Summary
- Wrap built-in theme names, contrast warnings, and theme-import errors with `ui()`.
- Widen the AST gate to theme-config and theme-import.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/theme-config.test.ts tests/theme-import.test.ts tests/theme-export.test.ts`
