### PR TITLE
fix(tui): freeze ENGLISH_PATTERNS[0] as the applies-immediately rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DbTu1PjP.js";
+import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-Cx6Oq8rk.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
-import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-MwEmc33l.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-CHRGVEzL.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-Cn88zMYL.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-By-snPE3.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";

--- a/lib/locale-Cx6Oq8rk.js
+++ b/lib/locale-Cx6Oq8rk.js
@@ -686,9 +686,11 @@ const ENGLISH_TEXT = new Map([
 	["TUI 重启交接提示无效", "TUI restart handoff has an invalid notice"],
 	["TUI 重启交接与 launcher 参数不一致", "TUI restart handoff does not match the launcher arguments"]
 ]);
+/** Frozen first catalog rule. New ENGLISH_PATTERNS entries must append after this. */
+const FIRST_ENGLISH_PATTERN = /^(.+) · 立即生效$/u;
 const ENGLISH_PATTERNS = [
 	{
-		pattern: /^(.+) · 立即生效$/u,
+		pattern: FIRST_ENGLISH_PATTERN,
 		replace: (value) => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately`
 	},
 	{

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
-import { c as ui } from "./locale-DbTu1PjP.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-MwEmc33l.js";
+import { c as ui } from "./locale-Cx6Oq8rk.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-Cn88zMYL.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-Cn88zMYL.js
+++ b/lib/plugin-marketplace-Cn88zMYL.js
@@ -1,4 +1,4 @@
-import { c as ui } from "./locale-DbTu1PjP.js";
+import { c as ui } from "./locale-Cx6Oq8rk.js";
 import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/lib/startup-By-snPE3.js
+++ b/lib/startup-By-snPE3.js
@@ -1,4 +1,4 @@
-import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-DbTu1PjP.js";
+import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-Cx6Oq8rk.js";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
-import "./locale-DbTu1PjP.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-CHRGVEzL.js";
+import "./locale-Cx6Oq8rk.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-By-snPE3.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -703,11 +703,14 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['TUI 重启交接与 launcher 参数不一致', 'TUI restart handoff does not match the launcher arguments'],
 ])
 
+/** Frozen first catalog rule. New ENGLISH_PATTERNS entries must append after this. */
+export const FIRST_ENGLISH_PATTERN = /^(.+) · 立即生效$/u
+
 const ENGLISH_PATTERNS: readonly {
   readonly pattern: RegExp
   readonly replace: (...groups: string[]) => string
 }[] = [
-  { pattern: /^(.+) · 立即生效$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
+  { pattern: FIRST_ENGLISH_PATTERN, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · applies immediately` },
   { pattern: /^(.+) · 需重启$/u, replace: value => `${ENGLISH_TEXT.get(value) ?? value} · restart required` },
   { pattern: /^设置 · (.+)$/u, replace: value => `Settings · ${value}` },
   { pattern: /^设置 (.+) 已更新并立即生效$/u, replace: value => `${value} was updated and is now active` },

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   LOCALE_PREFERENCE_FIELD,
@@ -13,6 +15,7 @@ import {
   saveLanguage,
   setUiLocale,
   translateUiText,
+  FIRST_ENGLISH_PATTERN,
   ui,
   uiLocale,
 } from '../src/client/locale.ts'
@@ -88,6 +91,14 @@ describe('terminal locale preference', () => {
       [{ op: 'unset', path: [LOCALE_PREFERENCE_FIELD] }],
       1,
     )
+  })
+
+  it('keeps ENGLISH_PATTERNS[0] as the original applies-immediately rule', () => {
+    expect(FIRST_ENGLISH_PATTERN.source).toBe('^(.+) · 立即生效$')
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/locale.ts'), 'utf8')
+    expect(source).toMatch(/const ENGLISH_PATTERNS[\s\S]*?=\s*\[\s*\{\s*pattern:\s*FIRST_ENGLISH_PATTERN/u)
+    setUiLocale('en')
+    expect(translateUiText('设置 · 立即生效')).toBe('Settings · applies immediately')
   })
 
   it('switches authored and catalog-backed terminal copy without changing unknown content', () => {


### PR DESCRIPTION
## Summary
- Export `FIRST_ENGLISH_PATTERN` as `/^(.+) · 立即生效$/u` and make `ENGLISH_PATTERNS[0]` use that binding.
- Lock the catalog order so later translation regexes can only append.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/locale.test.ts`
- [ ] Do not merge until the review-fix stack is complete.
