### PR TITLE
fix(tui): export Markdown from the Host session log

### DIFF
--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -41,7 +41,6 @@ import { TuiSettingsConflictError } from '@deepseek-ai/dsh-tui-protocol'
 import type { TuiManagementBridge } from './management.ts'
 import type { TuiClientContext } from './context.ts'
 import { copyTargets } from './copy-content.ts'
-import { conversationMarkdown } from './conversation-markdown.ts'
 import { flattenProducedFiles, groupProducedFiles } from './produced-files.ts'
 import { explainFailure } from './error-advice.ts'
 import { ui, uiLocale } from './locale.ts'
@@ -1491,19 +1490,19 @@ export class HarnessTuiCapabilities {
   }
 
   /**
-   * Write a client-rendered Markdown transcript beside the workspace.
+   * Write Host Session-log Markdown beside the workspace.
    * @param requestedPath - absolute or Workspace-relative destination.
    * @returns saved path, byte count, and Markdown media type.
    */
-  async exportMarkdown(requestedPath?: string): Promise<TuiExportResult> {
+  async exportMarkdown(requestedPath?: string, signal?: AbortSignal): Promise<TuiExportResult> {
     const active = this.requireActive()
-    const markdown = conversationMarkdown(
-      active.summary.displayTitle,
-      active.session.getSnapshot().nodes,
+    const payload = await this.managementBridge().sessionExport.markdown(active.sessionId, signal)
+    const path = resolve(
+      active.workspacePath,
+      requestedPath ?? payload.suggestedFilename ?? markdownExportName(active.summary.displayTitle),
     )
-    const path = resolve(active.workspacePath, requestedPath ?? markdownExportName(active.summary.displayTitle))
-    const bytes = await saveTextExport(path, markdown)
-    return { path, bytes, mediaType: 'text/markdown', includeDescendants: false }
+    const bytes = await saveExport(path, payload.stream)
+    return { path, bytes, mediaType: payload.mediaType, includeDescendants: false }
   }
 
   /**

--- a/src/client/conversation-markdown.ts
+++ b/src/client/conversation-markdown.ts
@@ -1,4 +1,6 @@
-/** Client-side Markdown export of a conversation snapshot. */
+/** Markdown export of an authoritative Host Session-log snapshot. */
+
+import { inflateRawSync } from 'node:zlib'
 
 export interface MarkdownUserNode {
   readonly kind: 'user'
@@ -81,4 +83,84 @@ export function conversationMarkdown(
     }
   }
   return `${sections.join('\n\n')}\n`
+}
+
+function asNodes(value: unknown): readonly MarkdownConversationNode[] | undefined {
+  if (Array.isArray(value)) return value as MarkdownConversationNode[]
+  if (typeof value !== 'object' || value === null) return undefined
+  const record = value as Record<string, unknown>
+  if (Array.isArray(record.nodes)) return record.nodes as MarkdownConversationNode[]
+  if (typeof record.conversation === 'object' && record.conversation !== null) {
+    const conversation = record.conversation as Record<string, unknown>
+    if (Array.isArray(conversation.nodes)) return conversation.nodes as MarkdownConversationNode[]
+  }
+  if (Array.isArray(record.messages)) return record.messages as MarkdownConversationNode[]
+  return undefined
+}
+
+function titleOf(value: unknown, fallback: string): string {
+  if (typeof value === 'object' && value !== null && 'title' in value) {
+    const title = (value as { title?: unknown }).title
+    if (typeof title === 'string' && title !== '') return title
+  }
+  return fallback
+}
+
+function parseJsonSnapshot(bytes: Uint8Array): unknown | undefined {
+  const text = Buffer.from(bytes).toString('utf8').trim()
+  if (text === '' || (text[0] !== '{' && text[0] !== '[')) return undefined
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function zipEntries(bytes: Uint8Array): readonly { readonly name: string; readonly data: Uint8Array }[] {
+  const buffer = Buffer.from(bytes)
+  if (buffer.length < 4 || buffer.readUInt32LE(0) !== 0x04034b50) return []
+  const entries: { name: string; data: Uint8Array }[] = []
+  let offset = 0
+  while (offset + 30 <= buffer.length && buffer.readUInt32LE(offset) === 0x04034b50) {
+    const method = buffer.readUInt16LE(offset + 8)
+    const compressed = buffer.readUInt32LE(offset + 18)
+    const nameLength = buffer.readUInt16LE(offset + 26)
+    const extraLength = buffer.readUInt16LE(offset + 28)
+    const nameStart = offset + 30
+    const dataStart = nameStart + nameLength + extraLength
+    const dataEnd = dataStart + compressed
+    if (dataEnd > buffer.length) break
+    const name = buffer.subarray(nameStart, nameStart + nameLength).toString('utf8')
+    const payload = buffer.subarray(dataStart, dataEnd)
+    const data = method === 0
+      ? payload
+      : method === 8
+        ? inflateRawSync(payload)
+        : undefined
+    if (data !== undefined) entries.push({ name, data })
+    offset = dataEnd
+  }
+  return entries
+}
+
+/**
+ * Render a complete Host Session-log payload as Markdown.
+ * Accepts JSON snapshots and ZIP exports that contain a conversation JSON file.
+ * @param bytes - authoritative Session-log body.
+ * @param fallbackTitle - used when the log does not name the session.
+ */
+export function markdownFromSessionLog(bytes: Uint8Array, fallbackTitle: string): string {
+  const direct = parseJsonSnapshot(bytes)
+  const snapshot = direct ?? zipEntries(bytes).reduce<unknown | undefined>((found, entry) => {
+    if (found !== undefined || !entry.name.endsWith('.json')) return found
+    return parseJsonSnapshot(entry.data)
+  }, undefined)
+  if (snapshot === undefined) {
+    throw new Error('Session-log snapshot is not a conversation JSON or ZIP')
+  }
+  const nodes = asNodes(snapshot)
+  if (nodes === undefined) {
+    throw new Error('Session-log snapshot does not contain conversation nodes')
+  }
+  return conversationMarkdown(titleOf(snapshot, fallbackTitle), nodes)
 }

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -30,6 +30,7 @@ import type {} from './marketplace-provider.ts'
 import { assertCredentialFreeUrl, PluginMarketplace, redactMarketplaceUrl } from './plugin-marketplace.ts'
 import { installerSecrets, redactInstallerText } from './installer-output.ts'
 import { killHostJob, type HostJobRegistry } from '../client/job-control.ts'
+import { markdownFromSessionLog } from '../client/conversation-markdown.ts'
 import { ui } from '../client/locale.ts'
 
 const MARKETPLACE_NAMESPACE = settingsNamespace('tui-plugin-marketplace')
@@ -267,6 +268,35 @@ function sessionExportFilename(sessionId: string): string {
   return `dsh-session-${safe}.zip`
 }
 
+function sessionMarkdownFilename(sessionId: string): string {
+  const safe = sessionId.replace(/[^A-Za-z0-9._-]/gu, '_').slice(0, 120) || 'session'
+  return `${safe}.md`
+}
+
+async function bufferStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  try {
+    while (true) {
+      const next = await reader.read()
+      if (next.done) break
+      chunks.push(next.value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return Buffer.concat(chunks)
+}
+
+function textStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(Buffer.from(text, 'utf8'))
+      controller.close()
+    },
+  })
+}
+
 function validateCatalogSource(source: TuiMarketplaceSource): StoredCatalogSource {
   if (source.builtIn || source.kind !== 'catalog') {
     throw new Error(ui('内置 npm Source 不能写入用户来源', 'The built-in npm Source cannot be written as a user source'))
@@ -448,43 +478,61 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
     }
   }
 
+  const downloadSessionLog = async (
+    sessionId: string,
+    includeDescendants: boolean,
+    signal?: AbortSignal,
+  ) => {
+    const apiProxy = ctx.get('apiProxy')
+    if (apiProxy === undefined) {
+      throw new Error(ui(
+        'Harness Session Export 服务未装配',
+        'Harness Session Export service is not mounted',
+      ))
+    }
+    const request: Parameters<typeof apiProxy.downloads.sessionLog>[0] = {
+      sessionId: sessionId as Parameters<typeof apiProxy.downloads.sessionLog>[0]['sessionId'],
+      ...(includeDescendants ? { includeDescendants: true } : {}),
+    }
+    const response = await apiProxy.downloads.sessionLog(request, signal ?? new AbortController().signal)
+    if (!response.ok) {
+      const detail = (await response.text()).trim().slice(0, 1_000)
+      throw new Error(ui(
+        `Harness Session Export 失败（HTTP ${String(response.status)}）${detail === '' ? '' : `：${detail}`}`,
+        `Harness Session Export failed (HTTP ${String(response.status)})${detail === '' ? '' : `: ${detail}`}`,
+      ))
+    }
+    if (response.body === null) {
+      throw new Error(ui(
+        'Harness Session Export 返回了空响应体',
+        'Harness Session Export returned an empty response body',
+      ))
+    }
+    const rawLength = response.headers.get('content-length')
+    const contentLength = rawLength === null ? undefined : Number.parseInt(rawLength, 10)
+    return {
+      suggestedFilename: sessionExportFilename(sessionId),
+      mediaType: response.headers.get('content-type') ?? 'application/zip',
+      ...(contentLength === undefined || !Number.isSafeInteger(contentLength) || contentLength < 0
+        ? {}
+        : { contentLength }),
+      stream: response.body,
+    }
+  }
+
   return {
     sessionExport: {
-      download: async (sessionId, includeDescendants, signal) => {
-        const apiProxy = ctx.get('apiProxy')
-        if (apiProxy === undefined) {
-          throw new Error(ui(
-            'Harness Session Export 服务未装配',
-            'Harness Session Export service is not mounted',
-          ))
-        }
-        const request: Parameters<typeof apiProxy.downloads.sessionLog>[0] = {
-          sessionId: sessionId as Parameters<typeof apiProxy.downloads.sessionLog>[0]['sessionId'],
-          ...(includeDescendants ? { includeDescendants: true } : {}),
-        }
-        const response = await apiProxy.downloads.sessionLog(request, signal ?? new AbortController().signal)
-        if (!response.ok) {
-          const detail = (await response.text()).trim().slice(0, 1_000)
-          throw new Error(ui(
-            `Harness Session Export 失败（HTTP ${String(response.status)}）${detail === '' ? '' : `：${detail}`}`,
-            `Harness Session Export failed (HTTP ${String(response.status)})${detail === '' ? '' : `: ${detail}`}`,
-          ))
-        }
-        if (response.body === null) {
-          throw new Error(ui(
-            'Harness Session Export 返回了空响应体',
-            'Harness Session Export returned an empty response body',
-          ))
-        }
-        const rawLength = response.headers.get('content-length')
-        const contentLength = rawLength === null ? undefined : Number.parseInt(rawLength, 10)
+      download: downloadSessionLog,
+      markdown: async (sessionId, signal) => {
+        const exported = await downloadSessionLog(sessionId, false, signal)
+        const bytes = await bufferStream(exported.stream)
+        const markdown = markdownFromSessionLog(bytes, sessionId)
+        const encoded = Buffer.from(markdown, 'utf8')
         return {
-          suggestedFilename: sessionExportFilename(sessionId),
-          mediaType: response.headers.get('content-type') ?? 'application/zip',
-          ...(contentLength === undefined || !Number.isSafeInteger(contentLength) || contentLength < 0
-            ? {}
-            : { contentLength }),
-          stream: response.body,
+          suggestedFilename: sessionMarkdownFilename(sessionId),
+          mediaType: 'text/markdown',
+          contentLength: encoded.byteLength,
+          stream: textStream(markdown),
         }
       },
     },

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -325,6 +325,7 @@ export interface TuiSessionExport {
 export interface TuiManagementBridge {
   readonly sessionExport: {
     download(sessionId: string, includeDescendants: boolean, signal?: AbortSignal): Promise<TuiSessionExport>
+    markdown(sessionId: string, signal?: AbortSignal): Promise<TuiSessionExport>
   }
   readonly settings: {
     describe(namespace?: string): Promise<readonly TuiSettingsDocument[]>

--- a/tests/export-markdown.test.ts
+++ b/tests/export-markdown.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { formatByteSize } from '../src/client/byte-size.ts'
-import { conversationMarkdown } from '../src/client/conversation-markdown.ts'
+import { conversationMarkdown, markdownFromSessionLog } from '../src/client/conversation-markdown.ts'
 
 describe('export size and markdown', () => {
   it('renders binary byte sizes with one decimal below 100 units', () => {
@@ -38,5 +40,22 @@ describe('export size and markdown', () => {
       '- tool `Read`',
       '',
     ].join('\n'))
+  })
+
+  it('builds Markdown from a Host session-log snapshot, not the loaded client page', () => {
+    const log = {
+      title: 'Full session',
+      nodes: [
+        { kind: 'user', content: [{ type: 'text', text: 'early turn that paging hid' }] },
+        { kind: 'assistant', blocks: [{ kind: 'text', text: 'complete answer' }] },
+      ],
+    }
+    const markdown = markdownFromSessionLog(Buffer.from(JSON.stringify(log)), 'fallback')
+    expect(markdown).toContain('early turn that paging hid')
+    expect(markdown).toContain('complete answer')
+    expect(markdown).toContain('# Full session')
+    const capabilities = readFileSync(resolve(import.meta.dirname, '../src/client/capabilities.ts'), 'utf8')
+    expect(capabilities).toMatch(/sessionExport\.markdown\(/u)
+    expect(capabilities).not.toMatch(/exportMarkdown[\s\S]*getSnapshot\(\)\.nodes/u)
   })
 })


### PR DESCRIPTION
## Summary
- Markdown export reads the Host Session-log/export snapshot instead of the already-loaded client conversation page.
- Host converts the complete log (JSON or ZIP conversation JSON) to Markdown, then the client writes the file.

## Test plan
- `vitest run tests/export-markdown.test.ts tests/overlay-abort.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)