### PR TITLE
fix(tui): validate the full keymap before write and apply

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -30,8 +30,8 @@ import { formatByteSize } from './byte-size.ts'
 import { helpSectionChoices, helpSectionText, type HelpSectionId } from './help.ts'
 import {
   applyKeyBindingOverrides,
-  bindingConflict,
   bindingKeysLabel,
+  keyBindingsIssue,
   normalizeChord,
   SURFACE_KEYMAP,
 } from './keymap.ts'
@@ -1903,15 +1903,10 @@ The directory, user files, and all session logs are kept; sessions become ungrou
           `Cannot parse chord ${rest}`,
         ))
       }
-      const conflict = bindingConflict(id, chord)
-      if (conflict !== undefined) {
-        throw new Error(ui(
-          `与 ${conflict} 冲突`,
-          `Conflicts with ${conflict}`,
-        ))
-      }
       next[id] = chord
     }
+    const issue = keyBindingsIssue(next)
+    if (issue !== undefined) throw new Error(issue)
     const updated = await this.capabilities.managementBridge().settings.mutate(
       TUI_BEHAVIOR_SETTINGS_NAMESPACE,
       [{ op: 'set', path: ['keyBindings'], value: next }],

--- a/src/client/keymap.ts
+++ b/src/client/keymap.ts
@@ -221,13 +221,129 @@ function matchChord(data: string, chord: string): boolean {
   return matchesKey(data, chord as KeyId)
 }
 
-function effectiveChords(binding: SurfaceKeyBinding): readonly string[] {
-  const override = overrides[binding.id]
-  if (override !== undefined) return [override]
+function defaultChords(binding: SurfaceKeyBinding): readonly string[] {
   return binding.keys.flatMap(key => {
     const chord = normalizeChord(key)
     return chord === undefined ? [] : [chord]
   })
+}
+
+function effectiveChords(binding: SurfaceKeyBinding): readonly string[] {
+  const override = overrides[binding.id]
+  if (override !== undefined) return [override]
+  return defaultChords(binding)
+}
+
+const BARE_SPECIAL_KEYS = new Set([
+  'tab',
+  'enter',
+  'escape',
+  'left',
+  'right',
+  'up',
+  'down',
+  'home',
+  'end',
+  'backspace',
+  'delete',
+])
+
+function isUnmodifiedPrintableChord(chord: string): boolean {
+  if (chord.includes('+')) return false
+  if (BARE_SPECIAL_KEYS.has(chord)) return false
+  if (/^f([1-9]|1[0-2])$/u.test(chord)) return false
+  return chord.length === 1
+}
+
+function parsedOverrides(value: unknown): {
+  readonly bindings: Record<string, string>
+  readonly issue?: string
+} {
+  if (typeof value !== 'object' || value === null) return { bindings: {} }
+  const bindings: Record<string, string> = {}
+  for (const [id, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw !== 'string') {
+      return {
+        bindings,
+        issue: ui(`键位 ${id} 必须是字符串`, `Key binding ${id} must be a string`),
+      }
+    }
+    const binding = byId.get(id)
+    if (binding === undefined || !isConfigurable(binding)) continue
+    const chord = normalizeChord(raw)
+    if (chord === undefined) {
+      return {
+        bindings,
+        issue: ui(`无法解析组合键 ${raw}`, `Cannot parse chord ${raw}`),
+      }
+    }
+    if (isUnmodifiedPrintableChord(chord)) {
+      return {
+        bindings,
+        issue: ui(
+          `不能把无修饰可打印字符 ${formatChord(chord)} 设为全局快捷键`,
+          `Cannot bind unmodified printable character ${formatChord(chord)} as a global shortcut`,
+        ),
+      }
+    }
+    bindings[id] = chord
+  }
+  return { bindings }
+}
+
+function conflictIssue(overrides: Readonly<Record<string, string>>): string | undefined {
+  const owners = new Map<string, string>()
+  for (const binding of SURFACE_KEYMAP) {
+    const override = overrides[binding.id]
+    const chords = override === undefined ? defaultChords(binding) : [override]
+    for (const chord of chords) {
+      const owner = owners.get(chord)
+      if (owner !== undefined && owner !== binding.id) {
+        const reported = overrides[owner] !== undefined && overrides[binding.id] === undefined
+          ? binding.id
+          : owner
+        return ui(`与 ${reported} 冲突`, `Conflicts with ${reported}`)
+      }
+      owners.set(chord, binding.id)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Explain why a complete override map cannot be written or applied.
+ * @param value - persisted or typed override map.
+ * @returns a localized error, or undefined when the map is valid.
+ */
+export function keyBindingsIssue(value: unknown): string | undefined {
+  const parsed = parsedOverrides(value)
+  return parsed.issue ?? conflictIssue(parsed.bindings)
+}
+
+function dropConflictingOverrides(overrides: Record<string, string>): Record<string, string> {
+  const next = { ...overrides }
+  for (;;) {
+    const owners = new Map<string, string[]>()
+    for (const binding of SURFACE_KEYMAP) {
+      const override = next[binding.id]
+      const chords = override === undefined ? defaultChords(binding) : [override]
+      for (const chord of chords) {
+        const list = owners.get(chord) ?? []
+        list.push(binding.id)
+        owners.set(chord, list)
+      }
+    }
+    let dropped = false
+    for (const ids of owners.values()) {
+      if (ids.length < 2) continue
+      for (const id of ids) {
+        if (next[id] === undefined) continue
+        delete next[id]
+        dropped = true
+      }
+    }
+    if (!dropped) return next
+  }
 }
 
 /**
@@ -242,10 +358,10 @@ export function sanitizeKeyBindings(value: unknown): Readonly<Record<string, str
     const binding = byId.get(id)
     if (binding === undefined || !isConfigurable(binding)) continue
     const chord = normalizeChord(raw)
-    if (chord === undefined) continue
+    if (chord === undefined || isUnmodifiedPrintableChord(chord)) continue
     next[id] = chord
   }
-  return next
+  return dropConflictingOverrides(next)
 }
 
 /**

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -32,6 +32,7 @@ import { installerSecrets, redactInstallerText } from './installer-output.ts'
 import { killHostJob, type HostJobRegistry } from '../client/job-control.ts'
 import { markdownFromSessionLog } from '../client/conversation-markdown.ts'
 import { producedFilesFromSessionLog } from '../client/produced-files.ts'
+import { keyBindingsIssue, sanitizeKeyBindings } from '../client/keymap.ts'
 import { ui } from '../client/locale.ts'
 
 const MARKETPLACE_NAMESPACE = settingsNamespace('tui-plugin-marketplace')
@@ -190,7 +191,11 @@ export const BehaviorSettingsSchema = z.object({
       zh: '危险确认默认焦点；cancel 表示回车不执行。',
       en: 'Default focus for danger confirmation; cancel means Enter does not proceed.',
     })),
-  keyBindings: z.dict(z.string()).default({})
+  keyBindings: z.transform(z.dict(z.string()), (value) => {
+    const issue = keyBindingsIssue(value)
+    if (issue !== undefined) throw new Error(issue)
+    return sanitizeKeyBindings(value)
+  }).default({})
     .description(localeDescription({
       zh: '覆盖默认快捷键；键为绑定 id，值为 Ctrl+P 这类组合。空对象表示使用默认键位。',
       en: 'Override default shortcuts; keys are binding ids and values are chords such as Ctrl+P. An empty object uses the defaults.',

--- a/tests/behavior.test.ts
+++ b/tests/behavior.test.ts
@@ -53,6 +53,9 @@ describe('seektty-behavior settings', () => {
       keyBindings: { commandPalette: 'Ctrl+K', submit: 'ctrl+n', mystery: 'ctrl+f' },
     }).keyBindings).toEqual({ commandPalette: 'ctrl+k' })
     expect(normalizeBehavior({
+      keyBindings: { commandPalette: 'k', historySearch: 'ctrl+s' },
+    }).keyBindings).toEqual({})
+    expect(normalizeBehavior({
       toolCards: 'mystery',
       composerHistoryLimit: 99_999,
       clipboardFallback: 'pbcopy',

--- a/tests/keymap-bindings.test.ts
+++ b/tests/keymap-bindings.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { BehaviorSettingsSchema } from '../src/host/management.ts'
 import {
   applyKeyBindingOverrides,
   bindingConflict,
   helpKeymapText,
+  keyBindingsIssue,
   matchesBinding,
   normalizeChord,
+  sanitizeKeyBindings,
   SURFACE_KEYMAP,
 } from '../src/client/keymap.ts'
 
@@ -65,5 +68,30 @@ describe('key binding overrides', () => {
     applyKeyBindingOverrides({ sessions: 'ctrl+k' })
     expect(bindingConflict('commandPalette', 'ctrl+k')).toBe('sessions')
     expect(bindingConflict('historySearch', 'ctrl+s')).toBeUndefined()
+  })
+
+  it('rejects unmodified printable characters and duplicate chords in the full map', () => {
+    expect(keyBindingsIssue({ commandPalette: 'k' })).toMatch(/printable|可打印/u)
+    expect(keyBindingsIssue({ commandPalette: '/' })).toMatch(/printable|可打印/u)
+    expect(keyBindingsIssue({ commandPalette: 'ctrl+s' })).toMatch(/sessions/u)
+    expect(keyBindingsIssue({
+      commandPalette: 'ctrl+k',
+      historySearch: 'ctrl+k',
+    })).toMatch(/conflict|冲突/u)
+    expect(keyBindingsIssue({ commandPalette: 'Ctrl+K' })).toBeUndefined()
+    expect(sanitizeKeyBindings({
+      commandPalette: 'k',
+      historySearch: 'ctrl+k',
+      sessions: 'ctrl+k',
+    })).toEqual({})
+    applyKeyBindingOverrides({ commandPalette: 'k' })
+    expect(matchesBinding('commandPalette', 'k')).toBe(false)
+    expect(matchesBinding('commandPalette', '\u0010')).toBe(true)
+    expect(() => BehaviorSettingsSchema({ keyBindings: { commandPalette: 'k' } })).toThrow(/printable|可打印/u)
+    expect(() => BehaviorSettingsSchema({
+      keyBindings: { commandPalette: 'ctrl+k', historySearch: 'ctrl+k' },
+    })).toThrow(/conflict|冲突/u)
+    expect(BehaviorSettingsSchema({ keyBindings: { commandPalette: 'Ctrl+K' } }).keyBindings)
+      .toEqual({ commandPalette: 'ctrl+k' })
   })
 })

--- a/tests/keymap.test.ts
+++ b/tests/keymap.test.ts
@@ -102,6 +102,14 @@ describe('/keymap', () => {
     expect(host.notice).toHaveBeenCalledWith(expect.stringContaining('sessions'), 'error')
   })
 
+  it('refuses an unmodified printable character as a global shortcut', async () => {
+    const { actions, host, mutate } = actionHarness()
+    await actions.execute('keymap', 'commandPalette k')
+    expect(mutate).not.toHaveBeenCalled()
+    expect(host.applyBehavior).not.toHaveBeenCalled()
+    expect(host.notice).toHaveBeenCalledWith(expect.stringMatching(/printable|可打印/u), 'error')
+  })
+
   it('restores the shipped default for one action', async () => {
     const { actions, mutate } = actionHarness({
       ...DEFAULT_TUI_BEHAVIOR,


### PR DESCRIPTION
## Summary
- Validate the complete key-binding map on Settings write and before live apply.
- Reject duplicate chords and unmodified printable characters so ordinary typing cannot become a global shortcut.

## Test plan
- `vitest run tests/keymap-bindings.test.ts tests/keymap.test.ts tests/behavior.test.ts tests/settings-schema-i18n.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)