### PR TITLE
fix(tui): keep Settings conflict errors language-agnostic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9105,10 +9105,7 @@ var TuiSettingsConflictError = class extends Error {
 	* @param actual - current Host revision.
 	*/
 	constructor(namespace, expected, actual) {
-		super({
-			zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
-			en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`
-		}.zh);
+		super(`TUI_SETTINGS_CONFLICT ${JSON.stringify(namespace)} expected=${String(expected)} actual=${String(actual)}`);
 		this.namespace = namespace;
 		this.expected = expected;
 		this.actual = actual;
@@ -21170,6 +21167,7 @@ var HarnessTuiCapabilities = class {
 * @returns a safe user-facing failure message.
 */
 function capabilityError(error) {
+	if (error instanceof TuiSettingsConflictError) return ui(`设置 ${JSON.stringify(error.namespace)} 已在其他界面更新（期望 revision ${String(error.expected)}，当前 ${String(error.actual)}）`, `Settings ${JSON.stringify(error.namespace)} was updated in another surface (expected revision ${String(error.expected)}, actual ${String(error.actual)})`);
 	return explainFailure(messageOf(error));
 }
 

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -37,6 +37,7 @@ import type {
   MessageFeedbackVersion,
 } from '@deepseek-ai/dsh-message-feedback/types'
 import type { TrajectorySnapshot } from '@deepseek-ai/dsh-client-ui-trajectory/projection'
+import { TuiSettingsConflictError } from '@deepseek-ai/dsh-tui-protocol'
 import type { TuiManagementBridge } from './management.ts'
 import type { TuiClientContext } from './context.ts'
 import { copyTargets } from './copy-content.ts'
@@ -1662,5 +1663,11 @@ export class HarnessTuiCapabilities {
  * @returns a safe user-facing failure message.
  */
 export function capabilityError(error: unknown): string {
+  if (error instanceof TuiSettingsConflictError) {
+    return ui(
+      `设置 ${JSON.stringify(error.namespace)} 已在其他界面更新（期望 revision ${String(error.expected)}，当前 ${String(error.actual)}）`,
+      `Settings ${JSON.stringify(error.namespace)} was updated in another surface (expected revision ${String(error.expected)}, actual ${String(error.actual)})`,
+    )
+  }
   return explainFailure(messageOf(error))
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -191,10 +191,9 @@ export class TuiSettingsConflictError extends Error {
     readonly expected: number,
     readonly actual: number,
   ) {
-    super(({
-      zh: `设置 ${JSON.stringify(namespace)} 已在其他界面更新（期望 revision ${String(expected)}，当前 ${String(actual)}）`,
-      en: `Settings ${JSON.stringify(namespace)} was updated in another surface (expected revision ${String(expected)}, actual ${String(actual)})`,
-    }).zh)
+    super(
+      `TUI_SETTINGS_CONFLICT ${JSON.stringify(namespace)} expected=${String(expected)} actual=${String(actual)}`,
+    )
     this.name = 'TuiSettingsConflictError'
   }
 }

--- a/tests/settings-conflict.test.ts
+++ b/tests/settings-conflict.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { TuiSettingsConflictError } from '../src/protocol.ts'
+import { capabilityError } from '../src/client/capabilities.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('settings conflict protocol copy (review #64)', () => {
+  it('keeps the Error message language-agnostic and localizes at the client boundary', () => {
+    const error = new TuiSettingsConflictError('seektty-behavior', 3, 5)
+    expect(error.code).toBe('TUI_SETTINGS_CONFLICT')
+    expect(error.message).not.toMatch(/\p{Script=Han}/u)
+    expect(error.message).toContain('seektty-behavior')
+    expect(error.message).toContain('3')
+    expect(error.message).toContain('5')
+
+    setUiLocale('en')
+    const english = capabilityError(error)
+    expect(english).toContain('another surface')
+    expect(english).toContain('seektty-behavior')
+    expect(english).not.toMatch(/\p{Script=Han}/u)
+
+    setUiLocale('zh')
+    expect(capabilityError(error)).toContain('其他界面')
+  })
+})


### PR DESCRIPTION
## Summary
- `TuiSettingsConflictError` now carries a language-agnostic machine message plus `code`/`namespace`/`expected`/`actual`.
- `capabilityError()` localizes from those fields so English chrome is reachable (Strengths.md #64).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/settings-conflict.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
