### PR TITLE
fix(tui): keep EOF newlines in a linear-space line diff

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3125,14 +3125,14 @@ var Text = class {
 		const wrappedLines = wrapTextWithAnsi(this.text.replace(/\t/g, "   "), Math.max(1, width - this.paddingX * 2));
 		const leftMargin = " ".repeat(this.paddingX);
 		const rightMargin = " ".repeat(this.paddingX);
-		const contentLines$1 = [];
+		const contentLines = [];
 		for (const line of wrappedLines) {
 			const lineWithMargins = leftMargin + line + rightMargin;
-			if (this.customBgFn) contentLines$1.push(applyBackgroundToLine(lineWithMargins, width, this.customBgFn));
+			if (this.customBgFn) contentLines.push(applyBackgroundToLine(lineWithMargins, width, this.customBgFn));
 			else {
 				const visibleLen = visibleWidth(lineWithMargins);
 				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines$1.push(lineWithMargins + " ".repeat(paddingNeeded));
+				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
 			}
 		}
 		const emptyLine = " ".repeat(width);
@@ -3143,7 +3143,7 @@ var Text = class {
 		}
 		const result = [
 			...emptyLines,
-			...contentLines$1,
+			...contentLines,
 			...emptyLines
 		];
 		this.cachedText = this.text;
@@ -6862,9 +6862,9 @@ ${currentText}` : currentText;
 			rows: []
 		};
 		if (headers.length !== aligns.length) return;
-		for (const align of aligns) if (this.rules.other.tableAlignRight.test(align)) item.align.push("right");
-		else if (this.rules.other.tableAlignCenter.test(align)) item.align.push("center");
-		else if (this.rules.other.tableAlignLeft.test(align)) item.align.push("left");
+		for (const align$1 of aligns) if (this.rules.other.tableAlignRight.test(align$1)) item.align.push("right");
+		else if (this.rules.other.tableAlignCenter.test(align$1)) item.align.push("center");
+		else if (this.rules.other.tableAlignLeft.test(align$1)) item.align.push("left");
 		else item.align.push(null);
 		for (let i = 0; i < headers.length; i++) item.header.push({
 			text: headers[i],
@@ -8164,18 +8164,18 @@ var Markdown = class {
 		const leftMargin = " ".repeat(this.paddingX);
 		const rightMargin = " ".repeat(this.paddingX);
 		const bgFn = this.defaultTextStyle?.bgColor;
-		const contentLines$1 = [];
+		const contentLines = [];
 		for (const line of wrappedLines) {
 			if (isImageLine(line)) {
-				contentLines$1.push(line);
+				contentLines.push(line);
 				continue;
 			}
 			const lineWithMargins = leftMargin + line + rightMargin;
-			if (bgFn) contentLines$1.push(applyBackgroundToLine(lineWithMargins, width, bgFn));
+			if (bgFn) contentLines.push(applyBackgroundToLine(lineWithMargins, width, bgFn));
 			else {
 				const visibleLen = visibleWidth(lineWithMargins);
 				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines$1.push(lineWithMargins + " ".repeat(paddingNeeded));
+				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
 			}
 		}
 		const emptyLine = " ".repeat(width);
@@ -8186,7 +8186,7 @@ var Markdown = class {
 		}
 		const result = [
 			...emptyLines,
-			...contentLines$1,
+			...contentLines,
 			...emptyLines
 		];
 		this.cachedText = this.text;
@@ -29063,91 +29063,155 @@ function foldLineBlock(text$1, limit) {
 
 //#endregion
 //#region src/client/line-diff.ts
-/** Context-bounded unified hunks for transcript file diffs. */
-const MAX_LCS_CELLS = 25e4;
-function contentLines(text$1) {
-	if (text$1 === "") return [];
-	return (text$1.endsWith("\n") ? text$1.slice(0, -1) : text$1).split("\n");
+/** Context-bounded unified hunks for transcript file diffs. Linear-space LCS. */
+const MAX_LCS_CELLS = 2e6;
+const NO_NEWLINE = "\0NO_NL";
+const NO_NEWLINE_MARK = "\\ No newline at end of file";
+function splitFileLines(text$1) {
+	if (text$1 === "") return {
+		lines: [],
+		eofNewline: false
+	};
+	const eofNewline = text$1.endsWith("\n");
+	return {
+		lines: (eofNewline ? text$1.slice(0, -1) : text$1).split("\n"),
+		eofNewline
+	};
 }
-function lcsEdits(oldLines, newLines) {
-	const n = oldLines.length;
-	const m = newLines.length;
-	if (n * m > MAX_LCS_CELLS) return [...oldLines.map((line, index) => ({
-		kind: "del",
-		line,
-		oldLine: index + 1,
-		newLine: 0
-	})), ...newLines.map((line, index) => ({
-		kind: "add",
-		line,
-		oldLine: 0,
-		newLine: index + 1
-	}))];
-	const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
-	for (let i$1 = n - 1; i$1 >= 0; i$1 -= 1) {
-		const row = dp[i$1];
-		if (row === void 0) continue;
-		for (let j$1 = m - 1; j$1 >= 0; j$1 -= 1) row[j$1] = oldLines[i$1] === newLines[j$1] ? (dp[i$1 + 1]?.[j$1 + 1] ?? 0) + 1 : Math.max(dp[i$1 + 1]?.[j$1] ?? 0, row[j$1 + 1] ?? 0);
+function keyedLines(file) {
+	if (file.lines.length === 0) return [];
+	if (file.eofNewline) return [...file.lines];
+	return [...file.lines.slice(0, -1), `${file.lines.at(-1) ?? ""}${NO_NEWLINE}`];
+}
+function decodeLine(token) {
+	if (token.endsWith(NO_NEWLINE)) return {
+		line: token.slice(0, -6),
+		noNewline: true
+	};
+	return {
+		line: token,
+		noNewline: false
+	};
+}
+function lcsRow(left, right) {
+	const current = new Uint32Array(right.length + 1);
+	for (const token of left) {
+		let last = 0;
+		for (let j = 0; j < right.length; j += 1) {
+			const next = current[j + 1] ?? 0;
+			current[j + 1] = token === right[j] ? last + 1 : Math.max(next, current[j] ?? 0);
+			last = next;
+		}
 	}
-	const edits = [];
-	let i = 0;
-	let j = 0;
+	return current;
+}
+function greedyAlign(left, right) {
+	const ops = [];
+	const used = /* @__PURE__ */ new Set();
+	for (const token of left) {
+		const index = right.findIndex((candidate, j) => !used.has(j) && candidate === token);
+		if (index === -1) {
+			ops.push({
+				kind: "del",
+				...decodeLine(token)
+			});
+			continue;
+		}
+		for (let j = 0; j < index; j += 1) {
+			if (used.has(j)) continue;
+			ops.push({
+				kind: "add",
+				...decodeLine(right[j] ?? "")
+			});
+			used.add(j);
+		}
+		ops.push({
+			kind: "eq",
+			...decodeLine(token)
+		});
+		used.add(index);
+	}
+	for (let j = 0; j < right.length; j += 1) if (!used.has(j)) ops.push({
+		kind: "add",
+		...decodeLine(right[j] ?? "")
+	});
+	return ops;
+}
+function align(left, right) {
+	if (left.length === 0) return right.map((token) => ({
+		kind: "add",
+		...decodeLine(token)
+	}));
+	if (right.length === 0) return left.map((token) => ({
+		kind: "del",
+		...decodeLine(token)
+	}));
+	if (left.length === 1 || right.length === 1) return greedyAlign(left, right);
+	const mid = Math.floor(left.length / 2);
+	const leftPart = left.slice(0, mid);
+	const rightPart = left.slice(mid);
+	const leftScore = lcsRow(leftPart, right);
+	const rightScore = lcsRow([...rightPart].reverse(), [...right].reverse());
+	let split = 0;
+	let best = -1;
+	for (let k = 0; k <= right.length; k += 1) {
+		const score = (leftScore[k] ?? 0) + (rightScore[right.length - k] ?? 0);
+		if (score > best) {
+			best = score;
+			split = k;
+		}
+	}
+	return [...align(leftPart, right.slice(0, split)), ...align(rightPart, right.slice(split))];
+}
+function numberEdits(ops) {
 	let oldLine = 0;
 	let newLine = 0;
-	while (i < n && j < m) if (oldLines[i] === newLines[j]) {
-		oldLine += 1;
+	return ops.map((op) => {
+		if (op.kind === "eq") {
+			oldLine += 1;
+			newLine += 1;
+			return {
+				...op,
+				oldLine,
+				newLine
+			};
+		}
+		if (op.kind === "del") {
+			oldLine += 1;
+			return {
+				...op,
+				oldLine,
+				newLine
+			};
+		}
 		newLine += 1;
-		edits.push({
-			kind: "eq",
-			line: oldLines[i] ?? "",
+		return {
+			...op,
 			oldLine,
 			newLine
-		});
-		i += 1;
-		j += 1;
-	} else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
-		oldLine += 1;
-		edits.push({
-			kind: "del",
-			line: oldLines[i] ?? "",
-			oldLine,
-			newLine
-		});
-		i += 1;
-	} else {
-		newLine += 1;
-		edits.push({
-			kind: "add",
-			line: newLines[j] ?? "",
-			oldLine,
-			newLine
-		});
-		j += 1;
-	}
-	while (i < n) {
-		oldLine += 1;
-		edits.push({
-			kind: "del",
-			line: oldLines[i] ?? "",
-			oldLine,
-			newLine
-		});
-		i += 1;
-	}
-	while (j < m) {
-		newLine += 1;
-		edits.push({
-			kind: "add",
-			line: newLines[j] ?? "",
-			oldLine,
-			newLine
-		});
-		j += 1;
-	}
-	return edits;
+		};
+	});
+}
+function fallbackEdits(oldTokens, newTokens) {
+	return numberEdits([...oldTokens.map((token) => ({
+		kind: "del",
+		...decodeLine(token)
+	})), ...newTokens.map((token) => ({
+		kind: "add",
+		...decodeLine(token)
+	}))]);
+}
+function lcsEdits(oldTokens, newTokens) {
+	if (oldTokens.length * newTokens.length > MAX_LCS_CELLS) return fallbackEdits(oldTokens, newTokens);
+	return numberEdits(align(oldTokens, newTokens));
 }
 function hunkHeader(oldStart, oldCount, newStart, newCount) {
 	return `@@ -${String(oldStart)},${String(oldCount)} +${String(newStart)},${String(newCount)} @@`;
+}
+function formatEdit(edit$1) {
+	const prefix = edit$1.kind === "eq" ? " " : edit$1.kind === "del" ? "-" : "+";
+	if (edit$1.kind !== "eq" && edit$1.noNewline) return [`${prefix}${edit$1.line}`, NO_NEWLINE_MARK];
+	return [`${prefix}${edit$1.line}`];
 }
 /**
 * Emit unified hunks for one file, keeping `context` unchanged lines around each change.
@@ -29157,7 +29221,12 @@ function hunkHeader(oldStart, oldCount, newStart, newCount) {
 */
 function unifiedHunks(oldText, newText, context) {
 	const bounded = Math.max(0, Math.floor(context));
-	const edits = lcsEdits(oldText === null ? [] : contentLines(oldText), contentLines(newText));
+	const oldFile = oldText === null ? {
+		lines: [],
+		eofNewline: true
+	} : splitFileLines(oldText);
+	const newFile = splitFileLines(newText);
+	const edits = lcsEdits(keyedLines(oldFile), keyedLines(newFile));
 	const changeIndexes = edits.flatMap((edit$1, index) => edit$1.kind === "eq" ? [] : [index]);
 	if (changeIndexes.length === 0) return [];
 	const windows = [];
@@ -29175,11 +29244,9 @@ function unifiedHunks(oldText, newText, context) {
 		const slice = edits.slice(start, end);
 		const oldRows = slice.filter((edit$1) => edit$1.kind !== "add");
 		const newRows = slice.filter((edit$1) => edit$1.kind !== "del");
-		return [hunkHeader(oldRows[0]?.oldLine ?? 0, oldRows.length, newRows[0]?.newLine ?? 0, newRows.length), ...slice.map((edit$1) => {
-			if (edit$1.kind === "eq") return ` ${edit$1.line}`;
-			if (edit$1.kind === "del") return `-${edit$1.line}`;
-			return `+${edit$1.line}`;
-		})];
+		const oldStart = oldRows[0]?.oldLine ?? slice[0]?.oldLine ?? 0;
+		const newStart = newRows[0]?.newLine ?? slice[0]?.newLine ?? 0;
+		return [hunkHeader(oldStart, oldRows.length, newStart, newRows.length), ...slice.flatMap(formatEdit)];
 	});
 }
 

--- a/src/client/line-diff.ts
+++ b/src/client/line-diff.ts
@@ -1,85 +1,152 @@
-/** Context-bounded unified hunks for transcript file diffs. */
+/** Context-bounded unified hunks for transcript file diffs. Linear-space LCS. */
 
-const MAX_LCS_CELLS = 250_000
+const MAX_LCS_CELLS = 2_000_000
+const NO_NEWLINE = '\0NO_NL'
+const NO_NEWLINE_MARK = '\\ No newline at end of file'
 
-export function contentLines(text: string): string[] {
-  if (text === '') return []
-  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
+interface FileLines {
+  readonly lines: string[]
+  readonly eofNewline: boolean
 }
 
-interface Edit {
+interface Op {
   readonly kind: 'eq' | 'del' | 'add'
   readonly line: string
+  readonly noNewline: boolean
+}
+
+interface Edit extends Op {
   readonly oldLine: number
   readonly newLine: number
 }
 
-function lcsEdits(oldLines: readonly string[], newLines: readonly string[]): Edit[] {
-  const n = oldLines.length
-  const m = newLines.length
-  if (n * m > MAX_LCS_CELLS) {
-    return [
-      ...oldLines.map((line, index) => ({
-        kind: 'del' as const,
-        line,
-        oldLine: index + 1,
-        newLine: 0,
-      })),
-      ...newLines.map((line, index) => ({
-        kind: 'add' as const,
-        line,
-        oldLine: 0,
-        newLine: index + 1,
-      })),
-    ]
+/**
+ * Split file text into lines, dropping a single trailing newline from the last line.
+ * @param text - raw file body.
+ */
+export function contentLines(text: string): string[] {
+  return splitFileLines(text).lines
+}
+
+function splitFileLines(text: string): FileLines {
+  if (text === '') return { lines: [], eofNewline: false }
+  const eofNewline = text.endsWith('\n')
+  const body = eofNewline ? text.slice(0, -1) : text
+  return { lines: body.split('\n'), eofNewline }
+}
+
+function keyedLines(file: FileLines): string[] {
+  if (file.lines.length === 0) return []
+  if (file.eofNewline) return [...file.lines]
+  return [...file.lines.slice(0, -1), `${file.lines.at(-1) ?? ''}${NO_NEWLINE}`]
+}
+
+function decodeLine(token: string): { readonly line: string; readonly noNewline: boolean } {
+  if (token.endsWith(NO_NEWLINE)) {
+    return { line: token.slice(0, -NO_NEWLINE.length), noNewline: true }
   }
-  const dp: number[][] = Array.from({ length: n + 1 }, () => Array<number>(m + 1).fill(0))
-  for (let i = n - 1; i >= 0; i -= 1) {
-    const row = dp[i]
-    if (row === undefined) continue
-    for (let j = m - 1; j >= 0; j -= 1) {
-      row[j] = oldLines[i] === newLines[j]
-        ? (dp[i + 1]?.[j + 1] ?? 0) + 1
-        : Math.max(dp[i + 1]?.[j] ?? 0, row[j + 1] ?? 0)
+  return { line: token, noNewline: false }
+}
+
+function lcsRow(left: readonly string[], right: readonly string[]): Uint32Array {
+  const current = new Uint32Array(right.length + 1)
+  for (const token of left) {
+    let last = 0
+    for (let j = 0; j < right.length; j += 1) {
+      const next = current[j + 1] ?? 0
+      current[j + 1] = token === right[j]
+        ? last + 1
+        : Math.max(next, current[j] ?? 0)
+      last = next
     }
   }
-  const edits: Edit[] = []
-  let i = 0
-  let j = 0
+  return current
+}
+
+function greedyAlign(left: readonly string[], right: readonly string[]): Op[] {
+  const ops: Op[] = []
+  const used = new Set<number>()
+  for (const token of left) {
+    const index = right.findIndex((candidate, j) => !used.has(j) && candidate === token)
+    if (index === -1) {
+      ops.push({ kind: 'del', ...decodeLine(token) })
+      continue
+    }
+    for (let j = 0; j < index; j += 1) {
+      if (used.has(j)) continue
+      ops.push({ kind: 'add', ...decodeLine(right[j] ?? '') })
+      used.add(j)
+    }
+    ops.push({ kind: 'eq', ...decodeLine(token) })
+    used.add(index)
+  }
+  for (let j = 0; j < right.length; j += 1) {
+    if (!used.has(j)) ops.push({ kind: 'add', ...decodeLine(right[j] ?? '') })
+  }
+  return ops
+}
+
+function align(left: readonly string[], right: readonly string[]): Op[] {
+  if (left.length === 0) return right.map(token => ({ kind: 'add' as const, ...decodeLine(token) }))
+  if (right.length === 0) return left.map(token => ({ kind: 'del' as const, ...decodeLine(token) }))
+  if (left.length === 1 || right.length === 1) return greedyAlign(left, right)
+  const mid = Math.floor(left.length / 2)
+  const leftPart = left.slice(0, mid)
+  const rightPart = left.slice(mid)
+  const leftScore = lcsRow(leftPart, right)
+  const rightScore = lcsRow([...rightPart].reverse(), [...right].reverse())
+  let split = 0
+  let best = -1
+  for (let k = 0; k <= right.length; k += 1) {
+    const score = (leftScore[k] ?? 0) + (rightScore[right.length - k] ?? 0)
+    if (score > best) {
+      best = score
+      split = k
+    }
+  }
+  return [...align(leftPart, right.slice(0, split)), ...align(rightPart, right.slice(split))]
+}
+
+function numberEdits(ops: readonly Op[]): Edit[] {
   let oldLine = 0
   let newLine = 0
-  while (i < n && j < m) {
-    if (oldLines[i] === newLines[j]) {
+  return ops.map((op) => {
+    if (op.kind === 'eq') {
       oldLine += 1
       newLine += 1
-      edits.push({ kind: 'eq', line: oldLines[i] ?? '', oldLine, newLine })
-      i += 1
-      j += 1
-    } else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
-      oldLine += 1
-      edits.push({ kind: 'del', line: oldLines[i] ?? '', oldLine, newLine })
-      i += 1
-    } else {
-      newLine += 1
-      edits.push({ kind: 'add', line: newLines[j] ?? '', oldLine, newLine })
-      j += 1
+      return { ...op, oldLine, newLine }
     }
-  }
-  while (i < n) {
-    oldLine += 1
-    edits.push({ kind: 'del', line: oldLines[i] ?? '', oldLine, newLine })
-    i += 1
-  }
-  while (j < m) {
+    if (op.kind === 'del') {
+      oldLine += 1
+      return { ...op, oldLine, newLine }
+    }
     newLine += 1
-    edits.push({ kind: 'add', line: newLines[j] ?? '', oldLine, newLine })
-    j += 1
-  }
-  return edits
+    return { ...op, oldLine, newLine }
+  })
+}
+
+function fallbackEdits(oldTokens: readonly string[], newTokens: readonly string[]): Edit[] {
+  return numberEdits([
+    ...oldTokens.map(token => ({ kind: 'del' as const, ...decodeLine(token) })),
+    ...newTokens.map(token => ({ kind: 'add' as const, ...decodeLine(token) })),
+  ])
+}
+
+function lcsEdits(oldTokens: readonly string[], newTokens: readonly string[]): Edit[] {
+  const n = oldTokens.length
+  const m = newTokens.length
+  if (n * m > MAX_LCS_CELLS) return fallbackEdits(oldTokens, newTokens)
+  return numberEdits(align(oldTokens, newTokens))
 }
 
 function hunkHeader(oldStart: number, oldCount: number, newStart: number, newCount: number): string {
   return `@@ -${String(oldStart)},${String(oldCount)} +${String(newStart)},${String(newCount)} @@`
+}
+
+function formatEdit(edit: Edit): string[] {
+  const prefix = edit.kind === 'eq' ? ' ' : edit.kind === 'del' ? '-' : '+'
+  if (edit.kind !== 'eq' && edit.noNewline) return [`${prefix}${edit.line}`, NO_NEWLINE_MARK]
+  return [`${prefix}${edit.line}`]
 }
 
 /**
@@ -90,7 +157,9 @@ function hunkHeader(oldStart: number, oldCount: number, newStart: number, newCou
  */
 export function unifiedHunks(oldText: string | null, newText: string, context: number): string[] {
   const bounded = Math.max(0, Math.floor(context))
-  const edits = lcsEdits(oldText === null ? [] : contentLines(oldText), contentLines(newText))
+  const oldFile = oldText === null ? { lines: [], eofNewline: true } : splitFileLines(oldText)
+  const newFile = splitFileLines(newText)
+  const edits = lcsEdits(keyedLines(oldFile), keyedLines(newFile))
   const changeIndexes = edits.flatMap((edit, index) => edit.kind === 'eq' ? [] : [index])
   if (changeIndexes.length === 0) return []
   const windows: Array<{ start: number; end: number }> = []
@@ -105,19 +174,11 @@ export function unifiedHunks(oldText: string | null, newText: string, context: n
     const slice = edits.slice(start, end)
     const oldRows = slice.filter(edit => edit.kind !== 'add')
     const newRows = slice.filter(edit => edit.kind !== 'del')
-    const lines = [
-      hunkHeader(
-        oldRows[0]?.oldLine ?? 0,
-        oldRows.length,
-        newRows[0]?.newLine ?? 0,
-        newRows.length,
-      ),
-      ...slice.map((edit) => {
-        if (edit.kind === 'eq') return ` ${edit.line}`
-        if (edit.kind === 'del') return `-${edit.line}`
-        return `+${edit.line}`
-      }),
+    const oldStart = oldRows[0]?.oldLine ?? slice[0]?.oldLine ?? 0
+    const newStart = newRows[0]?.newLine ?? slice[0]?.newLine ?? 0
+    return [
+      hunkHeader(oldStart, oldRows.length, newStart, newRows.length),
+      ...slice.flatMap(formatEdit),
     ]
-    return lines
   })
 }

--- a/tests/line-diff.test.ts
+++ b/tests/line-diff.test.ts
@@ -16,10 +16,45 @@ describe('unified hunks (task 8 leftover: diff context lines)', () => {
   })
 
   it('treats a missing old file as all additions', () => {
-    expect(unifiedHunks(null, 'one\ntwo', 3).join('\n')).toBe([
+    expect(unifiedHunks(null, 'one\ntwo\n', 3).join('\n')).toBe([
       '@@ -0,0 +1,2 @@',
       '+one',
       '+two',
     ].join('\n'))
+  })
+
+  it('does not drop a final-newline-only change', () => {
+    const hunks = unifiedHunks('a\n', 'a', 0).join('\n')
+    expect(hunks).not.toBe('')
+    expect(hunks).toContain('-a')
+    expect(hunks).toContain('+a')
+    expect(hunks).toContain('No newline at end of file')
+  })
+
+  it('uses a non-zero old start for a mid-file insert when context is 0', () => {
+    const hunks = unifiedHunks('a\nb\n', 'a\nINSERTED\nb\n', 0)
+    expect(hunks[0]).toBe('@@ -1,0 +2,1 @@')
+    expect(hunks.join('\n')).toContain('+INSERTED')
+  })
+
+  it('uses a non-zero new start for a mid-file delete when context is 0', () => {
+    const hunks = unifiedHunks('a\nGONE\nb\n', 'a\nb\n', 0)
+    expect(hunks[0]).toBe('@@ -2,1 +1,0 @@')
+    expect(hunks.join('\n')).toContain('-GONE')
+  })
+
+  it('diffs an empty file against a new line', () => {
+    expect(unifiedHunks('', 'hello\n', 0).join('\n')).toBe([
+      '@@ -0,0 +1,1 @@',
+      '+hello',
+    ].join('\n'))
+  })
+
+  it('falls back on oversized inputs instead of allocating a full LCS table', () => {
+    const oldText = `${Array.from({ length: 3000 }, (_, index) => `o${String(index)}`).join('\n')}\n`
+    const newText = `${Array.from({ length: 3000 }, (_, index) => `n${String(index)}`).join('\n')}\n`
+    const hunks = unifiedHunks(oldText, newText, 0)
+    expect(hunks[0]).toBe('@@ -1,3000 +1,3000 @@')
+    expect(hunks).toHaveLength(6001)
   })
 })


### PR DESCRIPTION
## Summary
- Replace the quadratic LCS table with Hirschberg (linear space) and a size fallback.
- Preserve end-of-file newline changes and emit non-zero hunk starts for context-0 inserts and deletes.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/line-diff.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vitest run`
- [x] `./node_modules/.bin/tsdown`
- [ ] Do not merge until the review-fix stack is complete
