### PR TITLE
fix(tui): do not cache marketplace search as a failure on abort

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DbTu1PjP.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
-import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-CUo0j988.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-MwEmc33l.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
 import { c as ui } from "./locale-DbTu1PjP.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CUo0j988.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-MwEmc33l.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-MwEmc33l.js
+++ b/lib/plugin-marketplace-MwEmc33l.js
@@ -291,6 +291,7 @@ var PluginMarketplace = class {
 			if (source.kind === "catalog") return await this.searchCatalog(text, source, signal);
 			return await this.searchProvider(text, source, sources, signal);
 		}));
+		if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : new DOMException("The operation was aborted.", "AbortError");
 		const deduped = /* @__PURE__ */ new Map();
 		for (const [index, result$1] of settled.entries()) {
 			const source = enabled[index];

--- a/src/host/plugin-marketplace.ts
+++ b/src/host/plugin-marketplace.ts
@@ -447,6 +447,9 @@ export class PluginMarketplace {
       if (source.kind === 'catalog') return await this.searchCatalog(text, source, signal)
       return await this.searchProvider(text, source, sources, signal)
     }))
+    if (signal?.aborted) {
+      throw signal.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted.', 'AbortError')
+    }
     const deduped = new Map<string, TuiMarketplaceCandidate>()
     for (const [index, result] of settled.entries()) {
       const source = enabled[index]

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -171,6 +171,44 @@ describe('plugin marketplace search (task 5.3)', () => {
     expect(rows[0]?.diagnostics.join(' ')).toMatch(/aborted|timeout/iu)
   })
 
+  it('rethrows user abort instead of caching a source-failure diagnostic', async () => {
+    const controller = new AbortController()
+    let searches = 0
+    let started!: () => void
+    const ready = new Promise<void>(resolve => { started = resolve })
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input, init) => {
+        const url = String(input)
+        if (!url.includes('/-/v1/search')) throw new Error(`unexpected fetch ${url}`)
+        searches += 1
+        if (searches === 1) {
+          started()
+          return await new Promise<Response>((_resolve, reject) => {
+            const fail = () => reject(init?.signal?.reason ?? new Error('aborted'))
+            if (init?.signal?.aborted) {
+              fail()
+              return
+            }
+            init?.signal?.addEventListener('abort', fail, { once: true })
+          })
+        }
+        return jsonResponse(searchBody())
+      }) as typeof fetch,
+    })
+    const pending = marketplace.search('demo', [source], controller.signal)
+    await ready
+    controller.abort(new DOMException('The operation was aborted.', 'AbortError'))
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+
+    const rows = await marketplace.search('demo', [source])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.name).toBe('demo-plugin')
+    expect(rows[0]?.diagnostics ?? []).not.toContainEqual(expect.stringMatching(/Source failed|来源失败/u))
+    expect(searches).toBe(2)
+  })
+
   it('keeps successful sources when another catalog source fails', async () => {
     const catalog: TuiMarketplaceSource = {
       id: 'bad-catalog',


### PR DESCRIPTION
## Summary
- Marketplace `search()` now rethrows the user abort reason after `allSettled` instead of turning cancel into a Source-failed diagnostic.
- Aborted searches are not written to the search cache, matching Strengths.md #47.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/plugin-marketplace.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
