### PR TITLE
fix(tui): persist composer history through Settings revision

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ import { readdirSync, statSync } from "fs";
 import { homedir as homedir$1 } from "os";
 import { basename as basename$1, dirname as dirname$1, join as join$1 } from "path";
 import * as fs from "node:fs";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { EventEmitter } from "events";
 import { Context, Service } from "@deepseek-ai/cordis";
@@ -9056,6 +9056,63 @@ var ProcessTerminal = class {
 		clearInterval(this.progressInterval);
 		this.progressInterval = void 0;
 		return true;
+	}
+};
+
+//#endregion
+//#region src/protocol.ts
+/** Harness Settings namespace that persists SeekTTY-only visual preferences. */
+const TUI_APPEARANCE_SETTINGS_NAMESPACE = "seektty-appearance";
+/** First-run color scheme when no user override has been stored. */
+const DEFAULT_TUI_THEME = "dark";
+/** Default code pairing follows the active interface theme. */
+const DEFAULT_TUI_CODE_THEME = "auto";
+/** Maximum named themes accepted by one Settings document. */
+const MAX_CUSTOM_THEMES = 32;
+/** Maximum imported TextMate rules stored in one custom theme. */
+const MAX_TEXTMATE_RULES = 4096;
+/** Harness Settings namespace that persists SeekTTY interaction defaults. */
+const TUI_BEHAVIOR_SETTINGS_NAMESPACE = "seektty-behavior";
+/** Harness Settings namespace that persists composer prompt history with revision. */
+const TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE = "seektty-composer-history";
+/** First-run interaction defaults when no user override has been stored. */
+const DEFAULT_TUI_BEHAVIOR = Object.freeze({
+	toolCards: "collapsed",
+	showReasoning: false,
+	desktopNotifications: true,
+	followTerminalTitle: true,
+	composerHistoryLimit: 200,
+	statusElapsed: true,
+	clipboardFallback: "auto",
+	toolOutputLineLimit: 200,
+	diffContextLines: 3,
+	dangerConfirmDefault: "cancel",
+	keyBindings: Object.freeze({})
+});
+/** Upper bound for persisted composer history entries. */
+const MAX_COMPOSER_HISTORY = 1e4;
+/** Upper bound for one expanded tool-output block; 0 disables folding. */
+const MAX_TOOL_OUTPUT_LINE_LIMIT = 1e4;
+/** Upper bound for unified-diff context lines around each change. */
+const MAX_DIFF_CONTEXT_LINES = 100;
+/** A stale TUI Settings writer was rejected before changing durable state. */
+var TuiSettingsConflictError = class extends Error {
+	/** Stable machine-readable conflict discriminator. */
+	code = "TUI_SETTINGS_CONFLICT";
+	/**
+	* @param namespace - registered Settings namespace that changed.
+	* @param expected - revision held by the terminal editor.
+	* @param actual - current Host revision.
+	*/
+	constructor(namespace, expected, actual) {
+		super({
+			zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
+			en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`
+		}.zh);
+		this.namespace = namespace;
+		this.expected = expected;
+		this.actual = actual;
+		this.name = "TuiSettingsConflictError";
 	}
 };
 
@@ -21228,61 +21285,6 @@ async function startTuiClient(options$1) {
 }
 
 //#endregion
-//#region src/protocol.ts
-/** Harness Settings namespace that persists SeekTTY-only visual preferences. */
-const TUI_APPEARANCE_SETTINGS_NAMESPACE = "seektty-appearance";
-/** First-run color scheme when no user override has been stored. */
-const DEFAULT_TUI_THEME = "dark";
-/** Default code pairing follows the active interface theme. */
-const DEFAULT_TUI_CODE_THEME = "auto";
-/** Maximum named themes accepted by one Settings document. */
-const MAX_CUSTOM_THEMES = 32;
-/** Maximum imported TextMate rules stored in one custom theme. */
-const MAX_TEXTMATE_RULES = 4096;
-/** Harness Settings namespace that persists SeekTTY interaction defaults. */
-const TUI_BEHAVIOR_SETTINGS_NAMESPACE = "seektty-behavior";
-/** First-run interaction defaults when no user override has been stored. */
-const DEFAULT_TUI_BEHAVIOR = Object.freeze({
-	toolCards: "collapsed",
-	showReasoning: false,
-	desktopNotifications: true,
-	followTerminalTitle: true,
-	composerHistoryLimit: 200,
-	statusElapsed: true,
-	clipboardFallback: "auto",
-	toolOutputLineLimit: 200,
-	diffContextLines: 3,
-	dangerConfirmDefault: "cancel",
-	keyBindings: Object.freeze({})
-});
-/** Upper bound for persisted composer history entries. */
-const MAX_COMPOSER_HISTORY = 1e4;
-/** Upper bound for one expanded tool-output block; 0 disables folding. */
-const MAX_TOOL_OUTPUT_LINE_LIMIT = 1e4;
-/** Upper bound for unified-diff context lines around each change. */
-const MAX_DIFF_CONTEXT_LINES = 100;
-/** A stale TUI Settings writer was rejected before changing durable state. */
-var TuiSettingsConflictError = class extends Error {
-	/** Stable machine-readable conflict discriminator. */
-	code = "TUI_SETTINGS_CONFLICT";
-	/**
-	* @param namespace - registered Settings namespace that changed.
-	* @param expected - revision held by the terminal editor.
-	* @param actual - current Host revision.
-	*/
-	constructor(namespace, expected, actual) {
-		super({
-			zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
-			en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`
-		}.zh);
-		this.namespace = namespace;
-		this.expected = expected;
-		this.actual = actual;
-		this.name = "TuiSettingsConflictError";
-	}
-};
-
-//#endregion
 //#region src/client/theme-config.ts
 const UI_COLOR_KEYS = [
 	"text",
@@ -23179,11 +23181,18 @@ function settingsFieldLabel(namespace, path$1) {
 	return named === void 0 ? dotted : ui(named.zh, named.en);
 }
 /**
+* Drop Host-internal Settings namespaces that are not user-editable.
+* @param documents - redacted Settings descriptors.
+*/
+function visibleSettingsDocuments(documents) {
+	return documents.filter((document) => document.namespace !== TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE);
+}
+/**
 * Flatten every registered Settings document into a cross-namespace field index.
 * @param documents - redacted Settings descriptors.
 */
 function indexSettingsFields(documents) {
-	return documents.flatMap((document) => settingsFields(document).map((field) => ({
+	return visibleSettingsDocuments(documents).flatMap((document) => settingsFields(document).map((field) => ({
 		namespace: document.namespace,
 		section: settingsSectionLabel(document.namespace),
 		field
@@ -23194,11 +23203,12 @@ function indexSettingsFields(documents) {
 * @param documents - redacted Settings descriptors.
 */
 function settingsRootChoices(documents) {
-	return [...documents.map((document) => ({
+	const visible = visibleSettingsDocuments(documents);
+	return [...visible.map((document) => ({
 		id: document.namespace,
 		label: document.namespace,
 		description: `${settingsSectionLabel(document.namespace)} · ${document.applies === "live" ? ui("立即生效", "applies immediately") : ui("需重启", "restart required")}`
-	})), ...indexSettingsFields(documents).map((item) => ({
+	})), ...indexSettingsFields(visible).map((item) => ({
 		id: `field:${item.namespace}:${JSON.stringify(item.field.path)}`,
 		label: item.field.label,
 		description: `${item.namespace}.${item.field.path.join(".")} · ${item.section}`
@@ -25580,7 +25590,8 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		this.host.notice(ui("已清空待发送图片", "Pending images cleared"), "success");
 	}
 	async settings(args) {
-		const documents = await this.capabilities.managementBridge().settings.describe();
+		const bridge = this.capabilities.managementBridge().settings;
+		const documents = visibleSettingsDocuments(await bridge.describe());
 		if (documents.length === 0) throw new Error(ui("当前 Profile 未注册任何 Settings 命名空间", "The current Profile has no registered Settings namespaces"));
 		if (args !== "") {
 			if (documents.find((candidate) => candidate.namespace === args) === void 0) throw new Error(ui(`Settings 命名空间 ${JSON.stringify(args)} 不存在`, `Settings namespace ${JSON.stringify(args)} does not exist`));
@@ -27776,18 +27787,6 @@ var PromptEditor = class extends Editor {
 
 //#endregion
 //#region src/client/composer-history.ts
-/** File name stored inside the launcher-selected Profile directory. */
-const COMPOSER_HISTORY_FILENAME = "seektty-composer-history.json";
-/**
-* Resolve the durable composer-history path for one Profile.
-* @param profile - launcher-selected Profile name.
-* @param env - process environment; `DSH_HOME` overrides `~/.dsh`.
-* @param home - account home used when `DSH_HOME` is absent.
-* @returns absolute JSON path under the Profile directory.
-*/
-function composerHistoryPath(profile, env = process.env, home = homedir()) {
-	return join(env.DSH_HOME?.trim() || join(home, ".dsh"), "profiles", profile, COMPOSER_HISTORY_FILENAME);
-}
 function asEntries(value) {
 	if (!Array.isArray(value)) return [];
 	return value.filter((entry) => typeof entry === "string" && entry.trim() !== "");
@@ -27806,30 +27805,21 @@ function rememberComposerHistory(entries, text$1, limit) {
 	return (entries[0] === trimmed ? [...entries] : [trimmed, ...entries]).slice(0, limit);
 }
 /**
-* Read persisted composer history, ignoring a missing or corrupt file.
-* @param path - absolute JSON path.
+* Project Host Settings into the in-editor history list and its revision.
+* @param documents - redacted Settings descriptors from the Host.
 * @param limit - maximum entries to keep; 0 disables persistence.
-* @returns newest-first prompt list.
 */
-function loadComposerHistory(path$1, limit) {
-	if (limit <= 0) return [];
-	try {
-		return asEntries(JSON.parse(readFileSync(path$1, "utf8"))).slice(0, limit);
-	} catch {
-		return [];
-	}
-}
-/**
-* Replace the persisted composer history.
-* @param path - absolute JSON path.
-* @param entries - newest-first prompt list.
-*/
-function saveComposerHistory(path$1, entries) {
-	mkdirSync(dirname(path$1), { recursive: true });
-	writeFileSync(path$1, `${JSON.stringify(entries, null, 2)}\n`, {
-		encoding: "utf8",
-		mode: 384
-	});
+function composerHistoryFromDocuments(documents, limit) {
+	const document = documents.find((item) => item.namespace === TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE);
+	if (document === void 0) return {
+		entries: [],
+		revision: 0
+	};
+	const record = typeof document.value === "object" && document.value !== null ? document.value : {};
+	return {
+		entries: limit <= 0 ? [] : asEntries(record.entries).slice(0, limit),
+		revision: document.revision
+	};
 }
 
 //#endregion
@@ -31157,10 +31147,30 @@ async function startTuiSurface(options$1) {
 		const profile = options$1.profile ?? "tui";
 		const contextBar = new ContextBar(profile, options$1.cwd);
 		const editor = new PromptEditor(tui);
-		const historyPath = composerHistoryPath(profile);
 		const historyLimit = initialBehavior.composerHistoryLimit;
-		let composerHistory = loadComposerHistory(historyPath, historyLimit);
+		let { entries: composerHistory, revision: composerHistoryRevision } = composerHistoryFromDocuments(settingsDocuments, historyLimit);
 		for (const entry of [...composerHistory].reverse()) editor.addToHistory(entry);
+		let historyPersist = Promise.resolve();
+		const persistComposerHistory = (entries) => {
+			if (historyLimit <= 0) return;
+			historyPersist = historyPersist.then(async () => {
+				const settings = capabilities.managementBridge().settings;
+				const write = (revision, next) => settings.mutate(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE, [{
+					op: "set",
+					path: ["entries"],
+					value: [...next]
+				}], revision).then((saved) => saved.revision);
+				try {
+					composerHistoryRevision = await write(composerHistoryRevision, entries);
+				} catch (error) {
+					if (!(error instanceof TuiSettingsConflictError)) return;
+					const latest = composerHistoryFromDocuments(await settings.describe(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE), historyLimit);
+					const merged = rememberComposerHistory(latest.entries, entries[0] ?? "", historyLimit);
+					composerHistory = merged;
+					composerHistoryRevision = await write(latest.revision, merged);
+				}
+			}).catch(() => {});
+		};
 		let transcriptFocused = false;
 		const transcript = new Transcript(() => transcriptFocused ? transcriptViewportRows(terminal.rows, editor.render(terminal.columns).length) : Number.POSITIVE_INFINITY, () => {
 			if (stopping === void 0) tui.requestRender();
@@ -31568,9 +31578,7 @@ async function startTuiSurface(options$1) {
 			if (text$1 !== "") {
 				editor.addToHistory(text$1);
 				composerHistory = rememberComposerHistory(composerHistory, text$1, historyLimit);
-				if (historyLimit > 0) try {
-					saveComposerHistory(historyPath, composerHistory);
-				} catch {}
+				persistComposerHistory(composerHistory);
 			}
 			editor.setText("");
 			if (text$1.startsWith("/")) dispatchCommand(text$1);
@@ -31821,6 +31829,7 @@ function isActiveFiber(state, warn = () => void 0) {
 const MARKETPLACE_NAMESPACE = settingsNamespace("tui-plugin-marketplace");
 const APPEARANCE_NAMESPACE = settingsNamespace(TUI_APPEARANCE_SETTINGS_NAMESPACE);
 const BEHAVIOR_NAMESPACE = settingsNamespace(TUI_BEHAVIOR_SETTINGS_NAMESPACE);
+const COMPOSER_HISTORY_NAMESPACE = settingsNamespace(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE);
 const TUI_BUNDLE = "seektty";
 const NON_TUI_SURFACE_BUNDLES = ["@deepseek-ai/dsh-web-app", "@deepseek-ai/dsh-headless"];
 const NPM_SOURCE = Object.freeze({
@@ -31922,6 +31931,7 @@ const BehaviorSettingsSchema = z$1.object({
 	dangerConfirmDefault: z$1.union(["cancel", "confirm"]).default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault).description(ui("危险确认默认焦点；cancel 表示回车不执行。", "Default focus for danger confirmation; cancel means Enter does not proceed.")),
 	keyBindings: z$1.dict(z$1.string()).default({}).description(ui("覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。", "Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults."))
 });
+const ComposerHistorySettingsSchema = z$1.object({ entries: z$1.array(z$1.string().max(1e5)).max(MAX_COMPOSER_HISTORY).default([]) });
 function settingsDocument(descriptor) {
 	return {
 		namespace: descriptor.ns,
@@ -32070,6 +32080,7 @@ function createTuiManagementBridge(ctx, cwd) {
 	settings.register(MARKETPLACE_NAMESPACE, MarketplaceSettingsSchema, { applies: "live" });
 	settings.register(APPEARANCE_NAMESPACE, AppearanceSettingsSchema, { applies: "live" });
 	settings.register(BEHAVIOR_NAMESPACE, BehaviorSettingsSchema, { applies: "live" });
+	settings.register(COMPOSER_HISTORY_NAMESPACE, ComposerHistorySettingsSchema, { applies: "live" });
 	const marketplace = new PluginMarketplace({
 		cwd,
 		resolveCredential: async (ref) => (await credentials.resolve(credentialRef(ref)))?.value,

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -64,6 +64,7 @@ import {
   settingsFields,
   settingsRootChoices,
   settingsSectionLabel,
+  visibleSettingsDocuments,
   type TuiSettingsField,
 } from './settings.ts'
 import type { Transcript } from './transcript.ts'
@@ -1845,7 +1846,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 
   private async settings(args: string): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const documents = await bridge.describe()
+    const documents = visibleSettingsDocuments(await bridge.describe())
     if (documents.length === 0) throw new Error(ui('当前 Profile 未注册任何 Settings 命名空间', "The current Profile has no registered Settings namespaces"))
     if (args !== '') {
       const document = documents.find(candidate => candidate.namespace === args)

--- a/src/client/composer-history.ts
+++ b/src/client/composer-history.ts
@@ -1,27 +1,9 @@
-/** Profile-scoped composer history for Up/Down recall and Ctrl+R search. */
+/** Composer history helpers. Durable entries live in Harness Settings. */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
-
-/** File name stored inside the launcher-selected Profile directory. */
-export const COMPOSER_HISTORY_FILENAME = 'seektty-composer-history.json'
-
-/**
- * Resolve the durable composer-history path for one Profile.
- * @param profile - launcher-selected Profile name.
- * @param env - process environment; `DSH_HOME` overrides `~/.dsh`.
- * @param home - account home used when `DSH_HOME` is absent.
- * @returns absolute JSON path under the Profile directory.
- */
-export function composerHistoryPath(
-  profile: string,
-  env: NodeJS.ProcessEnv = process.env,
-  home: string = homedir(),
-): string {
-  const root = env.DSH_HOME?.trim() || join(home, '.dsh')
-  return join(root, 'profiles', profile, COMPOSER_HISTORY_FILENAME)
-}
+import {
+  TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
+  type TuiSettingsDocument,
+} from '@deepseek-ai/dsh-tui-protocol'
 
 function asEntries(value: unknown): string[] {
   if (!Array.isArray(value)) return []
@@ -48,26 +30,19 @@ export function rememberComposerHistory(
 }
 
 /**
- * Read persisted composer history, ignoring a missing or corrupt file.
- * @param path - absolute JSON path.
+ * Project Host Settings into the in-editor history list and its revision.
+ * @param documents - redacted Settings descriptors from the Host.
  * @param limit - maximum entries to keep; 0 disables persistence.
- * @returns newest-first prompt list.
  */
-export function loadComposerHistory(path: string, limit: number): string[] {
-  if (limit <= 0) return []
-  try {
-    return asEntries(JSON.parse(readFileSync(path, 'utf8'))).slice(0, limit)
-  } catch {
-    return []
-  }
-}
-
-/**
- * Replace the persisted composer history.
- * @param path - absolute JSON path.
- * @param entries - newest-first prompt list.
- */
-export function saveComposerHistory(path: string, entries: readonly string[]): void {
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, `${JSON.stringify(entries, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+export function composerHistoryFromDocuments(
+  documents: readonly TuiSettingsDocument[],
+  limit: number,
+): { readonly entries: string[]; readonly revision: number } {
+  const document = documents.find(item => item.namespace === TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE)
+  if (document === undefined) return { entries: [], revision: 0 }
+  const record = typeof document.value === 'object' && document.value !== null
+    ? document.value as { readonly entries?: unknown }
+    : {}
+  const entries = limit <= 0 ? [] : asEntries(record.entries).slice(0, limit)
+  return { entries, revision: document.revision }
 }

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -10,6 +10,7 @@ import { LOCALE_SETTINGS_NAMESPACE } from '@deepseek-ai/dsh-client-locale'
 import {
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+  TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
 } from '@deepseek-ai/dsh-tui-protocol'
 import { ui, uiLocale } from './locale.ts'
 import type { TuiSettingsDocument } from './management.ts'
@@ -241,13 +242,23 @@ export interface IndexedSettingsField {
 }
 
 /**
+ * Drop Host-internal Settings namespaces that are not user-editable.
+ * @param documents - redacted Settings descriptors.
+ */
+export function visibleSettingsDocuments(
+  documents: readonly TuiSettingsDocument[],
+): readonly TuiSettingsDocument[] {
+  return documents.filter(document => document.namespace !== TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE)
+}
+
+/**
  * Flatten every registered Settings document into a cross-namespace field index.
  * @param documents - redacted Settings descriptors.
  */
 export function indexSettingsFields(
   documents: readonly TuiSettingsDocument[],
 ): readonly IndexedSettingsField[] {
-  return documents.flatMap(document => settingsFields(document).map(field => ({
+  return visibleSettingsDocuments(documents).flatMap(document => settingsFields(document).map(field => ({
     namespace: document.namespace,
     section: settingsSectionLabel(document.namespace),
     field,
@@ -268,13 +279,14 @@ export interface SettingsRootChoice {
 export function settingsRootChoices(
   documents: readonly TuiSettingsDocument[],
 ): readonly SettingsRootChoice[] {
+  const visible = visibleSettingsDocuments(documents)
   return [
-    ...documents.map(document => ({
+    ...visible.map(document => ({
       id: document.namespace,
       label: document.namespace,
       description: `${settingsSectionLabel(document.namespace)} · ${document.applies === 'live' ? ui('立即生效', 'applies immediately') : ui('需重启', 'restart required')}`,
     })),
-    ...indexSettingsFields(documents).map(item => ({
+    ...indexSettingsFields(visible).map(item => ({
       id: `field:${item.namespace}:${JSON.stringify(item.field.path)}`,
       label: item.field.label,
       description: `${item.namespace}.${item.field.path.join('.')} · ${item.section}`,

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -11,6 +11,10 @@ import {
   TUI,
   type Terminal,
 } from '@mariozechner/pi-tui'
+import {
+  TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
+  TuiSettingsConflictError,
+} from '@deepseek-ai/dsh-tui-protocol'
 import type { TuiStartOptions, TuiSurfaceHandle, TuiSurfaceOutcome } from './index.ts'
 import { startTuiClient, type TuiClient } from './client-runtime.ts'
 import { capabilityError, type TuiActiveSession } from './capabilities.ts'
@@ -26,10 +30,8 @@ import {
 import { appearanceSettings, themeFromAppearance } from './appearance.ts'
 import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
 import {
-  composerHistoryPath,
-  loadComposerHistory,
+  composerHistoryFromDocuments,
   rememberComposerHistory,
-  saveComposerHistory,
 } from './composer-history.ts'
 import {
   localeFromSettings,
@@ -152,10 +154,36 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const profile = options.profile ?? 'tui'
     const contextBar = new ContextBar(profile, options.cwd)
     const editor = new PromptEditor(tui)
-    const historyPath = composerHistoryPath(profile)
     const historyLimit = initialBehavior.composerHistoryLimit
-    let composerHistory = loadComposerHistory(historyPath, historyLimit)
+    let { entries: composerHistory, revision: composerHistoryRevision } =
+      composerHistoryFromDocuments(settingsDocuments, historyLimit)
     for (const entry of [...composerHistory].reverse()) editor.addToHistory(entry)
+    let historyPersist = Promise.resolve()
+    const persistComposerHistory = (entries: readonly string[]): void => {
+      if (historyLimit <= 0) return
+      historyPersist = historyPersist.then(async () => {
+        const settings = capabilities.managementBridge().settings
+        const write = (revision: number, next: readonly string[]): Promise<number> => (
+          settings.mutate(
+            TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
+            [{ op: 'set', path: ['entries'], value: [...next] }],
+            revision,
+          ).then(saved => saved.revision)
+        )
+        try {
+          composerHistoryRevision = await write(composerHistoryRevision, entries)
+        } catch (error) {
+          if (!(error instanceof TuiSettingsConflictError)) return
+          const latest = composerHistoryFromDocuments(
+            await settings.describe(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE),
+            historyLimit,
+          )
+          const merged = rememberComposerHistory(latest.entries, entries[0] ?? '', historyLimit)
+          composerHistory = merged
+          composerHistoryRevision = await write(latest.revision, merged)
+        }
+      }).catch(() => { /* send must not wait on Settings */ })
+    }
     let transcriptFocused = false
     const transcript = new Transcript(
       // The default full transcript becomes normal terminal scrollback, which keeps
@@ -621,9 +649,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (text !== '') {
         editor.addToHistory(text)
         composerHistory = rememberComposerHistory(composerHistory, text, historyLimit)
-        if (historyLimit > 0) {
-          try { saveComposerHistory(historyPath, composerHistory) } catch { /* send must not wait on disk */ }
-        }
+        persistComposerHistory(composerHistory)
       }
       editor.setText('')
       if (text.startsWith('/')) void dispatchCommand(text)

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -23,6 +23,7 @@ import {
   MAX_DIFF_CONTEXT_LINES,
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+  TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
 } from '@deepseek-ai/dsh-tui-protocol'
 import type {} from './marketplace-provider.ts'
@@ -34,6 +35,7 @@ import { ui } from '../client/locale.ts'
 const MARKETPLACE_NAMESPACE = settingsNamespace('tui-plugin-marketplace')
 const APPEARANCE_NAMESPACE = settingsNamespace(TUI_APPEARANCE_SETTINGS_NAMESPACE)
 const BEHAVIOR_NAMESPACE = settingsNamespace(TUI_BEHAVIOR_SETTINGS_NAMESPACE)
+const COMPOSER_HISTORY_NAMESPACE = settingsNamespace(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE)
 const TUI_BUNDLE = 'seektty'
 const NON_TUI_SURFACE_BUNDLES = ['@deepseek-ai/dsh-web-app', '@deepseek-ai/dsh-headless'] as const
 const NPM_SOURCE: TuiMarketplaceSource = Object.freeze({
@@ -174,6 +176,9 @@ const BehaviorSettingsSchema = z.object({
       '覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。',
       'Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults.',
     )),
+})
+const ComposerHistorySettingsSchema = z.object({
+  entries: z.array(z.string().max(100_000)).max(MAX_COMPOSER_HISTORY).default([]),
 })
 
 interface StoredCatalogSource {
@@ -391,6 +396,7 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
   settings.register(MARKETPLACE_NAMESPACE, MarketplaceSettingsSchema, { applies: 'live' })
   settings.register(APPEARANCE_NAMESPACE, AppearanceSettingsSchema, { applies: 'live' })
   settings.register(BEHAVIOR_NAMESPACE, BehaviorSettingsSchema, { applies: 'live' })
+  settings.register(COMPOSER_HISTORY_NAMESPACE, ComposerHistorySettingsSchema, { applies: 'live' })
   const marketplace = new PluginMarketplace({
     cwd,
     resolveCredential: async ref => (await credentials.resolve(credentialRef(ref)))?.value,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -108,6 +108,9 @@ export const MAX_TEXTMATE_RULES = 4_096
 /** Harness Settings namespace that persists SeekTTY interaction defaults. */
 export const TUI_BEHAVIOR_SETTINGS_NAMESPACE = 'seektty-behavior'
 
+/** Harness Settings namespace that persists composer prompt history with revision. */
+export const TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE = 'seektty-composer-history'
+
 /** Startup presentation for tool cards in the transcript. */
 export type TuiToolCardDisplay = 'collapsed' | 'expanded' | 'hidden'
 

--- a/tests/composer-history.test.ts
+++ b/tests/composer-history.test.ts
@@ -1,20 +1,27 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
 import {
-  COMPOSER_HISTORY_FILENAME,
-  composerHistoryPath,
-  loadComposerHistory,
+  composerHistoryFromDocuments,
   rememberComposerHistory,
-  saveComposerHistory,
 } from '../src/client/composer-history.ts'
+import { visibleSettingsDocuments } from '../src/client/settings.ts'
+import {
+  TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
+  type TuiSettingsDocument,
+} from '../src/protocol.ts'
 
-const temporaryDirs: string[] = []
-
-afterEach(() => {
-  for (const dir of temporaryDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
-})
+function document(namespace: string, value: unknown, revision = 3): TuiSettingsDocument {
+  return {
+    namespace,
+    schema: {},
+    value,
+    revision,
+    applies: 'live',
+    secrets: [],
+  }
+}
 
 describe('composer history persistence', () => {
   it('keeps newest-first entries, skips consecutive duplicates, and honors a zero limit', () => {
@@ -25,20 +32,24 @@ describe('composer history persistence', () => {
     expect(rememberComposerHistory(['keep'], '   ', 8)).toEqual(['keep'])
   })
 
-  it('loads and saves under the Profile directory, ignoring corrupt files', () => {
-    const home = mkdtempSync(join(tmpdir(), 'seektty-history-'))
-    temporaryDirs.push(home)
-    const path = composerHistoryPath('tui', { DSH_HOME: home }, home)
-    expect(path).toBe(join(home, 'profiles', 'tui', COMPOSER_HISTORY_FILENAME))
-    expect(loadComposerHistory(path, 200)).toEqual([])
+  it('reads entries and revision from the Host Settings document', () => {
+    expect(composerHistoryFromDocuments([], 200)).toEqual({ entries: [], revision: 0 })
+    expect(composerHistoryFromDocuments([
+      document(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE, { entries: ['alpha', 'beta', 1, ''] }, 7),
+    ], 1)).toEqual({ entries: ['alpha'], revision: 7 })
+    expect(composerHistoryFromDocuments([
+      document(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE, { entries: ['keep'] }, 4),
+    ], 0)).toEqual({ entries: [], revision: 4 })
+  })
 
-    mkdirSync(join(home, 'profiles', 'tui'), { recursive: true })
-    writeFileSync(path, '{not json')
-    expect(loadComposerHistory(path, 200)).toEqual([])
+  it('does not read or write Profile-directory JSON from the client', () => {
+    const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../src/client/composer-history.ts'), 'utf8')
+    expect(source).not.toMatch(/node:fs|writeFileSync|readFileSync|mkdirSync|DSH_HOME|seektty-composer-history\.json/u)
+  })
 
-    saveComposerHistory(path, ['alpha', 'beta'])
-    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(['alpha', 'beta'])
-    expect(loadComposerHistory(path, 1)).toEqual(['alpha'])
-    expect(loadComposerHistory(path, 0)).toEqual([])
+  it('hides the history namespace from the Settings editor', () => {
+    const history = document(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE, { entries: ['secret prompt'] })
+    const behavior = document('seektty-behavior', { composerHistoryLimit: 200 })
+    expect(visibleSettingsDocuments([history, behavior]).map(item => item.namespace)).toEqual(['seektty-behavior'])
   })
 })


### PR DESCRIPTION
## Summary
- Remove Profile-directory `seektty-composer-history.json` I/O from the TUI client.
- Persist newest-first prompt history in a Host Settings namespace with revision; keep only the in-editor Up/Down cursor locally. The Settings editor hides this namespace.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/composer-history.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vitest run`
- [x] `./node_modules/.bin/tsdown`
- [ ] Do not merge until the review-fix stack is complete
