### PR TITLE
fix(tui): localize built-in theme names at display time

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21330,7 +21330,9 @@ const SYNTAX_COLOR_KEYS = [
 ];
 const BUILT_IN_DARK = Object.freeze({
 	id: "dark",
-	name: ui("DeepSeek 暗色", "DeepSeek dark"),
+	get name() {
+		return ui("DeepSeek 暗色", "DeepSeek dark");
+	},
 	tone: "dark",
 	syntaxTone: "dark",
 	source: "builtin",
@@ -21370,7 +21372,9 @@ const BUILT_IN_DARK = Object.freeze({
 });
 const BUILT_IN_LIGHT = Object.freeze({
 	id: "light",
-	name: ui("DeepSeek 亮色", "DeepSeek light"),
+	get name() {
+		return ui("DeepSeek 亮色", "DeepSeek light");
+	},
 	tone: "light",
 	syntaxTone: "light",
 	source: "builtin",

--- a/src/client/theme-config.ts
+++ b/src/client/theme-config.ts
@@ -71,7 +71,9 @@ const SYNTAX_COLOR_KEYS = [
 
 const BUILT_IN_DARK: ResolvedTuiTheme = Object.freeze({
   id: 'dark',
-  name: ui('DeepSeek 暗色', 'DeepSeek dark'),
+  get name() {
+    return ui('DeepSeek 暗色', 'DeepSeek dark')
+  },
   tone: 'dark',
   syntaxTone: 'dark',
   source: 'builtin',
@@ -92,7 +94,9 @@ const BUILT_IN_DARK: ResolvedTuiTheme = Object.freeze({
 
 const BUILT_IN_LIGHT: ResolvedTuiTheme = Object.freeze({
   id: 'light',
-  name: ui('DeepSeek 亮色', 'DeepSeek light'),
+  get name() {
+    return ui('DeepSeek 亮色', 'DeepSeek light')
+  },
   tone: 'light',
   syntaxTone: 'light',
   source: 'builtin',

--- a/tests/theme-config.test.ts
+++ b/tests/theme-config.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { setUiLocale } from '../src/client/locale.ts'
 import {
   BUILT_IN_THEMES,
   editableTheme,
@@ -16,7 +17,17 @@ import {
   themeIdFromName,
 } from '../src/client/theme-config.ts'
 
+afterEach(() => { setUiLocale('zh') })
+
 describe('theme colors and generated palettes', () => {
+  it('localizes built-in theme names at the display site', () => {
+    setUiLocale('en')
+    expect(BUILT_IN_THEMES.dark.name).toBe('DeepSeek dark')
+    expect(BUILT_IN_THEMES.light.name).toBe('DeepSeek light')
+    setUiLocale('zh')
+    expect(BUILT_IN_THEMES.dark.name).toBe('DeepSeek 暗色')
+    expect(BUILT_IN_THEMES.light.name).toBe('DeepSeek 亮色')
+  })
   it('normalizes supported opaque HEX/RGB forms', () => {
     expect(normalizeThemeColor('#abc')).toBe('#AABBCC')
     expect(normalizeThemeColor('rgb(10, 20, 30)')).toBe('#0A141E')


### PR DESCRIPTION
## Summary
- Built-in theme `name` is now a getter over `ui()`, so English lists and notices no longer freeze as `DeepSeek 暗色/亮色` (Strengths.md #58).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/theme-config.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
