### PR TITLE
fix(tui): highlight search hits with a once-built Set

### DIFF
--- a/src/client/transcript-search.ts
+++ b/src/client/transcript-search.ts
@@ -24,6 +24,22 @@ export function findLineMatches(lines: readonly string[], query: string): number
     stripAnsi(line).toLowerCase().includes(needle) ? [index] : [])
 }
 
+/** One search pass: ordered matches plus a Set for constant-time highlight. */
+export interface LineSearchPlan {
+  readonly matches: readonly number[]
+  readonly hit: ReadonlySet<number>
+}
+
+/**
+ * Compute match indexes once per query so highlight can use Set lookup.
+ * @param lines - full transcript lines before viewport clipping.
+ * @param query - user-typed needle; blank queries match nothing.
+ */
+export function planLineSearch(lines: readonly string[], query: string): LineSearchPlan {
+  const matches = findLineMatches(lines, query)
+  return { matches, hit: new Set(matches) }
+}
+
 /**
  * Move to the next or previous match, wrapping at the ends.
  * @param matches - document-order line indexes.

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -41,6 +41,7 @@ import {
   findLineMatches,
   highlightQuery,
   nextMatchIndex,
+  planLineSearch,
   scrollOffsetToReveal,
 } from './transcript-search.ts'
 import {
@@ -1436,13 +1437,13 @@ export class Transcript implements Component, Focusable {
     this.renderedLineCount = lines.length
     this.turnAnchors = anchors
     if (this.search !== undefined) {
-      const matches = findLineMatches(lines, this.search.query)
-      if (this.search.matchIndex >= matches.length) this.search.matchIndex = 0
-      const current = matches[this.search.matchIndex]
+      const plan = planLineSearch(lines, this.search.query)
+      if (this.search.matchIndex >= plan.matches.length) this.search.matchIndex = 0
+      const current = plan.matches[this.search.matchIndex]
       const query = this.search.query
       if (query.trim() !== '') {
         for (const [index, line] of lines.entries()) {
-          if (!matches.includes(index)) continue
+          if (!plan.hit.has(index)) continue
           lines[index] = highlightQuery(line, query, matched =>
             index === current ? `\u001B[7m${matched}\u001B[0m` : color.accent(matched))
         }

--- a/tests/transcript-search.test.ts
+++ b/tests/transcript-search.test.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   findLineMatches,
   highlightQuery,
   nextMatchIndex,
+  planLineSearch,
   scrollOffsetToReveal,
   stripAnsi,
 } from '../src/client/transcript-search.ts'
@@ -18,5 +21,15 @@ describe('transcript in-session search', () => {
     expect(highlightQuery('Hello World', 'lo', text => `[${text}]`)).toBe('Hel[lo] World')
     expect(stripAnsi('\u001B[7mhit\u001B[0m')).toBe('hit')
     expect(scrollOffsetToReveal(20, 8, 2)).toBe(10)
+  })
+
+  it('builds a Set of match indexes so highlight does not rescan includes()', () => {
+    const plan = planLineSearch(['a', 'hit', 'b', 'HIT'], 'hit')
+    expect(plan.matches).toEqual([1, 3])
+    expect(plan.hit.has(1)).toBe(true)
+    expect(plan.hit.has(0)).toBe(false)
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/transcript.ts'), 'utf8')
+    expect(source).toMatch(/planLineSearch\(/u)
+    expect(source).not.toMatch(/matches\.includes\(/u)
   })
 })


### PR DESCRIPTION
## Summary
- Each search query now builds the match index array and a `Set<number>` once.
- Highlight uses constant-time Set lookup instead of `matches.includes(index)` on every line.

## Test plan
- `vitest run tests/transcript-search.test.ts tests/transcript.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)