### PR TITLE
fix(tui): keep Host command descriptions and locale-keyed catalog cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19799,8 +19799,8 @@ const HOST_COMMAND_ARGUMENT_HINTS = new Map([["permission", {
 }]]);
 function shortFunctionDescription(description, fallback) {
 	const normalized = description.replace(/\s+/gu, " ").trim();
-	if (!/\p{Script=Han}/u.test(normalized)) return fallback;
-	const firstSentence = normalized.split(/[。；]/u, 1)[0] ?? fallback;
+	if (normalized === "") return fallback;
+	const firstSentence = normalized.split(/[。；！？\n]/u, 1)[0]?.trim() || fallback;
 	const characters = Array.from(firstSentence);
 	return characters.length <= 48 ? firstSentence : `${characters.slice(0, 48).join("")}…`;
 }
@@ -20189,7 +20189,7 @@ var HarnessTuiCapabilities = class {
 			this.commandCatalogs.clear();
 		});
 		ctx.remote.$on("agent-preset/selected", (sessionId) => {
-			this.commandCatalogs.delete(sessionId);
+			this.dropCommandCatalog(sessionId);
 			this.invalidateModels();
 		});
 		ctx.remote.$on("llm/adapters-updated", () => {
@@ -20313,12 +20313,13 @@ var HarnessTuiCapabilities = class {
 		signal?.throwIfAborted();
 		const sessionId = this.active()?.sessionId;
 		if (sessionId === void 0) return Promise.resolve(tuiCommands());
-		const existing = this.commandCatalogs.get(sessionId);
+		const key = `${sessionId}:${uiLocale()}`;
+		const existing = this.commandCatalogs.get(key);
 		const request = existing ?? this.readCommandCatalog(sessionId).catch((error) => {
-			this.commandCatalogs.delete(sessionId);
+			this.commandCatalogs.delete(key);
 			throw error;
 		});
-		if (existing === void 0) this.commandCatalogs.set(sessionId, request);
+		if (existing === void 0) this.commandCatalogs.set(key, request);
 		if (signal === void 0) return request;
 		return request.then((catalog) => {
 			signal.throwIfAborted();
@@ -20327,8 +20328,15 @@ var HarnessTuiCapabilities = class {
 	}
 	/** Invalidate the current command/Skill snapshot and repull on next use. */
 	invalidateCommandCatalog() {
-		const id = this.active()?.sessionId;
-		if (id !== void 0) this.commandCatalogs.delete(id);
+		this.dropCommandCatalog(this.active()?.sessionId);
+	}
+	dropCommandCatalog(sessionId) {
+		if (sessionId === void 0) {
+			this.commandCatalogs.clear();
+			return;
+		}
+		const prefix = `${sessionId}:`;
+		for (const key of this.commandCatalogs.keys()) if (key.startsWith(prefix)) this.commandCatalogs.delete(key);
 	}
 	/**
 	* List every Host Agent Preset without a client-side enum.
@@ -20387,7 +20395,7 @@ var HarnessTuiCapabilities = class {
 		if (!response.result.ok) throw new Error(ui(`切换模式失败：${response.result.error.message}`, `Failed to change mode: ${response.result.error.message}`));
 		this.ctx.sessions.noteAgentPreset(target.sessionId, response.result.value.agentPreset);
 		this.ctx.sessions.open(target.sessionId);
-		this.commandCatalogs.delete(target.sessionId);
+		this.dropCommandCatalog(target.sessionId);
 		return target.sessionId;
 	}
 	/**
@@ -21131,7 +21139,7 @@ var HarnessTuiCapabilities = class {
 		const merged = [...commands];
 		const names = new Set(commands.map((command) => command.name));
 		for (const command of hostResult.value) {
-			if (local.get(command.name) !== void 0) throw new Error(ui(`命令冲突：TUI 与 Host 都注册了 /${command.name}`, `Command conflict: both TUI and Host registered /${command.name}`));
+			if (local.get(command.name) !== void 0) continue;
 			names.add(command.name);
 			merged.push({
 				name: command.name,
@@ -31390,6 +31398,7 @@ async function startTuiSurface(options$1) {
 			},
 			applyLocale: (locale) => {
 				setUiLocale(locale);
+				capabilities.invalidateCommandCatalog();
 				transcript.refreshPresentation();
 				refreshHeader(false);
 				refresh();

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -44,7 +44,7 @@ import { copyTargets } from './copy-content.ts'
 import { conversationMarkdown } from './conversation-markdown.ts'
 import { flattenProducedFiles, groupProducedFiles } from './produced-files.ts'
 import { explainFailure } from './error-advice.ts'
-import { ui } from './locale.ts'
+import { ui, uiLocale } from './locale.ts'
 
 /** A command shown by the terminal's merged slash directory. */
 export interface TuiCommandCandidate {
@@ -202,10 +202,10 @@ const HOST_COMMAND_ARGUMENT_HINTS = new Map<string, { readonly zh: string; reado
   ['feedback', { zh: '[内容]', en: '[text]' }],
 ])
 
-function shortFunctionDescription(description: string, fallback: string): string {
+export function shortFunctionDescription(description: string, fallback: string): string {
   const normalized = description.replace(/\s+/gu, ' ').trim()
-  if (!/\p{Script=Han}/u.test(normalized)) return fallback
-  const firstSentence = normalized.split(/[。；]/u, 1)[0] ?? fallback
+  if (normalized === '') return fallback
+  const firstSentence = normalized.split(/[。；！？\n]/u, 1)[0]?.trim() || fallback
   const characters = Array.from(firstSentence)
   return characters.length <= 48 ? firstSentence : `${characters.slice(0, 48).join('')}…`
 }
@@ -416,7 +416,7 @@ function workspaceFor(
  * through the mounted Harness API, Remote, Session, or Workspace face.
  */
 export class HarnessTuiCapabilities {
-  private readonly commandCatalogs = new Map<SessionId, Promise<readonly TuiCommandCandidate[]>>()
+  private readonly commandCatalogs = new Map<string, Promise<readonly TuiCommandCandidate[]>>()
   private readonly modelCatalogs = new Map<SessionId, SessionModels>()
   private readonly modelLoads = new Map<SessionId, Promise<SessionModels>>()
   private readonly attachments: TuiDraftAttachment[] = []
@@ -437,7 +437,7 @@ export class HarnessTuiCapabilities {
   ) {
     ctx.remote.$on('commands/change', () => { this.commandCatalogs.clear() })
     ctx.remote.$on('agent-preset/selected', (sessionId: SessionId) => {
-      this.commandCatalogs.delete(sessionId)
+      this.dropCommandCatalog(sessionId)
       this.invalidateModels()
     })
     ctx.remote.$on('llm/adapters-updated', () => { this.invalidateModels() })
@@ -574,13 +574,14 @@ export class HarnessTuiCapabilities {
     signal?.throwIfAborted()
     const sessionId = this.active()?.sessionId
     if (sessionId === undefined) return Promise.resolve(tuiCommands())
-    const existing = this.commandCatalogs.get(sessionId)
+    const key = `${sessionId}:${uiLocale()}`
+    const existing = this.commandCatalogs.get(key)
     const request = existing ?? this.readCommandCatalog(sessionId)
       .catch((error: unknown) => {
-        this.commandCatalogs.delete(sessionId)
+        this.commandCatalogs.delete(key)
         throw error
       })
-    if (existing === undefined) this.commandCatalogs.set(sessionId, request)
+    if (existing === undefined) this.commandCatalogs.set(key, request)
     if (signal === undefined) return request
     return request.then((catalog) => {
       signal.throwIfAborted()
@@ -590,8 +591,18 @@ export class HarnessTuiCapabilities {
 
   /** Invalidate the current command/Skill snapshot and repull on next use. */
   invalidateCommandCatalog(): void {
-    const id = this.active()?.sessionId
-    if (id !== undefined) this.commandCatalogs.delete(id)
+    this.dropCommandCatalog(this.active()?.sessionId)
+  }
+
+  private dropCommandCatalog(sessionId?: SessionId): void {
+    if (sessionId === undefined) {
+      this.commandCatalogs.clear()
+      return
+    }
+    const prefix = `${sessionId}:`
+    for (const key of this.commandCatalogs.keys()) {
+      if (key.startsWith(prefix)) this.commandCatalogs.delete(key)
+    }
   }
 
   /**
@@ -663,7 +674,7 @@ export class HarnessTuiCapabilities {
     }
     this.ctx.sessions.noteAgentPreset(target.sessionId, response.result.value.agentPreset)
     this.ctx.sessions.open(target.sessionId)
-    this.commandCatalogs.delete(target.sessionId)
+    this.dropCommandCatalog(target.sessionId)
     return target.sessionId
   }
 
@@ -1613,12 +1624,7 @@ export class HarnessTuiCapabilities {
     const names = new Set(commands.map(command => command.name))
     for (const command of hostResult.value as readonly HostCommandDescriptor[]) {
       const localCommand = local.get(command.name)
-      if (localCommand !== undefined) {
-        throw new Error(ui(
-          `命令冲突：TUI 与 Host 都注册了 /${command.name}`,
-          `Command conflict: both TUI and Host registered /${command.name}`,
-        ))
-      }
+      if (localCommand !== undefined) continue
       names.add(command.name)
       merged.push({
         name: command.name,

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -482,6 +482,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       applyLocale: (locale) => {
         setUiLocale(locale)
+        capabilities.invalidateCommandCatalog()
         transcript.refreshPresentation()
         refreshHeader(false)
         refresh()

--- a/tests/command-catalog.test.ts
+++ b/tests/command-catalog.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { shortFunctionDescription } from '../src/client/capabilities.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('command catalog copy (review #60)', () => {
+  it('truncates Host and Skill descriptions without requiring Han characters', () => {
+    expect(shortFunctionDescription('Run the linter on changed files.', 'Run command'))
+      .toBe('Run the linter on changed files.')
+    expect(shortFunctionDescription('按名称执行对应能力。更多说明。', 'fallback'))
+      .toBe('按名称执行对应能力')
+    const long = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
+    expect(shortFunctionDescription(long, 'fallback')).toBe(`${[...long].slice(0, 48).join('')}…`)
+  })
+
+  it('keys the catalog cache by locale and shadows Host commands instead of failing the directory', () => {
+    const source = readFileSync(resolve(root, 'src/client/capabilities.ts'), 'utf8')
+    expect(source).toMatch(/\$\{sessionId\}:\$\{uiLocale\(\)\}/u)
+    expect(source).not.toMatch(/命令冲突：TUI 与 Host 都注册了/u)
+    expect(source).toMatch(/if \(localCommand !== undefined\) continue/u)
+    const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
+    expect(surface).toMatch(/invalidateCommandCatalog\(\)/u)
+  })
+})


### PR DESCRIPTION
## Summary
- Host/Skill command blurbs are truncated without requiring Han characters.
- Command catalog cache keys include the UI locale and `applyLocale` invalidates the cache.
- Duplicate Host names are shadowed by TUI commands instead of failing the directory (Strengths.md #60 / cross-stack #9).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/command-catalog.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
