### PR TITLE
fix(tui): bind marketplace, Settings, and plugin caches to source fingerprints

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -449,7 +449,10 @@ export class TuiActions {
   private async settingsConflict(error: TuiSettingsConflictError): Promise<void> {
     let actual = error.actual
     try {
-      const document = (await this.capabilities.managementBridge().settings.describe(error.namespace))[0]
+      const document = (await this.capabilities.managementBridge().settings.describe(
+        error.namespace,
+        { bypassCache: true },
+      ))[0]
       if (document !== undefined) actual = document.revision
     } catch (refreshError) {
       this.host.notice(ui(`设置冲突后重新读取失败：${capabilityError(refreshError)}`, `Failed to reload after a Settings conflict: ${capabilityError(refreshError)}`), 'error')

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -237,18 +237,24 @@ function settingsDocument(descriptor: SettingsDescriptor): TuiSettingsDocument {
  */
 export function createSettingsDescribeCache(
   load: () => readonly TuiSettingsDocument[],
+  fingerprint?: () => string,
 ): {
-  describe(namespace?: string): readonly TuiSettingsDocument[]
-  one(namespace: string): TuiSettingsDocument
+  describe(namespace?: string, options?: { bypassCache?: boolean }): readonly TuiSettingsDocument[]
+  one(namespace: string, options?: { bypassCache?: boolean }): TuiSettingsDocument
   invalidate(): void
 } {
   let cached: readonly TuiSettingsDocument[] | undefined
-  const all = (): readonly TuiSettingsDocument[] => {
-    cached ??= load()
+  let cachedFingerprint: string | undefined
+  const all = (bypass = false): readonly TuiSettingsDocument[] => {
+    const stamp = fingerprint?.()
+    if (bypass || cached === undefined || (stamp !== undefined && stamp !== cachedFingerprint)) {
+      cached = load()
+      cachedFingerprint = stamp
+    }
     return cached
   }
-  const one = (namespace: string): TuiSettingsDocument => {
-    const document = all().find(row => row.namespace === namespace)
+  const one = (namespace: string, options?: { bypassCache?: boolean }): TuiSettingsDocument => {
+    const document = all(options?.bypassCache === true).find(row => row.namespace === namespace)
     if (document === undefined) {
       throw new Error(ui(
         `设置命名空间 ${JSON.stringify(namespace)} 已卸载`,
@@ -258,13 +264,14 @@ export function createSettingsDescribeCache(
     return document
   }
   return {
-    describe(namespace?: string): readonly TuiSettingsDocument[] {
-      if (namespace === undefined) return all()
-      return [one(namespace)]
+    describe(namespace?: string, options?: { bypassCache?: boolean }): readonly TuiSettingsDocument[] {
+      if (namespace === undefined) return all(options?.bypassCache === true)
+      return [one(namespace, options)]
     },
     one,
     invalidate(): void {
       cached = undefined
+      cachedFingerprint = undefined
     },
   }
 }
@@ -464,9 +471,15 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
     ...(providers === undefined ? {} : { providers }),
   })
 
+  let settingsGeneration = 0
   const documents = createSettingsDescribeCache(
     () => settings.describe({ redactSecrets: true }).map(settingsDocument),
+    () => String(settingsGeneration),
   )
+  ctx.on('settings/document-updated', () => {
+    settingsGeneration += 1
+    documents.invalidate()
+  })
   const sourceSnapshot = (): TuiMarketplaceSources => {
     const document = documents.one(MARKETPLACE_NAMESPACE)
     const value = document.value as MarketplaceSettings
@@ -550,9 +563,14 @@ export function createTuiManagementBridge(ctx: Context, cwd: string): TuiManagem
       },
     },
     settings: {
-      describe: namespace => Promise.resolve(documents.describe(namespace)),
+      describe: (namespace, options) => Promise.resolve(documents.describe(namespace, options)),
       mutate: async (namespace, ops, expectedRevision) => {
-        await mutateSettings(settings, namespace, ops, expectedRevision)
+        try {
+          await mutateSettings(settings, namespace, ops, expectedRevision)
+        } catch (error) {
+          documents.invalidate()
+          throw error
+        }
         documents.invalidate()
         return documents.one(namespace)
       },

--- a/src/host/plugin-marketplace.ts
+++ b/src/host/plugin-marketplace.ts
@@ -439,7 +439,7 @@ export class PluginMarketplace {
     const text = query.trim()
     if (text === '') throw new Error(ui('插件搜索词不能为空', 'Plugin search query cannot be empty'))
     const enabled = sources.filter(source => source.enabled)
-    const cacheKey = `search:${text}:${enabled.map(source => source.id).join(',')}`
+    const cacheKey = this.searchCacheKey(text, enabled)
     const cached = this.searchCache.get(cacheKey)
     if (cached !== undefined) return cached
     const settled = await Promise.allSettled(enabled.map(async (source) => {
@@ -491,11 +491,46 @@ export class PluginMarketplace {
   ): Promise<TuiMarketplaceCandidate> {
     const value = spec.trim()
     if (value === '') throw new Error(ui('插件 spec 不能为空', 'Plugin spec cannot be empty'))
-    const cached = this.inspectCache.get(value)
-    if (cached !== undefined) return cached
+    const cacheKey = this.inspectCacheKey(value, sources)
+    if (cacheKey !== undefined) {
+      const cached = this.inspectCache.get(cacheKey)
+      if (cached !== undefined) return cached
+    }
     const candidate = await this.inspectUncached(value, sources, signal)
-    this.inspectCache.set(value, candidate)
+    if (cacheKey !== undefined) this.inspectCache.set(cacheKey, candidate)
     return candidate
+  }
+
+  private sourceFingerprint(source: TuiMarketplaceSource): string {
+    return [
+      source.id,
+      source.kind,
+      source.url,
+      source.credentialRef ?? '',
+      source.enabled ? '1' : '0',
+      this.localCatalogStamp(source),
+    ].join('\0')
+  }
+
+  private localCatalogStamp(source: TuiMarketplaceSource): string {
+    if (source.kind !== 'catalog' || /^https?:/iu.test(source.url)) return ''
+    try {
+      const path = source.url.startsWith('file:') ? fileURLToPath(source.url) : resolve(this.cwd, source.url)
+      if (!existsSync(path)) return 'missing'
+      const stat = statSync(path)
+      return `${stat.mtimeMs}:${stat.size}`
+    } catch {
+      return 'invalid'
+    }
+  }
+
+  private searchCacheKey(query: string, sources: readonly TuiMarketplaceSource[]): string {
+    return `search:${query}:${sources.map(source => this.sourceFingerprint(source)).join('|')}`
+  }
+
+  private inspectCacheKey(spec: string, sources: readonly TuiMarketplaceSource[]): string | undefined {
+    if (sourceType(spec) === 'local') return undefined
+    return `inspect:${spec}:${sources.filter(source => source.enabled).map(source => this.sourceFingerprint(source)).join('|')}`
   }
 
   private async inspectUncached(

--- a/src/host/profile-plugin-manager.ts
+++ b/src/host/profile-plugin-manager.ts
@@ -688,8 +688,19 @@ export class ProfilePluginManager {
   }
 
   private profileStamp(): string {
-    const path = join(this.dir, 'package.json')
-    return existsSync(path) ? String(statSync(path).mtimeMs) : 'missing'
+    return [
+      join(this.dir, 'package.json'),
+      join(this.dir, 'pnpm-lock.yaml'),
+      join(this.dir, 'package-lock.json'),
+      join(this.dir, PROFILE_PATCH_FILENAME),
+      join(this.dir, 'node_modules'),
+    ].map(path => this.pathStamp(path)).join('|')
+  }
+
+  private pathStamp(path: string): string {
+    if (!existsSync(path)) return `${basename(path)}:missing`
+    const stat = statSync(path)
+    return `${basename(path)}:${stat.mtimeMs}:${stat.isFile() ? stat.size : 'dir'}`
   }
 
   private forgetInstalled(): void {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -337,7 +337,7 @@ export interface TuiManagementBridge {
     index(sessionId: string, signal?: AbortSignal): Promise<readonly TuiProducedFileGroup[]>
   }
   readonly settings: {
-    describe(namespace?: string): Promise<readonly TuiSettingsDocument[]>
+    describe(namespace?: string, options?: { bypassCache?: boolean }): Promise<readonly TuiSettingsDocument[]>
     mutate(namespace: string, ops: readonly TuiSettingsPathOp[], expectedRevision: number): Promise<TuiSettingsDocument>
     credentialInfo(ref: string): Promise<TuiCredentialInfo>
     setCredential(ref: string, value: string): Promise<TuiCredentialInfo>

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,6 +1,7 @@
 import { gzipSync } from 'node:zlib'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { PluginMarketplace } from '../src/host/plugin-marketplace.ts'
 import type { TuiMarketplaceSource } from '../src/protocol.ts'
@@ -230,5 +231,45 @@ describe('plugin marketplace search (task 5.3)', () => {
     const rows = await marketplace.search('demo', [source, catalog])
     expect(rows.some(row => row.name === 'demo-plugin')).toBe(true)
     expect(rows.some(row => row.sourceId === 'bad-catalog' && row.diagnostics.some(item => item.includes('catalog down')))).toBe(true)
+  })
+
+  it('does not reuse a search when the registry URL or credential changes', async () => {
+    let searches = 0
+    const marketplace = new PluginMarketplace({
+      cwd: root,
+      resolveCredential: () => Promise.resolve(undefined),
+      fetch: (async (input) => {
+        const url = String(input)
+        if (url.includes('/-/v1/search')) {
+          searches += 1
+          return jsonResponse(searchBody())
+        }
+        throw new Error(`unexpected fetch ${url}`)
+      }) as typeof fetch,
+    })
+    await marketplace.search('demo', [source])
+    await marketplace.search('demo', [{ ...source, url: 'https://registry.example.test/' }])
+    await marketplace.search('demo', [{ ...source, credentialRef: 'NPM_TOKEN' }])
+    expect(searches).toBe(3)
+  })
+
+  it('does not cache inspect results for a local mutable spec', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'seektty-local-inspect-'))
+    const spec = join(home, 'plugin')
+    mkdirSync(spec)
+    writeFileSync(join(spec, 'package.json'), '{"name":"local-plugin","version":"1.0.0"}\n')
+    try {
+      const marketplace = new PluginMarketplace({
+        cwd: home,
+        resolveCredential: () => Promise.resolve(undefined),
+      })
+      const first = await marketplace.inspect(spec, [])
+      expect(first.version).toBe('1.0.0')
+      writeFileSync(join(spec, 'package.json'), '{"name":"local-plugin","version":"2.0.0"}\n')
+      const second = await marketplace.inspect(spec, [])
+      expect(second.version).toBe('2.0.0')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/profile-plugin-snapshot.test.ts
+++ b/tests/profile-plugin-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -21,5 +21,12 @@ describe('profile plugin snapshot (task 5.3)', () => {
     const third = manager.snapshot()
     expect(third).not.toBe(first)
     expect(third.profile).toBe('tui')
+    writeFileSync(join(manager.dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n')
+    const afterLock = manager.snapshot()
+    expect(afterLock).not.toBe(third)
+    mkdirSync(join(manager.dir, 'node_modules'))
+    writeFileSync(join(manager.dir, 'node_modules', '.modules.yaml'), 'hoisted: {}\n')
+    const afterModules = manager.snapshot()
+    expect(afterModules).not.toBe(afterLock)
   })
 })

--- a/tests/settings-describe.test.ts
+++ b/tests/settings-describe.test.ts
@@ -20,7 +20,7 @@ function document(namespace: string): TuiSettingsDocument {
 describe('settings describe (task 5.3)', () => {
   it('exposes an optional namespace on the management bridge', () => {
     const source = readFileSync(resolve(root, 'src/protocol.ts'), 'utf8')
-    expect(source).toMatch(/describe\(namespace\?: string\): Promise<readonly TuiSettingsDocument\[\]>/u)
+    expect(source).toMatch(/describe\(namespace\?: string, options\?: \{ bypassCache\?: boolean \}\): Promise<readonly TuiSettingsDocument\[\]>/u)
   })
 
   it('loads every namespace once then serves one() from that snapshot', () => {
@@ -54,5 +54,20 @@ describe('settings describe (task 5.3)', () => {
     revision = 2
     cache.invalidate()
     expect(cache.one('seektty-appearance').revision).toBe(2)
+  })
+
+  it('reloads when the Host revision fingerprint changes or bypass is requested', () => {
+    let revision = 1
+    let hostRevision = '1'
+    const cache = createSettingsDescribeCache(
+      () => [{ ...document('seektty-appearance'), revision }],
+      () => hostRevision,
+    )
+    expect(cache.one('seektty-appearance').revision).toBe(1)
+    revision = 2
+    hostRevision = '2'
+    expect(cache.one('seektty-appearance').revision).toBe(2)
+    revision = 3
+    expect(cache.describe('seektty-appearance', { bypassCache: true })[0]?.revision).toBe(3)
   })
 })


### PR DESCRIPTION
## Summary
- Marketplace search/inspect cache keys include URL, credentials, and local catalog stamps; local mutable specs are not cached.
- Settings describe binds to a Host revision generation, reloads after `settings/document-updated` or write conflicts, and supports `bypassCache`.
- Plugin snapshots invalidate when lockfile, patch, or `node_modules` changes, not only `package.json` mtime.

## Test plan
- `vitest run tests/plugin-marketplace.test.ts tests/settings-describe.test.ts tests/profile-plugin-snapshot.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)