### PR TITLE
fix(tui): ignore a trailing newline when folding tool output

### DIFF
--- a/src/client/tool-output-limit.ts
+++ b/src/client/tool-output-limit.ts
@@ -7,14 +7,22 @@ import { ui } from './locale.ts'
  * @param text - one tool-output block.
  * @param limit - line cap; 0 or negative means unlimited.
  */
+export function toolOutputLines(text: string): { readonly lines: readonly string[]; readonly eofNewline: boolean } {
+  const eofNewline = text.endsWith('\n')
+  const body = eofNewline ? text.slice(0, -1) : text
+  return { lines: body.split('\n'), eofNewline }
+}
+
 export function foldLineBlock(text: string, limit: number): { text: string; omitted: number } {
   if (!Number.isFinite(limit) || limit <= 0) return { text, omitted: 0 }
   const cap = Math.floor(limit)
-  const lines = text.split('\n')
+  const { lines, eofNewline } = toolOutputLines(text)
   if (lines.length <= cap) return { text, omitted: 0 }
   const omitted = lines.length - cap
+  const kept = lines.slice(0, cap).join('\n')
+  const suffix = eofNewline || omitted > 0 ? '\n' : ''
   return {
-    text: `${lines.slice(0, cap).join('\n')}\n${ui(`还有 ${String(omitted)} 行`, `${String(omitted)} more line(s)`)}`,
+    text: `${kept}${suffix}${ui(`还有 ${String(omitted)} 行`, `${String(omitted)} more line(s)`)}`,
     omitted,
   }
 }

--- a/tests/tool-output-limit.test.ts
+++ b/tests/tool-output-limit.test.ts
@@ -104,6 +104,9 @@ describe('tool output folding', () => {
     ])
     expect(foldLineBlock(lines.join('\n'), 0).omitted).toBe(0)
     expect(foldLineBlock(lines.join('\n'), 0).text).toBe(lines.join('\n'))
+    expect(foldLineBlock('line-1\n', 1)).toEqual({ text: 'line-1\n', omitted: 0 })
+    expect(foldLineBlock('line-1\nline-2\n', 1).omitted).toBe(1)
+    expect(foldLineBlock('line-1\nline-2\n', 1).text).toContain('还有 1 行')
   })
 
   it('folds expanded shell output using the behavior default of 200 lines', () => {


### PR DESCRIPTION
## Summary
- Tool output records a trailing newline separately instead of inventing an empty line.
- Fold counts and footers use the real visible line count.

## Test plan
- `vitest run tests/tool-output-limit.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)