### PR TITLE
fix(tui): report answered and skipped questions separately

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3588,7 +3588,24 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
     }
     this.host.transcript.followLatest()
     await this.capabilities.answerQuestion(wait, { answers })
+    this.host.notice(questionBatchSummary(answers), 'info')
   }
+}
+
+/**
+ * Summarize a completed question batch without counting skipped items as answered.
+ * @param answers - submitted answers, including empty skip rows.
+ */
+export function questionBatchSummary(
+  answers: readonly { readonly selected: readonly string[]; readonly custom?: string }[],
+): string {
+  const skipped = answers.filter(answer =>
+    answer.selected.length === 0 && (answer.custom === undefined || answer.custom === '')).length
+  const answered = answers.length - skipped
+  return ui(
+    `已处理 ${String(answers.length)} 项（回答 ${String(answered)} · 跳过 ${String(skipped)}）`,
+    `Processed ${String(answers.length)} item(s) (answered ${String(answered)} · skipped ${String(skipped)})`,
+  )
 }
 
 /**

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@deepseek-ai/dsh-client-runtime/node-client'
 import type { SessionId } from '@deepseek-ai/dsh-api-remotes/node-client'
 import {
+  questionBatchSummary,
   TuiActions,
   type TuiActionHost,
 } from '../src/client/actions.ts'
@@ -74,5 +75,14 @@ describe('pending interaction continuation', () => {
     expect(answerQuestion).toHaveBeenCalledWith(question, {
       answers: [{ id: 'which_pkg', selected: ['visualtex-src 根目录 (Recommended)'] }],
     })
+  })
+
+  it('summarizes answered and skipped items instead of calling skips answered', () => {
+    expect(questionBatchSummary([
+      { selected: ['a'] },
+      { selected: [] },
+      { selected: [], custom: 'note' },
+    ])).toContain('已处理 3 项（回答 2 · 跳过 1）')
+    expect(questionBatchSummary([{ selected: [] }])).not.toContain('已回答')
   })
 })


### PR DESCRIPTION
## Summary
- Question-batch completion says processed, with answered and skipped counts.
- Skipped items are no longer counted as answered.

## Test plan
- `vitest run tests/actions-interaction.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)