### PR TITLE
fix(tui): keep the selected empty-session example visible

### DIFF
--- a/src/client/transcript-search.ts
+++ b/src/client/transcript-search.ts
@@ -96,3 +96,20 @@ export function scrollOffsetToReveal(
   const preferred = lineCount - lineIndex - rows
   return Math.max(0, Math.min(maxOffset, preferred))
 }
+
+/**
+ * Keep `lineIndex` visible while preferring the top of the document.
+ * Compatible with Transcript's bottom-origin scrollOffset.
+ */
+export function scrollOffsetToContain(
+  lineCount: number,
+  viewportRows: number,
+  lineIndex: number,
+): number {
+  const rows = Math.max(1, Math.floor(viewportRows))
+  const maxOffset = Math.max(0, lineCount - rows)
+  const selected = Math.max(0, Math.min(lineIndex, Math.max(0, lineCount - 1)))
+  const minOffset = Math.max(0, lineCount - selected - rows)
+  const preferred = Math.min(maxOffset, Math.max(0, lineCount - selected - 1))
+  return Math.max(minOffset, preferred)
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -42,6 +42,7 @@ import {
   highlightQuery,
   nextMatchIndex,
   planLineSearch,
+  scrollOffsetToContain,
   scrollOffsetToReveal,
 } from './transcript-search.ts'
 import {
@@ -1479,10 +1480,23 @@ export class Transcript implements Component, Focusable {
       ])
     }
     const maxOffset = Math.max(0, lines.length - rows)
-    this.scrollOffset = this.emptyState ? maxOffset : Math.min(this.scrollOffset, maxOffset)
+    if (this.emptyState) {
+      const example = EMPTY_SESSION_EXAMPLES[this.exampleCursor]
+      const needle = example === undefined ? undefined : emptyExampleText(example)
+      const selected = needle === undefined
+        ? -1
+        : lines.findIndex(line => line.includes(needle))
+      this.scrollOffset = scrollOffsetToContain(
+        lines.length,
+        rows,
+        selected === -1 ? 0 : selected,
+      )
+    } else {
+      this.scrollOffset = Math.min(this.scrollOffset, maxOffset)
+    }
     const end = lines.length - this.scrollOffset
     const start = Math.max(0, end - rows)
-    if (this.scrollOffset === 0 && start > 0) {
+    if (!this.emptyState && this.scrollOffset === 0 && start > 0) {
       const alignedStart = this.turnAnchors.find(anchor =>
         anchor >= start && end - anchor <= rows - 1)
       if (alignedStart !== undefined) {
@@ -1495,17 +1509,19 @@ export class Transcript implements Component, Focusable {
       }
     }
     const visible = lines.slice(start, end)
-    if (start > 0 && visible.length > 0) {
-      visible[0] = olderMarker(start)
-    } else if (this.hasMore && visible.length > 0) {
-      visible[0] = olderMarker(0)
-    }
-    if (end < lines.length && visible.length > 0) {
-      const hint = this.focused ? 'PgDn/End' : ui('滚轮下翻', 'Scroll down')
-      visible[visible.length - 1] = color.muted(ui(
-        `↓ ${String(lines.length - end)} 行更新内容 · ${hint}`,
-        `↓ ${String(lines.length - end)} newer line(s) · ${hint}`,
-      ))
+    if (!this.emptyState) {
+      if (start > 0 && visible.length > 0) {
+        visible[0] = olderMarker(start)
+      } else if (this.hasMore && visible.length > 0) {
+        visible[0] = olderMarker(0)
+      }
+      if (end < lines.length && visible.length > 0) {
+        const hint = this.focused ? 'PgDn/End' : ui('滚轮下翻', 'Scroll down')
+        visible[visible.length - 1] = color.muted(ui(
+          `↓ ${String(lines.length - end)} 行更新内容 · ${hint}`,
+          `↓ ${String(lines.length - end)} newer line(s) · ${hint}`,
+        ))
+      }
     }
     return withInset(visible)
   }

--- a/tests/empty-examples.test.ts
+++ b/tests/empty-examples.test.ts
@@ -86,4 +86,17 @@ describe('empty session examples', () => {
     expect(rendered).toContain('Review the current changes and call out risks')
     expect(rendered).not.toContain('审查当前改动并指出风险')
   })
+
+  it('keeps the selected empty-session example inside a short viewport', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 4)
+    transcript.update(snapshot())
+    transcript.focused = true
+    transcript.handleInput('\u001b[B')
+    transcript.handleInput('\u001b[B')
+    const last = emptyExampleText(EMPTY_SESSION_EXAMPLES[2]!)
+    expect(transcript.activateFocused()).toEqual({ kind: 'example', text: last })
+    const visible = stripAnsi(transcript.render(80).join('\n'))
+    expect(visible).toContain(last)
+  })
 })


### PR DESCRIPTION
## Summary
- Empty-session examples use the same selection-aware viewport as ordinary lists.
- The selected starter prompt stays on screen in a short terminal; header lines stay visible when they still fit.

## Test plan
- `vitest run tests/empty-examples.test.ts tests/transcript.test.ts tests/transcript-search.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)