### PR TITLE
fix(tui): drop a stale restart ticket before spawning the child

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-Cx6Oq8rk.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-Cn88zMYL.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-By-snPE3.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-DK5DlBzn.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import { randomUUID } from "node:crypto";

--- a/lib/startup-DK5DlBzn.js
+++ b/lib/startup-DK5DlBzn.js
@@ -156,6 +156,18 @@ function sweepStaleAppHandoffs() {
 * @param payload - JSON-compatible references and draft metadata.
 * @returns absolute handoff path for {@link APP_HANDOFF_ENV}.
 */
+/**
+* Build a child process env that never inherits a stale handoff ticket.
+* Only a path from a successful {@link writeAppHandoff} is published.
+* @param parentEnv - current process environment.
+* @param handoffPath - newly written ticket, when restart carries a payload.
+*/
+function restartChildEnv(parentEnv, handoffPath) {
+	const env = { ...parentEnv };
+	delete env[APP_HANDOFF_ENV];
+	if (handoffPath !== void 0) env[APP_HANDOFF_ENV] = handoffPath;
+	return env;
+}
 function writeAppHandoff(channel, payload) {
 	if (channel.trim() === "") throw new Error("app handoff channel cannot be blank");
 	sweepStaleAppHandoffs();
@@ -817,6 +829,7 @@ function restartProvider(ctx) {
 	return async (request) => {
 		const entry = process.argv[1];
 		if (entry === void 0) throw new Error(ui("无法定位 dsh 启动文件", "Cannot locate the dsh entry file"));
+		delete process.env[APP_HANDOFF_ENV];
 		const handoffPath = request.handoff === void 0 ? void 0 : writeAppHandoff(request.handoff.channel, request.handoff.payload);
 		const child = spawn(process.execPath, [
 			realpathSync(entry),
@@ -825,10 +838,7 @@ function restartProvider(ctx) {
 			...request.args
 		], {
 			stdio: "inherit",
-			env: {
-				...process.env,
-				...handoffPath === void 0 ? {} : { [APP_HANDOFF_ENV]: handoffPath }
-			}
+			env: restartChildEnv(process.env, handoffPath)
 		});
 		try {
 			await new Promise((resolveSpawn, reject) => {

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
 import "./locale-Cx6Oq8rk.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-By-snPE3.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-DK5DlBzn.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/host/app-handoff.ts
+++ b/src/host/app-handoff.ts
@@ -84,6 +84,22 @@ export function sweepStaleAppHandoffs(): void {
  * @param payload - JSON-compatible references and draft metadata.
  * @returns absolute handoff path for {@link APP_HANDOFF_ENV}.
  */
+/**
+ * Build a child process env that never inherits a stale handoff ticket.
+ * Only a path from a successful {@link writeAppHandoff} is published.
+ * @param parentEnv - current process environment.
+ * @param handoffPath - newly written ticket, when restart carries a payload.
+ */
+export function restartChildEnv(
+  parentEnv: NodeJS.Dict<string | undefined>,
+  handoffPath?: string,
+): NodeJS.ProcessEnv {
+  const env = { ...parentEnv }
+  delete env[APP_HANDOFF_ENV]
+  if (handoffPath !== undefined) env[APP_HANDOFF_ENV] = handoffPath
+  return env
+}
+
 export function writeAppHandoff(channel: string, payload: unknown): string {
   if (channel.trim() === '') throw new Error('app handoff channel cannot be blank')
   sweepStaleAppHandoffs()

--- a/src/host/startup.ts
+++ b/src/host/startup.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander'
 import type { Context } from '@deepseek-ai/cordis'
 import { parseCmdline } from '@deepseek-ai/dsh-cmdline'
 import { localeFromEnvironment, setUiLocale, ui } from '../client/locale.ts'
-import { APP_HANDOFF_ENV, consumeAppHandoff, writeAppHandoff } from './app-handoff.ts'
+import { APP_HANDOFF_ENV, consumeAppHandoff, restartChildEnv, writeAppHandoff } from './app-handoff.ts'
 import { ProfilePluginManager } from './profile-plugin-manager.ts'
 import { readRestartHandoff, reconcileHandoff } from './restart-handoff.ts'
 
@@ -94,15 +94,13 @@ function restartProvider(ctx: Context): AppRestart {
       '无法定位 dsh 启动文件',
       'Cannot locate the dsh entry file',
     ))
+    delete process.env[APP_HANDOFF_ENV]
     const handoffPath = request.handoff === undefined
       ? undefined
       : writeAppHandoff(request.handoff.channel, request.handoff.payload)
     const child = spawn(process.execPath, [realpathSync(entry), '--profile', request.profile, ...request.args], {
       stdio: 'inherit',
-      env: {
-        ...process.env,
-        ...(handoffPath === undefined ? {} : { [APP_HANDOFF_ENV]: handoffPath }),
-      },
+      env: restartChildEnv(process.env, handoffPath),
     })
     try {
       await new Promise<void>((resolveSpawn, reject) => {

--- a/tests/app-handoff.test.ts
+++ b/tests/app-handoff.test.ts
@@ -6,6 +6,7 @@ import {
   APP_HANDOFF_ENV,
   consumeAppHandoff,
   internals,
+  restartChildEnv,
   sweepStaleAppHandoffs,
   writeAppHandoff,
 } from '../src/host/app-handoff.ts'
@@ -51,6 +52,15 @@ describe('app handoff (task 6.6)', () => {
     sweepStaleAppHandoffs()
     process.env[APP_HANDOFF_ENV] = path
     expect(consumeAppHandoff('seektty-v1')).toMatchObject({ kind: 'degraded' })
+  })
+
+  it('drops a stale handoff ticket before publishing a new child env', () => {
+    const published = restartChildEnv({ [APP_HANDOFF_ENV]: '/old.json', PATH: '/bin' }, '/new.json')
+    expect(published[APP_HANDOFF_ENV]).toBe('/new.json')
+    expect(published.PATH).toBe('/bin')
+    const failedWrite = restartChildEnv({ [APP_HANDOFF_ENV]: '/old.json', PATH: '/bin' })
+    expect(failedWrite[APP_HANDOFF_ENV]).toBeUndefined()
+    expect(failedWrite.PATH).toBe('/bin')
   })
 
   it('continues a normal start when the handoff does not match launcher args', () => {


### PR DESCRIPTION
## Summary
- Delete the inherited `APP_HANDOFF_ENV` ticket before writing a replacement handoff.
- Give the child `restartChildEnv()` so a failed write cannot republish the old path.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/app-handoff.test.ts tests/startup-path.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Do not merge until the review-fix stack is complete.
