### PR TITLE
fix(tui): match startup timeouts on a stable 超时 mark

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19723,11 +19723,22 @@ function flattenProducedFiles(groups) {
 
 //#endregion
 //#region src/client/error-advice.ts
-/** Host timeout copy stays Chinese so matching does not follow the UI locale. */
-const TIMEOUT_MARK = { zh: "超时" };
+/** Stable Chinese machine mark for startup timeouts; matching must not follow the UI locale. */
+const STARTUP_TIMEOUT = {
+	zh: "超时",
+	en: "timed out"
+};
+const STARTUP_TIMEOUT_MARK = STARTUP_TIMEOUT.zh;
 function unwrapTransport(message) {
 	const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message);
 	return match === null ? void 0 : match[1]?.trim();
+}
+/**
+* Build the language-agnostic timeout Error thrown by snapshot waits.
+* @param label - startup phase already chosen by the caller.
+*/
+function startupTimeoutError(label) {
+	return /* @__PURE__ */ new Error(`${label}${STARTUP_TIMEOUT_MARK}`);
 }
 /**
 * Combine installer streams so pnpm PATH warnings survive a non-zero exit.
@@ -19748,7 +19759,7 @@ function pluginFailureDetail(result) {
 function explainFailure(message) {
 	const inner = unwrapTransport(message);
 	if (inner !== void 0) return ui(`内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`, `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`);
-	if (message.includes(TIMEOUT_MARK.zh) && message.includes("/doctor")) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
+	if (message.includes(STARTUP_TIMEOUT_MARK)) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "").replace(/。下一步：.*$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
 	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui(`${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`, `${message}\nNext: install pnpm, keep it on PATH, then retry.`);
 	if (/\bENOENT\b/u.test(message)) return ui(`${message}\n下一步：确认路径存在且当前进程有权读取。`, `${message}\nNext: confirm the path exists and this process can read it.`);
 	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui(`${message}\n下一步：检查文件权限，或换一个可写目录。`, `${message}\nNext: check file permissions, or use a writable directory.`);
@@ -21192,7 +21203,7 @@ function waitForSnapshot(source, accepts, label) {
 			if (settled) return;
 			settled = true;
 			unsubscribe();
-			reject(new Error(ui(`${label}超时。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek`, `${label} timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again`)));
+			reject(startupTimeoutError(label));
 		}, STARTUP_TIMEOUT_MS);
 		unsubscribe = source.subscribe(() => {
 			const snapshot = source.getSnapshot();
@@ -21280,6 +21291,7 @@ async function startTuiClient(options$1) {
 		};
 	} catch (error) {
 		await ctx.fiber.dispose();
+		if (error instanceof Error) throw new Error(explainFailure(error.message), { cause: error });
 		throw error;
 	}
 }

--- a/src/client/client-runtime.ts
+++ b/src/client/client-runtime.ts
@@ -31,6 +31,7 @@ import {
 } from '../dsh-compat.ts'
 import { measureStartup } from '../startup-trace.ts'
 import { ui } from './locale.ts'
+import { explainFailure, startupTimeoutError } from './error-advice.ts'
 
 const STARTUP_TIMEOUT_MS = 20_000
 
@@ -78,10 +79,7 @@ export function waitForSnapshot<T>(
       if (settled) return
       settled = true
       unsubscribe()
-      reject(new Error(ui(
-        `${label}超时。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek`,
-        `${label} timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again`,
-      )))
+      reject(startupTimeoutError(label))
     }, STARTUP_TIMEOUT_MS)
     const registeredUnsubscribe = source.subscribe(() => {
       const snapshot = source.getSnapshot()
@@ -227,6 +225,7 @@ export async function startTuiClient(
     }
   } catch (error) {
     await ctx.fiber.dispose()
+    if (error instanceof Error) throw new Error(explainFailure(error.message), { cause: error })
     throw error
   }
 }

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -2,8 +2,9 @@
 
 import { ui } from './locale.ts'
 
-/** Host timeout copy stays Chinese so matching does not follow the UI locale. */
-const TIMEOUT_MARK = { zh: '超时' }
+/** Stable Chinese machine mark for startup timeouts; matching must not follow the UI locale. */
+const STARTUP_TIMEOUT = { zh: '超时', en: 'timed out' } as const
+export const STARTUP_TIMEOUT_MARK = STARTUP_TIMEOUT.zh
 
 export interface PluginFailureOutput {
   readonly stderr: string
@@ -14,6 +15,14 @@ export interface PluginFailureOutput {
 function unwrapTransport(message: string): string | undefined {
   const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message)
   return match === null ? undefined : match[1]?.trim()
+}
+
+/**
+ * Build the language-agnostic timeout Error thrown by snapshot waits.
+ * @param label - startup phase already chosen by the caller.
+ */
+export function startupTimeoutError(label: string): Error {
+  return new Error(`${label}${STARTUP_TIMEOUT_MARK}`)
 }
 
 /**
@@ -39,9 +48,9 @@ export function explainFailure(message: string): string {
       `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`,
     )
   }
-  if (message.includes(TIMEOUT_MARK.zh) && message.includes('/doctor')) {
+  if (message.includes(STARTUP_TIMEOUT_MARK)) {
     return ui(
-      `${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, '')}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`,
+      `${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, '').replace(/。下一步：.*$/u, '')}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`,
       'Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
     )
   }

--- a/tests/error-advice.test.ts
+++ b/tests/error-advice.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { explainFailure, pluginFailureDetail } from '../src/client/error-advice.ts'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { explainFailure, pluginFailureDetail, startupTimeoutError } from '../src/client/error-advice.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+afterEach(() => { setUiLocale('zh') })
 
 describe('actionable failure text', () => {
   it('unwraps in-process transport failures and keeps installer warnings', () => {
@@ -7,10 +14,23 @@ describe('actionable failure text', () => {
     expect(explainFailure('transport failure for /api/foo: handler failure: boom')).toContain('下一步')
     expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).not.toContain('/doctor')
     expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).toContain('重新运行 deepseek')
+    expect(explainFailure('读取工作区与会话超时')).toContain('重新运行 deepseek')
     expect(pluginFailureDetail({
       stderr: '',
       stdout: '',
       warnings: ['pnpm 不在 PATH 中；请安装 pnpm 后重试'],
     })).toContain('pnpm 不在 PATH')
+  })
+
+  it('localizes a stable 超时 machine mark instead of English timed-out copy', () => {
+    setUiLocale('en')
+    const message = startupTimeoutError('Reading workspace').message
+    expect(message).toContain('超时')
+    const explained = explainFailure(message)
+    expect(explained).toContain('Startup timed out')
+    expect(explained).not.toMatch(/\p{Script=Han}/u)
+    const source = readFileSync(resolve(root, 'src/client/client-runtime.ts'), 'utf8')
+    expect(source).toMatch(/startupTimeoutError\(label\)/u)
+    expect(source).not.toMatch(/reject\(new Error\(ui\(/u)
   })
 })


### PR DESCRIPTION
## Summary
- `waitForSnapshot` now throws a machine error containing the stable `超时` mark instead of locale-dependent `timed out` copy.
- `explainFailure()` localizes that mark for the user, so English startup timeouts hit the dedicated advice branch (Strengths.md #56/#63).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/error-advice.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
