### PR TITLE
fix(tui): highlight search hits without stripping line styles

### DIFF
--- a/src/client/transcript-search.ts
+++ b/src/client/transcript-search.ts
@@ -71,12 +71,32 @@ export function highlightQuery(
   query: string,
   paint: (matched: string) => string,
 ): string {
-  const plain = stripAnsi(line)
   const needle = query.trim()
-  if (needle === '') return plain
+  if (needle === '') return line
+  const plain = stripAnsi(line)
   const index = plain.toLowerCase().indexOf(needle.toLowerCase())
-  if (index < 0) return plain
-  return `${plain.slice(0, index)}${paint(plain.slice(index, index + needle.length))}${plain.slice(index + needle.length)}`
+  if (index < 0) return line
+  const start = visibleOffset(line, index)
+  const end = visibleOffset(line, index + needle.length)
+  if (start < 0 || end < 0) return line
+  return `${line.slice(0, start)}${paint(line.slice(start, end))}${line.slice(end)}`
+}
+
+function visibleOffset(line: string, visibleIndex: number): number {
+  if (visibleIndex === 0) return 0
+  const token = /^\u001B\[[0-9;:]*m/u
+  let visible = 0
+  for (let index = 0; index < line.length; ) {
+    const match = token.exec(line.slice(index))
+    if (match !== null) {
+      index += match[0].length
+      continue
+    }
+    visible += 1
+    index += 1
+    if (visible === visibleIndex) return index
+  }
+  return visibleIndex === visible ? line.length : -1
 }
 
 /**

--- a/tests/transcript-search.test.ts
+++ b/tests/transcript-search.test.ts
@@ -19,6 +19,8 @@ describe('transcript in-session search', () => {
     expect(nextMatchIndex([0, 5], 5, 1)).toBe(0)
     expect(nextMatchIndex([0, 5], 5, -1)).toBe(0)
     expect(highlightQuery('Hello World', 'lo', text => `[${text}]`)).toBe('Hel[lo] World')
+    expect(highlightQuery('\u001B[32mhello\u001B[0m there', 'hello', text => `{${text}}`))
+      .toBe('{\u001B[32mhello}\u001B[0m there')
     expect(stripAnsi('\u001B[7mhit\u001B[0m')).toBe('hit')
     expect(scrollOffsetToReveal(20, 8, 2)).toBe(10)
   })


### PR DESCRIPTION
## Summary
- Transcript search highlight wraps the match at visible-character offsets.
- Existing ANSI on the line is no longer stripped before painting.

## Test plan
- `vitest run tests/transcript-search.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)