### PR TITLE
fix(compat): ignore official host.describe 0.0.1 placeholder

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_VERSION, c as isVersionRequest, d as versionMessage, i as PACKAGE_NAME, l as launcherCopy, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as launcherPrefersEnglish } from "./startup-trace-Bjb556WQ.js";
+import { a as PACKAGE_VERSION, c as isVersionRequest, d as versionMessage, i as PACKAGE_NAME, l as launcherCopy, n as measureStartupSync, o as defaultPluginSpec, r as DSH_COMPATIBILITY, u as launcherPrefersEnglish } from "./startup-trace-BYa9XU45.js";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-Cx6Oq8rk.js";
-import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-Bjb556WQ.js";
+import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-BYa9XU45.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-Di2x50P-.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-C08eAhrI.js";
 import { createRequire } from "node:module";

--- a/lib/startup-trace-BYa9XU45.js
+++ b/lib/startup-trace-BYa9XU45.js
@@ -5,6 +5,13 @@ const DSH_COMPATIBILITY = {
 	minimum: "0.1.0-rc.6",
 	tested: "0.1.0-rc.6"
 };
+/**
+* Value returned by official `@deepseek-ai/dsh-host-apiproxy` `host.describe`.
+* The gateway still hardcodes `version: '0.0.1'` as a TODO placeholder
+* (present in 0.1.0-rc.6 and 0.1.0-rc.7) instead of reading `apps/cli`
+* package.json. Treat it as "version unknown", not as a real 0.0.1 CLI.
+*/
+const HOST_DESCRIBE_VERSION_PLACEHOLDER = "0.0.1";
 function parseVersion(value) {
 	const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/u.exec(value.trim());
 	if (match === null) return void 0;
@@ -52,11 +59,13 @@ function compareDshVersion(left, right) {
 }
 /**
 * Explain why a running dsh version is outside this Bundle's declared range.
-* @param hostVersion - `host.describe` version, when known.
+* @param hostVersion - Host-reported version. Official `host.describe` still
+*   returns the placeholder `0.0.1`; that value is ignored.
 * @param compatibility - package.json `dsh.compatibility`.
 * @param english - launcher-safe language choice (no locale.ts).
 */
 function dshCompatibilityError(hostVersion, compatibility, english) {
+	if (hostVersion === HOST_DESCRIBE_VERSION_PLACEHOLDER) return void 0;
 	if (hostVersion === void 0 || hostVersion.trim() === "") return english ? `Could not read the dsh version. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).` : `无法读取 dsh 版本。SeekTTY 需要 dsh >= ${compatibility.minimum}（已测试 ${compatibility.tested}）。`;
 	const order = compareDshVersion(hostVersion, compatibility.minimum);
 	if (order === void 0) return english ? `Unrecognized dsh version ${hostVersion}. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).` : `无法识别 dsh 版本 ${hostVersion}。SeekTTY 需要 dsh >= ${compatibility.minimum}（已测试 ${compatibility.tested}）。`;

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -12,6 +12,14 @@ export const DSH_COMPATIBILITY: DshCompatibility = {
   tested: '0.1.0-rc.6',
 }
 
+/**
+ * Value returned by official `@deepseek-ai/dsh-host-apiproxy` `host.describe`.
+ * The gateway still hardcodes `version: '0.0.1'` as a TODO placeholder
+ * (present in 0.1.0-rc.6 and 0.1.0-rc.7) instead of reading `apps/cli`
+ * package.json. Treat it as "version unknown", not as a real 0.0.1 CLI.
+ */
+export const HOST_DESCRIBE_VERSION_PLACEHOLDER = '0.0.1'
+
 interface VersionParts {
   readonly major: number
   readonly minor: number
@@ -69,7 +77,8 @@ export function compareDshVersion(left: string, right: string): number | undefin
 
 /**
  * Explain why a running dsh version is outside this Bundle's declared range.
- * @param hostVersion - `host.describe` version, when known.
+ * @param hostVersion - Host-reported version. Official `host.describe` still
+ *   returns the placeholder `0.0.1`; that value is ignored.
  * @param compatibility - package.json `dsh.compatibility`.
  * @param english - launcher-safe language choice (no locale.ts).
  */
@@ -78,6 +87,7 @@ export function dshCompatibilityError(
   compatibility: DshCompatibility,
   english: boolean,
 ): string | undefined {
+  if (hostVersion === HOST_DESCRIBE_VERSION_PLACEHOLDER) return undefined
   if (hostVersion === undefined || hostVersion.trim() === '') {
     return english
       ? `Could not read the dsh version. SeekTTY needs dsh >= ${compatibility.minimum} (tested ${compatibility.tested}).`

--- a/tests/dsh-compat.test.ts
+++ b/tests/dsh-compat.test.ts
@@ -37,4 +37,10 @@ describe('dsh version and compatibility', () => {
     expect(dshCompatibilityError('0.2.0', range, true)).toMatch(/tested 0\.1\.0-rc\.6/u)
     expect(dshCompatibilityError('0.1.0-rc.6', range, true)).toBeUndefined()
   })
+
+  it('does not treat the official host.describe placeholder as a real dsh version', () => {
+    const range = { minimum: '0.1.0-rc.6', tested: '0.1.0-rc.6' }
+    expect(dshCompatibilityError('0.0.1', range, false)).toBeUndefined()
+    expect(dshCompatibilityError('0.0.1', range, true)).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- Official `@deepseek-ai/dsh-host-apiproxy` still hardcodes `host.describe.version` as `0.0.1` (TODO placeholder), including on dsh 0.1.0-rc.6 / rc.7.
- SeekTTY treated that field as the real CLI version and refused to start with `dsh 0.0.1 过旧`.
- Ignore the known placeholder so current official dsh can boot; real version gates still apply to actual version strings.

## Test plan
- [x] `vitest run tests/dsh-compat.test.ts tests/package-contract.test.ts`
- [ ] Run `deepseek` in a real TTY against dsh `0.1.0-rc.6` and confirm it no longer exits with `dsh 0.0.1 过旧`
- [ ] Confirm `deepseek --version` still prints the declared `>= 0.1.0-rc.6` range


Made with [Cursor](https://cursor.com)