### PR TITLE
fix(tui): copy assistant replies without trimming edges

### DIFF
--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -286,7 +286,7 @@ function assistantText(message: AssistantMessageNode): string {
     if (block.kind === 'text') return [block.text]
     if (block.kind === 'image') return [ui('[图片]', '[image]')]
     return []
-  }).join('\n').trim()
+  }).join('\n')
 }
 
 function latestModelRoute(snapshot: ConversationSnapshot): string | undefined {

--- a/src/client/copy-content.ts
+++ b/src/client/copy-content.ts
@@ -26,12 +26,11 @@ export function copyTargets(
   entries: readonly { readonly id: string; readonly text: string }[],
 ): readonly { readonly id: string; readonly preview: string; readonly text: string }[] {
   return [...entries].reverse().flatMap((entry) => {
-    const text = entry.text.trim()
-    if (text === '') return []
+    if (entry.text === '') return []
     return [{
       id: entry.id,
-      preview: text.replace(/\s+/gu, ' ').slice(0, 160),
-      text,
+      preview: entry.text.replace(/\s+/gu, ' ').slice(0, 160),
+      text: entry.text,
     }]
   })
 }

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { lastFencedCode, copyTargets } from '../src/client/copy-content.ts'
 import { OSC52_BYTE_LIMIT, osc52Sequence, writeClipboard } from '../src/client/clipboard.ts'
@@ -10,6 +12,9 @@ describe('copy content', () => {
       { id: '1', text: 'older' },
       { id: '2', text: 'newer line' },
     ]).map(row => row.id)).toEqual(['2', '1'])
+    expect(copyTargets([{ id: '3', text: '  keep edges  \n' }])[0]?.text).toBe('  keep edges  \n')
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/capabilities.ts'), 'utf8')
+    expect(source).not.toMatch(/join\('\\n'\)\.trim\(\)/u)
   })
 })
 


### PR DESCRIPTION
## Summary
- Last-reply and picker copy keep the original leading and trailing whitespace.
- Empty replies are still skipped; whitespace-only replies can be copied.

## Test plan
- `vitest run tests/clipboard.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)