### PR TITLE
fix(tui): submit multiline overlays only on Ctrl+Enter

### DIFF
--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -203,6 +203,26 @@ function modalOptions(options: OverlayOptions | undefined): OverlayOptions {
   }
 }
 
+const MULTILINE_VISIBLE_ROWS = 12
+
+/**
+ * Keep the cursor row inside a bounded multiline editor window.
+ * @param lines - rendered editor rows.
+ * @param cursorLine - 0-based cursor row in that array.
+ * @param maxVisible - maximum rows to keep on screen.
+ */
+export function visibleEditorWindow(
+  lines: readonly string[],
+  cursorLine: number,
+  maxVisible = MULTILINE_VISIBLE_ROWS,
+): readonly string[] {
+  if (lines.length <= maxVisible) return lines
+  const cursor = Math.max(0, Math.min(cursorLine, lines.length - 1))
+  const maxStart = lines.length - maxVisible
+  const start = Math.max(0, Math.min(cursor - Math.floor((maxVisible - 1) / 2), maxStart))
+  return lines.slice(start, start + maxVisible)
+}
+
 function wrappedDetail(detail: string, width: number, maxLines = 4): string[] {
   const lines = wrapTextWithAnsi(escapeTerminalText(translateUiText(detail)), Math.max(1, width))
   if (lines.length <= maxLines) return lines.map(line => color.muted(line))
@@ -383,7 +403,12 @@ class MultilineEditorOverlay implements Component {
   render(width: number): string[] {
     const safeWidth = frameContentWidth(width)
     this.editor.focused = this.focused
-    const body = this.editor.render(Math.max(8, safeWidth)).slice(0, 12)
+    const rendered = this.editor.render(Math.max(8, safeWidth))
+    const cursorLine = rendered.findIndex(line => line.includes(CURSOR_MARKER))
+    const body = visibleEditorWindow(
+      rendered,
+      cursorLine === -1 ? this.editor.getCursor().line : cursorLine,
+    )
     return modalFrame(this.request.title, [
       ...(this.request.detail === undefined
         ? []
@@ -394,11 +419,11 @@ class MultilineEditorOverlay implements Component {
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.ctrl(Key.enter)) || data === '\n') {
+    if (matchesKey(data, Key.ctrl(Key.enter))) {
       this.submit(escapeTerminalText(this.editor.getExpandedText()))
       return
     }
-    if (matchesKey(data, Key.enter) || data === '\r') {
+    if (matchesKey(data, Key.enter) || data === '\r' || data === '\n') {
       this.editor.insertTextAtCursor('\n')
       return
     }

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
-import { OverlayQueue, type OverlayNavigation } from '../src/client/overlays.ts'
+import { OverlayQueue, visibleEditorWindow, type OverlayNavigation } from '../src/client/overlays.ts'
 
 const ESCAPE = '\u001B'
 const ENTER = '\r'
@@ -202,7 +202,7 @@ describe('overlay navigation', () => {
     expect(actions).toMatch(/\.catch\(/u)
   })
 
-  it('submits multiline overlay text with Ctrl+Enter and keeps Enter as a newline', async () => {
+  it('submits multiline overlay text only on Kitty Ctrl+Enter, not raw LF', async () => {
     const harness = overlayHarness()
     const submitted = harness.overlays.multilineInput({
       title: 'edit queued',
@@ -213,9 +213,19 @@ describe('overlay navigation', () => {
     })
     harness.component().handleInput(ENTER)
     harness.component().handleInput('x')
-    expect(plain(harness.component().render(80))).toContain('Ctrl+Enter')
     harness.component().handleInput('\n')
-    await expect(submitted).resolves.toBe('hello\nx')
+    expect(plain(harness.component().render(80))).toContain('Ctrl+Enter')
+    expect(plain(harness.component().render(80))).toContain('hello')
+    harness.component().handleInput('\u001B[13;5u')
+    await expect(submitted).resolves.toBe('hello\nx\n')
+  })
+
+  it('keeps the multiline cursor row inside the visible editor window', () => {
+    const lines = Array.from({ length: 20 }, (_, index) => `line-${String(index)}`)
+    expect(visibleEditorWindow(lines, 0, 12).at(0)).toBe('line-0')
+    expect(visibleEditorWindow(lines, 19, 12).at(-1)).toBe('line-19')
+    expect(visibleEditorWindow(lines, 10, 12)).toContain('line-10')
+    expect(visibleEditorWindow(lines, 10, 12)).toHaveLength(12)
   })
 
   it('aborts the navigation signal when Escape closes a busy session', async () => {


### PR DESCRIPTION
## Summary
- Multiline overlays submit only on a reliably identified Ctrl+Enter sequence.
- Ordinary CR/LF insert a newline so terminals that send LF for Enter no longer submit unfinished text.
- The visible window scrolls with the cursor instead of always clipping the first 12 lines.

## Test plan
- `vitest run tests/overlays-navigation.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)