### PR TITLE
fix(tui): label Settings fields only by namespace and path

### DIFF
--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -205,32 +205,33 @@ export function settingsSectionLabel(namespace: string): string {
 }
 
 const FIELD_LABELS: Readonly<Record<string, { readonly zh: string; readonly en: string }>> = {
-  defaultPreset: { zh: '默认 Agent 模式', en: 'Default Agent preset' },
-  default: { zh: '默认权限', en: 'Default permission' },
-  theme: { zh: '界面主题', en: 'Interface theme' },
-  codeTheme: { zh: '代码块主题', en: 'Code theme' },
-  toolCards: { zh: '工具卡片默认形态', en: 'Default tool-card shape' },
-  showReasoning: { zh: '推理默认显示', en: 'Show reasoning by default' },
-  desktopNotifications: { zh: '完成/审批桌面通知', en: 'Desktop notifications' },
-  followTerminalTitle: { zh: '终端标题跟随', en: 'Follow the terminal title' },
-  composerHistoryLimit: { zh: '输入历史条数', en: 'Composer history size' },
-  statusElapsed: { zh: '状态栏实时耗时', en: 'Live status elapsed time' },
-  clipboardFallback: { zh: '剪贴板回退', en: 'Clipboard fallback' },
-  toolOutputLineLimit: { zh: '工具输出行数上限', en: 'Tool output line limit' },
-  diffContextLines: { zh: 'Diff 上下文行数', en: 'Diff context lines' },
-  dangerConfirmDefault: { zh: '危险确认默认焦点', en: 'Danger confirm default focus' },
-  keyBindings: { zh: '快捷键覆盖', en: 'Key binding overrides' },
+  'agent-presets.defaultPreset': { zh: '默认 Agent 模式', en: 'Default Agent preset' },
+  'permission.default': { zh: '默认权限', en: 'Default permission' },
+  [`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.theme`]: { zh: '界面主题', en: 'Interface theme' },
+  [`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.codeTheme`]: { zh: '代码块主题', en: 'Code theme' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.toolCards`]: { zh: '工具卡片默认形态', en: 'Default tool-card shape' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.showReasoning`]: { zh: '推理默认显示', en: 'Show reasoning by default' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.desktopNotifications`]: { zh: '完成/审批桌面通知', en: 'Desktop notifications' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.followTerminalTitle`]: { zh: '终端标题跟随', en: 'Follow the terminal title' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.composerHistoryLimit`]: { zh: '输入历史条数', en: 'Composer history size' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.statusElapsed`]: { zh: '状态栏实时耗时', en: 'Live status elapsed time' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.clipboardFallback`]: { zh: '剪贴板回退', en: 'Clipboard fallback' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.toolOutputLineLimit`]: { zh: '工具输出行数上限', en: 'Tool output line limit' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.diffContextLines`]: { zh: 'Diff 上下文行数', en: 'Diff context lines' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.dangerConfirmDefault`]: { zh: '危险确认默认焦点', en: 'Danger confirm default focus' },
+  [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.keyBindings`]: { zh: '快捷键覆盖', en: 'Key binding overrides' },
 }
 
 /**
  * Label a known high-frequency field while keeping unknown paths visible.
+ * Known labels match `namespace + path` only; unknown fields use the dotted path.
  * @param namespace - registered Harness Settings namespace.
  * @param path - schema path inside that namespace.
  */
 export function settingsFieldLabel(namespace: string, path: readonly string[]): string {
   if (path.length === 0) return namespace
   const dotted = path.join('.')
-  const named = FIELD_LABELS[`${namespace}.${dotted}`] ?? FIELD_LABELS[dotted]
+  const named = FIELD_LABELS[`${namespace}.${dotted}`]
   return named === undefined ? dotted : ui(named.zh, named.en)
 }
 

--- a/tests/settings-search.test.ts
+++ b/tests/settings-search.test.ts
@@ -56,4 +56,11 @@ describe('settings field index', () => {
     })
     expect(parseSettingsRootChoice('agent-presets')).toEqual({ namespace: 'agent-presets' })
   })
+
+  it('labels known fields only by namespace and path, not a bare field name', () => {
+    expect(settingsFieldLabel('other-plugin', ['theme'])).toBe('theme')
+    expect(settingsFieldLabel('other-plugin', ['default'])).toBe('default')
+    expect(settingsFieldLabel('seektty-appearance', ['theme'])).toBe('界面主题')
+    expect(settingsFieldLabel('permission', ['default'])).toBe('默认权限')
+  })
 })


### PR DESCRIPTION
## Summary
- Known Settings labels match `namespace + path` only.
- Unknown fields display the original dotted path, so another namespace's `theme` or `default` is not mislabeled.

## Test plan
- `vitest run tests/settings-search.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)