### PR TITLE
fix(tui): include deliverables in the transcript node fingerprint

### DIFF
--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -864,6 +864,13 @@ function grouped(rows: readonly TranscriptRow[]): TranscriptRow[] {
   return rows.map((row, index) => index === 0 ? { ...row, gapBefore: true } : row)
 }
 
+function deliverablesFingerprint(node: ChatConversationViewNode): readonly string[] {
+  if (!isConversationNode(node.data) || node.data.kind !== 'assistant') return []
+  const location = node.location
+  if (location.kind !== 'turn' && location.kind !== 'step') return []
+  return producedForClosing(location.turn.data.get('deliverables'), node.data.seq)
+}
+
 function nodeFingerprint(
   node: ChatConversationViewNode,
   preferences: TranscriptPreferences,
@@ -871,6 +878,7 @@ function nodeFingerprint(
   return JSON.stringify({
     kind: node.kind,
     data: node.data,
+    deliverables: deliverablesFingerprint(node),
     tools: preferences.tools,
     reasoning: preferences.reasoning,
     toolOutputLineLimit: preferences.toolOutputLineLimit,

--- a/tests/transcript-cache.test.ts
+++ b/tests/transcript-cache.test.ts
@@ -108,4 +108,36 @@ describe('transcript node cache (task 5.2)', () => {
     transcript.render(80)
     expect(internals.componentRenders).toBe(first)
   })
+
+  it('rebuilds when deliverables change even if node.data stays the same', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const data = {
+      kind: 'assistant',
+      seq: 2,
+      time: 2,
+      turn: 1,
+      step: 1,
+      blocks: [{ kind: 'text', text: 'done' }],
+    }
+    const node = (files: readonly string[]): ChatConversationViewNode => ({
+      ...assistant('a1', 'done'),
+      data,
+      location: {
+        kind: 'turn',
+        turn: {
+          turn: 1,
+          data: {
+            get: (key: string) => key === 'deliverables'
+              ? { produced: files.map(path => ({ seq: 1, path })) }
+              : undefined,
+          },
+        },
+      },
+    } as ChatConversationViewNode)
+    const transcript = new Transcript(() => Number.POSITIVE_INFINITY)
+    transcript.update(snapshot([node([])]))
+    expect(transcript.render(80).join('\n')).not.toContain('notes.md')
+    transcript.update(snapshot([node(['notes.md'])]))
+    expect(transcript.render(80).join('\n')).toContain('notes.md')
+  })
 })


### PR DESCRIPTION
## Summary
- Transcript cache fingerprints include the normalized produced-file list used by deliverables rendering.
- New generated files appear while streaming even when `node.data` is unchanged.

## Test plan
- `vitest run tests/transcript-cache.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)