### PR TITLE
fix(tui): redact installer streams with a tail-hold buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DbTu1PjP.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
 import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-swCofv4S.js";
-import { t as TUI_STARTUP_SERVICE } from "./startup-Dk_6a6_Y.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";
@@ -31961,14 +31961,6 @@ function createSettingsDescribeCache(load) {
 		}
 	};
 }
-function redactInstallerOutput(value) {
-	let redacted = value.replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, "$1***@").replace(/(https?:\/\/)[^\s/@]+@/giu, "$1***@").replace(/((?:_authToken|authorization|password|token)\s*[=:]\s*)[^\s]+/giu, "$1***");
-	for (const [key, secret] of Object.entries(process.env)) {
-		if (!/(?:TOKEN|KEY|SECRET|PASSWORD|AUTH|CREDENTIAL)/iu.test(key) || secret === void 0 || secret.length < 4) continue;
-		redacted = redacted.replaceAll(secret, "***");
-	}
-	return redacted;
-}
 function sessionExportFilename(sessionId) {
 	return `dsh-session-${sessionId.replace(/[^A-Za-z0-9._-]/gu, "_").slice(0, 120) || "session"}.zip`;
 }
@@ -32147,18 +32139,15 @@ function createTuiManagementBridge(ctx, cwd) {
 		plugins: {
 			snapshot: () => Promise.resolve(manager.snapshot()),
 			run: async (args, options$1 = {}) => {
-				const output = options$1.onOutput;
-				const result = await manager.run(args, { ...options$1.signal === void 0 ? {} : { signal: options$1.signal } });
-				const stdout = redactInstallerOutput(result.stdout);
-				const stderr = redactInstallerOutput(result.stderr);
-				if (output !== void 0) {
-					if (stdout !== "") output("stdout", stdout);
-					if (stderr !== "") output("stderr", stderr);
-				}
+				const result = await manager.run(args, {
+					...options$1.signal === void 0 ? {} : { signal: options$1.signal },
+					...options$1.onOutput === void 0 ? {} : { onOutput: options$1.onOutput }
+				});
+				const secrets = installerSecrets();
 				return {
 					exitCode: result.exitCode,
-					stdout,
-					stderr,
+					stdout: redactInstallerText(result.stdout, secrets),
+					stderr: redactInstallerText(result.stderr, secrets),
 					warnings: result.warnings,
 					changed: result.changed,
 					restartRequired: result.restartRequired,

--- a/lib/startup-tM5WVZUh.js
+++ b/lib/startup-tM5WVZUh.js
@@ -11,6 +11,90 @@ import { parseCmdline } from "@deepseek-ai/dsh-cmdline";
 import crossSpawn from "cross-spawn";
 import { DEFAULT_PROFILE_BUNDLES, PROFILES_DIR, PROFILE_PATCH_FILENAME, PROFILE_TEMPLATES, initProfile, readProfileManifest, resolveBundleDir, resolveProfileDir, writeProfileManifest } from "@deepseek-ai/dsh-app-boot";
 
+//#region src/host/installer-output.ts
+/** Stateful redaction of pnpm installer streams that may split secrets across chunks. */
+const INSTALLER_OUTPUT_LIMIT = 1024 * 1024;
+const DEFAULT_HOLD = 512;
+function appendBounded(current, chunk, maxBytes) {
+	const joined = current + chunk;
+	if (Buffer.byteLength(joined) <= maxBytes) return joined;
+	let start = Math.max(0, joined.length - maxBytes);
+	while (start < joined.length && Buffer.byteLength(joined.slice(start)) > maxBytes) start += 1;
+	return joined.slice(start);
+}
+/**
+* Collect environment values that must never appear in installer output.
+* @param env - process environment.
+*/
+function installerSecrets(env = process.env) {
+	return Object.entries(env).flatMap(([key, secret]) => {
+		if (secret === void 0 || secret.length < 4) return [];
+		if (!/(?:TOKEN|KEY|SECRET|PASSWORD|AUTH|CREDENTIAL)/iu.test(key)) return [];
+		return [secret];
+	});
+}
+/**
+* Redact credentials in one complete installer fragment.
+* @param value - text that will not be extended by a later chunk.
+* @param secrets - explicit environment secrets to erase.
+*/
+function redactInstallerText(value, secrets = []) {
+	let redacted = value.replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, "$1***@").replace(/(https?:\/\/)[^\s/@]+@/giu, "$1***@").replace(/((?:_authToken|authorization|password|token)\s*[=:]\s*)[^\s]+/giu, "$1***");
+	for (const secret of secrets) if (secret.length >= 4) redacted = redacted.replaceAll(secret, "***");
+	return redacted;
+}
+function holdLength(secrets, hold) {
+	const longest = secrets.reduce((max, secret) => Math.max(max, secret.length), 0);
+	return Math.max(hold, longest + 32);
+}
+/** One stdout or stderr stream that only releases prefixes that cannot complete a later secret match. */
+var InstallerOutputRedactor = class {
+	pending = "";
+	released = "";
+	secrets;
+	maxBytes;
+	hold;
+	constructor(options = {}) {
+		this.secrets = options.secrets ?? installerSecrets();
+		this.maxBytes = options.maxBytes ?? INSTALLER_OUTPUT_LIMIT;
+		this.hold = holdLength(this.secrets, options.hold ?? DEFAULT_HOLD);
+	}
+	/**
+	* Absorb one chunk and return only the redacted prefix that is safe to display.
+	* @param chunk - raw installer bytes.
+	*/
+	push(chunk) {
+		this.pending += chunk;
+		const split = this.splitIndex(this.pending);
+		if (split <= 0) return "";
+		const emit = redactInstallerText(this.pending.slice(0, split), this.secrets);
+		this.pending = this.pending.slice(split);
+		this.released = appendBounded(this.released, emit, this.maxBytes);
+		return emit;
+	}
+	splitIndex(value) {
+		let split = value.length - this.hold;
+		if (split < 0) split = 0;
+		const url = /https?:\/\/\S*$/iu.exec(value);
+		if (url !== null && url.index < split) split = url.index;
+		const token = /(?:_authToken|authorization|password|token)\s*[=:]\s*\S*$/iu.exec(value);
+		if (token !== null && token.index < split) split = token.index;
+		return split;
+	}
+	/** Redact and release every held suffix. */
+	flush() {
+		const emit = redactInstallerText(this.pending, this.secrets);
+		this.pending = "";
+		this.released = appendBounded(this.released, emit, this.maxBytes);
+		return emit;
+	}
+	/** Bounded redacted capture for the completed stream. */
+	text() {
+		return this.released;
+	}
+};
+
+//#endregion
 //#region src/host/app-handoff.ts
 /** Inherited environment key carrying one single-use handoff path. */
 const APP_HANDOFF_ENV = "DSH_APP_HANDOFF_FILE";
@@ -124,7 +208,6 @@ function consumeAppHandoff(channel, env = process.env) {
 //#endregion
 //#region src/host/profile-plugin-manager.ts
 const NAME = "dsh";
-const MAX_CAPTURE_BYTES = 1024 * 1024;
 const MAX_PATCH_BYTES = 2 * 1024 * 1024;
 const SENSITIVE_QUERY_KEY = new RegExp(String.raw`(?:^|[-_])(?:access[-_]?token|api[-_]?key|auth|authorization|credential|password|secret|signature|token)(?:$|[-_])`, "i");
 function convertedBundles(bundles, options) {
@@ -171,10 +254,6 @@ function validPatch(packageDir, patch) {
 	} catch {
 		return false;
 	}
-}
-function appendBounded(current, chunk) {
-	const joined = current + chunk;
-	return Buffer.byteLength(joined) <= MAX_CAPTURE_BYTES ? joined : joined.slice(Math.max(0, joined.length - MAX_CAPTURE_BYTES));
 }
 function sameJson(left, right) {
 	return JSON.stringify(left) === JSON.stringify(right);
@@ -282,54 +361,69 @@ var ProfilePluginManager = class {
 		const command = args.map((argument) => this.anchorPathSpec(argument));
 		let stdout = "";
 		let stderr = "";
-		const exitCode = await new Promise((resolvePromise, reject) => {
-			const child = crossSpawn("pnpm", command, {
-				cwd: this.dir,
-				stdio: [
-					"ignore",
-					"pipe",
-					"pipe"
-				]
-			});
-			const abort = () => {
-				child.kill();
-			};
-			options.signal?.addEventListener("abort", abort, { once: true });
-			if (child.stdout === null || child.stderr === null) {
-				reject(/* @__PURE__ */ new Error("pnpm output pipes are unavailable"));
-				return;
-			}
-			child.stdout.setEncoding("utf8");
-			child.stderr.setEncoding("utf8");
-			child.stdout.on("data", (chunk) => {
-				stdout = appendBounded(stdout, chunk);
-				options.onOutput?.("stdout", chunk);
-			});
-			child.stderr.on("data", (chunk) => {
-				stderr = appendBounded(stderr, chunk);
-				options.onOutput?.("stderr", chunk);
-			});
-			child.once("error", (error) => {
-				options.signal?.removeEventListener("abort", abort);
-				reject(error);
-			});
-			child.once("close", (code, signal) => {
-				options.signal?.removeEventListener("abort", abort);
-				if (options.signal?.aborted === true) {
-					const reason = options.signal.reason;
-					reject(reason instanceof Error ? reason : new Error("pnpm operation aborted", { cause: reason }));
+		const stdoutRedactor = new InstallerOutputRedactor();
+		const stderrRedactor = new InstallerOutputRedactor();
+		const flushVisible = () => {
+			const stdoutTail = stdoutRedactor.flush();
+			const stderrTail = stderrRedactor.flush();
+			if (stdoutTail !== "") options.onOutput?.("stdout", stdoutTail);
+			if (stderrTail !== "") options.onOutput?.("stderr", stderrTail);
+			stdout = stdoutRedactor.text();
+			stderr = stderrRedactor.text();
+		};
+		let exitCode;
+		try {
+			exitCode = await new Promise((resolvePromise, reject) => {
+				const child = crossSpawn("pnpm", command, {
+					cwd: this.dir,
+					stdio: [
+						"ignore",
+						"pipe",
+						"pipe"
+					]
+				});
+				const abort = () => {
+					child.kill();
+				};
+				options.signal?.addEventListener("abort", abort, { once: true });
+				if (child.stdout === null || child.stderr === null) {
+					reject(/* @__PURE__ */ new Error("pnpm output pipes are unavailable"));
 					return;
 				}
-				if (signal !== null) {
-					reject(/* @__PURE__ */ new Error(`pnpm terminated by signal ${signal}`));
-					return;
-				}
-				resolvePromise(code ?? 1);
+				child.stdout.setEncoding("utf8");
+				child.stderr.setEncoding("utf8");
+				child.stdout.on("data", (chunk) => {
+					const visible = stdoutRedactor.push(chunk);
+					if (visible !== "") options.onOutput?.("stdout", visible);
+				});
+				child.stderr.on("data", (chunk) => {
+					const visible = stderrRedactor.push(chunk);
+					if (visible !== "") options.onOutput?.("stderr", visible);
+				});
+				child.once("error", (error) => {
+					options.signal?.removeEventListener("abort", abort);
+					reject(error);
+				});
+				child.once("close", (code, signal) => {
+					options.signal?.removeEventListener("abort", abort);
+					if (options.signal?.aborted === true) {
+						const reason = options.signal.reason;
+						reject(reason instanceof Error ? reason : new Error("pnpm operation aborted", { cause: reason }));
+						return;
+					}
+					if (signal !== null) {
+						reject(/* @__PURE__ */ new Error(`pnpm terminated by signal ${signal}`));
+						return;
+					}
+					resolvePromise(code ?? 1);
+				});
+			}).catch((error) => {
+				if (error?.code === "ENOENT") return 127;
+				throw error;
 			});
-		}).catch((error) => {
-			if (error?.code === "ENOENT") return 127;
-			throw error;
-		});
+		} finally {
+			flushVisible();
+		}
 		this.forgetInstalled();
 		const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode);
 		const snapshot = this.snapshot();
@@ -376,8 +470,8 @@ var ProfilePluginManager = class {
 			dir: this.dir,
 			command: ["pnpm", ...command.map(safeDependencySpec)],
 			exitCode,
-			stdout: typeof result.stdout === "string" ? result.stdout : "",
-			stderr: typeof result.stderr === "string" ? result.stderr : "",
+			stdout: typeof result.stdout === "string" ? redactInstallerText(result.stdout, installerSecrets()) : "",
+			stderr: typeof result.stderr === "string" ? redactInstallerText(result.stderr, installerSecrets()) : "",
 			warnings,
 			initialized,
 			changed,
@@ -811,4 +905,4 @@ function apply(ctx) {
 }
 
 //#endregion
-export { name as i, apply as n, inject as r, TUI_STARTUP_SERVICE as t };
+export { installerSecrets as a, name as i, apply as n, redactInstallerText as o, inject as r, TUI_STARTUP_SERVICE as t };

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
 import "./locale-DbTu1PjP.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-Dk_6a6_Y.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/host/installer-output.ts
+++ b/src/host/installer-output.ts
@@ -1,0 +1,101 @@
+/** Stateful redaction of pnpm installer streams that may split secrets across chunks. */
+
+export const INSTALLER_OUTPUT_LIMIT = 1024 * 1024
+const DEFAULT_HOLD = 512
+
+function appendBounded(current: string, chunk: string, maxBytes: number): string {
+  const joined = current + chunk
+  if (Buffer.byteLength(joined) <= maxBytes) return joined
+  let start = Math.max(0, joined.length - maxBytes)
+  while (start < joined.length && Buffer.byteLength(joined.slice(start)) > maxBytes) start += 1
+  return joined.slice(start)
+}
+
+/**
+ * Collect environment values that must never appear in installer output.
+ * @param env - process environment.
+ */
+export function installerSecrets(env: NodeJS.ProcessEnv = process.env): readonly string[] {
+  return Object.entries(env).flatMap(([key, secret]) => {
+    if (secret === undefined || secret.length < 4) return []
+    if (!/(?:TOKEN|KEY|SECRET|PASSWORD|AUTH|CREDENTIAL)/iu.test(key)) return []
+    return [secret]
+  })
+}
+
+/**
+ * Redact credentials in one complete installer fragment.
+ * @param value - text that will not be extended by a later chunk.
+ * @param secrets - explicit environment secrets to erase.
+ */
+export function redactInstallerText(value: string, secrets: readonly string[] = []): string {
+  let redacted = value
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, '$1***@')
+    .replace(/(https?:\/\/)[^\s/@]+@/giu, '$1***@')
+    .replace(/((?:_authToken|authorization|password|token)\s*[=:]\s*)[^\s]+/giu, '$1***')
+  for (const secret of secrets) {
+    if (secret.length >= 4) redacted = redacted.replaceAll(secret, '***')
+  }
+  return redacted
+}
+
+function holdLength(secrets: readonly string[], hold: number): number {
+  const longest = secrets.reduce((max, secret) => Math.max(max, secret.length), 0)
+  return Math.max(hold, longest + 32)
+}
+
+/** One stdout or stderr stream that only releases prefixes that cannot complete a later secret match. */
+export class InstallerOutputRedactor {
+  private pending = ''
+  private released = ''
+  private readonly secrets: readonly string[]
+  private readonly maxBytes: number
+  private readonly hold: number
+
+  constructor(options: {
+    readonly secrets?: readonly string[]
+    readonly maxBytes?: number
+    readonly hold?: number
+  } = {}) {
+    this.secrets = options.secrets ?? installerSecrets()
+    this.maxBytes = options.maxBytes ?? INSTALLER_OUTPUT_LIMIT
+    this.hold = holdLength(this.secrets, options.hold ?? DEFAULT_HOLD)
+  }
+
+  /**
+   * Absorb one chunk and return only the redacted prefix that is safe to display.
+   * @param chunk - raw installer bytes.
+   */
+  push(chunk: string): string {
+    this.pending += chunk
+    const split = this.splitIndex(this.pending)
+    if (split <= 0) return ''
+    const emit = redactInstallerText(this.pending.slice(0, split), this.secrets)
+    this.pending = this.pending.slice(split)
+    this.released = appendBounded(this.released, emit, this.maxBytes)
+    return emit
+  }
+
+  private splitIndex(value: string): number {
+    let split = value.length - this.hold
+    if (split < 0) split = 0
+    const url = /https?:\/\/\S*$/iu.exec(value)
+    if (url !== null && url.index < split) split = url.index
+    const token = /(?:_authToken|authorization|password|token)\s*[=:]\s*\S*$/iu.exec(value)
+    if (token !== null && token.index < split) split = token.index
+    return split
+  }
+
+  /** Redact and release every held suffix. */
+  flush(): string {
+    const emit = redactInstallerText(this.pending, this.secrets)
+    this.pending = ''
+    this.released = appendBounded(this.released, emit, this.maxBytes)
+    return emit
+  }
+
+  /** Bounded redacted capture for the completed stream. */
+  text(): string {
+    return this.released
+  }
+}

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -27,6 +27,7 @@ import {
 } from '@deepseek-ai/dsh-tui-protocol'
 import type {} from './marketplace-provider.ts'
 import { assertCredentialFreeUrl, PluginMarketplace } from './plugin-marketplace.ts'
+import { installerSecrets, redactInstallerText } from './installer-output.ts'
 import { killHostJob, type HostJobRegistry } from '../client/job-control.ts'
 import { ui } from '../client/locale.ts'
 
@@ -237,18 +238,6 @@ export function createSettingsDescribeCache(
       cached = undefined
     },
   }
-}
-
-function redactInstallerOutput(value: string): string {
-  let redacted = value
-    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, '$1***@')
-    .replace(/(https?:\/\/)[^\s/@]+@/giu, '$1***@')
-    .replace(/((?:_authToken|authorization|password|token)\s*[=:]\s*)[^\s]+/giu, '$1***')
-  for (const [key, secret] of Object.entries(process.env)) {
-    if (!/(?:TOKEN|KEY|SECRET|PASSWORD|AUTH|CREDENTIAL)/iu.test(key) || secret === undefined || secret.length < 4) continue
-    redacted = redacted.replaceAll(secret, '***')
-  }
-  return redacted
 }
 
 function sessionExportFilename(sessionId: string): string {
@@ -495,20 +484,15 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
     plugins: {
       snapshot: () => Promise.resolve(manager.snapshot()),
       run: async (args, options = {}) => {
-        const output = options.onOutput
         const result = await manager.run(args, {
           ...options.signal === undefined ? {} : { signal: options.signal },
+          ...options.onOutput === undefined ? {} : { onOutput: options.onOutput },
         })
-        const stdout = redactInstallerOutput(result.stdout)
-        const stderr = redactInstallerOutput(result.stderr)
-        if (output !== undefined) {
-          if (stdout !== '') output('stdout', stdout)
-          if (stderr !== '') output('stderr', stderr)
-        }
+        const secrets = installerSecrets()
         return {
           exitCode: result.exitCode,
-          stdout,
-          stderr,
+          stdout: redactInstallerText(result.stdout, secrets),
+          stderr: redactInstallerText(result.stderr, secrets),
           warnings: result.warnings,
           changed: result.changed,
           restartRequired: result.restartRequired,

--- a/src/host/profile-plugin-manager.ts
+++ b/src/host/profile-plugin-manager.ts
@@ -32,9 +32,9 @@ import {
   type ProfileManifest,
 } from '@deepseek-ai/dsh-app-boot'
 import { ui } from '../client/locale.ts'
+import { InstallerOutputRedactor, installerSecrets, redactInstallerText } from './installer-output.ts'
 
 const NAME = 'dsh'
-const MAX_CAPTURE_BYTES = 1024 * 1024
 const MAX_PATCH_BYTES = 2 * 1024 * 1024
 const SENSITIVE_QUERY_KEY = new RegExp(
   String.raw`(?:^|[-_])(?:access[-_]?token|api[-_]?key|auth|authorization|credential|password|secret|signature|token)(?:$|[-_])`,
@@ -211,13 +211,6 @@ function validPatch(packageDir: string, patch: string): boolean {
   }
 }
 
-function appendBounded(current: string, chunk: string): string {
-  const joined = current + chunk
-  return Buffer.byteLength(joined) <= MAX_CAPTURE_BYTES
-    ? joined
-    : joined.slice(Math.max(0, joined.length - MAX_CAPTURE_BYTES))
-}
-
 function sameJson(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right)
 }
@@ -320,7 +313,19 @@ export class ProfilePluginManager {
     const command = args.map(argument => this.anchorPathSpec(argument))
     let stdout = ''
     let stderr = ''
-    const exitCode = await new Promise<number>((resolvePromise, reject) => {
+    const stdoutRedactor = new InstallerOutputRedactor()
+    const stderrRedactor = new InstallerOutputRedactor()
+    const flushVisible = (): void => {
+      const stdoutTail = stdoutRedactor.flush()
+      const stderrTail = stderrRedactor.flush()
+      if (stdoutTail !== '') options.onOutput?.('stdout', stdoutTail)
+      if (stderrTail !== '') options.onOutput?.('stderr', stderrTail)
+      stdout = stdoutRedactor.text()
+      stderr = stderrRedactor.text()
+    }
+    let exitCode: number
+    try {
+      exitCode = await new Promise<number>((resolvePromise, reject) => {
       const child = crossSpawn('pnpm', command, {
         cwd: this.dir,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -334,12 +339,12 @@ export class ProfilePluginManager {
       child.stdout.setEncoding('utf8')
       child.stderr.setEncoding('utf8')
       child.stdout.on('data', (chunk: string) => {
-        stdout = appendBounded(stdout, chunk)
-        options.onOutput?.('stdout', chunk)
+        const visible = stdoutRedactor.push(chunk)
+        if (visible !== '') options.onOutput?.('stdout', visible)
       })
       child.stderr.on('data', (chunk: string) => {
-        stderr = appendBounded(stderr, chunk)
-        options.onOutput?.('stderr', chunk)
+        const visible = stderrRedactor.push(chunk)
+        if (visible !== '') options.onOutput?.('stderr', visible)
       })
       child.once('error', (error) => {
         options.signal?.removeEventListener('abort', abort)
@@ -362,6 +367,9 @@ export class ProfilePluginManager {
       if ((error as NodeJS.ErrnoException | null)?.code === 'ENOENT') return 127
       throw error
     })
+    } finally {
+      flushVisible()
+    }
     this.forgetInstalled()
     const warnings = exitCode === 0 ? this.reconcile(before) : this.failureWarnings(command, exitCode)
     const snapshot = this.snapshot()
@@ -411,8 +419,8 @@ export class ProfilePluginManager {
       dir: this.dir,
       command: ['pnpm', ...command.map(safeDependencySpec)],
       exitCode,
-      stdout: typeof result.stdout === 'string' ? result.stdout : '',
-      stderr: typeof result.stderr === 'string' ? result.stderr : '',
+      stdout: typeof result.stdout === 'string' ? redactInstallerText(result.stdout, installerSecrets()) : '',
+      stderr: typeof result.stderr === 'string' ? redactInstallerText(result.stderr, installerSecrets()) : '',
       warnings,
       initialized,
       changed,

--- a/tests/installer-output.test.ts
+++ b/tests/installer-output.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  InstallerOutputRedactor,
+  redactInstallerText,
+} from '../src/host/installer-output.ts'
+
+describe('installer output redaction (review #17)', () => {
+  it('does not emit a token that arrives split across chunks', () => {
+    const redactor = new InstallerOutputRedactor({ secrets: [], hold: 32, maxBytes: 4096 })
+    const first = redactor.push('npm notice token=abc')
+    const second = redactor.push('defGHI\nnext line\n')
+    const flushed = redactor.flush()
+    const visible = `${first}${second}${flushed}`
+    expect(visible).not.toContain('abcdefGHI')
+    expect(visible).toContain('token=***')
+  })
+
+  it('does not emit a basic-auth URL that arrives split across chunks', () => {
+    const redactor = new InstallerOutputRedactor({ secrets: [], hold: 32, maxBytes: 4096 })
+    expect(redactor.push('fetch https://user:se')).not.toContain('secret')
+    const rest = `${redactor.push('cret@registry.example/pkg')}${redactor.flush()}`
+    expect(rest).not.toContain('user:secret')
+    expect(rest).toMatch(/https:\/\/\*\*\*@registry\.example\/pkg/u)
+  })
+
+  it('redacts environment secrets even when split, and bounds stored text', () => {
+    const secret = 's3cret-value-ABCDEF'
+    const redactor = new InstallerOutputRedactor({
+      secrets: [secret],
+      hold: 8,
+      maxBytes: 40,
+    })
+    redactor.push('prefix ')
+    redactor.push(secret.slice(0, 9))
+    redactor.push(`${secret.slice(9)} trailing-output-that-should-be-trimmed`)
+    const stored = redactor.flush()
+    const text = redactor.text()
+    expect(`${stored}${text}`).not.toContain(secret)
+    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(40)
+  })
+
+  it('redacts a complete chunk immediately', () => {
+    expect(redactInstallerText('password=hunter2 https://a:b@host/x')).toBe(
+      'password=*** https://***@host/x',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Hold a suffix of each pnpm stream so a token or basic-auth URL split across Node chunks is redacted before any prefix reaches `onOutput` or the stored result.
- Bound captured stdout/stderr to 1 MiB of already-redacted text; do not re-emit the complete streams after streaming.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/installer-output.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vitest run`
- [x] `./node_modules/.bin/tsdown`
- [ ] Do not merge until the review-fix stack is complete
