### PR TITLE
fix(tui): keep Settings descriptions and pnpm PATH warnings bilingual

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DbTu1PjP.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-MwEmc33l.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-CHRGVEzL.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";
@@ -19757,7 +19757,7 @@ function explainFailure(message) {
 	const inner = unwrapTransport(message);
 	if (inner !== void 0) return ui(`内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`, `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`);
 	if (message.includes(STARTUP_TIMEOUT_MARK)) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "").replace(/。下一步：.*$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
-	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui(`${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`, `${message}\nNext: install pnpm, keep it on PATH, then retry.`);
+	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui("pnpm 不在 PATH 中；请安装 pnpm 后重试。下一步：安装 pnpm 并确保它在 PATH 中，然后重试。", "pnpm is not on PATH; install pnpm and retry.\nNext: install pnpm, keep it on PATH, then retry.");
 	if (/\bENOENT\b/u.test(message)) return ui(`${message}\n下一步：确认路径存在且当前进程有权读取。`, `${message}\nNext: confirm the path exists and this process can read it.`);
 	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui(`${message}\n下一步：检查文件权限，或换一个可写目录。`, `${message}\nNext: check file permissions, or use a writable directory.`);
 	return message;
@@ -31856,31 +31856,76 @@ const CustomThemeSchema = z$1.object({
 	syntax: SyntaxThemeColorsSchema,
 	tokenColors: z$1.array(TextMateRuleSchema).max(MAX_TEXTMATE_RULES).default([])
 });
+function localeDescription(copy) {
+	return copy;
+}
 const AppearanceSettingsSchema = z$1.object({
-	theme: z$1.string().pattern(/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_THEME).description(ui("SeekTTY 当前使用的界面主题。", "The interface theme currently used by SeekTTY.")),
-	codeTheme: z$1.string().pattern(/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_CODE_THEME).description(ui("代码块独立主题；auto 跟随当前界面主题。", "Independent code-block theme; auto follows the current interface theme.")),
-	customThemes: z$1.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([]).description(ui("SeekTTY 命名自定义主题。", "Named custom SeekTTY themes."))
+	theme: z$1.string().pattern(/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_THEME).description(localeDescription({
+		zh: "SeekTTY 当前使用的界面主题。",
+		en: "The interface theme currently used by SeekTTY."
+	})),
+	codeTheme: z$1.string().pattern(/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_CODE_THEME).description(localeDescription({
+		zh: "代码块独立主题；auto 跟随当前界面主题。",
+		en: "Independent code-block theme; auto follows the current interface theme."
+	})),
+	customThemes: z$1.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([]).description(localeDescription({
+		zh: "SeekTTY 命名自定义主题。",
+		en: "Named custom SeekTTY themes."
+	}))
 });
 const BehaviorSettingsSchema = z$1.object({
 	toolCards: z$1.union([
 		"collapsed",
 		"expanded",
 		"hidden"
-	]).default(DEFAULT_TUI_BEHAVIOR.toolCards).description(ui("工具卡片默认形态；启动时应用到当前会话。", "Default tool-card shape; applied to the current session at startup.")),
-	showReasoning: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.showReasoning).description(ui("推理内容默认是否显示。", "Whether reasoning is shown by default.")),
-	desktopNotifications: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.desktopNotifications).description(ui("回合完成或待审批时发送终端桌面通知。", "Send a desktop notification when a turn completes or an approval is pending.")),
-	followTerminalTitle: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.followTerminalTitle).description(ui("终端标题跟随当前会话运行状态。", "Follow the current session status in the terminal title.")),
-	composerHistoryLimit: z$1.natural().max(MAX_COMPOSER_HISTORY).default(DEFAULT_TUI_BEHAVIOR.composerHistoryLimit).description(ui("输入历史持久化条数；0 表示关闭。", "Number of persisted composer history entries; 0 disables history.")),
-	statusElapsed: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.statusElapsed).description(ui("状态栏显示当前回合实时耗时。", "Show live elapsed time for the current turn in the status bar.")),
+	]).default(DEFAULT_TUI_BEHAVIOR.toolCards).description(localeDescription({
+		zh: "工具卡片默认形态；启动时应用到当前会话。",
+		en: "Default tool-card shape; applied to the current session at startup."
+	})),
+	showReasoning: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.showReasoning).description(localeDescription({
+		zh: "推理内容默认是否显示。",
+		en: "Whether reasoning is shown by default."
+	})),
+	desktopNotifications: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.desktopNotifications).description(localeDescription({
+		zh: "回合完成或待审批时发送终端桌面通知。",
+		en: "Send a desktop notification when a turn completes or an approval is pending."
+	})),
+	followTerminalTitle: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.followTerminalTitle).description(localeDescription({
+		zh: "终端标题跟随当前会话运行状态。",
+		en: "Follow the current session status in the terminal title."
+	})),
+	composerHistoryLimit: z$1.natural().max(MAX_COMPOSER_HISTORY).default(DEFAULT_TUI_BEHAVIOR.composerHistoryLimit).description(localeDescription({
+		zh: "输入历史持久化条数；0 表示关闭。",
+		en: "Number of persisted composer history entries; 0 disables history."
+	})),
+	statusElapsed: z$1.boolean().default(DEFAULT_TUI_BEHAVIOR.statusElapsed).description(localeDescription({
+		zh: "状态栏显示当前回合实时耗时。",
+		en: "Show live elapsed time for the current turn in the status bar."
+	})),
 	clipboardFallback: z$1.union([
 		"auto",
 		"osc52",
 		"off"
-	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description(ui("OSC 52 失败后的剪贴板回退命令；auto 按平台探测。", "Clipboard fallback after OSC 52 fails; auto probes the platform.")),
-	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description(ui("展开态工具输出单块行数上限；0 表示不折叠。", "Line cap for one expanded tool-output block; 0 means no folding.")),
-	diffContextLines: z$1.natural().max(MAX_DIFF_CONTEXT_LINES).default(DEFAULT_TUI_BEHAVIOR.diffContextLines).description(ui("Diff 上下文行数。", "Number of diff context lines.")),
-	dangerConfirmDefault: z$1.union(["cancel", "confirm"]).default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault).description(ui("危险确认默认焦点；cancel 表示回车不执行。", "Default focus for danger confirmation; cancel means Enter does not proceed.")),
-	keyBindings: z$1.dict(z$1.string()).default({}).description(ui("覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。", "Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults."))
+	]).default(DEFAULT_TUI_BEHAVIOR.clipboardFallback).description(localeDescription({
+		zh: "OSC 52 失败后的剪贴板回退命令；auto 按平台探测。",
+		en: "Clipboard fallback after OSC 52 fails; auto probes the platform."
+	})),
+	toolOutputLineLimit: z$1.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT).default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit).description(localeDescription({
+		zh: "展开态工具输出单块行数上限；0 表示不折叠。",
+		en: "Line cap for one expanded tool-output block; 0 means no folding."
+	})),
+	diffContextLines: z$1.natural().max(MAX_DIFF_CONTEXT_LINES).default(DEFAULT_TUI_BEHAVIOR.diffContextLines).description(localeDescription({
+		zh: "Diff 上下文行数。",
+		en: "Number of diff context lines."
+	})),
+	dangerConfirmDefault: z$1.union(["cancel", "confirm"]).default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault).description(localeDescription({
+		zh: "危险确认默认焦点；cancel 表示回车不执行。",
+		en: "Default focus for danger confirmation; cancel means Enter does not proceed."
+	})),
+	keyBindings: z$1.dict(z$1.string()).default({}).description(localeDescription({
+		zh: "覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。",
+		en: "Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults."
+	}))
 });
 const ComposerHistorySettingsSchema = z$1.object({ entries: z$1.array(z$1.string().max(1e5)).max(MAX_COMPOSER_HISTORY).default([]) });
 function settingsDocument(descriptor) {

--- a/lib/startup-CHRGVEzL.js
+++ b/lib/startup-CHRGVEzL.js
@@ -729,7 +729,10 @@ var ProfilePluginManager = class {
 		return `${match.groups.prefix ?? ""}${resolve(this.invokingCwd, match.groups.path)}`;
 	}
 	failureWarnings(command, exitCode) {
-		if (exitCode === 127) return [ui("pnpm 不在 PATH 中；请安装 pnpm 后重试", "pnpm is not on PATH; install pnpm and retry")];
+		if (exitCode === 127) return [{
+			zh: "pnpm 不在 PATH 中；请安装 pnpm 后重试",
+			en: "pnpm is not on PATH; install pnpm and retry"
+		}.zh];
 		const warnings = [ui(`pnpm 在 Profile 目录 ${this.dir} 中失败，退出码 ${exitCode}`, `pnpm failed in Profile directory ${this.dir} with exit code ${exitCode}`)];
 		if (command.some((argument) => /^git\+|^github:|\.git(?:#|$)/.test(argument))) warnings.push(ui(`Git 插件的 prepare/install 脚本可能需要在 ${join(this.dir, "pnpm-workspace.yaml")} 的 allowBuilds 中明确授权`, `prepare/install scripts for a Git plugin may need an explicit allowBuilds entry in ${join(this.dir, "pnpm-workspace.yaml")}`));
 		return warnings;

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
 import "./locale-DbTu1PjP.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-tM5WVZUh.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-CHRGVEzL.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -56,8 +56,8 @@ export function explainFailure(message: string): string {
   }
   if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) {
     return ui(
-      `${message}\n下一步：安装 pnpm 并确保它在 PATH 中，然后重试。`,
-      `${message}\nNext: install pnpm, keep it on PATH, then retry.`,
+      'pnpm 不在 PATH 中；请安装 pnpm 后重试。下一步：安装 pnpm 并确保它在 PATH 中，然后重试。',
+      'pnpm is not on PATH; install pnpm and retry.\nNext: install pnpm, keep it on PATH, then retry.',
     )
   }
   if (/\bENOENT\b/u.test(message)) {

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -108,75 +108,91 @@ const CustomThemeSchema = z.object({
   syntax: SyntaxThemeColorsSchema,
   tokenColors: z.array(TextMateRuleSchema).max(MAX_TEXTMATE_RULES).default([]),
 })
-const AppearanceSettingsSchema = z.object({
+function localeDescription(copy: { readonly zh: string; readonly en: string }): string {
+  return copy as unknown as string
+}
+
+export const AppearanceSettingsSchema = z.object({
   theme: z.string().pattern(/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u)
     .default(DEFAULT_TUI_THEME)
-    .description(ui('SeekTTY 当前使用的界面主题。', 'The interface theme currently used by SeekTTY.')),
+    .description(localeDescription({
+      zh: 'SeekTTY 当前使用的界面主题。',
+      en: 'The interface theme currently used by SeekTTY.',
+    })),
   codeTheme: z.string().pattern(/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u)
     .default(DEFAULT_TUI_CODE_THEME)
-    .description(ui(
-      '代码块独立主题；auto 跟随当前界面主题。',
-      'Independent code-block theme; auto follows the current interface theme.',
-    )),
+    .description(localeDescription({
+      zh: '代码块独立主题；auto 跟随当前界面主题。',
+      en: 'Independent code-block theme; auto follows the current interface theme.',
+    })),
   customThemes: z.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([])
-    .description(ui('SeekTTY 命名自定义主题。', 'Named custom SeekTTY themes.')),
+    .description(localeDescription({
+      zh: 'SeekTTY 命名自定义主题。',
+      en: 'Named custom SeekTTY themes.',
+    })),
 })
-const BehaviorSettingsSchema = z.object({
+export const BehaviorSettingsSchema = z.object({
   toolCards: z.union(['collapsed', 'expanded', 'hidden'])
     .default(DEFAULT_TUI_BEHAVIOR.toolCards)
-    .description(ui(
-      '工具卡片默认形态；启动时应用到当前会话。',
-      'Default tool-card shape; applied to the current session at startup.',
-    )),
+    .description(localeDescription({
+      zh: '工具卡片默认形态；启动时应用到当前会话。',
+      en: 'Default tool-card shape; applied to the current session at startup.',
+    })),
   showReasoning: z.boolean().default(DEFAULT_TUI_BEHAVIOR.showReasoning)
-    .description(ui('推理内容默认是否显示。', 'Whether reasoning is shown by default.')),
+    .description(localeDescription({
+      zh: '推理内容默认是否显示。',
+      en: 'Whether reasoning is shown by default.',
+    })),
   desktopNotifications: z.boolean().default(DEFAULT_TUI_BEHAVIOR.desktopNotifications)
-    .description(ui(
-      '回合完成或待审批时发送终端桌面通知。',
-      'Send a desktop notification when a turn completes or an approval is pending.',
-    )),
+    .description(localeDescription({
+      zh: '回合完成或待审批时发送终端桌面通知。',
+      en: 'Send a desktop notification when a turn completes or an approval is pending.',
+    })),
   followTerminalTitle: z.boolean().default(DEFAULT_TUI_BEHAVIOR.followTerminalTitle)
-    .description(ui(
-      '终端标题跟随当前会话运行状态。',
-      'Follow the current session status in the terminal title.',
-    )),
+    .description(localeDescription({
+      zh: '终端标题跟随当前会话运行状态。',
+      en: 'Follow the current session status in the terminal title.',
+    })),
   composerHistoryLimit: z.natural().max(MAX_COMPOSER_HISTORY)
     .default(DEFAULT_TUI_BEHAVIOR.composerHistoryLimit)
-    .description(ui(
-      '输入历史持久化条数；0 表示关闭。',
-      'Number of persisted composer history entries; 0 disables history.',
-    )),
+    .description(localeDescription({
+      zh: '输入历史持久化条数；0 表示关闭。',
+      en: 'Number of persisted composer history entries; 0 disables history.',
+    })),
   statusElapsed: z.boolean().default(DEFAULT_TUI_BEHAVIOR.statusElapsed)
-    .description(ui(
-      '状态栏显示当前回合实时耗时。',
-      'Show live elapsed time for the current turn in the status bar.',
-    )),
+    .description(localeDescription({
+      zh: '状态栏显示当前回合实时耗时。',
+      en: 'Show live elapsed time for the current turn in the status bar.',
+    })),
   clipboardFallback: z.union(['auto', 'osc52', 'off'])
     .default(DEFAULT_TUI_BEHAVIOR.clipboardFallback)
-    .description(ui(
-      'OSC 52 失败后的剪贴板回退命令；auto 按平台探测。',
-      'Clipboard fallback after OSC 52 fails; auto probes the platform.',
-    )),
+    .description(localeDescription({
+      zh: 'OSC 52 失败后的剪贴板回退命令；auto 按平台探测。',
+      en: 'Clipboard fallback after OSC 52 fails; auto probes the platform.',
+    })),
   toolOutputLineLimit: z.natural().max(MAX_TOOL_OUTPUT_LINE_LIMIT)
     .default(DEFAULT_TUI_BEHAVIOR.toolOutputLineLimit)
-    .description(ui(
-      '展开态工具输出单块行数上限；0 表示不折叠。',
-      'Line cap for one expanded tool-output block; 0 means no folding.',
-    )),
+    .description(localeDescription({
+      zh: '展开态工具输出单块行数上限；0 表示不折叠。',
+      en: 'Line cap for one expanded tool-output block; 0 means no folding.',
+    })),
   diffContextLines: z.natural().max(MAX_DIFF_CONTEXT_LINES)
     .default(DEFAULT_TUI_BEHAVIOR.diffContextLines)
-    .description(ui('Diff 上下文行数。', 'Number of diff context lines.')),
+    .description(localeDescription({
+      zh: 'Diff 上下文行数。',
+      en: 'Number of diff context lines.',
+    })),
   dangerConfirmDefault: z.union(['cancel', 'confirm'])
     .default(DEFAULT_TUI_BEHAVIOR.dangerConfirmDefault)
-    .description(ui(
-      '危险确认默认焦点；cancel 表示回车不执行。',
-      'Default focus for danger confirmation; cancel means Enter does not proceed.',
-    )),
+    .description(localeDescription({
+      zh: '危险确认默认焦点；cancel 表示回车不执行。',
+      en: 'Default focus for danger confirmation; cancel means Enter does not proceed.',
+    })),
   keyBindings: z.dict(z.string()).default({})
-    .description(ui(
-      '覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。',
-      'Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults.',
-    )),
+    .description(localeDescription({
+      zh: '覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。',
+      en: 'Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults.',
+    })),
 })
 const ComposerHistorySettingsSchema = z.object({
   entries: z.array(z.string().max(100_000)).max(MAX_COMPOSER_HISTORY).default([]),

--- a/src/host/profile-plugin-manager.ts
+++ b/src/host/profile-plugin-manager.ts
@@ -705,7 +705,10 @@ export class ProfilePluginManager {
 
   private failureWarnings(command: readonly string[], exitCode: number): readonly string[] {
     if (exitCode === 127) {
-      return [ui('pnpm 不在 PATH 中；请安装 pnpm 后重试', 'pnpm is not on PATH; install pnpm and retry')]
+      return [({
+        zh: 'pnpm 不在 PATH 中；请安装 pnpm 后重试',
+        en: 'pnpm is not on PATH; install pnpm and retry',
+      }).zh]
     }
     const warnings = [ui(
       `pnpm 在 Profile 目录 ${this.dir} 中失败，退出码 ${exitCode}`,

--- a/tests/settings-schema-i18n.test.ts
+++ b/tests/settings-schema-i18n.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TUI_APPEARANCE_SETTINGS_NAMESPACE, TUI_BEHAVIOR_SETTINGS_NAMESPACE } from '../src/protocol.ts'
+import { AppearanceSettingsSchema, BehaviorSettingsSchema } from '../src/host/management.ts'
+import { settingsFields } from '../src/client/settings.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import { explainFailure } from '../src/client/error-advice.ts'
+
+const root = resolve(import.meta.dirname, '..')
+const HAN = /\p{Script=Han}/u
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('settings schema locale metadata (review #57)', () => {
+  it('localizes appearance and behavior field descriptions from {zh,en} metadata', () => {
+    const appearance = {
+      namespace: TUI_APPEARANCE_SETTINGS_NAMESPACE,
+      schema: AppearanceSettingsSchema.toJSON(),
+      value: { theme: 'dark', codeTheme: 'auto', customThemes: [] },
+      revision: 1,
+      applies: 'live' as const,
+      secrets: [],
+    }
+    const behavior = {
+      namespace: TUI_BEHAVIOR_SETTINGS_NAMESPACE,
+      schema: BehaviorSettingsSchema.toJSON(),
+      value: {},
+      revision: 1,
+      applies: 'live' as const,
+      secrets: [],
+    }
+
+    setUiLocale('en')
+    const theme = settingsFields(appearance).find(field => field.path[0] === 'theme')
+    expect(theme?.description).toContain('interface theme')
+    expect(theme?.description).not.toMatch(HAN)
+    const elapsed = settingsFields(behavior).find(field => field.path[0] === 'statusElapsed')
+    expect(elapsed?.description).toContain('elapsed')
+    expect(elapsed?.description).not.toMatch(HAN)
+
+    setUiLocale('zh')
+    expect(settingsFields(appearance).find(field => field.path[0] === 'theme')?.description).toContain('界面主题')
+  })
+
+  it('keeps the pnpm PATH warning as a stable machine string', () => {
+    const source = readFileSync(resolve(root, 'src/host/profile-plugin-manager.ts'), 'utf8')
+    expect(source).toMatch(/'pnpm 不在 PATH 中；请安装 pnpm 后重试'/u)
+    expect(source).not.toMatch(/ui\('pnpm 不在 PATH/u)
+    setUiLocale('en')
+    const explained = explainFailure('pnpm 不在 PATH 中；请安装 pnpm 后重试')
+    expect(explained).toContain('not on PATH')
+    expect(explained).not.toMatch(HAN)
+  })
+})


### PR DESCRIPTION
## Summary
- Appearance and behavior schema descriptions now store `{zh,en}` metadata so Settings fields follow the current locale.
- `failureWarnings()` returns a stable `pnpm 不在 PATH` machine string; `explainFailure()` localizes it (Strengths.md #57).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/settings-schema-i18n.test.ts tests/error-advice.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
