### PR TITLE
fix(tui): warn once per unknown fiber state per connection

### DIFF
--- a/src/host/fiber-state.ts
+++ b/src/host/fiber-state.ts
@@ -13,6 +13,12 @@ export const FIBER_STATE = {
 } as const
 
 const KNOWN = new Set<number>(Object.values(FIBER_STATE))
+const warned = new Set<number>()
+
+/** Clear per-connection unknown-state warnings. Call when a Host connection starts. */
+export function resetUnknownFiberWarnings(): void {
+  warned.clear()
+}
 
 /**
  * True when the Host fiber is ACTIVE. Unknown numeric states warn instead of
@@ -24,6 +30,9 @@ export function isActiveFiber(
   state: number,
   warn: (chunk: string) => unknown = () => undefined,
 ): boolean {
-  if (!KNOWN.has(state)) warn(`seektty: unknown Cordis fiber.state ${String(state)}\n`)
+  if (!KNOWN.has(state) && !warned.has(state)) {
+    warned.add(state)
+    warn(`seektty: unknown Cordis fiber.state ${String(state)}\n`)
+  }
   return state === FIBER_STATE.ACTIVE
 }

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -9,7 +9,7 @@ import type { ClientConnectionRpc } from '@deepseek-ai/dsh-client-connection'
 import type { TuiManagementBridge, TuiSurfaceOutcome } from '@deepseek-ai/dsh-tui-protocol'
 import { startTui } from '../client/index.ts'
 import { translateUiText, ui } from '../client/locale.ts'
-import { isActiveFiber } from './fiber-state.ts'
+import { isActiveFiber, resetUnknownFiberWarnings } from './fiber-state.ts'
 import { createTuiManagementBridge } from './management.ts'
 import { TUI_STARTUP_SERVICE, type TuiStartupValues } from './startup.ts'
 
@@ -46,6 +46,7 @@ export const internals: {
 }
 
 async function run(ctx: Context): Promise<void> {
+  resetUnknownFiberWarnings()
   await ctx.get('loader')?.await()
   if (!isActive(ctx)) return
   const startup = ctx.get(TUI_STARTUP_SERVICE) as TuiStartupValues | undefined

--- a/tests/fiber-state.test.ts
+++ b/tests/fiber-state.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { FIBER_STATE, isActiveFiber } from '../src/host/fiber-state.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FIBER_STATE, isActiveFiber, resetUnknownFiberWarnings } from '../src/host/fiber-state.ts'
+
+afterEach(() => {
+  resetUnknownFiberWarnings()
+})
 
 describe('Cordis fiber state (task 6.8)', () => {
   it('treats ACTIVE as 2 and warns on an unknown numeric state', () => {
@@ -7,6 +11,12 @@ describe('Cordis fiber state (task 6.8)', () => {
     expect(isActiveFiber(FIBER_STATE.ACTIVE)).toBe(true)
     expect(isActiveFiber(FIBER_STATE.FAILED)).toBe(false)
     const warnings: string[] = []
+    expect(isActiveFiber(99, chunk => { warnings.push(chunk) })).toBe(false)
+    expect(warnings.join('')).toContain('unknown Cordis fiber.state 99')
+    warnings.length = 0
+    expect(isActiveFiber(99, chunk => { warnings.push(chunk) })).toBe(false)
+    expect(warnings).toEqual([])
+    resetUnknownFiberWarnings()
     expect(isActiveFiber(99, chunk => { warnings.push(chunk) })).toBe(false)
     expect(warnings.join('')).toContain('unknown Cordis fiber.state 99')
   })


### PR DESCRIPTION
## Summary
- Unknown `fiber.state` values warn once per Host connection.
- A new connection clears the dedupe set.

## Test plan
- `vitest run tests/fiber-state.test.ts`
- `tsc --noEmit`

Made with [Cursor](https://cursor.com)