### PR TITLE
fix(tui): bind the i18n AST gate to real ui imports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24738,18 +24738,17 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		const settings = this.capabilities.managementBridge().settings;
 		const document = suppliedDocument ?? localeSettings(await settings.describe(LOCALE_SETTINGS_NAMESPACE));
 		const requested = args.toLowerCase();
-		const aliases = new Map([
+		let selection = requested === "" ? void 0 : new Map([
 			["auto", "auto"],
 			["zh", "zh"],
 			["zh-cn", "zh"],
 			["chinese", "zh"],
-			[{ zh: "中文" }.zh, "zh"],
+			["中文", "zh"],
 			["en", "en"],
 			["en-us", "en"],
 			["english", "en"],
-			[{ zh: "英语" }.zh, "en"]
-		]);
-		let selection = requested === "" ? void 0 : aliases.get(requested);
+			["英语", "en"]
+		]).get(requested);
 		if (requested !== "" && selection === void 0) throw new Error(ui("用法：/language [auto|zh|en]", "Usage: /language [auto|zh|en]"));
 		if (selection === void 0) {
 			const current = languageSelection(document);

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1061,11 +1061,11 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       ['zh', 'zh'],
       ['zh-cn', 'zh'],
       ['chinese', 'zh'],
-      [{ zh: '中文' }.zh, 'zh'],
+      ['中文', 'zh'],
       ['en', 'en'],
       ['en-us', 'en'],
       ['english', 'en'],
-      [{ zh: '英语' }.zh, 'en'],
+      ['英语', 'en'],
     ])
     let selection = requested === '' ? undefined : aliases.get(requested)
     if (requested !== '' && selection === undefined) {

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -41,6 +41,15 @@ const GATED = [
   'protocol.ts',
 ]
 
+/** Stable machine marks that must stay Chinese for detectors; never user chrome. */
+const MACHINE_MARK_LITERALS = new Set([
+  '超时',
+  'pnpm 不在 PATH 中；请安装 pnpm 后重试',
+])
+
+/** /language input aliases; not rendered chrome. */
+const LANGUAGE_ALIAS_LITERALS = new Set(['中文', '英语'])
+
 function walk(directory: string): string[] {
   return readdirSync(directory).flatMap((name) => {
     const path = join(directory, name)
@@ -48,23 +57,72 @@ function walk(directory: string): string[] {
   })
 }
 
-function callName(node: ts.CallExpression): string | undefined {
-  const expression = node.expression
-  if (ts.isIdentifier(expression)) return expression.text
-  if (ts.isPropertyAccessExpression(expression)) return expression.name.text
+function literalText(node: ts.Node): string | undefined {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text
+  if (ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)) return node.text
   return undefined
 }
 
-function insideAllowedCall(node: ts.Node): boolean {
+function importedBindings(source: ts.SourceFile): { readonly ui: ReadonlySet<string>; readonly launcherCopy: ReadonlySet<string> } {
+  const ui = new Set<string>()
+  const launcherCopy = new Set<string>()
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || statement.importClause === undefined) continue
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue
+    const specifier = statement.moduleSpecifier.text
+    const fromLocale = /(?:^|\/)locale\.ts$/u.test(specifier)
+    const fromCompat = /(?:^|\/)dsh-compat\.ts$/u.test(specifier)
+    if (!fromLocale && !fromCompat) continue
+    const named = statement.importClause.namedBindings
+    if (named === undefined || !ts.isNamedImports(named)) continue
+    for (const element of named.elements) {
+      const imported = (element.propertyName ?? element.name).text
+      const local = element.name.text
+      if (fromLocale && imported === 'ui') ui.add(local)
+      if (fromCompat && imported === 'launcherCopy') launcherCopy.add(local)
+    }
+  }
+  return { ui, launcherCopy }
+}
+
+function isFunctionLike(node: ts.Node): boolean {
+  return ts.isFunctionDeclaration(node)
+    || ts.isFunctionExpression(node)
+    || ts.isArrowFunction(node)
+    || ts.isMethodDeclaration(node)
+    || ts.isGetAccessorDeclaration(node)
+    || ts.isSetAccessorDeclaration(node)
+    || ts.isConstructorDeclaration(node)
+}
+
+function isModuleInit(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node.parent
+  while (current !== undefined) {
+    if (isFunctionLike(current)) return false
+    current = current.parent
+  }
+  return true
+}
+
+function isImportedCall(expression: ts.Expression, names: ReadonlySet<string>): boolean {
+  return ts.isIdentifier(expression) && names.has(expression.text)
+}
+
+function ancestor(node: ts.Node, root: ts.Node): boolean {
   let current: ts.Node | undefined = node
   while (current !== undefined) {
-    const parent: ts.Node | undefined = current.parent as ts.Node | undefined
+    if (current === root) return true
+    current = current.parent
+  }
+  return false
+}
+
+function insideFirstArgOf(node: ts.Node, names: ReadonlySet<string>): boolean {
+  let current: ts.Node | undefined = node
+  while (current !== undefined) {
+    const parent: ts.Node | undefined = current.parent
     if (parent === undefined) return false
-    if (ts.isCallExpression(parent)) {
-      const name = callName(parent)
-      if ((name === 'ui' || name === 'launcherCopy') && parent.arguments[0] === current) return true
-    }
-    if (ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name) && parent.name.text === 'zh') {
+    if (ts.isCallExpression(parent) && isImportedCall(parent.expression, names) && parent.arguments[0] === current) {
       return true
     }
     current = parent
@@ -72,36 +130,103 @@ function insideAllowedCall(node: ts.Node): boolean {
   return false
 }
 
-function englishTernary(node: ts.Node): boolean {
-  let current: ts.Node | undefined = node.parent as ts.Node | undefined
+function enclosingZhObject(node: ts.Node): ts.ObjectLiteralExpression | undefined {
+  let current: ts.Node | undefined = node
   while (current !== undefined) {
-    if (ts.isConditionalExpression(current)) return true
-    current = current.parent as ts.Node | undefined
+    const parent: ts.Node | undefined = current.parent
+    if (parent === undefined) return undefined
+    if (
+      ts.isPropertyAssignment(parent)
+      && ts.isIdentifier(parent.name)
+      && parent.name.text === 'zh'
+      && ts.isObjectLiteralExpression(parent.parent)
+    ) {
+      return parent.parent
+    }
+    current = parent
+  }
+  return undefined
+}
+
+function hasEnSibling(object: ts.ObjectLiteralExpression): boolean {
+  return object.properties.some(property => (
+    ts.isPropertyAssignment(property)
+    && ts.isIdentifier(property.name)
+    && property.name.text === 'en'
+  ))
+}
+
+function isImmediateZhSelect(object: ts.ObjectLiteralExpression): boolean {
+  const parent = object.parent
+  return ts.isPropertyAccessExpression(parent)
+    && parent.expression === object
+    && parent.name.text === 'zh'
+}
+
+function isEnglishSelectTernary(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node
+  while (current !== undefined) {
+    const parent: ts.Node | undefined = current.parent
+    if (parent !== undefined && ts.isConditionalExpression(parent) && ts.isIdentifier(parent.condition) && parent.condition.text === 'english') {
+      return ancestor(node, parent.whenTrue) || ancestor(node, parent.whenFalse)
+    }
+    current = parent
   }
   return false
 }
 
-function chineseLiterals(path: string): readonly string[] {
+function isLanguageAliasLiteral(relativePath: string, node: ts.Node, text: string): boolean {
+  if (relativePath !== 'client/actions.ts' || !ts.isStringLiteral(node) || !LANGUAGE_ALIAS_LITERALS.has(text)) {
+    return false
+  }
+  return enclosingZhObject(node) === undefined
+}
+
+function report(relativePath: string, source: ts.SourceFile, node: ts.Node, text: string): string {
+  return `${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}:${text.slice(0, 60)}`
+}
+
+/**
+ * Chinese in gated files must come from an imported `ui`/`launcherCopy` binding,
+ * a paired `{zh,en}` record selected at the use site, or a precise machine mark.
+ */
+export function analyzeSource(relativePath: string, sourceText: string): readonly string[] {
   const source = ts.createSourceFile(
-    path,
-    readFileSync(path, 'utf8'),
+    relativePath,
+    sourceText,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS,
   )
+  const bindings = importedBindings(source)
   const found: string[] = []
   const visit = (node: ts.Node): void => {
-    const text = ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)
-      ? node.text
-      : ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)
-        ? node.text
-        : undefined
-    if (text !== undefined && HAN.test(text) && !insideAllowedCall(node)) {
-      if (relative(SRC, path) === 'dsh-compat.ts' && englishTernary(node)) {
+    if (ts.isCallExpression(node) && isImportedCall(node.expression, bindings.ui) && isModuleInit(node)) {
+      found.push(report(relativePath, source, node, 'module-init ui()'))
+    }
+    const text = literalText(node)
+    if (text !== undefined && HAN.test(text)) {
+      if (isLanguageAliasLiteral(relativePath, node, text)) {
         ts.forEachChild(node, visit)
         return
       }
-      found.push(`${relative(SRC, path)}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}:${text.slice(0, 60)}`)
+      if (insideFirstArgOf(node, bindings.ui) || insideFirstArgOf(node, bindings.launcherCopy)) {
+        ts.forEachChild(node, visit)
+        return
+      }
+      if (relativePath === 'dsh-compat.ts' && isEnglishSelectTernary(node)) {
+        ts.forEachChild(node, visit)
+        return
+      }
+      const object = enclosingZhObject(node)
+      if (object !== undefined && hasEnSibling(object)) {
+        if (isImmediateZhSelect(object) && !MACHINE_MARK_LITERALS.has(text)) {
+          found.push(report(relativePath, source, node, text))
+        }
+        ts.forEachChild(node, visit)
+        return
+      }
+      found.push(report(relativePath, source, node, text))
     }
     ts.forEachChild(node, visit)
   }
@@ -109,11 +234,83 @@ function chineseLiterals(path: string): readonly string[] {
   return found
 }
 
+describe('i18n AST gate fixtures (review #54)', () => {
+  it('rejects property-access .ui() that is not the imported binding', () => {
+    expect(analyzeSource('client/fake.ts', `
+import { ui } from './locale.ts'
+const helper = { ui: (zh: string) => zh }
+helper.ui('中文冻结')
+`)).not.toEqual([])
+  })
+
+  it('rejects unpaired { zh } object literals', () => {
+    expect(analyzeSource('protocol.ts', `
+export const frozen = { zh: '设置冲突' }.zh
+`)).not.toEqual([])
+  })
+
+  it('rejects arbitrary ternaries in dsh-compat.ts', () => {
+    expect(analyzeSource('dsh-compat.ts', `
+export function pick(flag: boolean): string {
+  return flag ? '中文旁路' : 'other'
+}
+`)).not.toEqual([])
+  })
+
+  it('rejects module-init ui() that freezes the boot locale', () => {
+    expect(analyzeSource('client/theme-config.ts', `
+import { ui } from './locale.ts'
+export const NAME = ui('DeepSeek 暗色', 'DeepSeek dark')
+`)).not.toEqual([])
+  })
+
+  it('allows imported ui() inside a function or getter and paired {zh,en} catalogs', () => {
+    expect(analyzeSource('client/empty-examples.ts', `
+import { ui } from './locale.ts'
+export const ROW = { zh: '审查当前改动', en: 'Review the current changes' }
+export function text(): string { return ui(ROW.zh, ROW.en) }
+export const theme = { get name() { return ui('DeepSeek 暗色', 'DeepSeek dark') } }
+`)).toEqual([])
+  })
+
+  it('allows the startup-timeout and pnpm PATH machine marks', () => {
+    expect(analyzeSource('client/error-advice.ts', `
+const STARTUP_TIMEOUT = { zh: '超时', en: 'timed out' } as const
+export const STARTUP_TIMEOUT_MARK = STARTUP_TIMEOUT.zh
+`)).toEqual([])
+    expect(analyzeSource('host/profile-plugin-manager.ts', `
+function warn(): string {
+  return ({ zh: 'pnpm 不在 PATH 中；请安装 pnpm 后重试', en: 'pnpm is not on PATH; install pnpm and retry' }).zh
+}
+`)).toEqual([])
+  })
+
+  it('allows bare /language aliases but still rejects { zh }.zh freezes in actions.ts', () => {
+    expect(analyzeSource('client/actions.ts', `
+const aliases = new Map([['中文', 'zh'], ['英语', 'en']])
+`)).toEqual([])
+    expect(analyzeSource('client/actions.ts', `
+const aliases = new Map([[{ zh: '中文' }.zh, 'zh']])
+`)).not.toEqual([])
+  })
+
+  it('allows launcherCopy and english ? en : zh in dsh-compat.ts', () => {
+    expect(analyzeSource('dsh-compat.ts', `
+export function launcherCopy(zh: string, en: string, english: boolean): string {
+  return english ? en : zh
+}
+export function message(english: boolean): string {
+  return english ? 'too old' : 'dsh 过旧'
+}
+`)).toEqual([])
+  })
+})
+
 describe('i18n AST gate (task 7)', () => {
-  it('keeps Chinese literals in gated files as ui/launcherCopy first arguments', () => {
+  it('keeps Chinese literals in gated files on imported ui/launcherCopy or paired {zh,en}', () => {
     const gated = new Set(GATED.map(file => join(SRC, file)))
     const files = walk(SRC).filter(path => gated.has(path))
     expect(files).toHaveLength(GATED.length)
-    expect(files.flatMap(chineseLiterals)).toEqual([])
+    expect(files.flatMap(path => analyzeSource(relative(SRC, path), readFileSync(path, 'utf8')))).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Tighten `tests/i18n-ast.test.ts` so only imported `ui` / `launcherCopy` bindings, paired `{zh,en}` catalogs, and the timeout / pnpm PATH machine marks are legal.
- Reject property-access `.ui()`, unpaired `{ zh }`, arbitrary `dsh-compat` ternaries, and module-init `ui()` that freeze the boot locale.
- Keep `/language` aliases `中文` / `英语` as input literals instead of `{zh}.zh` freezes.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/i18n-ast.test.ts tests/locale.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Do not merge until the review-fix stack is complete.
