### PR TITLE
fix(tui): restore cooked mode before async Surface teardown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31047,6 +31047,42 @@ function sessionTerminalTitle(facts) {
 }
 
 //#endregion
+//#region src/process-guards.ts
+/** Synchronous terminal restore used before any async Surface teardown. */
+const SHOW_CURSOR = "\x1B[?25h";
+const CLEANUP_TIMEOUT_MS = 2e3;
+/**
+* Put the user terminal back into cooked mode and show the cursor.
+* Must run before drain, dispose, or Host cleanup that can hang.
+*/
+function restoreTerminalSync(stdin = process.stdin, write = (chunk) => {
+	process.stdout.write(chunk);
+}, terminal) {
+	try {
+		stdin.setRawMode?.(false);
+	} catch {}
+	try {
+		terminal?.showCursor();
+	} catch {}
+	try {
+		write(SHOW_CURSOR);
+	} catch {}
+}
+/**
+* Bound a teardown step so a hung drain or dispose cannot trap the process.
+*/
+async function withCleanupTimeout(work, ms = CLEANUP_TIMEOUT_MS) {
+	let timer;
+	try {
+		return await Promise.race([work(), new Promise((resolve$1) => {
+			timer = setTimeout(() => resolve$1(void 0), ms);
+		})]);
+	} finally {
+		if (timer !== void 0) clearTimeout(timer);
+	}
+}
+
+//#endregion
 //#region src/client/surface.ts
 /** Replaceable terminal seams used by virtual-terminal tests. */
 const internals$1 = {
@@ -31336,6 +31372,9 @@ async function startTuiSurface(options$1) {
 		};
 		const close = (outcome) => {
 			if (stopping !== void 0) return stopping;
+			restoreTerminalSync(process.stdin, (chunk) => {
+				process.stdout.write(chunk);
+			}, terminal);
 			stopping = (async () => {
 				const failures = [];
 				if (elapsedTimer !== void 0) {
@@ -31356,7 +31395,7 @@ async function startTuiSurface(options$1) {
 					failures.push(error);
 				}
 				try {
-					await terminal.drainInput(250, 30);
+					await withCleanupTimeout(() => terminal.drainInput(250, 30));
 				} catch (error) {
 					failures.push(error);
 				}
@@ -31366,7 +31405,7 @@ async function startTuiSurface(options$1) {
 					failures.push(error);
 				}
 				try {
-					await client.ctx.fiber.dispose();
+					await withCleanupTimeout(() => client.ctx.fiber.dispose());
 				} catch (error) {
 					failures.push(error);
 				}
@@ -31738,6 +31777,9 @@ async function startTuiSurface(options$1) {
 			})
 		};
 	} catch (error) {
+		restoreTerminalSync(process.stdin, (chunk) => {
+			process.stdout.write(chunk);
+		}, terminal);
 		setCodeHighlighter(void 0);
 		try {
 			disposeConstructedSyntax();
@@ -31746,7 +31788,7 @@ async function startTuiSurface(options$1) {
 			stopConstructedTui();
 		} catch {}
 		try {
-			await client.ctx.fiber.dispose();
+			await withCleanupTimeout(() => client.ctx.fiber.dispose());
 		} catch {}
 		throw error;
 	}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -54,6 +54,7 @@ import {
 } from './desktop-notify.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, matchesBinding } from './keymap.ts'
+import { restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
@@ -430,6 +431,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
 
     const close = (outcome: TuiSurfaceOutcome): Promise<void> => {
       if (stopping !== undefined) return stopping
+      restoreTerminalSync(process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
       stopping = (async () => {
         const failures: unknown[] = []
         if (elapsedTimer !== undefined) {
@@ -442,7 +444,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         try { syntax?.dispose() } catch (error) { failures.push(error) }
         try { unsubscribeActive() } catch (error) { failures.push(error) }
         try {
-          await terminal.drainInput(250, 30)
+          await withCleanupTimeout(() => terminal.drainInput(250, 30))
         } catch (error) {
           failures.push(error)
         }
@@ -452,7 +454,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           failures.push(error)
         }
         try {
-          await client.ctx.fiber.dispose()
+          await withCleanupTimeout(() => client.ctx.fiber.dispose())
         } catch (error) {
           failures.push(error)
         }
@@ -862,11 +864,12 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
     return { closed, stop: () => close({ kind: 'exit', code: 0 }) }
   } catch (error) {
+    restoreTerminalSync(process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
     setCodeHighlighter(undefined)
     try { disposeConstructedSyntax() } catch { /* preserve the setup failure */ }
     try { stopConstructedTui() } catch { /* preserve the setup failure */ }
     try {
-      await client.ctx.fiber.dispose()
+      await withCleanupTimeout(() => client.ctx.fiber.dispose())
     } catch { /* preserve the setup failure */ }
     throw error
   }

--- a/src/process-guards.ts
+++ b/src/process-guards.ts
@@ -1,0 +1,46 @@
+/** Synchronous terminal restore used before any async Surface teardown. */
+
+export const SHOW_CURSOR = '\u001B[?25h'
+export const CLEANUP_TIMEOUT_MS = 2_000
+
+export interface RestorableStdin {
+  setRawMode?(mode: boolean): unknown
+}
+
+export interface RestorableTerminal {
+  showCursor(): void
+}
+
+/**
+ * Put the user terminal back into cooked mode and show the cursor.
+ * Must run before drain, dispose, or Host cleanup that can hang.
+ */
+export function restoreTerminalSync(
+  stdin: RestorableStdin = process.stdin,
+  write: (chunk: string) => void = chunk => { process.stdout.write(chunk) },
+  terminal?: RestorableTerminal,
+): void {
+  try { stdin.setRawMode?.(false) } catch { /* cooked restore is best-effort */ }
+  try { terminal?.showCursor() } catch { /* prefer the explicit cursor write below */ }
+  try { write(SHOW_CURSOR) } catch { /* cursor restore is best-effort */ }
+}
+
+/**
+ * Bound a teardown step so a hung drain or dispose cannot trap the process.
+ */
+export async function withCleanupTimeout<T>(
+  work: () => Promise<T>,
+  ms: number = CLEANUP_TIMEOUT_MS,
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work(),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), ms)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { restoreTerminalSync, withCleanupTimeout } from '../src/process-guards.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('fatal terminal restore (review #14)', () => {
+  it('restores cooked mode and the cursor synchronously before any cleanup', () => {
+    const order: string[] = []
+    const stdin = { setRawMode: (mode: boolean) => { order.push(`raw:${String(mode)}`) } }
+    const terminal = { showCursor: () => { order.push('cursor') } }
+    restoreTerminalSync(stdin, chunk => { order.push(`write:${chunk}`) }, terminal)
+    expect(order[0]).toBe('raw:false')
+    expect(order).toContain('cursor')
+  })
+
+  it('bounds hanging async cleanup so restore is never waited on', async () => {
+    const finished = await withCleanupTimeout(async () => {
+      await new Promise(() => undefined)
+      return 'never'
+    }, 20)
+    expect(finished).toBeUndefined()
+  })
+
+  it('restores the terminal in surface close before drainInput', () => {
+    const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
+    const restoreAt = source.indexOf('restoreTerminalSync')
+    const drainAt = source.indexOf('drainInput')
+    expect(restoreAt).toBeGreaterThan(-1)
+    expect(drainAt).toBeGreaterThan(restoreAt)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `restoreTerminalSync()` so cooked mode and the cursor return before any async teardown.
- Bound `drainInput` and fiber dispose with a timeout, and restore first on both `close()` and setup failure.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/process-guards.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Do not merge until the review-fix stack is complete.
