### PR TITLE
feat(tui): author protocol conflict copy without importing locale

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21271,7 +21271,10 @@ var TuiSettingsConflictError = class extends Error {
 	* @param actual - current Host revision.
 	*/
 	constructor(namespace, expected, actual) {
-		super(`设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`);
+		super({
+			zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
+			en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`
+		}.zh);
 		this.namespace = namespace;
 		this.expected = expected;
 		this.actual = actual;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -188,7 +188,10 @@ export class TuiSettingsConflictError extends Error {
     readonly expected: number,
     readonly actual: number,
   ) {
-    super(`设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`)
+    super(({
+      zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
+      en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`,
+    }).zh)
     this.name = 'TuiSettingsConflictError'
   }
 }

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -38,6 +38,7 @@ const GATED = [
   'client/transcript.ts',
   'client/actions.ts',
   'client/error-advice.ts',
+  'protocol.ts',
 ]
 
 function walk(directory: string): string[] {


### PR DESCRIPTION
## Summary
- Author Chinese and English Settings-conflict copy on the protocol error without importing locale.ts.
- Widen the AST gate to protocol.ts.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts`
