### PR TITLE
feat(tui): wrap leftover transcript titles and empty copy with ui()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29495,22 +29495,55 @@ function diffText(value, context = DEFAULT_TUI_BEHAVIOR.diffContextLines) {
 	return visible.join("\n");
 }
 const PRODUCT_TOOL_TITLES = {
-	ask_user_question: ["向用户提问", "Ask user"],
-	create_goal: ["创建目标", "Create goal"],
-	exit_plan_mode: ["计划审查", "Plan review"],
-	get_goal: ["查看目标", "View goal"],
-	job_kill: ["停止后台任务", "Stop background job"],
-	job_list: ["查看后台任务", "View background jobs"],
-	job_output: ["读取后台任务", "Read background job"],
-	subagent: ["子 Agent", "Subagent"],
-	todo_write: ["更新任务清单", "Update task list"],
-	update_goal: ["更新目标", "Update goal"],
-	workflow: ["工作流", "Workflow"]
+	ask_user_question: {
+		zh: "向用户提问",
+		en: "Ask user"
+	},
+	create_goal: {
+		zh: "创建目标",
+		en: "Create goal"
+	},
+	exit_plan_mode: {
+		zh: "计划审查",
+		en: "Plan review"
+	},
+	get_goal: {
+		zh: "查看目标",
+		en: "View goal"
+	},
+	job_kill: {
+		zh: "停止后台任务",
+		en: "Stop background job"
+	},
+	job_list: {
+		zh: "查看后台任务",
+		en: "View background jobs"
+	},
+	job_output: {
+		zh: "读取后台任务",
+		en: "Read background job"
+	},
+	subagent: {
+		zh: "子 Agent",
+		en: "Subagent"
+	},
+	todo_write: {
+		zh: "更新任务清单",
+		en: "Update task list"
+	},
+	update_goal: {
+		zh: "更新目标",
+		en: "Update goal"
+	},
+	workflow: {
+		zh: "工作流",
+		en: "Workflow"
+	}
 };
 function toolTitle(node) {
 	const name$1 = "kind" in node ? node.call?.name : node.name;
 	const productTitle = name$1 === void 0 ? void 0 : PRODUCT_TOOL_TITLES[name$1];
-	if (productTitle !== void 0) return ui(productTitle[0], productTitle[1]);
+	if (productTitle !== void 0) return ui(productTitle.zh, productTitle.en);
 	const callView = node.callView;
 	if (callView?.card === "terminal") {
 		const description = callView.description?.trim();
@@ -30087,7 +30120,7 @@ var Transcript = class {
 	imageGeneration = 0;
 	imageLoader;
 	snapshot;
-	emptyMessage = "在下方输入消息，或用 /help 查看命令。";
+	emptyMessage = ui("在下方输入消息，或用 /help 查看命令。", "Enter a message below, or use /help to view commands.");
 	sessionId;
 	toolVisibility = "collapsed";
 	reasoningVisible = false;
@@ -30165,7 +30198,7 @@ var Transcript = class {
 	* Replace the transcript with non-durable empty-selection guidance.
 	* @param message - guidance rendered when no Session is active.
 	*/
-	empty(message = "在下方输入消息，或用 /help 查看命令。") {
+	empty(message = ui("在下方输入消息，或用 /help 查看命令。", "Enter a message below, or use /help to view commands.")) {
 		this.imageGeneration += 1;
 		this.imageLoader = void 0;
 		this.snapshot = void 0;

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -429,24 +429,24 @@ function diffText(value: unknown, context = DEFAULT_TUI_BEHAVIOR.diffContextLine
   return visible.join('\n')
 }
 
-const PRODUCT_TOOL_TITLES: Readonly<Record<string, readonly [zh: string, en: string]>> = {
-  ask_user_question: ['向用户提问', 'Ask user'],
-  create_goal: ['创建目标', 'Create goal'],
-  exit_plan_mode: ['计划审查', 'Plan review'],
-  get_goal: ['查看目标', 'View goal'],
-  job_kill: ['停止后台任务', 'Stop background job'],
-  job_list: ['查看后台任务', 'View background jobs'],
-  job_output: ['读取后台任务', 'Read background job'],
-  subagent: ['子 Agent', 'Subagent'],
-  todo_write: ['更新任务清单', 'Update task list'],
-  update_goal: ['更新目标', 'Update goal'],
-  workflow: ['工作流', 'Workflow'],
+const PRODUCT_TOOL_TITLES: Readonly<Record<string, { readonly zh: string; readonly en: string }>> = {
+  ask_user_question: { zh: '向用户提问', en: 'Ask user' },
+  create_goal: { zh: '创建目标', en: 'Create goal' },
+  exit_plan_mode: { zh: '计划审查', en: 'Plan review' },
+  get_goal: { zh: '查看目标', en: 'View goal' },
+  job_kill: { zh: '停止后台任务', en: 'Stop background job' },
+  job_list: { zh: '查看后台任务', en: 'View background jobs' },
+  job_output: { zh: '读取后台任务', en: 'Read background job' },
+  subagent: { zh: '子 Agent', en: 'Subagent' },
+  todo_write: { zh: '更新任务清单', en: 'Update task list' },
+  update_goal: { zh: '更新目标', en: 'Update goal' },
+  workflow: { zh: '工作流', en: 'Workflow' },
 }
 
 function toolTitle(node: ToolResultNode | RunningToolCall): string {
   const name = 'kind' in node ? node.call?.name : node.name
   const productTitle = name === undefined ? undefined : PRODUCT_TOOL_TITLES[name]
-  if (productTitle !== undefined) return ui(productTitle[0], productTitle[1])
+  if (productTitle !== undefined) return ui(productTitle.zh, productTitle.en)
   const callView = node.callView
   if (callView?.card === 'terminal') {
     const description = callView.description?.trim()
@@ -1119,7 +1119,7 @@ export class Transcript implements Component, Focusable {
   private imageGeneration = 0
   private imageLoader: TranscriptImageLoader | undefined
   private snapshot: ConversationSnapshot | undefined
-  private emptyMessage = '在下方输入消息，或用 /help 查看命令。'
+  private emptyMessage = ui('在下方输入消息，或用 /help 查看命令。', 'Enter a message below, or use /help to view commands.')
   private sessionId: string | undefined
   private toolVisibility: ToolVisibility = 'collapsed'
   private reasoningVisible = false
@@ -1215,7 +1215,7 @@ export class Transcript implements Component, Focusable {
    * Replace the transcript with non-durable empty-selection guidance.
    * @param message - guidance rendered when no Session is active.
    */
-  empty(message = '在下方输入消息，或用 /help 查看命令。'): void {
+  empty(message = ui('在下方输入消息，或用 /help 查看命令。', 'Enter a message below, or use /help to view commands.')): void {
     this.imageGeneration += 1
     this.imageLoader = undefined
     this.snapshot = undefined

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -35,6 +35,7 @@ const GATED = [
   'client/theme-import.ts',
   'client/surface.ts',
   'client/capabilities.ts',
+  'client/transcript.ts',
 ]
 
 function walk(directory: string): string[] {


### PR DESCRIPTION
## Summary
- Convert product tool titles to `zh`/`en` pairs and wrap the empty-session prompt with `ui()`.
- Widen the AST gate to transcript.ts.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/transcript.test.ts tests/transcript-cache.test.ts`
