### PR TITLE
fix(tui): isolate elapsed, notify, and title by session

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31044,6 +31044,41 @@ function desktopNotifyBody(kind) {
 }
 
 //#endregion
+//#region src/client/session-chrome.ts
+function emptyChrome() {
+	return {
+		runningSince: void 0,
+		notify: {
+			running: false,
+			pending: []
+		},
+		notifyPrimed: false,
+		lastTitle: ""
+	};
+}
+/**
+* Isolate running/notify/title state so switching sessions cannot inherit
+* the previous Session's elapsed clock or completion bell.
+*/
+function createSessionChromeStore() {
+	const states = /* @__PURE__ */ new Map();
+	return { of(sessionId) {
+		let state = states.get(sessionId);
+		if (state === void 0) {
+			state = emptyChrome();
+			states.set(sessionId, state);
+		}
+		return state;
+	} };
+}
+/**
+* Return the next OSC title only when it differs from the last write.
+*/
+function nextTitleWrite(previous, next) {
+	return previous === next ? void 0 : next;
+}
+
+//#endregion
 //#region src/client/terminal-title.ts
 /** OSC window-title text derived from the current Session facts. */
 const DEFAULT_TERMINAL_TITLE = "DeepSeek Harness";
@@ -31241,13 +31276,8 @@ async function startTuiSurface(options$1) {
 		let notice;
 		let restartRequired;
 		let headerGeneration = 0;
-		let runningSince;
 		let elapsedTimer;
-		let notifySnapshot = {
-			running: false,
-			pending: []
-		};
-		let notifyPrimed = false;
+		const sessionChrome = createSessionChromeStore();
 		const focusEditor = () => {
 			transcriptFocused = false;
 			tui.setFocus(editor);
@@ -31276,37 +31306,45 @@ async function startTuiSurface(options$1) {
 		};
 		const applyTerminalTitle = () => {
 			const snapshot = active?.session.getSnapshot();
-			terminal.setTitle(sessionTerminalTitle({
+			const chrome = sessionChrome.of(latestSessionId);
+			const title = sessionTerminalTitle({
 				follow: liveBehavior.get().followTerminalTitle,
 				sessionTitle: active?.summary.displayTitle ?? "",
 				running: snapshot?.running === true,
 				pendingApproval: snapshot?.pending.some((wait) => wait.kind === "approval") === true
-			}));
+			});
+			const next = nextTitleWrite(chrome.lastTitle, title);
+			if (next === void 0) return;
+			chrome.lastTitle = next;
+			terminal.setTitle(next);
 		};
 		let actions;
 		const updateStatus = () => {
 			if (stopping !== void 0) return;
+			const chrome = sessionChrome.of(latestSessionId);
 			const snapshot = active?.session.getSnapshot();
 			if (snapshot?.running === true) {
-				runningSince ??= Date.now();
+				chrome.runningSince ??= Date.now();
 				if (elapsedTimer === void 0 && liveBehavior.get().statusElapsed) elapsedTimer = setInterval(() => {
 					if (stopping !== void 0) return;
-					updateStatus();
+					const elapsed = sessionChrome.of(latestSessionId);
+					if (elapsed.runningSince === void 0 || !liveBehavior.get().statusElapsed) return;
+					status.setDetail(color.accent(ui(`生成中 · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C to stop`)));
 					renderWhileOpen();
 				}, 500);
 			} else {
-				runningSince = void 0;
+				chrome.runningSince = void 0;
 				if (elapsedTimer !== void 0) {
 					clearInterval(elapsedTimer);
 					elapsedTimer = void 0;
 				}
 			}
 			if (snapshot === void 0) {
-				notifySnapshot = {
+				chrome.notify = {
 					running: false,
 					pending: []
 				};
-				notifyPrimed = false;
+				chrome.notifyPrimed = false;
 				status.setDetail(color.warning(ui("未打开会话", "No session open")));
 				applyTerminalTitle();
 				return;
@@ -31319,13 +31357,13 @@ async function startTuiSurface(options$1) {
 				}))
 			};
 			if (liveBehavior.get().desktopNotifications) {
-				const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed);
+				const kind = nextDesktopNotify(chrome.notify, currentNotify, chrome.notifyPrimed);
 				if (kind !== void 0) terminal.write(desktopNotifySequence(desktopNotifyBody(kind)));
 			}
-			notifySnapshot = currentNotify;
-			notifyPrimed = true;
+			chrome.notify = currentNotify;
+			chrome.notifyPrimed = true;
 			const pendingCount = snapshot.pending.length;
-			const generating = liveBehavior.get().statusElapsed && runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
+			const generating = liveBehavior.get().statusElapsed && chrome.runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
 			const primary = snapshot.removed ? color.danger(ui("会话已删除", "Session deleted")) : snapshot.promptError !== null ? color.danger(ui(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`, `${snapshot.promptError.op === "send" ? "Send" : "Stop"} failed: ${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(ui(`/pending 处理 ${String(pendingCount)} 项交互`, `/pending handles ${String(pendingCount)} interaction(s)`)) : snapshot.running ? color.accent(generating) : void 0;
 			const facts = [];
 			if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`));
@@ -31348,10 +31386,14 @@ async function startTuiSurface(options$1) {
 			const generation = ++headerGeneration;
 			capabilities.headerFacts(forceModel).then((facts) => {
 				if (stopping !== void 0 || generation !== headerGeneration) return;
-				contextBar.setFacts({
+				const since = sessionChrome.of(latestSessionId).runningSince;
+				const header = {
 					...facts,
-					...runningSince === void 0 ? {} : { runningSince },
 					statusElapsed: liveBehavior.get().statusElapsed
+				};
+				contextBar.setFacts(since === void 0 ? header : {
+					...header,
+					runningSince: since
 				});
 				editor.setFacts(facts);
 				status.setPermission(facts.permission);

--- a/src/client/session-chrome.ts
+++ b/src/client/session-chrome.ts
@@ -1,0 +1,47 @@
+/** Per-session elapsed, notify, and title snapshots for the running Surface. */
+
+import type { DesktopNotifySnapshot } from './desktop-notify.ts'
+
+/** Mutable chrome that must not leak across Session ids. */
+export interface SessionRuntimeChrome {
+  runningSince: number | undefined
+  notify: DesktopNotifySnapshot
+  notifyPrimed: boolean
+  lastTitle: string
+}
+
+function emptyChrome(): SessionRuntimeChrome {
+  return {
+    runningSince: undefined,
+    notify: { running: false, pending: [] },
+    notifyPrimed: false,
+    lastTitle: '',
+  }
+}
+
+/**
+ * Isolate running/notify/title state so switching sessions cannot inherit
+ * the previous Session's elapsed clock or completion bell.
+ */
+export function createSessionChromeStore(): {
+  of(sessionId: string): SessionRuntimeChrome
+} {
+  const states = new Map<string, SessionRuntimeChrome>()
+  return {
+    of(sessionId) {
+      let state = states.get(sessionId)
+      if (state === undefined) {
+        state = emptyChrome()
+        states.set(sessionId, state)
+      }
+      return state
+    },
+  }
+}
+
+/**
+ * Return the next OSC title only when it differs from the last write.
+ */
+export function nextTitleWrite(previous: string, next: string): string | undefined {
+  return previous === next ? undefined : next
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -52,6 +52,7 @@ import {
   nextDesktopNotify,
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
+import { createSessionChromeStore, nextTitleWrite } from './session-chrome.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, matchesBinding } from './keymap.ts'
 import { restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
@@ -254,10 +255,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     let notice: { message: string; tone: NoticeTone } | undefined
     let restartRequired: string | undefined
     let headerGeneration = 0
-    let runningSince: number | undefined
     let elapsedTimer: ReturnType<typeof setInterval> | undefined
-    let notifySnapshot: DesktopNotifySnapshot = { running: false, pending: [] }
-    let notifyPrimed = false
+    const sessionChrome = createSessionChromeStore()
 
     const focusEditor = (): void => {
       transcriptFocused = false
@@ -291,38 +290,49 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
 
     const applyTerminalTitle = (): void => {
       const snapshot = active?.session.getSnapshot()
-      terminal.setTitle(sessionTerminalTitle({
+      const chrome = sessionChrome.of(latestSessionId)
+      const title = sessionTerminalTitle({
         follow: liveBehavior.get().followTerminalTitle,
         sessionTitle: active?.summary.displayTitle ?? '',
         running: snapshot?.running === true,
         pendingApproval: snapshot?.pending.some(wait => wait.kind === 'approval') === true,
-      }))
+      })
+      const next = nextTitleWrite(chrome.lastTitle, title)
+      if (next === undefined) return
+      chrome.lastTitle = next
+      terminal.setTitle(next)
     }
 
     let actions!: TuiActions
 
     const updateStatus = (): void => {
       if (stopping !== undefined) return
+      const chrome = sessionChrome.of(latestSessionId)
       const snapshot = active?.session.getSnapshot()
       if (snapshot?.running === true) {
-        runningSince ??= Date.now()
+        chrome.runningSince ??= Date.now()
         if (elapsedTimer === undefined && liveBehavior.get().statusElapsed) {
           elapsedTimer = setInterval(() => {
             if (stopping !== undefined) return
-            updateStatus()
+            const elapsed = sessionChrome.of(latestSessionId)
+            if (elapsed.runningSince === undefined || !liveBehavior.get().statusElapsed) return
+            status.setDetail(color.accent(ui(
+              `生成中 · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C 停止`,
+              `Generating · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C to stop`,
+            )))
             renderWhileOpen()
           }, 500)
         }
       } else {
-        runningSince = undefined
+        chrome.runningSince = undefined
         if (elapsedTimer !== undefined) {
           clearInterval(elapsedTimer)
           elapsedTimer = undefined
         }
       }
       if (snapshot === undefined) {
-        notifySnapshot = { running: false, pending: [] }
-        notifyPrimed = false
+        chrome.notify = { running: false, pending: [] }
+        chrome.notifyPrimed = false
         status.setDetail(color.warning(ui('未打开会话', 'No session open')))
         applyTerminalTitle()
         return
@@ -332,18 +342,18 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         pending: snapshot.pending.map(wait => ({ key: wait.key, kind: wait.kind })),
       }
       if (liveBehavior.get().desktopNotifications) {
-        const kind = nextDesktopNotify(notifySnapshot, currentNotify, notifyPrimed)
+        const kind = nextDesktopNotify(chrome.notify, currentNotify, chrome.notifyPrimed)
         if (kind !== undefined) {
           terminal.write(desktopNotifySequence(desktopNotifyBody(kind)))
         }
       }
-      notifySnapshot = currentNotify
-      notifyPrimed = true
+      chrome.notify = currentNotify
+      chrome.notifyPrimed = true
       const pendingCount = snapshot.pending.length
-      const generating = liveBehavior.get().statusElapsed && runningSince !== undefined
+      const generating = liveBehavior.get().statusElapsed && chrome.runningSince !== undefined
         ? ui(
-          `生成中 · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C 停止`,
-          `Generating · ${formatElapsed(Date.now() - runningSince)} · Ctrl+C to stop`,
+          `生成中 · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C 停止`,
+          `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`,
         )
         : ui('生成中 · Ctrl+C 停止', 'Generating · Ctrl+C to stop')
       const primary = snapshot.removed
@@ -388,11 +398,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       const generation = ++headerGeneration
       void capabilities.headerFacts(forceModel).then((facts) => {
         if (stopping !== undefined || generation !== headerGeneration) return
-        contextBar.setFacts({
-          ...facts,
-          ...(runningSince === undefined ? {} : { runningSince }),
-          statusElapsed: liveBehavior.get().statusElapsed,
-        })
+        const since = sessionChrome.of(latestSessionId).runningSince
+        const header = { ...facts, statusElapsed: liveBehavior.get().statusElapsed }
+        contextBar.setFacts(since === undefined ? header : { ...header, runningSince: since })
         editor.setFacts(facts)
         status.setPermission(facts.permission)
         renderWhileOpen()

--- a/tests/session-chrome.test.ts
+++ b/tests/session-chrome.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createSessionChromeStore, nextTitleWrite } from '../src/client/session-chrome.ts'
+
+describe('session-scoped chrome (review #20 #21 #22)', () => {
+  it('isolates runningSince, notify snapshots, and last title by sessionId', () => {
+    const store = createSessionChromeStore()
+    const first = store.of('sess-a')
+    first.runningSince = 1_000
+    first.notifyPrimed = true
+    first.lastTitle = 'A'
+    const second = store.of('sess-b')
+    expect(second.runningSince).toBeUndefined()
+    expect(second.notifyPrimed).toBe(false)
+    expect(second.lastTitle).toBe('')
+    expect(store.of('sess-a').runningSince).toBe(1_000)
+  })
+
+  it('writes a terminal title only when the OSC payload changed', () => {
+    expect(nextTitleWrite('', 'Inspect')).toBe('Inspect')
+    expect(nextTitleWrite('Inspect', 'Inspect')).toBeUndefined()
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/surface.ts'), 'utf8')
+    expect(source).toMatch(/createSessionChromeStore\(/u)
+    expect(source).toMatch(/nextTitleWrite\(/u)
+    const timer = /elapsedTimer = setInterval\(([\s\S]*?)\}, 500\)/u.exec(source)
+    expect(timer?.[1]).toBeDefined()
+    expect(timer?.[1]).not.toContain('refreshHeader')
+  })
+})


### PR DESCRIPTION
## Summary
- Store `runningSince`, notify snapshots, and last title per sessionId so a switch cannot inherit the previous Session.
- Elapsed timer updates only the local status line; OSC title writes only when the payload changes.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/session-chrome.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Do not merge until the review-fix stack is complete.
