### PR TITLE
fix(tui): hide queue reorder until Host has an atomic move

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22907,25 +22907,6 @@ function jobKillNotice(result) {
 }
 
 //#endregion
-//#region src/client/queue-order.ts
-/** Queue reorder helpers. Host QueueAction has no native move. */
-/**
-* Return a new array with one item swapped toward `direction`.
-* @param items - current order.
-* @param index - item to move.
-* @param direction - -1 up, +1 down.
-*/
-function moveIndex(items, index, direction) {
-	const next = index + direction;
-	if (index < 0 || next < 0 || next >= items.length) return [...items];
-	const copy = [...items];
-	const [row] = copy.splice(index, 1);
-	if (row === void 0) return copy;
-	copy.splice(next, 0, row);
-	return copy;
-}
-
-//#endregion
 //#region src/client/relative-time.ts
 /**
 * Format an updatedAt epoch as a compact relative clock.
@@ -25492,8 +25473,6 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		}
 		const row = rows.find((candidate) => candidate.id === id);
 		if (row === void 0 || row.placement !== "queued") return;
-		const index = queued.findIndex((candidate) => candidate.id === row.id);
-		const canReorder = queued.length > 1 && queued.every((item) => item.text !== null);
 		const action = await nav.select({
 			title: ui("队列操作", "Queue action"),
 			choices: [
@@ -25506,18 +25485,6 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 					id: "edit",
 					label: ui("编辑", "Edit"),
 					...row.text === null ? { disabledReason: ui("含非文本内容，无法文本编辑", "Contains non-text content and cannot be edited as text") } : {}
-				},
-				{
-					id: "up",
-					label: ui("上移", "Move up"),
-					description: ui("与上一条排队消息对调", "Swap with the previous queued message"),
-					...!canReorder || index <= 0 ? { disabledReason: !canReorder ? ui("含非文本内容或不足两条，无法重排", "Cannot reorder: a non-text item is present, or fewer than two items") : ui("已在队首", "Already first") } : {}
-				},
-				{
-					id: "down",
-					label: ui("下移", "Move down"),
-					description: ui("与下一条排队消息对调", "Swap with the next queued message"),
-					...!canReorder || index >= queued.length - 1 ? { disabledReason: !canReorder ? ui("含非文本内容或不足两条，无法重排", "Cannot reorder: a non-text item is present, or fewer than two items") : ui("已在队尾", "Already last") } : {}
 				},
 				{
 					id: "remove",
@@ -25543,26 +25510,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 				}]
 			});
 		}
-		if (action.id === "up" || action.id === "down") await this.reorderQueued(queued, index, action.id === "up" ? -1 : 1);
 		this.host.notice(ui("队列操作已提交", "Queue action submitted"), "success");
-	}
-	async reorderQueued(queued, index, direction) {
-		const movable = queued.filter((row) => row.placement === "queued");
-		if (movable.some((row) => row.text === null)) throw new Error(ui("含非文本内容，无法重排", "Cannot reorder a non-text item"));
-		const ordered = moveIndex(movable, index, direction);
-		if (ordered.every((row, position) => row.id === movable[position]?.id)) return;
-		const active = this.capabilities.active();
-		if (active === void 0) return;
-		for (const row of movable) await this.capabilities.updateQueue(row.id, { kind: "remove" });
-		for (const row of ordered) {
-			const text$1 = row.text;
-			if (text$1 === null) continue;
-			const result = await active.session.prompt([{
-				type: "text",
-				text: text$1
-			}], "queue");
-			if (!result.ok) throw new Error(ui(`重排队列失败：${result.error.message}`, `Failed to reorder the queue: ${result.error.message}`));
-		}
 	}
 	async steer(args) {
 		if (args === "") throw new Error(ui("用法：/steer <消息>", "Usage: /steer <message>"));

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -39,7 +39,6 @@ import { pluginFailureDetail } from './error-advice.ts'
 import { SessionToolAllowlist } from './session-tool-allowlist.ts'
 import { trajectoryRequestDetail } from './trajectory-detail.ts'
 import { isStoppableJob, jobElapsedMs, jobKillNotice } from './job-control.ts'
-import { moveIndex } from './queue-order.ts'
 import { relativeTime, sortSessionsByUpdatedAt } from './relative-time.ts'
 import type {
   TuiMarketplaceCandidate,
@@ -1751,29 +1750,11 @@ The directory, user files, and all session logs are kept; sessions become ungrou
     }
     const row = rows.find(candidate => candidate.id === id)
     if (row === undefined || row.placement !== 'queued') return
-    const index = queued.findIndex(candidate => candidate.id === row.id)
-    const canReorder = queued.length > 1 && queued.every(item => item.text !== null)
     const action = await nav.select({
       title: ui('队列操作', "Queue action"),
       choices: [
         { id: 'steer', label: ui('转为引导', "Convert to steering"), description: ui('并入当前轮次', "Merge into current turn") },
         { id: 'edit', label: ui('编辑', "Edit"), ...(row.text === null ? { disabledReason: ui('含非文本内容，无法文本编辑', "Contains non-text content and cannot be edited as text") } : {}) },
-        {
-          id: 'up',
-          label: ui('上移', "Move up"),
-          description: ui('与上一条排队消息对调', "Swap with the previous queued message"),
-          ...(!canReorder || index <= 0
-            ? { disabledReason: !canReorder ? ui('含非文本内容或不足两条，无法重排', "Cannot reorder: a non-text item is present, or fewer than two items") : ui('已在队首', "Already first") }
-            : {}),
-        },
-        {
-          id: 'down',
-          label: ui('下移', "Move down"),
-          description: ui('与下一条排队消息对调', "Swap with the next queued message"),
-          ...(!canReorder || index >= queued.length - 1
-            ? { disabledReason: !canReorder ? ui('含非文本内容或不足两条，无法重排', "Cannot reorder: a non-text item is present, or fewer than two items") : ui('已在队尾', "Already last") }
-            : {}),
-        },
         { id: 'remove', label: ui('删除', "Delete"), description: ui('从待处理队列移除', "Remove from the pending queue") },
       ],
       searchable: false,
@@ -1785,30 +1766,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       const text = await nav.multilineInput({ title: ui('编辑排队消息', "Edit queued message"), initialValue: row.text })
       if (text !== undefined) await this.capabilities.updateQueue(row.id, { kind: 'edit', content: [{ type: 'text', text }] })
     }
-    if (action.id === 'up' || action.id === 'down') {
-      await this.reorderQueued(queued, index, action.id === 'up' ? -1 : 1)
-    }
     this.host.notice(ui('队列操作已提交', "Queue action submitted"), 'success')
-  }
-
-  private async reorderQueued(
-    queued: ConversationSnapshot['queue'],
-    index: number,
-    direction: -1 | 1,
-  ): Promise<void> {
-    const movable = queued.filter(row => row.placement === 'queued')
-    if (movable.some(row => row.text === null)) throw new Error(ui('含非文本内容，无法重排', "Cannot reorder a non-text item"))
-    const ordered = moveIndex(movable, index, direction)
-    if (ordered.every((row, position) => row.id === movable[position]?.id)) return
-    const active = this.capabilities.active()
-    if (active === undefined) return
-    for (const row of movable) await this.capabilities.updateQueue(row.id, { kind: 'remove' })
-    for (const row of ordered) {
-      const text = row.text
-      if (text === null) continue
-      const result = await active.session.prompt([{ type: 'text', text }], 'queue')
-      if (!result.ok) throw new Error(ui(`重排队列失败：${result.error.message}`, `Failed to reorder the queue: ${result.error.message}`))
-    }
   }
 
   private async steer(args: string): Promise<void> {

--- a/src/client/queue-order.ts
+++ b/src/client/queue-order.ts
@@ -1,4 +1,4 @@
-/** Queue reorder helpers. Host QueueAction has no native move. */
+/** Queue order helpers. Host QueueAction has no atomic move; the TUI must not fake one. */
 
 /**
  * Return a new array with one item swapped toward `direction`.

--- a/tests/queue-order.test.ts
+++ b/tests/queue-order.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { moveIndex } from '../src/client/queue-order.ts'
 
@@ -8,5 +11,12 @@ describe('queue reorder', () => {
     expect(moveIndex(rows, 1, 1)).toEqual(['a', 'c', 'b'])
     expect(moveIndex(rows, 0, -1)).toEqual(['a', 'b', 'c'])
     expect(moveIndex(rows, 2, 1)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not rebuild the queue by deleting items and re-prompting', () => {
+    const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../src/client/actions.ts'), 'utf8')
+    expect(source.includes('reorderQueued')).toBe(false)
+    expect(source.includes('与上一条排队消息对调')).toBe(false)
+    expect(source.includes('Swap with the previous queued message')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Remove the TUI fake that deleted every queued item and re-prompted them in a new order.
- Hide Move up/down until Harness exposes an atomic `queue.reorder`; steer, edit, and delete remain.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/queue-order.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vitest run`
- [x] `./node_modules/.bin/tsdown`
- [ ] Do not merge until the review-fix stack is complete
