### PR TITLE
feat(tui): keep error-advice timeout matching on a zh key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19666,6 +19666,8 @@ function flattenProducedFiles(groups) {
 
 //#endregion
 //#region src/client/error-advice.ts
+/** Host timeout copy stays Chinese so matching does not follow the UI locale. */
+const TIMEOUT_MARK = { zh: "超时" };
 function unwrapTransport(message) {
 	const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message);
 	return match === null ? void 0 : match[1]?.trim();
@@ -19689,7 +19691,7 @@ function pluginFailureDetail(result) {
 function explainFailure(message) {
 	const inner = unwrapTransport(message);
 	if (inner !== void 0) return ui(`内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`, `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`);
-	if (message.includes("超时") && message.includes("/doctor")) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
+	if (message.includes(TIMEOUT_MARK.zh) && message.includes("/doctor")) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
 	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui(`${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`, `${message}\nNext: install pnpm, keep it on PATH, then retry.`);
 	if (/\bENOENT\b/u.test(message)) return ui(`${message}\n下一步：确认路径存在且当前进程有权读取。`, `${message}\nNext: confirm the path exists and this process can read it.`);
 	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui(`${message}\n下一步：检查文件权限，或换一个可写目录。`, `${message}\nNext: check file permissions, or use a writable directory.`);

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -2,6 +2,9 @@
 
 import { ui } from './locale.ts'
 
+/** Host timeout copy stays Chinese so matching does not follow the UI locale. */
+const TIMEOUT_MARK = { zh: '超时' }
+
 export interface PluginFailureOutput {
   readonly stderr: string
   readonly stdout: string
@@ -36,7 +39,7 @@ export function explainFailure(message: string): string {
       `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`,
     )
   }
-  if (message.includes('超时') && message.includes('/doctor')) {
+  if (message.includes(TIMEOUT_MARK.zh) && message.includes('/doctor')) {
     return ui(
       `${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, '')}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`,
       'Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -37,6 +37,7 @@ const GATED = [
   'client/capabilities.ts',
   'client/transcript.ts',
   'client/actions.ts',
+  'client/error-advice.ts',
 ]
 
 function walk(directory: string): string[] {


### PR DESCRIPTION
## Summary
- Store the timeout detector as a `zh` key so matching does not follow the UI locale.
- Widen the AST gate to error-advice.ts.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/error-advice.test.ts`
