### PR TITLE
fix(tui): keep clipboard images in a private temp dir

### DIFF
--- a/src/client/clipboard-image.ts
+++ b/src/client/clipboard-image.ts
@@ -1,10 +1,15 @@
 /** Read a PNG bitmap from the platform clipboard when paste is not a file path. */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { chmodSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
 
 /** PNG signature used to reject empty or non-image clipboard payloads. */
 export const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+/** Hung pngpaste/wl-paste/xclip must not pin the TUI input thread. */
+export const CLIPBOARD_IMAGE_DEADLINE_MS = 2_000
 
 export interface ClipboardImageSpawnResult {
   readonly status: number | null
@@ -14,9 +19,28 @@ export interface ClipboardImageSpawnResult {
 export interface ClipboardImageCaptureOptions {
   readonly platform: NodeJS.Platform
   readonly dest: string
-  readonly spawn?: (command: string, args: readonly string[]) => ClipboardImageSpawnResult
+  readonly spawn?: (command: string, args: readonly string[]) => ClipboardImageSpawnResult | Promise<ClipboardImageSpawnResult>
   readonly writeFile?: (path: string, bytes: Buffer) => void
   readonly readFile?: (path: string) => Buffer
+  readonly deadlineMs?: number
+}
+
+export interface ClipboardImageWorkspaceOptions {
+  readonly tmpdir?: string
+  readonly mkdir?: (path: string, mode: number) => void
+  readonly destName?: string
+}
+
+export interface ClipboardImageWorkspace {
+  readonly dir: string
+  readonly dest: string
+}
+
+export interface ClipboardImageCleanupOptions {
+  readonly readFile?: (path: string) => Buffer
+  readonly chmod?: (path: string, mode: number) => void
+  readonly unlink?: (path: string) => void
+  readonly rmdir?: (path: string) => void
 }
 
 interface ImagePasteCommand {
@@ -49,16 +73,55 @@ function commandsFor(platform: NodeJS.Platform, dest: string): readonly ImagePas
   return []
 }
 
-function defaultSpawn(command: string, args: readonly string[]): ClipboardImageSpawnResult {
-  const result: SpawnSyncReturns<Buffer> = spawnSync(command, [...args], {
-    encoding: 'buffer',
-    maxBuffer: 20 * 1024 * 1024,
-    timeout: 2_000,
-    windowsHide: true,
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  deadlineMs: number,
+): Promise<ClipboardImageSpawnResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, [...args], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    })
+    const chunks: Buffer[] = []
+    child.stdout?.on('data', (chunk: Buffer) => { chunks.push(chunk) })
+    let settled = false
+    const finish = (result: ClipboardImageSpawnResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+    const timer = setTimeout(() => {
+      child.kill()
+      finish({ status: null, stdout: Buffer.alloc(0) })
+    }, deadlineMs)
+    child.on('error', () => { finish({ status: null, stdout: Buffer.alloc(0) }) })
+    child.on('close', (status) => {
+      finish({ status, stdout: Buffer.concat(chunks) })
+    })
   })
-  return {
-    status: result.status,
-    stdout: Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.alloc(0),
+}
+
+async function spawnWithDeadline(
+  command: string,
+  args: readonly string[],
+  options: ClipboardImageCaptureOptions,
+): Promise<ClipboardImageSpawnResult> {
+  const deadlineMs = options.deadlineMs ?? CLIPBOARD_IMAGE_DEADLINE_MS
+  if (options.spawn === undefined) return defaultSpawn(command, args, deadlineMs)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      Promise.resolve(options.spawn(command, args)),
+      new Promise<ClipboardImageSpawnResult>((resolve) => {
+        timer = setTimeout(() => {
+          resolve({ status: null, stdout: Buffer.alloc(0) })
+        }, deadlineMs)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
   }
 }
 
@@ -71,16 +134,65 @@ export function isPng(bytes: Buffer): boolean {
 }
 
 /**
+ * Create a 0700 owner-only directory for one clipboard PNG.
+ * @param options - temp root and mkdir seams.
+ */
+export function createClipboardImageWorkspace(
+  options: ClipboardImageWorkspaceOptions = {},
+): ClipboardImageWorkspace {
+  const root = options.tmpdir ?? tmpdir()
+  const dir = join(root, `seektty-paste-${randomUUID()}`)
+  const mkdir = options.mkdir ?? ((path, mode) => { mkdirSync(path, { mode }) })
+  mkdir(dir, 0o700)
+  return { dir, dest: join(dir, options.destName ?? 'clipboard.png') }
+}
+
+/**
+ * Read a captured PNG, lock it to 0600, then delete the private workspace.
+ * @param workspace - dest created by {@link createClipboardImageWorkspace}.
+ * @param options - I/O seams.
+ */
+export function readCapturedClipboardImage(
+  workspace: ClipboardImageWorkspace,
+  options: ClipboardImageCleanupOptions = {},
+): Buffer {
+  const readFile = options.readFile ?? (path => readFileSync(path))
+  const chmod = options.chmod ?? ((path, mode) => { chmodSync(path, mode) })
+  const unlink = options.unlink ?? ((path) => { unlinkSync(path) })
+  const rmdir = options.rmdir ?? ((path) => { rmdirSync(path) })
+  try {
+    chmod(workspace.dest, 0o600)
+    return readFile(workspace.dest)
+  } finally {
+    cleanupClipboardImageWorkspace(workspace, { unlink, rmdir })
+  }
+}
+
+/**
+ * Remove the private clipboard PNG and its 0700 directory.
+ * @param workspace - dest created by {@link createClipboardImageWorkspace}.
+ * @param options - unlink/rmdir seams.
+ */
+export function cleanupClipboardImageWorkspace(
+  workspace: ClipboardImageWorkspace,
+  options: Pick<ClipboardImageCleanupOptions, 'unlink' | 'rmdir'> = {},
+): void {
+  const unlink = options.unlink ?? ((path) => { unlinkSync(path) })
+  const rmdir = options.rmdir ?? ((path) => { rmdirSync(path) })
+  try { unlink(workspace.dest) } catch { /* dest may never have been written */ }
+  try { rmdir(workspace.dir) } catch { /* best-effort private dir cleanup */ }
+}
+
+/**
  * Capture a PNG from the OS clipboard into `dest` when a platform tool is available.
  * @param options - platform, destination path, and I/O seams.
  * @returns dest when a PNG was written, otherwise undefined.
  */
-export function captureClipboardImage(options: ClipboardImageCaptureOptions): string | undefined {
-  const spawn = options.spawn ?? defaultSpawn
-  const writeFile = options.writeFile ?? ((path, bytes) => { writeFileSync(path, bytes) })
+export async function captureClipboardImage(options: ClipboardImageCaptureOptions): Promise<string | undefined> {
+  const writeFile = options.writeFile ?? ((path, bytes) => { writeFileSync(path, bytes, { mode: 0o600 }) })
   const readFile = options.readFile ?? (path => readFileSync(path))
   for (const candidate of commandsFor(options.platform, options.dest)) {
-    const result = spawn(candidate.command, candidate.args)
+    const result = await spawnWithDeadline(candidate.command, candidate.args, options)
     if (result.status !== 0) continue
     if (candidate.stdoutToFile) {
       if (!isPng(result.stdout)) continue

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -1,8 +1,6 @@
 /** Interactive pi-tui lifecycle over the authoritative Harness Client Runtime. */
 
-import { randomUUID } from 'node:crypto'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { chmodSync } from 'node:fs'
 import {
   Box,
   Key,
@@ -45,7 +43,11 @@ import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } f
 import { Transcript } from './transcript.ts'
 import { formatElapsed } from './elapsed.ts'
 import { writeClipboard } from './clipboard.ts'
-import { captureClipboardImage } from './clipboard-image.ts'
+import {
+  captureClipboardImage,
+  cleanupClipboardImageWorkspace,
+  createClipboardImageWorkspace,
+} from './clipboard-image.ts'
 import {
   desktopNotifyBody,
   desktopNotifySequence,
@@ -696,9 +698,26 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (!transcriptFocused && paste !== null) {
         const content = paste[1] ?? ''
         if (content.trim() === '') {
-          const dest = join(tmpdir(), `seektty-paste-${randomUUID()}.png`)
-          const captured = captureClipboardImage({ platform: process.platform, dest })
-          if (captured !== undefined) return attachPastedImage(captured, '')
+          const workspace = createClipboardImageWorkspace()
+          void captureClipboardImage({ platform: process.platform, dest: workspace.dest })
+            .then(async (captured) => {
+              if (captured === undefined) return
+              chmodSync(workspace.dest, 0o600)
+              const attachment = await capabilities.addAttachment(captured)
+              const dimensions = attachment.width === undefined ? '' : ` · ${attachment.width}×${attachment.height}`
+              setNotice(ui(
+                `已从粘贴加入 ${attachment.name} · ${attachment.mediaType} · ${attachment.bytes} B${dimensions}`,
+                `Attached ${attachment.name} from paste · ${attachment.mediaType} · ${attachment.bytes} B${dimensions}`,
+              ), 'success')
+            })
+            .catch((error: unknown) => {
+              setNotice(ui(
+                `粘贴图片未加入：${capabilityError(error)}`,
+                `Pasted image was not attached: ${capabilityError(error)}`,
+              ), 'warning')
+            })
+            .finally(() => { cleanupClipboardImageWorkspace(workspace) })
+          return { consume: true }
         }
         const safeContent = escapeTerminalText(content)
         if (safeContent !== content) {

--- a/tests/clipboard-image.test.ts
+++ b/tests/clipboard-image.test.ts
@@ -1,12 +1,53 @@
 import { describe, expect, it } from 'vitest'
-import { PNG_MAGIC, captureClipboardImage, isPng } from '../src/client/clipboard-image.ts'
+import {
+  PNG_MAGIC,
+  captureClipboardImage,
+  createClipboardImageWorkspace,
+  isPng,
+  readCapturedClipboardImage,
+} from '../src/client/clipboard-image.ts'
 
 const png = Buffer.concat([PNG_MAGIC, Buffer.from('payload')])
 
 describe('clipboard image capture', () => {
-  it('writes pngpaste output on macOS and wl-paste stdout on Linux', () => {
+  it('creates a 0700 private workspace and 0600 dest, then deletes after read', () => {
+    const created: Array<{ path: string; mode: number }> = []
+    const removed: string[] = []
+    const workspace = createClipboardImageWorkspace({
+      tmpdir: '/tmp',
+      mkdir: (path, mode) => { created.push({ path, mode }) },
+      destName: 'paste.png',
+    })
+    expect(created).toEqual([{ path: workspace.dir, mode: 0o700 }])
+    expect(workspace.dest.endsWith('paste.png')).toBe(true)
+    const bytes = readCapturedClipboardImage(workspace, {
+      readFile: path => {
+        expect(path).toBe(workspace.dest)
+        return png
+      },
+      chmod: (path, mode) => { created.push({ path, mode }) },
+      unlink: path => { removed.push(path) },
+      rmdir: path => { removed.push(path) },
+    })
+    expect(bytes.equals(png)).toBe(true)
+    expect(created).toContainEqual({ path: workspace.dest, mode: 0o600 })
+    expect(removed).toEqual([workspace.dest, workspace.dir])
+  })
+
+  it('kills a hung clipboard image probe after the deadline', async () => {
+    const started = Date.now()
+    await expect(captureClipboardImage({
+      platform: 'darwin',
+      dest: '/tmp/seektty-paste.png',
+      deadlineMs: 40,
+      spawn: () => new Promise(() => undefined),
+    })).resolves.toBeUndefined()
+    expect(Date.now() - started).toBeLessThan(500)
+  })
+
+  it('writes pngpaste output on macOS and wl-paste stdout on Linux', async () => {
     const written: Array<{ path: string; bytes: Buffer }> = []
-    expect(captureClipboardImage({
+    await expect(captureClipboardImage({
       platform: 'darwin',
       dest: '/tmp/seektty-paste.png',
       spawn: (command, args) => {
@@ -16,10 +57,10 @@ describe('clipboard image capture', () => {
       },
       writeFile: (path, bytes) => { written.push({ path, bytes }) },
       readFile: () => png,
-    })).toBe('/tmp/seektty-paste.png')
+    })).resolves.toBe('/tmp/seektty-paste.png')
     expect(written).toEqual([])
 
-    expect(captureClipboardImage({
+    await expect(captureClipboardImage({
       platform: 'linux',
       dest: '/tmp/seektty-paste.png',
       spawn: (command) => command === 'wl-paste'
@@ -27,15 +68,15 @@ describe('clipboard image capture', () => {
         : { status: 1, stdout: Buffer.alloc(0) },
       writeFile: (path, bytes) => { written.push({ path, bytes }) },
       readFile: () => png,
-    })).toBe('/tmp/seektty-paste.png')
+    })).resolves.toBe('/tmp/seektty-paste.png')
     expect(written[0]?.path).toBe('/tmp/seektty-paste.png')
     expect(isPng(png)).toBe(true)
     expect(isPng(Buffer.from('not png'))).toBe(false)
   })
 
-  it('falls back from wl-paste to xclip on Linux', () => {
+  it('falls back from wl-paste to xclip on Linux', async () => {
     const written: Buffer[] = []
-    expect(captureClipboardImage({
+    await expect(captureClipboardImage({
       platform: 'linux',
       dest: '/tmp/seektty-paste.png',
       spawn: (command) => command === 'xclip'
@@ -43,17 +84,17 @@ describe('clipboard image capture', () => {
         : { status: 1, stdout: Buffer.alloc(0) },
       writeFile: (_path, bytes) => { written.push(bytes) },
       readFile: () => png,
-    })).toBe('/tmp/seektty-paste.png')
+    })).resolves.toBe('/tmp/seektty-paste.png')
     expect(written[0]?.equals(png)).toBe(true)
   })
 
-  it('returns undefined when no platform clipboard tool has a PNG', () => {
-    expect(captureClipboardImage({
+  it('returns undefined when no platform clipboard tool has a PNG', async () => {
+    await expect(captureClipboardImage({
       platform: 'linux',
       dest: '/tmp/seektty-paste.png',
       spawn: () => ({ status: 1, stdout: Buffer.alloc(0) }),
       writeFile: () => undefined,
       readFile: () => Buffer.alloc(0),
-    })).toBeUndefined()
+    })).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Clipboard image capture writes into a `0700` private directory with `0600` files.
- The file is deleted in `finally` after the attachment is read into memory.
- Clipboard probes are async and bounded by a deadline so paste cannot freeze the TUI.

## Test plan
- `vitest run tests/clipboard-image.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)