### PR TITLE
fix(tui): reject trajectory timestamps outside the Date range

### DIFF
--- a/src/client/trajectory-detail.ts
+++ b/src/client/trajectory-detail.ts
@@ -6,8 +6,12 @@ function text(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined
 }
 
+const MAX_DATE_MS = 8.64e15
+
 function millis(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) <= MAX_DATE_MS
+    ? value
+    : undefined
 }
 
 /**

--- a/tests/trajectory-detail.test.ts
+++ b/tests/trajectory-detail.test.ts
@@ -34,4 +34,23 @@ describe('trajectory request detail (task 6.4)', () => {
     })
     expect(text).toContain('结束: 运行中')
   })
+
+  it('omits timestamps outside the ECMAScript Date range instead of throwing', () => {
+    expect(() => trajectoryRequestDetail({
+      purpose: 'assistant',
+      status: 'completed',
+      startedAt: 8.64e15 + 1,
+      completedAt: -8.64e15 - 1,
+      requestConfig: { provider: 'deepseek', model: 'deepseek-chat' },
+    })).not.toThrow()
+    const text = trajectoryRequestDetail({
+      purpose: 'assistant',
+      status: 'completed',
+      startedAt: 8.64e15 + 1,
+      completedAt: Date.parse('2026-01-01T00:00:00.000Z'),
+      requestConfig: { provider: 'deepseek', model: 'deepseek-chat' },
+    })
+    expect(text).not.toContain('开始:')
+    expect(text).toContain('结束: 2026-01-01T00:00:00.000Z')
+  })
 })


### PR DESCRIPTION
## Summary
- Trajectory timestamps must be inside the ECMAScript Date range before `toISOString()`.
- Out-of-range values are omitted instead of crashing the inspector.

## Test plan
- `vitest run tests/trajectory-detail.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)