### PR TITLE
fix(tui): keep nested overlay Escape from aborting the session

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28125,8 +28125,12 @@ var NavigationOverlay = class {
 		const current = this.current();
 		if (current === void 0) return;
 		if (matchesKey(data, Key.escape)) {
-			this.abort();
-			if (current.busy) this.pendingBack = current;
+			if (current.busy) {
+				this.abort();
+				this.pendingBack = current;
+				return;
+			}
+			if (this.stack.length <= 1) this.finish();
 			else this.back();
 			return;
 		}

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -631,8 +631,12 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     const current = this.current()
     if (current === undefined) return
     if (matchesKey(data, Key.escape)) {
-      this.abort()
-      if (current.busy) this.pendingBack = current
+      if (current.busy) {
+        this.abort()
+        this.pendingBack = current
+        return
+      }
+      if (this.stack.length <= 1) this.finish()
       else this.back()
       return
     }

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -65,6 +65,35 @@ describe('overlay navigation', () => {
     expect(harness.hide).toHaveBeenCalledOnce()
   })
 
+  it('keeps the navigation signal live when Escape only returns from a child page', async () => {
+    const harness = overlayHarness()
+    let signal: AbortSignal | undefined
+    const session = harness.overlays.navigate(async (navigation) => {
+      signal = navigation.signal
+      await navigation.selectPage({
+        title: 'root page',
+        choices: [{ id: 'child', label: 'open child' }],
+      }, async () => {
+        await navigation.selectPage({
+          title: 'child page',
+          choices: [{ id: 'noop', label: 'stay here' }],
+        }, () => undefined)
+      })
+    })
+
+    harness.component().handleInput(ENTER)
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('child page')
+    })
+    harness.component().handleInput(ESCAPE)
+    expect(plain(harness.component().render(80))).toContain('root page')
+    expect(signal?.aborted).toBe(false)
+
+    harness.component().handleInput(ESCAPE)
+    await expect(session).resolves.toBeUndefined()
+    expect(signal?.aborted).toBe(true)
+  })
+
   it('treats Escape as Back even when a searchable page contains a query', async () => {
     const harness = overlayHarness()
     const selected = harness.overlays.select({


### PR DESCRIPTION
## Summary
- Nested overlay Escape now only returns to the parent page and leaves `navigation.signal` live.
- Busy-page Escape and closing the last page still abort the session, matching the Strengths.md #46 contract.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/overlays-navigation.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
