### PR TITLE
fix(tui): reject dsh newer than the tested compatibility range

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_VERSION, c as isVersionRequest, d as versionMessage, i as PACKAGE_NAME, l as launcherCopy, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
+import { a as PACKAGE_VERSION, c as isVersionRequest, d as versionMessage, i as PACKAGE_NAME, l as launcherCopy, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as launcherPrefersEnglish } from "./startup-trace-Bjb556WQ.js";
 import { join } from "node:path";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-Cx6Oq8rk.js";
-import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-QEGhP-_i.js";
+import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-Bjb556WQ.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-Cn88zMYL.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-DK5DlBzn.js";
 import { createRequire } from "node:module";

--- a/lib/startup-trace-Bjb556WQ.js
+++ b/lib/startup-trace-Bjb556WQ.js
@@ -61,6 +61,8 @@ function dshCompatibilityError(hostVersion, compatibility, english) {
 	const order = compareDshVersion(hostVersion, compatibility.minimum);
 	if (order === void 0) return english ? `Unrecognized dsh version ${hostVersion}. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).` : `无法识别 dsh 版本 ${hostVersion}。SeekTTY 需要 dsh >= ${compatibility.minimum}（已测试 ${compatibility.tested}）。`;
 	if (order < 0) return english ? `dsh ${hostVersion} is too old. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).` : `dsh ${hostVersion} 过旧。SeekTTY 需要 dsh >= ${compatibility.minimum}（已测试 ${compatibility.tested}）。`;
+	const newest = compareDshVersion(hostVersion, compatibility.tested);
+	if (newest !== void 0 && newest > 0) return english ? `dsh ${hostVersion} is newer than the tested range. SeekTTY needs dsh ${compatibility.minimum}–${compatibility.tested} (tested ${compatibility.tested}).` : `dsh ${hostVersion} 新于已测范围。SeekTTY 需要 dsh ${compatibility.minimum}–${compatibility.tested}（已测试 ${compatibility.tested}）。`;
 }
 /**
 * Default GitHub plugin spec pinned to this package version.

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -94,6 +94,12 @@ export function dshCompatibilityError(
       ? `dsh ${hostVersion} is too old. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).`
       : `dsh ${hostVersion} 过旧。SeekTTY 需要 dsh >= ${compatibility.minimum}（已测试 ${compatibility.tested}）。`
   }
+  const newest = compareDshVersion(hostVersion, compatibility.tested)
+  if (newest !== undefined && newest > 0) {
+    return english
+      ? `dsh ${hostVersion} is newer than the tested range. SeekTTY needs dsh ${compatibility.minimum}–${compatibility.tested} (tested ${compatibility.tested}).`
+      : `dsh ${hostVersion} 新于已测范围。SeekTTY 需要 dsh ${compatibility.minimum}–${compatibility.tested}（已测试 ${compatibility.tested}）。`
+  }
   return undefined
 }
 

--- a/tests/dsh-compat.test.ts
+++ b/tests/dsh-compat.test.ts
@@ -30,4 +30,11 @@ describe('dsh version and compatibility', () => {
     expect(dshCompatibilityError('0.1.0-rc.6', { minimum: '0.1.0-rc.6', tested: '0.1.0-rc.6' }, false))
       .toBeUndefined()
   })
+
+  it('rejects dsh newer than the tested upper bound', () => {
+    const range = { minimum: '0.1.0-rc.6', tested: '0.1.0-rc.6' }
+    expect(dshCompatibilityError('0.2.0', range, true)).toContain('0.2.0')
+    expect(dshCompatibilityError('0.2.0', range, true)).toMatch(/tested 0\.1\.0-rc\.6/u)
+    expect(dshCompatibilityError('0.1.0-rc.6', range, true)).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- Compatibility now requires `minimum <= host <= tested` instead of accepting every future dsh version.
- Untested newer hosts get an upgrade/adapt message naming the exact tested range.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/dsh-compat.test.ts`
- [ ] Do not merge until the review-fix stack is complete.
