### PR TITLE
fix(tui): refresh overlay lists without resetting query or selection

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1679,7 +1679,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       }
       const paint = (): void => {
         if (!onList) return
-        nav.replaceSelectPage(this.queueListRequest(), onSelect)
+        nav.updateChoices(this.queueListRequest().choices)
       }
       const timer = setInterval(paint, 1_000)
       timer.unref()
@@ -3055,7 +3055,7 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
       }
       const paint = (): void => {
         if (!onList) return
-        nav.replaceSelectPage(this.jobListRequest(currentId), onSelect)
+        nav.updateChoices(this.jobListRequest(currentId).choices)
       }
       const timer = setInterval(paint, 1_000)
       timer.unref()
@@ -3192,7 +3192,9 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
           inflight = true
           void this.capabilities.subagents(true).then((next) => {
             rows = [...next]
-            if (onList) nav.replaceSelectPage(request(), onSelect)
+            if (onList) nav.updateChoices(request().choices)
+          }).catch((error: unknown) => {
+            if (onList) nav.updateChoices(request().choices, capabilityError(error))
           }).finally(() => {
             inflight = false
           })

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -116,6 +116,7 @@ export interface OverlayNavigation<TResult = void> extends OverlayPrompts {
     request: SelectOverlayRequest,
     onSelect: (choice: OverlayChoice) => void | Promise<void>,
   ): void
+  updateChoices(choices: readonly OverlayChoice[], notice?: string): void
   back(): void
   finish(value?: TResult): void
 }
@@ -221,12 +222,25 @@ class SearchSelectOverlay implements Component {
   private notice = ''
 
   constructor(
-    private readonly request: SelectOverlayRequest,
+    private request: SelectOverlayRequest,
     private readonly submit: (value: OverlayChoice) => void,
   ) {
     this.filtered = request.choices
     this.list = this.createList(this.filtered, request.initialChoiceId)
     this.input.onSubmit = () => { this.choose() }
+  }
+
+  /**
+   * Refresh rows without dropping the typed query or the selected stable id.
+   * @param choices - latest rows from Host.
+   * @param notice - optional in-page diagnostic; empty clears a previous one.
+   */
+  updateChoices(choices: readonly OverlayChoice[], notice = ''): void {
+    const selectedId = this.list.getSelectedItem()?.value
+    this.request = { ...this.request, choices }
+    this.filtered = this.filterChoices(this.input.getValue())
+    this.list = this.createList(this.filtered, selectedId)
+    this.notice = notice
   }
 
   invalidate(): void {
@@ -290,11 +304,15 @@ class SearchSelectOverlay implements Component {
     return list
   }
 
-  private applyFilter(query: string): void {
-    this.filtered = query === ''
+  private filterChoices(query: string): readonly OverlayChoice[] {
+    return query === ''
       ? this.request.choices
       : fuzzyFilter([...this.request.choices], query, choice =>
         `${choice.label} ${choice.description ?? ''} ${choice.id}`)
+  }
+
+  private applyFilter(query: string): void {
+    this.filtered = this.filterChoices(query)
     this.list = this.createList(this.filtered)
     this.notice = ''
   }
@@ -675,6 +693,16 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     entry.component = new SearchSelectOverlay(request, choice => {
       this.dispatch(entry, () => onSelect(choice))
     })
+    this.requestRender()
+  }
+
+  updateChoices(choices: readonly OverlayChoice[], notice?: string): void {
+    if (this.closed) return
+    const entry = this.current()
+    if (entry === undefined || !(entry.component instanceof SearchSelectOverlay)) {
+      throw new Error(ui('没有可更新的选择页', 'No select page to update'))
+    }
+    entry.component.updateChoices(choices, notice ?? '')
     this.requestRender()
   }
 

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
 import { OverlayQueue, type OverlayNavigation } from '../src/client/overlays.ts'
@@ -154,6 +156,50 @@ describe('overlay navigation', () => {
     expect(harness.hide).not.toHaveBeenCalled()
     harness.component().handleInput(ESCAPE)
     await expect(session).resolves.toBeUndefined()
+  })
+
+  it('updateChoices keeps the typed query and selected id across auto-refresh', async () => {
+    const harness = overlayHarness()
+    let navigation: OverlayNavigation | undefined
+    const session = harness.overlays.navigate(async (nav) => {
+      navigation = nav
+      await nav.selectPage({
+        title: 'jobs snapshot',
+        choices: [
+          { id: 'alpha', label: 'alpha job' },
+          { id: 'bravo', label: 'bravo job' },
+          { id: 'other', label: 'unrelated' },
+        ],
+      }, () => undefined)
+    })
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('alpha job')
+    })
+    harness.component().handleInput('job')
+    harness.component().handleInput('\u001B[B')
+    expect(plain(harness.component().render(80))).toContain('job')
+    expect(plain(harness.component().render(80))).toContain('bravo job')
+    navigation?.updateChoices([
+      { id: 'alpha', label: 'alpha job · running' },
+      { id: 'bravo', label: 'bravo job · idle' },
+      { id: 'other', label: 'unrelated' },
+    ])
+    const after = plain(harness.component().render(80))
+    expect(after).toContain('bravo job · idle')
+    expect(after).toContain('alpha job · running')
+    expect(after).not.toContain('unrelated')
+    expect(after).toMatch(/job/u)
+    navigation?.updateChoices(
+      [{ id: 'alpha', label: 'alpha job · running' }],
+      'refresh failed',
+    )
+    expect(plain(harness.component().render(80))).toContain('refresh failed')
+    expect(harness.hide).not.toHaveBeenCalled()
+    harness.component().handleInput(ESCAPE)
+    await expect(session).resolves.toBeUndefined()
+    const actions = readFileSync(resolve(import.meta.dirname, '../src/client/actions.ts'), 'utf8')
+    expect(actions).toMatch(/nav\.updateChoices\(/u)
+    expect(actions).toMatch(/\.catch\(/u)
   })
 
   it('submits multiline overlay text with Ctrl+Enter and keeps Enter as a newline', async () => {


### PR DESCRIPTION
## Summary
- Select pages gain `updateChoices()` that keeps the typed query and selected stable id.
- Jobs, queue, and subagent auto-refresh use it instead of destroying the selector each second.
- Subagent refresh failures become an in-page diagnostic instead of an unhandled rejection.

## Test plan
- `vitest run tests/overlays-navigation.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)