### PR TITLE
fix(tui): resolve theme export paths against the workspace

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -89,6 +89,7 @@ import {
 } from './theme-config.ts'
 import { convertVsCodeTheme, loadVsCodeThemeFile } from './theme-import.ts'
 import { serializeThemeExport, themeForExport, writeThemeExport } from './theme-export.ts'
+import { resolveHarnessUserPath } from './workspace-path.ts'
 import {
   languageSelection,
   localeFromSettings,
@@ -1394,17 +1395,21 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       options: { width: '95%', maxHeight: '80%', anchor: 'center', margin: 1 },
     })
     if (path === undefined || path.trim() === '') return
+    const destination = resolveHarnessUserPath(
+      path.trim(),
+      this.capabilities.active()?.workspacePath ?? process.cwd(),
+    )
     try {
-      const bytes = await writeThemeExport(path.trim(), serializeThemeExport(payload))
+      const bytes = await writeThemeExport(destination, serializeThemeExport(payload))
       this.host.notice(ui(
-        `已导出 ${payload.name} → ${path.trim()} · ${bytes} B`,
-        `Exported ${payload.name} → ${path.trim()} · ${bytes} B`,
+        `已导出 ${payload.name} → ${destination} · ${bytes} B`,
+        `Exported ${payload.name} → ${destination} · ${bytes} B`,
       ), 'success')
     } catch (error) {
       if (error instanceof Error && 'code' in error && error.code === 'EEXIST') {
         throw new Error(ui(
-          `文件已存在：${path.trim()}`,
-          `File already exists: ${path.trim()}`,
+          `文件已存在：${destination}`,
+          `File already exists: ${destination}`,
         ))
       }
       throw error

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -1,9 +1,7 @@
 /** Platform-neutral TUI actions over authoritative Harness Client faces. */
 
 import { mkdir, open, readFile, stat, unlink } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { basename, dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { getImageDimensions } from '@mariozechner/pi-tui'
 import type {
   IApiClient,
@@ -44,6 +42,7 @@ import { copyTargets } from './copy-content.ts'
 import { flattenProducedFiles, type ProducedFileGroup } from './produced-files.ts'
 import { explainFailure } from './error-advice.ts'
 import { ui, uiLocale } from './locale.ts'
+import { resolveHarnessUserPath } from './workspace-path.ts'
 
 /** A command shown by the terminal's merged slash directory. */
 export interface TuiCommandCandidate {
@@ -982,25 +981,15 @@ export class HarnessTuiCapabilities {
    */
   async addAttachment(rawPath: string): Promise<TuiDraftAttachment> {
     const active = this.requireActive()
-    let input = rawPath.trim()
-    if ((input.startsWith('"') && input.endsWith('"'))
-      || (input.startsWith("'") && input.endsWith("'"))) {
-      input = input.slice(1, -1)
+    const input = rawPath.trim()
+    if (input === '' || input === '""' || input === "''") {
+      throw new Error(ui('附件路径不能为空', 'Attachment path cannot be empty'))
     }
-    if (input === '') throw new Error(ui('附件路径不能为空', 'Attachment path cannot be empty'))
     let path: string
-    if (input.startsWith('file://')) {
-      try {
-        path = fileURLToPath(input)
-      } catch {
-        throw new Error(ui('附件 file URL 无效', 'Attachment file URL is invalid'))
-      }
-    } else if (input === '~') {
-      path = homedir()
-    } else if (/^~[/\\]/u.test(input)) {
-      path = resolve(homedir(), input.slice(2))
-    } else {
-      path = resolve(active.workspacePath, input)
+    try {
+      path = resolveHarnessUserPath(input, active.workspacePath)
+    } catch {
+      throw new Error(ui('附件 file URL 无效', 'Attachment file URL is invalid'))
     }
     const file = await stat(path)
     if (!file.isFile()) throw new Error(ui('附件路径不是文件', 'Attachment path is not a file'))

--- a/src/client/workspace-path.ts
+++ b/src/client/workspace-path.ts
@@ -1,0 +1,27 @@
+/** Resolve user-typed paths against the current Harness workspace. */
+
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function stripQuotes(input: string): string {
+  if ((input.startsWith('"') && input.endsWith('"'))
+    || (input.startsWith("'") && input.endsWith("'"))) {
+    return input.slice(1, -1)
+  }
+  return input
+}
+
+/**
+ * Expand `~` and supported `file:` URLs, then resolve relative paths
+ * against the Harness workspace instead of the process cwd.
+ * @param rawPath - user-typed path, quoted path, home path, or file URL.
+ * @param workspacePath - current Session workspace root.
+ */
+export function resolveHarnessUserPath(rawPath: string, workspacePath: string): string {
+  const input = stripQuotes(rawPath.trim())
+  if (input.startsWith('file:')) return fileURLToPath(input)
+  if (input === '~') return homedir()
+  if (/^~[/\\]/u.test(input)) return resolve(homedir(), input.slice(2))
+  return resolve(workspacePath, input)
+}

--- a/tests/theme-export.test.ts
+++ b/tests/theme-export.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { resolveHarnessUserPath } from '../src/client/workspace-path.ts'
 import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
 import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
 import type { OverlayQueue } from '../src/client/overlays.ts'
@@ -30,6 +32,16 @@ function document(value: TuiAppearanceSettings, revision = 0): TuiSettingsDocume
     secrets: [],
   }
 }
+
+describe('theme export path resolution', () => {
+  it('expands ~ and file URLs, then resolves relative paths against the workspace', () => {
+    const workspace = '/tmp/seektty-workspace'
+    expect(resolveHarnessUserPath('./ocean.json', workspace)).toBe(resolve(workspace, 'ocean.json'))
+    expect(resolveHarnessUserPath('~/Themes/ocean.json', workspace)).toBe(resolve(homedir(), 'Themes/ocean.json'))
+    expect(resolveHarnessUserPath('~', workspace)).toBe(homedir())
+    expect(resolveHarnessUserPath(pathToFileURL('/tmp/ocean.json').href, workspace)).toBe('/tmp/ocean.json')
+  })
+})
 
 describe('theme export payload', () => {
   it('serializes a portable custom-theme snapshot from a built-in theme', () => {
@@ -99,7 +111,7 @@ describe('/theme export', () => {
       }
       const capabilities = {
         managementBridge: () => ({ settings }) as TuiManagementBridge,
-        active: () => undefined,
+        active: () => ({ workspacePath: root }),
       } as unknown as HarnessTuiCapabilities
       const actions = new TuiActions(capabilities, host)
       const path = join(root, 'ocean.json')
@@ -113,6 +125,12 @@ describe('/theme export', () => {
         colors: custom.colors,
       })
       expect(host.notice).toHaveBeenCalledWith(expect.stringContaining('ocean.json'), 'success')
+
+      await actions.execute('theme', 'export Ocean ./nested/workspace-ocean.json')
+      expect(JSON.parse(await readFile(join(root, 'nested', 'workspace-ocean.json'), 'utf8'))).toMatchObject({
+        id: 'ocean',
+        name: 'Ocean',
+      })
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- Theme export reuses the same workspace path resolver as attachments.
- `~` and supported `file:` URLs expand; relative paths resolve against the current Harness workspace.

## Test plan
- `vitest run tests/theme-export.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)