### PR TITLE
fix(tui): apply the latest theme before Shiki takes over

### DIFF
--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -38,7 +38,7 @@ import {
   ui,
 } from './locale.ts'
 import { OverlayQueue, setDangerConfirmDefault } from './overlays.ts'
-import { SyntaxHighlighter } from './syntax-highlighter.ts'
+import { adoptSyntaxHighlighter, SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
 import { formatElapsed } from './elapsed.ts'
@@ -144,6 +144,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let disposeConstructedSyntax = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
+    let liveTheme = initialTheme
     const liveBehavior = createLiveBehavior(behaviorFromSettings(behaviorSettings(settingsDocuments)))
     applyKeyBindingOverrides(liveBehavior.get().keyBindings)
     setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault)
@@ -220,9 +221,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         created.dispose()
         return
       }
-      syntax = created
-      disposeConstructedSyntax = () => { created.dispose() }
-      setCodeHighlighter((code, lang) => created.highlight(code, lang))
+      adoptSyntaxHighlighter(created, liveTheme, (ready) => {
+        syntax = ready
+        disposeConstructedSyntax = () => { ready.dispose() }
+        setCodeHighlighter((code, lang) => ready.highlight(code, lang))
+      })
       if (stopping !== undefined) {
         created.dispose()
         syntax = undefined
@@ -486,6 +489,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       refresh,
       refreshHeader: () => { refreshHeader(false) },
       applyTheme: (theme) => {
+        liveTheme = theme
         setTheme(theme)
         syntax?.setTheme(theme)
         transcript.refreshPresentation()

--- a/src/client/syntax-highlighter.ts
+++ b/src/client/syntax-highlighter.ts
@@ -212,6 +212,24 @@ function highlightable(code: string): boolean {
     && code.split('\n').every(line => line.length <= MAX_HIGHLIGHT_LINE_CHARS)
 }
 
+/** Theme-aware highlighter that can receive the latest Surface theme. */
+export interface SyntaxThemeTarget {
+  setTheme(theme: ResolvedTuiTheme): void
+}
+
+/**
+ * Apply the current theme, then hand the highlighter to the renderer.
+ * Call this only after construction finishes so a mid-load theme change wins.
+ */
+export function adoptSyntaxHighlighter<T extends SyntaxThemeTarget>(
+  created: T,
+  currentTheme: ResolvedTuiTheme,
+  takeOver: (highlighter: T) => void,
+): void {
+  created.setTheme(currentTheme)
+  takeOver(created)
+}
+
 /** Synchronous render face backed by asynchronously loaded Shiki grammars. */
 export class SyntaxHighlighter {
   private readonly loaded = new Set<SupportedLanguage>()

--- a/tests/syntax-highlighter.test.ts
+++ b/tests/syntax-highlighter.test.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  adoptSyntaxHighlighter,
   SyntaxHighlighter,
   syntaxLanguageForPath,
 } from '../src/client/syntax-highlighter.ts'
@@ -105,6 +108,23 @@ describe('Shiki terminal syntax rendering', () => {
     } finally {
       highlighter.dispose()
     }
+  })
+})
+
+describe('Shiki theme revision', () => {
+  it('applies the latest theme before the highlighter takes over the renderer', () => {
+    const order: string[] = []
+    adoptSyntaxHighlighter(
+      { setTheme: theme => { order.push(`theme:${theme.id}`) } },
+      BUILT_IN_THEMES.light,
+      highlighter => { order.push(`takeover:${highlighter === undefined ? 'missing' : 'ready'}`) },
+    )
+    expect(order).toEqual(['theme:light', 'takeover:ready'])
+
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/surface.ts'), 'utf8')
+    expect(source).toMatch(/liveTheme = initialTheme/u)
+    expect(source).toMatch(/adoptSyntaxHighlighter\(created, liveTheme,/u)
+    expect(source).toMatch(/liveTheme = theme/u)
   })
 })
 


### PR DESCRIPTION
## Summary
- Keep the latest Surface theme while Shiki loads.
- Apply that theme after the highlighter is created and only then hand it to the renderer.

## Test plan
- `vitest run tests/syntax-highlighter.test.ts -t \"Shiki theme revision\"`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)