### PR TITLE
fix(tui): re-localize the default empty-session prompt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30169,7 +30169,7 @@ var Transcript = class {
 	imageGeneration = 0;
 	imageLoader;
 	snapshot;
-	emptyMessage = ui("在下方输入消息，或用 /help 查看命令。", "Enter a message below, or use /help to view commands.");
+	emptyMessage;
 	sessionId;
 	toolVisibility = "collapsed";
 	reasoningVisible = false;
@@ -30247,7 +30247,7 @@ var Transcript = class {
 	* Replace the transcript with non-durable empty-selection guidance.
 	* @param message - guidance rendered when no Session is active.
 	*/
-	empty(message = ui("在下方输入消息，或用 /help 查看命令。", "Enter a message below, or use /help to view commands.")) {
+	empty(message) {
 		this.imageGeneration += 1;
 		this.imageLoader = void 0;
 		this.snapshot = void 0;
@@ -30261,8 +30261,11 @@ var Transcript = class {
 		this.loadingOlder = false;
 		this.replace([{
 			format: "plain",
-			text: color.muted(translateUiText(message))
+			text: color.muted(this.emptyCopy())
 		}]);
+	}
+	emptyCopy() {
+		return this.emptyMessage === void 0 ? ui("在下方输入消息，或用 /help 查看命令。", "Enter a message below, or use /help to view commands.") : translateUiText(this.emptyMessage);
 	}
 	/**
 	* Replace the rendered snapshot after a Harness observable notification.
@@ -30383,7 +30386,7 @@ var Transcript = class {
 		this.nodeCache.clear();
 		if (snapshot === void 0) this.replace([{
 			format: "plain",
-			text: color.muted(translateUiText(this.emptyMessage))
+			text: color.muted(this.emptyCopy())
 		}]);
 		else this.update(snapshot, this.imageLoader);
 		this.scrollOffset = scrollOffset;

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -1119,7 +1119,7 @@ export class Transcript implements Component, Focusable {
   private imageGeneration = 0
   private imageLoader: TranscriptImageLoader | undefined
   private snapshot: ConversationSnapshot | undefined
-  private emptyMessage = ui('在下方输入消息，或用 /help 查看命令。', 'Enter a message below, or use /help to view commands.')
+  private emptyMessage: string | undefined
   private sessionId: string | undefined
   private toolVisibility: ToolVisibility = 'collapsed'
   private reasoningVisible = false
@@ -1215,7 +1215,7 @@ export class Transcript implements Component, Focusable {
    * Replace the transcript with non-durable empty-selection guidance.
    * @param message - guidance rendered when no Session is active.
    */
-  empty(message = ui('在下方输入消息，或用 /help 查看命令。', 'Enter a message below, or use /help to view commands.')): void {
+  empty(message?: string): void {
     this.imageGeneration += 1
     this.imageLoader = undefined
     this.snapshot = undefined
@@ -1227,7 +1227,13 @@ export class Transcript implements Component, Focusable {
     this.emptyState = true
     this.hasMore = false
     this.loadingOlder = false
-    this.replace([{ format: 'plain', text: color.muted(translateUiText(message)) }])
+    this.replace([{ format: 'plain', text: color.muted(this.emptyCopy()) }])
+  }
+
+  private emptyCopy(): string {
+    return this.emptyMessage === undefined
+      ? ui('在下方输入消息，或用 /help 查看命令。', 'Enter a message below, or use /help to view commands.')
+      : translateUiText(this.emptyMessage)
   }
 
   /**
@@ -1353,7 +1359,7 @@ export class Transcript implements Component, Focusable {
     const snapshot = this.snapshot
     this.nodeCache.clear()
     if (snapshot === undefined) {
-      this.replace([{ format: 'plain', text: color.muted(translateUiText(this.emptyMessage)) }])
+      this.replace([{ format: 'plain', text: color.muted(this.emptyCopy()) }])
     } else {
       this.update(snapshot, this.imageLoader)
     }

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -157,6 +157,17 @@ describe('conversation viewport', () => {
     expect(rendered).not.toContain('Command palette')
   })
 
+  it('re-localizes the default empty prompt when the UI language changes', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    setUiLocale('en')
+    const transcript = new Transcript(() => 5)
+    transcript.empty()
+    expect(transcript.render(60).join('\n')).toContain('Enter a message below')
+    setUiLocale('zh')
+    transcript.refreshPresentation()
+    expect(transcript.render(60).join('\n')).toContain('在下方输入消息')
+  })
+
   it('renders every loaded line into the default terminal scrollback', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript()


### PR DESCRIPTION
## Summary
- Default empty-session copy is resolved at render time, so locale switches work in both directions (Strengths.md #61).
- Caller-supplied custom empty text is still stored as a plain string.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/transcript.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
