### PR TITLE
fix(tui): apply the whole live behavior object from Settings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22728,6 +22728,20 @@ function normalizeBehavior(value) {
 function behaviorFromSettings(document) {
 	return normalizeBehavior(document.value);
 }
+/**
+* Hold one replaceable behavior snapshot for the running Surface.
+* Settings marked `applies: live` replace the whole object.
+*/
+function createLiveBehavior(initial) {
+	let current = initial;
+	return {
+		get: () => current,
+		apply: (next) => {
+			current = next;
+			return current;
+		}
+	};
+}
 
 //#endregion
 //#region src/client/byte-size.ts
@@ -31135,9 +31149,9 @@ async function startTuiSurface(options$1) {
 	let disposeConstructedSyntax = () => void 0;
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
-		const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments));
-		applyKeyBindingOverrides(initialBehavior.keyBindings);
-		setDangerConfirmDefault(initialBehavior.dangerConfirmDefault);
+		const liveBehavior = createLiveBehavior(behaviorFromSettings(behaviorSettings(settingsDocuments)));
+		applyKeyBindingOverrides(liveBehavior.get().keyBindings);
+		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
 		stopConstructedTui = () => {
@@ -31149,12 +31163,12 @@ async function startTuiSurface(options$1) {
 		const profile = options$1.profile ?? "tui";
 		const contextBar = new ContextBar(profile, options$1.cwd);
 		const editor = new PromptEditor(tui);
-		const historyLimit = initialBehavior.composerHistoryLimit;
+		const historyLimit = liveBehavior.get().composerHistoryLimit;
 		let { entries: composerHistory, revision: composerHistoryRevision } = composerHistoryFromDocuments(settingsDocuments, historyLimit);
 		for (const entry of [...composerHistory].reverse()) editor.addToHistory(entry);
 		let historyPersist = Promise.resolve();
 		const persistComposerHistory = (entries) => {
-			if (historyLimit <= 0) return;
+			if (liveBehavior.get().composerHistoryLimit <= 0) return;
 			historyPersist = historyPersist.then(async () => {
 				const settings = capabilities.managementBridge().settings;
 				const write = (revision, next) => settings.mutate(TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE, [{
@@ -31182,7 +31196,7 @@ async function startTuiSurface(options$1) {
 			const snapshot = current.session.getSnapshot();
 			if (snapshot.hasMore && !snapshot.loadingOlder) current.session.loadOlder();
 		});
-		transcript.applyPresentationDefaults(initialBehavior.toolCards, initialBehavior.showReasoning, initialBehavior.toolOutputLineLimit, initialBehavior.diffContextLines);
+		transcript.applyPresentationDefaults(liveBehavior.get().toolCards, liveBehavior.get().showReasoning, liveBehavior.get().toolOutputLineLimit, liveBehavior.get().diffContextLines);
 		let syntax;
 		disposeConstructedSyntax = () => {
 			syntax?.dispose();
@@ -31263,7 +31277,7 @@ async function startTuiSurface(options$1) {
 		const applyTerminalTitle = () => {
 			const snapshot = active?.session.getSnapshot();
 			terminal.setTitle(sessionTerminalTitle({
-				follow: initialBehavior.followTerminalTitle,
+				follow: liveBehavior.get().followTerminalTitle,
 				sessionTitle: active?.summary.displayTitle ?? "",
 				running: snapshot?.running === true,
 				pendingApproval: snapshot?.pending.some((wait) => wait.kind === "approval") === true
@@ -31275,7 +31289,7 @@ async function startTuiSurface(options$1) {
 			const snapshot = active?.session.getSnapshot();
 			if (snapshot?.running === true) {
 				runningSince ??= Date.now();
-				if (elapsedTimer === void 0 && initialBehavior.statusElapsed) elapsedTimer = setInterval(() => {
+				if (elapsedTimer === void 0 && liveBehavior.get().statusElapsed) elapsedTimer = setInterval(() => {
 					if (stopping !== void 0) return;
 					updateStatus();
 					renderWhileOpen();
@@ -31304,14 +31318,14 @@ async function startTuiSurface(options$1) {
 					kind: wait.kind
 				}))
 			};
-			if (initialBehavior.desktopNotifications) {
+			if (liveBehavior.get().desktopNotifications) {
 				const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed);
 				if (kind !== void 0) terminal.write(desktopNotifySequence(desktopNotifyBody(kind)));
 			}
 			notifySnapshot = currentNotify;
 			notifyPrimed = true;
 			const pendingCount = snapshot.pending.length;
-			const generating = initialBehavior.statusElapsed && runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
+			const generating = liveBehavior.get().statusElapsed && runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
 			const primary = snapshot.removed ? color.danger(ui("会话已删除", "Session deleted")) : snapshot.promptError !== null ? color.danger(ui(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`, `${snapshot.promptError.op === "send" ? "Send" : "Stop"} failed: ${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(ui(`/pending 处理 ${String(pendingCount)} 项交互`, `/pending handles ${String(pendingCount)} interaction(s)`)) : snapshot.running ? color.accent(generating) : void 0;
 			const facts = [];
 			if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`));
@@ -31337,7 +31351,7 @@ async function startTuiSurface(options$1) {
 				contextBar.setFacts({
 					...facts,
 					...runningSince === void 0 ? {} : { runningSince },
-					statusElapsed: initialBehavior.statusElapsed
+					statusElapsed: liveBehavior.get().statusElapsed
 				});
 				editor.setFacts(facts);
 				status.setPermission(facts.permission);
@@ -31447,6 +31461,7 @@ async function startTuiSurface(options$1) {
 				tui.requestRender(true);
 			},
 			applyBehavior: (behavior) => {
+				liveBehavior.apply(behavior);
 				applyKeyBindingOverrides(behavior.keyBindings);
 				setDangerConfirmDefault(behavior.dangerConfirmDefault);
 				transcript.applyPresentationDefaults(behavior.toolCards, behavior.showReasoning, behavior.toolOutputLineLimit, behavior.diffContextLines);
@@ -31461,7 +31476,7 @@ async function startTuiSurface(options$1) {
 			},
 			copy: (text$1) => {
 				writeClipboard(text$1, {
-					fallback: initialBehavior.clipboardFallback,
+					fallback: liveBehavior.get().clipboardFallback,
 					platform: process.platform,
 					writeOsc52: (sequence) => {
 						terminal.write(sequence);

--- a/src/client/behavior.ts
+++ b/src/client/behavior.ts
@@ -121,3 +121,24 @@ export function normalizeBehavior(value: unknown): TuiBehaviorSettings {
 export function behaviorFromSettings(document: TuiSettingsDocument): TuiBehaviorSettings {
   return normalizeBehavior(document.value)
 }
+
+/** Mutable current behavior; every live path must read {@link LiveBehavior.get}. */
+export interface LiveBehavior {
+  get(): TuiBehaviorSettings
+  apply(next: TuiBehaviorSettings): TuiBehaviorSettings
+}
+
+/**
+ * Hold one replaceable behavior snapshot for the running Surface.
+ * Settings marked `applies: live` replace the whole object.
+ */
+export function createLiveBehavior(initial: TuiBehaviorSettings): LiveBehavior {
+  let current = initial
+  return {
+    get: () => current,
+    apply: (next) => {
+      current = next
+      return current
+    },
+  }
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -28,7 +28,7 @@ import {
   transcriptViewportRows,
 } from './chrome.ts'
 import { appearanceSettings, themeFromAppearance } from './appearance.ts'
-import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
+import { behaviorFromSettings, behaviorSettings, createLiveBehavior } from './behavior.ts'
 import {
   composerHistoryFromDocuments,
   rememberComposerHistory,
@@ -141,9 +141,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let disposeConstructedSyntax = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
-    const initialBehavior = behaviorFromSettings(behaviorSettings(settingsDocuments))
-    applyKeyBindingOverrides(initialBehavior.keyBindings)
-    setDangerConfirmDefault(initialBehavior.dangerConfirmDefault)
+    const liveBehavior = createLiveBehavior(behaviorFromSettings(behaviorSettings(settingsDocuments)))
+    applyKeyBindingOverrides(liveBehavior.get().keyBindings)
+    setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault)
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
     stopConstructedTui = () => {
@@ -155,13 +155,13 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const profile = options.profile ?? 'tui'
     const contextBar = new ContextBar(profile, options.cwd)
     const editor = new PromptEditor(tui)
-    const historyLimit = initialBehavior.composerHistoryLimit
+    const historyLimit = liveBehavior.get().composerHistoryLimit
     let { entries: composerHistory, revision: composerHistoryRevision } =
       composerHistoryFromDocuments(settingsDocuments, historyLimit)
     for (const entry of [...composerHistory].reverse()) editor.addToHistory(entry)
     let historyPersist = Promise.resolve()
     const persistComposerHistory = (entries: readonly string[]): void => {
-      if (historyLimit <= 0) return
+      if (liveBehavior.get().composerHistoryLimit <= 0) return
       historyPersist = historyPersist.then(async () => {
         const settings = capabilities.managementBridge().settings
         const write = (revision: number, next: readonly string[]): Promise<number> => (
@@ -201,10 +201,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
     )
     transcript.applyPresentationDefaults(
-      initialBehavior.toolCards,
-      initialBehavior.showReasoning,
-      initialBehavior.toolOutputLineLimit,
-      initialBehavior.diffContextLines,
+      liveBehavior.get().toolCards,
+      liveBehavior.get().showReasoning,
+      liveBehavior.get().toolOutputLineLimit,
+      liveBehavior.get().diffContextLines,
     )
     let syntax: SyntaxHighlighter | undefined
     disposeConstructedSyntax = () => { syntax?.dispose() }
@@ -292,7 +292,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const applyTerminalTitle = (): void => {
       const snapshot = active?.session.getSnapshot()
       terminal.setTitle(sessionTerminalTitle({
-        follow: initialBehavior.followTerminalTitle,
+        follow: liveBehavior.get().followTerminalTitle,
         sessionTitle: active?.summary.displayTitle ?? '',
         running: snapshot?.running === true,
         pendingApproval: snapshot?.pending.some(wait => wait.kind === 'approval') === true,
@@ -306,7 +306,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       const snapshot = active?.session.getSnapshot()
       if (snapshot?.running === true) {
         runningSince ??= Date.now()
-        if (elapsedTimer === undefined && initialBehavior.statusElapsed) {
+        if (elapsedTimer === undefined && liveBehavior.get().statusElapsed) {
           elapsedTimer = setInterval(() => {
             if (stopping !== undefined) return
             updateStatus()
@@ -331,7 +331,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         running: snapshot.running,
         pending: snapshot.pending.map(wait => ({ key: wait.key, kind: wait.kind })),
       }
-      if (initialBehavior.desktopNotifications) {
+      if (liveBehavior.get().desktopNotifications) {
         const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed)
         if (kind !== undefined) {
           terminal.write(desktopNotifySequence(desktopNotifyBody(kind)))
@@ -340,7 +340,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       notifySnapshot = currentNotify
       notifyPrimed = true
       const pendingCount = snapshot.pending.length
-      const generating = initialBehavior.statusElapsed && runningSince !== undefined
+      const generating = liveBehavior.get().statusElapsed && runningSince !== undefined
         ? ui(
           `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`,
           `Generating · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C to stop`,
@@ -391,7 +391,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         contextBar.setFacts({
           ...facts,
           ...(runningSince === undefined ? {} : { runningSince }),
-          statusElapsed: initialBehavior.statusElapsed,
+          statusElapsed: liveBehavior.get().statusElapsed,
         })
         editor.setFacts(facts)
         status.setPermission(facts.permission)
@@ -492,6 +492,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         tui.requestRender(true)
       },
       applyBehavior: (behavior) => {
+        liveBehavior.apply(behavior)
         applyKeyBindingOverrides(behavior.keyBindings)
         setDangerConfirmDefault(behavior.dangerConfirmDefault)
         transcript.applyPresentationDefaults(
@@ -511,7 +512,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       copy: (text) => {
         writeClipboard(text, {
-          fallback: initialBehavior.clipboardFallback,
+          fallback: liveBehavior.get().clipboardFallback,
           platform: process.platform,
           writeOsc52: sequence => { terminal.write(sequence) },
         })

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_TUI_BEHAVIOR,
@@ -7,6 +9,7 @@ import {
 import {
   behaviorFromSettings,
   behaviorSettings,
+  createLiveBehavior,
   normalizeBehavior,
 } from '../src/client/behavior.ts'
 import { Transcript } from '../src/client/transcript.ts'
@@ -79,5 +82,23 @@ describe('seektty-behavior settings', () => {
     transcript.applyPresentationDefaults(behavior.toolCards, behavior.showReasoning)
     expect(transcript.cycleToolVisibility()).toBe('collapsed')
     expect(transcript.toggleReasoning()).toBe(false)
+  })
+
+  it('replaces the whole live behavior object so Settings marked live actually apply', () => {
+    const live = createLiveBehavior(DEFAULT_TUI_BEHAVIOR)
+    expect(live.get().statusElapsed).toBe(true)
+    const next = normalizeBehavior({
+      ...DEFAULT_TUI_BEHAVIOR,
+      statusElapsed: false,
+      desktopNotifications: false,
+      followTerminalTitle: false,
+      clipboardFallback: 'off',
+      composerHistoryLimit: 0,
+    })
+    expect(live.apply(next)).toBe(live.get())
+    expect(live.get()).toEqual(next)
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/surface.ts'), 'utf8')
+    expect(source).toMatch(/createLiveBehavior\(/u)
+    expect(source).not.toMatch(/initialBehavior\.(statusElapsed|desktopNotifications|followTerminalTitle|clipboardFallback|composerHistoryLimit)/u)
   })
 })


### PR DESCRIPTION
## Summary
- Hold current behavior in `createLiveBehavior()` and replace the whole object from `applyBehavior()`.
- Read status elapsed, notifications, title follow, clipboard fallback, and history limit from that object instead of the startup snapshot.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/behavior.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Do not merge until the review-fix stack is complete.
