### PR TITLE
fix(tui): confirm removing the plugin from the Profile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26241,7 +26241,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
 			target = selected.id;
 		}
 		if (snapshot.plugins.find((candidate) => candidate.name === target) === void 0) throw new Error(ui(`当前 Profile 未安装 ${JSON.stringify(target)}`, `${JSON.stringify(target)} is not installed in the current Profile`));
-		if (!await this.host.overlays.confirm(ui(`从 ${snapshot.profile} 移除 ${target}？`, `Remove ${snapshot.profile} from ${target}?`), ui(`将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, `This will run: pnpm remove ${target}. The Bundle list is reconciled by the native Manager.`), ui("移除", "Remove"))) return;
+		if (!await this.host.overlays.confirm(ui(`从 ${snapshot.profile} 移除 ${target}？`, `Remove ${target} from ${snapshot.profile}?`), ui(`将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, `This will run: pnpm remove ${target}. The Bundle list is reconciled by the native Manager.`), ui("移除", "Remove"))) return;
 		const result = await this.host.overlays.runBusy(ui(`移除 ${target}`, `Remove ${target}`), (signal) => this.capabilities.managementBridge().plugins.run(["remove", target], { signal }));
 		if (result === void 0) return;
 		await this.pluginOperation(ui(`移除 ${target}`, `Remove ${target}`), result);

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -2563,7 +2563,7 @@ pnpm may run the package scripts listed above; a Git package can be revalidated 
     const plugin = snapshot.plugins.find(candidate => candidate.name === target)
     if (plugin === undefined) throw new Error(ui(`当前 Profile 未安装 ${JSON.stringify(target)}`, `${JSON.stringify(target)} is not installed in the current Profile`))
     const confirmed = await this.host.overlays.confirm(
-      ui(`从 ${snapshot.profile} 移除 ${target}？`, `Remove ${snapshot.profile} from ${target}?`),
+      ui(`从 ${snapshot.profile} 移除 ${target}？`, `Remove ${target} from ${snapshot.profile}?`),
       ui(`将执行：pnpm remove ${target}。Bundle 列表会由原生 Manager 对账。`, `This will run: pnpm remove ${target}. The Bundle list is reconciled by the native Manager.`),
       ui('移除', "Remove"),
     )

--- a/tests/plugin-remove.test.ts
+++ b/tests/plugin-remove.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('plugin remove confirm (review #62)', () => {
+  it('asks to remove the plugin from the Profile, not the Profile from the plugin', () => {
+    const source = readFileSync(resolve(root, 'src/client/actions.ts'), 'utf8')
+    expect(source).toContain('Remove ${target} from ${snapshot.profile}?')
+    expect(source).not.toContain('Remove ${snapshot.profile} from ${target}?')
+  })
+})


### PR DESCRIPTION
## Summary
- Plugin-remove English confirm is now `Remove ${target} from ${snapshot.profile}?` (Strengths.md #62).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/plugin-remove.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] full vitest + tsdown
- [ ] Do not merge until the Strengths.md review-fix stack is complete
