### PR TITLE
fix(tui): redact catalog URLs and address sources by rowKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DbTu1PjP.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
-import { n as assertCredentialFreeUrl, t as PluginMarketplace } from "./plugin-marketplace-swCofv4S.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-CUo0j988.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
@@ -23911,6 +23911,15 @@ function detailText(value) {
 		return typeof value === "bigint" ? value.toString() : ui("[内容无法序列化]", "[content cannot be serialized]");
 	}
 }
+function marketplaceSourceKey(source) {
+	return source.rowKey ?? source.id;
+}
+function findMarketplaceSource(sources, token) {
+	const byKey = sources.find((source) => source.rowKey === token);
+	if (byKey !== void 0) return byKey;
+	const matches$1 = sources.filter((source) => source.id === token);
+	return matches$1.length === 1 ? matches$1[0] : void 0;
+}
 function pluginIdentity(plugin) {
 	return `${plugin.name}${plugin.version === void 0 ? "" : `@${plugin.version}`}`;
 }
@@ -26331,9 +26340,10 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 		].includes(parsed.command)) {
 			if (parsed.rest === "") throw new Error(ui(`/plugin source ${parsed.command} 需要 Source id`, `/plugin source ${parsed.command} requires a Source id`));
 			const snapshot$1 = await bridge.sources();
-			const target = snapshot$1.sources.find((source$1) => source$1.id === parsed.rest);
+			const target = findMarketplaceSource(snapshot$1.sources, parsed.rest);
 			if (target === void 0 || target.builtIn) throw new Error(ui(`插件目录 ${JSON.stringify(parsed.rest)} 不存在或不可修改`, `Plugin catalog ${JSON.stringify(parsed.rest)} does not exist or is read-only`));
-			const sources = parsed.command === "remove" ? snapshot$1.sources.filter((source$1) => source$1.id !== target.id) : snapshot$1.sources.map((source$1) => source$1.id === target.id ? {
+			const key = marketplaceSourceKey(target);
+			const sources = parsed.command === "remove" ? snapshot$1.sources.filter((source$1) => marketplaceSourceKey(source$1) !== key) : snapshot$1.sources.map((source$1) => marketplaceSourceKey(source$1) === key ? {
 				...source$1,
 				enabled: parsed.command === "enable"
 			} : source$1);
@@ -26347,7 +26357,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			title: ui("插件市场来源", "Plugin marketplace sources"),
 			detail: ui("npm 与插件提供的目录为只读；你添加的插件目录可在这里管理", "npm and provider-owned catalogs are read-only; catalogs you add can be managed here"),
 			choices: [...snapshot.sources.map((source$1) => ({
-				id: `source:${source$1.id}`,
+				id: `source:${marketplaceSourceKey(source$1)}`,
 				label: `${source$1.enabled ? "● " : "○ "}${source$1.label}`,
 				description: `${source$1.kind} · ${source$1.url}${source$1.credentialRef === void 0 ? "" : ` · Credential ${source$1.credentialRef}`}${source$1.builtIn ? ui(" · 内置", " · built-in") : ""}${source$1.diagnostic === void 0 ? "" : ` · ${source$1.diagnostic}`}`
 			})), {
@@ -26366,7 +26376,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			await this.addPluginSource(overlays, snapshot.sources, snapshot.revision);
 			return;
 		}
-		const source = snapshot.sources.find((item) => item.id === selected.id.slice(7));
+		const source = findMarketplaceSource(snapshot.sources, selected.id.slice(7));
 		if (source === void 0) return;
 		await this.editPluginSource(overlays, source, snapshot.sources, snapshot.revision);
 	}
@@ -26447,7 +26457,7 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 				if (entered === void 0 || entered.trim() === "") return;
 				ref = entered.trim();
 				const credentialRef$1 = ref;
-				const updated = sources.map((item) => item.id === source.id ? {
+				const updated = sources.map((item) => marketplaceSourceKey(item) === marketplaceSourceKey(source) ? {
 					...item,
 					credentialRef: credentialRef$1
 				} : item);
@@ -26460,7 +26470,8 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 		if (selected.id === "remove") {
 			if (!await overlays.confirm(ui(`移除 ${source.label}？`, `Remove ${source.label}?`), ui("该目录将不再参与搜索；已安装插件不受影响。", "This catalog will no longer be searched; installed plugins are unaffected."), ui("移除", "Remove"))) return;
 		}
-		const next = selected.id === "remove" ? sources.filter((item) => item.id !== source.id) : sources.map((item) => item.id === source.id ? {
+		const key = marketplaceSourceKey(source);
+		const next = selected.id === "remove" ? sources.filter((item) => marketplaceSourceKey(item) !== key) : sources.map((item) => marketplaceSourceKey(item) === key ? {
 			...item,
 			enabled: !source.enabled
 		} : item);
@@ -31696,7 +31707,8 @@ const NPM_SOURCE = Object.freeze({
 	label: "npm Registry",
 	url: "https://registry.npmjs.org/",
 	enabled: true,
-	builtIn: true
+	builtIn: true,
+	rowKey: "builtin:npm"
 });
 const CatalogSourceSchema = z$1.object({
 	id: z$1.string().required(),
@@ -31846,11 +31858,16 @@ function validateCatalogSource(source) {
 		credentialRef: source.credentialRef ?? ""
 	};
 }
+function storedIndexFromRowKey(rowKey) {
+	const match = /^stored:(\d+)$/u.exec(rowKey ?? "");
+	if (match === null) return void 0;
+	return Number(match[1]);
+}
 function degradedCatalogSource(raw, index, diagnostic) {
 	const record = typeof raw === "object" && raw !== null ? raw : {};
 	const id = typeof record.id === "string" && record.id.trim() !== "" ? record.id.trim() : `invalid-${String(index)}`;
 	const label = typeof record.label === "string" && record.label.trim() !== "" ? record.label.trim() : id;
-	const url = typeof record.url === "string" ? record.url : "";
+	const url = typeof record.url === "string" ? redactMarketplaceUrl(record.url) : "";
 	return {
 		id,
 		kind: "catalog",
@@ -31858,7 +31875,8 @@ function degradedCatalogSource(raw, index, diagnostic) {
 		url,
 		enabled: false,
 		builtIn: false,
-		diagnostic
+		diagnostic,
+		rowKey: `stored:${String(index)}`
 	};
 }
 /**
@@ -31898,7 +31916,8 @@ function catalogSourcesFromStored(stored, reservedIds) {
 				url: storedSource.url,
 				enabled: storedSource.enabled,
 				...storedSource.credentialRef === "" ? {} : { credentialRef: storedSource.credentialRef },
-				builtIn: false
+				builtIn: false,
+				rowKey: `stored:${String(index)}`
 			});
 		} catch (error) {
 			sources.push(degradedCatalogSource(raw, index, error instanceof Error ? error.message : String(error)));
@@ -32027,7 +32046,17 @@ function createTuiManagementBridge(ctx, cwd) {
 			doctor: () => Promise.resolve(manager.doctor()),
 			sources: () => Promise.resolve(sourceSnapshot()),
 			saveSources: async (sources, expectedRevision) => {
-				const catalog = sources.filter((source) => !source.builtIn).map(validateCatalogSource);
+				const currentStored = documents.one(MARKETPLACE_NAMESPACE).value.sources;
+				const catalog = [];
+				for (const source of sources.filter((source$1) => !source$1.builtIn)) {
+					if (source.diagnostic !== void 0) {
+						const index = storedIndexFromRowKey(source.rowKey);
+						const raw = index === void 0 ? void 0 : currentStored[index];
+						if (typeof raw === "object" && raw !== null) catalog.push(raw);
+						continue;
+					}
+					catalog.push(validateCatalogSource(source));
+				}
 				if (new Set(catalog.map((source) => source.id)).size !== catalog.length) throw new Error(ui("Catalog Source id 不能重复", "Catalog Source IDs must be unique"));
 				const reserved = new Set([NPM_SOURCE.id, ...(providers?.sources() ?? []).map((source) => source.id)]);
 				const conflict = catalog.find((source) => reserved.has(source.id));

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
 import { c as ui } from "./locale-DbTu1PjP.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-swCofv4S.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CUo0j988.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts
@@ -28,7 +28,8 @@ function normalizeSource(kind, source) {
 		url,
 		enabled: source.enabled,
 		...credentialRef === void 0 ? {} : { credentialRef },
-		builtIn: true
+		builtIn: true,
+		rowKey: `provider:${source.id}`
 	});
 }
 function normalizeDiscovery(value, kind) {

--- a/lib/plugin-marketplace-CUo0j988.js
+++ b/lib/plugin-marketplace-CUo0j988.js
@@ -38,6 +38,26 @@ function requestInit(headers, timeoutMs, signal) {
 	};
 }
 /**
+* Strip embedded credentials from a URL before it crosses the Host boundary.
+* @param value - catalog URL or plugin spec that may contain userinfo or secret query keys.
+*/
+function redactMarketplaceUrl(value) {
+	const prefix = value.startsWith("git+") ? "git+" : "";
+	const raw = prefix === "" ? value : value.slice(4);
+	if (!/^https?:\/\//i.test(raw)) return value;
+	try {
+		const url = new URL(raw);
+		if (url.username !== "" || url.password !== "") {
+			url.username = "***";
+			url.password = "";
+		}
+		for (const key of [...url.searchParams.keys()]) if (SENSITIVE_QUERY_KEY.test(key)) url.searchParams.set(key, "***");
+		return `${prefix}${url.toString()}`;
+	} catch {
+		return value.replace(/(https?:\/\/)[^\s/@]+@/giu, "$1***@");
+	}
+}
+/**
 * Reject a user-visible HTTP spec or Source URL that embeds a Credential.
 * @param value - plugin spec or Catalog URL.
 * @param label - diagnostic subject.
@@ -498,4 +518,4 @@ var PluginMarketplace = class {
 };
 
 //#endregion
-export { assertCredentialFreeUrl as n, PluginMarketplace as t };
+export { assertCredentialFreeUrl as n, redactMarketplaceUrl as r, PluginMarketplace as t };

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -283,6 +283,20 @@ function detailText(value: unknown): string {
   }
 }
 
+function marketplaceSourceKey(source: TuiMarketplaceSource): string {
+  return source.rowKey ?? source.id
+}
+
+function findMarketplaceSource(
+  sources: readonly TuiMarketplaceSource[],
+  token: string,
+): TuiMarketplaceSource | undefined {
+  const byKey = sources.find(source => source.rowKey === token)
+  if (byKey !== undefined) return byKey
+  const matches = sources.filter(source => source.id === token)
+  return matches.length === 1 ? matches[0] : undefined
+}
+
 function pluginIdentity(plugin: TuiPluginEntry): string {
   return `${plugin.name}${plugin.version === undefined ? '' : `@${plugin.version}`}`
 }
@@ -2676,11 +2690,12 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
     if (['remove', 'enable', 'disable'].includes(parsed.command)) {
       if (parsed.rest === '') throw new Error(ui(`/plugin source ${parsed.command} 需要 Source id`, `/plugin source ${parsed.command} requires a Source id`))
       const snapshot = await bridge.sources()
-      const target = snapshot.sources.find(source => source.id === parsed.rest)
+      const target = findMarketplaceSource(snapshot.sources, parsed.rest)
       if (target === undefined || target.builtIn) throw new Error(ui(`插件目录 ${JSON.stringify(parsed.rest)} 不存在或不可修改`, `Plugin catalog ${JSON.stringify(parsed.rest)} does not exist or is read-only`))
+      const key = marketplaceSourceKey(target)
       const sources = parsed.command === 'remove'
-        ? snapshot.sources.filter(source => source.id !== target.id)
-        : snapshot.sources.map(source => source.id === target.id
+        ? snapshot.sources.filter(source => marketplaceSourceKey(source) !== key)
+        : snapshot.sources.map(source => marketplaceSourceKey(source) === key
           ? { ...source, enabled: parsed.command === 'enable' }
           : source)
       await bridge.saveSources(sources, snapshot.revision)
@@ -2696,7 +2711,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       detail: ui('npm 与插件提供的目录为只读；你添加的插件目录可在这里管理', "npm and provider-owned catalogs are read-only; catalogs you add can be managed here"),
       choices: [
         ...snapshot.sources.map(source => ({
-          id: `source:${source.id}`,
+          id: `source:${marketplaceSourceKey(source)}`,
           label: `${source.enabled ? '● ' : '○ '}${source.label}`,
           description: `${source.kind} · ${source.url}${source.credentialRef === undefined ? '' : ` · Credential ${source.credentialRef}`}${source.builtIn ? ui(' · 内置', " · built-in") : ''}${source.diagnostic === undefined ? '' : ` · ${source.diagnostic}`}`,
         })),
@@ -2709,7 +2724,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
       await this.addPluginSource(overlays, snapshot.sources, snapshot.revision)
       return
     }
-    const source = snapshot.sources.find(item => item.id === selected.id.slice('source:'.length))
+    const source = findMarketplaceSource(snapshot.sources, selected.id.slice('source:'.length))
     if (source === undefined) return
     await this.editPluginSource(overlays, source, snapshot.sources, snapshot.revision)
   }
@@ -2782,7 +2797,7 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
         if (entered === undefined || entered.trim() === '') return
         ref = entered.trim()
         const credentialRef = ref
-        const updated = sources.map(item => item.id === source.id ? { ...item, credentialRef } : item)
+        const updated = sources.map(item => marketplaceSourceKey(item) === marketplaceSourceKey(source) ? { ...item, credentialRef } : item)
         await this.capabilities.managementBridge().plugins.saveSources(updated, revision)
       }
       await this.configureSourceCredential(overlays, ref)
@@ -2793,9 +2808,10 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
       const confirmed = await overlays.confirm(ui(`移除 ${source.label}？`, `Remove ${source.label}?`), ui('该目录将不再参与搜索；已安装插件不受影响。', "This catalog will no longer be searched; installed plugins are unaffected."), ui('移除', "Remove"))
       if (!confirmed) return
     }
+    const key = marketplaceSourceKey(source)
     const next = selected.id === 'remove'
-      ? sources.filter(item => item.id !== source.id)
-      : sources.map(item => item.id === source.id ? { ...item, enabled: !source.enabled } : item)
+      ? sources.filter(item => marketplaceSourceKey(item) !== key)
+      : sources.map(item => marketplaceSourceKey(item) === key ? { ...item, enabled: !source.enabled } : item)
     await this.capabilities.managementBridge().plugins.saveSources(next, revision)
     this.host.notice(ui(`插件目录 ${source.id} 已${selected.id === 'remove' ? '移除' : source.enabled ? '停用' : '启用'}`, `Plugin catalog ${source.id} ${selected.id === 'remove' ? 'removed' : source.enabled ? 'disabled' : 'enabled'}`), 'success')
   }

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -27,7 +27,7 @@ import {
   TuiSettingsConflictError,
 } from '@deepseek-ai/dsh-tui-protocol'
 import type {} from './marketplace-provider.ts'
-import { assertCredentialFreeUrl, PluginMarketplace } from './plugin-marketplace.ts'
+import { assertCredentialFreeUrl, PluginMarketplace, redactMarketplaceUrl } from './plugin-marketplace.ts'
 import { installerSecrets, redactInstallerText } from './installer-output.ts'
 import { killHostJob, type HostJobRegistry } from '../client/job-control.ts'
 import { ui } from '../client/locale.ts'
@@ -45,6 +45,7 @@ const NPM_SOURCE: TuiMarketplaceSource = Object.freeze({
   url: 'https://registry.npmjs.org/',
   enabled: true,
   builtIn: true,
+  rowKey: 'builtin:npm',
 })
 
 const CatalogSourceSchema = z.object({
@@ -274,11 +275,17 @@ function validateCatalogSource(source: TuiMarketplaceSource): StoredCatalogSourc
   }
 }
 
+function storedIndexFromRowKey(rowKey: string | undefined): number | undefined {
+  const match = /^stored:(\d+)$/u.exec(rowKey ?? '')
+  if (match === null) return undefined
+  return Number(match[1])
+}
+
 function degradedCatalogSource(raw: unknown, index: number, diagnostic: string): TuiMarketplaceSource {
   const record = typeof raw === 'object' && raw !== null ? raw as Partial<StoredCatalogSource> : {}
   const id = typeof record.id === 'string' && record.id.trim() !== '' ? record.id.trim() : `invalid-${String(index)}`
   const label = typeof record.label === 'string' && record.label.trim() !== '' ? record.label.trim() : id
-  const url = typeof record.url === 'string' ? record.url : ''
+  const url = typeof record.url === 'string' ? redactMarketplaceUrl(record.url) : ''
   return {
     id,
     kind: 'catalog',
@@ -287,6 +294,7 @@ function degradedCatalogSource(raw: unknown, index: number, diagnostic: string):
     enabled: false,
     builtIn: false,
     diagnostic,
+    rowKey: `stored:${String(index)}`,
   }
 }
 
@@ -339,6 +347,7 @@ export function catalogSourcesFromStored(
         enabled: storedSource.enabled,
         ...(storedSource.credentialRef === '' ? {} : { credentialRef: storedSource.credentialRef }),
         builtIn: false,
+        rowKey: `stored:${String(index)}`,
       })
     } catch (error) {
       sources.push(degradedCatalogSource(raw, index, error instanceof Error ? error.message : String(error)))
@@ -509,7 +518,17 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
       doctor: () => Promise.resolve(manager.doctor()),
       sources: () => Promise.resolve(sourceSnapshot()),
       saveSources: async (sources, expectedRevision) => {
-        const catalog = sources.filter(source => !source.builtIn).map(validateCatalogSource)
+        const currentStored = (documents.one(MARKETPLACE_NAMESPACE).value as MarketplaceSettings).sources
+        const catalog: StoredCatalogSource[] = []
+        for (const source of sources.filter(source => !source.builtIn)) {
+          if (source.diagnostic !== undefined) {
+            const index = storedIndexFromRowKey(source.rowKey)
+            const raw = index === undefined ? undefined : currentStored[index]
+            if (typeof raw === 'object' && raw !== null) catalog.push(raw as StoredCatalogSource)
+            continue
+          }
+          catalog.push(validateCatalogSource(source))
+        }
         if (new Set(catalog.map(source => source.id)).size !== catalog.length) {
           throw new Error(ui('Catalog Source id 不能重复', 'Catalog Source IDs must be unique'))
         }

--- a/src/host/marketplace-provider.ts
+++ b/src/host/marketplace-provider.ts
@@ -91,6 +91,7 @@ function normalizeSource(kind: string, source: TuiMarketplaceProviderSource): Tu
     enabled: source.enabled,
     ...(credentialRef === undefined ? {} : { credentialRef }),
     builtIn: true,
+    rowKey: `provider:${source.id}`,
   })
 }
 

--- a/src/host/plugin-marketplace.ts
+++ b/src/host/plugin-marketplace.ts
@@ -90,6 +90,29 @@ function requestInit(
 }
 
 /**
+ * Strip embedded credentials from a URL before it crosses the Host boundary.
+ * @param value - catalog URL or plugin spec that may contain userinfo or secret query keys.
+ */
+export function redactMarketplaceUrl(value: string): string {
+  const prefix = value.startsWith('git+') ? 'git+' : ''
+  const raw = prefix === '' ? value : value.slice(4)
+  if (!/^https?:\/\//i.test(raw)) return value
+  try {
+    const url = new URL(raw)
+    if (url.username !== '' || url.password !== '') {
+      url.username = '***'
+      url.password = ''
+    }
+    for (const key of [...url.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_KEY.test(key)) url.searchParams.set(key, '***')
+    }
+    return `${prefix}${url.toString()}`
+  } catch {
+    return value.replace(/(https?:\/\/)[^\s/@]+@/giu, '$1***@')
+  }
+}
+
+/**
  * Reject a user-visible HTTP spec or Source URL that embeds a Credential.
  * @param value - plugin spec or Catalog URL.
  * @param label - diagnostic subject.

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -278,6 +278,11 @@ export interface TuiMarketplaceSource {
   readonly builtIn: boolean
   /** Present when a stored catalog row failed validation and was kept disabled. */
   readonly diagnostic?: string
+  /**
+   * Stable protocol row identity. Stored catalog rows use `stored:<index>` so
+   * duplicate or invalid ids cannot select the wrong Settings row.
+   */
+  readonly rowKey?: string
 }
 
 /** Marketplace source list with the native Settings revision that produced it. */

--- a/tests/catalog-sources.test.ts
+++ b/tests/catalog-sources.test.ts
@@ -17,6 +17,7 @@ describe('catalog sources (task 6.5)', () => {
       url: 'https://example.com/catalog.json',
       enabled: true,
       builtIn: false,
+      rowKey: 'stored:0',
     }])
   })
 
@@ -31,6 +32,17 @@ describe('catalog sources (task 6.5)', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]?.enabled).toBe(false)
     expect(rows[0]?.diagnostic).toMatch(/Credential|凭证|Secret/u)
+    expect(rows[0]?.url).not.toMatch(/user:secret|secret@/u)
+    expect(rows[0]?.rowKey).toBe('stored:0')
+  })
+
+  it('gives colliding catalog rows distinct rowKeys so later edits do not target the wrong source', () => {
+    const rows = catalogSourcesFromStored([
+      { id: 'dup', label: 'First', url: 'https://example.com/a.json', enabled: true, credentialRef: '' },
+      { id: 'dup', label: 'Second', url: 'https://example.com/b.json', enabled: true, credentialRef: '' },
+    ], new Set(['npm']))
+    expect(rows.map(row => row.rowKey)).toEqual(['stored:0', 'stored:1'])
+    expect(new Set(rows.map(row => row.id)).size).toBe(1)
   })
 
   it('degrades a row that collides with a reserved source id', () => {


### PR DESCRIPTION
## Summary
- Redact userinfo and secret query keys before a degraded catalog URL leaves Host.
- Give every stored row a stable `stored:<index>` rowKey so overlay edits and deletes cannot hit a duplicate id.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/catalog-sources.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vitest run`
- [x] `./node_modules/.bin/tsdown`
- [ ] Do not merge until the review-fix stack is complete
