### PR TITLE
fix(tui): surface daily commands first and hide catalog aliases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -19847,6 +19847,29 @@ function resolveHarnessUserPath(rawPath, workspacePath) {
 
 //#endregion
 //#region src/client/capabilities.ts
+/**
+* Compatible names that still execute, but stay out of `/`, Ctrl+P, and help.
+* Hidden name → visible canonical name.
+*/
+const TUI_HIDDEN_COMMAND_ALIASES = Object.freeze({
+	resume: "sessions",
+	plugins: "plugin",
+	quit: "exit"
+});
+/**
+* Map a typed command token to the catalog name used for lookup.
+* @param name - token without a leading slash.
+*/
+function canonicalTuiCommandName(name$1) {
+	return TUI_HIDDEN_COMMAND_ALIASES[name$1] ?? name$1;
+}
+/**
+* Visible TUI names plus hidden aliases that must keep occupying the merged catalog.
+* Host or Skill entries with these names must not steal typed `/resume` `/plugins` `/quit`.
+*/
+function reservedTuiCatalogNames() {
+	return new Set([...Object.keys(TUI_HIDDEN_COMMAND_ALIASES), ...tuiCommands().map((command) => command.name)]);
+}
 const SAFE_PERMISSION_PRESETS = new Set(["read-only", "workspace-write"]);
 const FULL_ACCESS_PRESET = "danger-full-access";
 const HOST_COMMAND_DECORATORS = new Set(["permission", "feedback"]);
@@ -19896,15 +19919,35 @@ function tuiCommands() {
 			behavior: "local"
 		},
 		{
-			name: "resume",
-			description: ui("恢复会话", "Resume session"),
+			name: "sessions",
+			description: ui("查看或搜索会话", "View or search sessions"),
+			argumentHint: ui("[搜索词]", "[query]"),
 			source: "TUI",
 			behavior: "local"
 		},
 		{
-			name: "sessions",
-			description: ui("查看或搜索会话", "View or search sessions"),
-			argumentHint: ui("[搜索词]", "[query]"),
+			name: "model",
+			description: ui("切换模型和推理强度", "Switch model and reasoning effort"),
+			source: "TUI",
+			behavior: "local"
+		},
+		{
+			name: "mode",
+			description: ui("切换模式", "Switch mode"),
+			source: "TUI",
+			behavior: "local"
+		},
+		{
+			name: "permission",
+			description: ui("切换权限", "Switch permission"),
+			argumentHint: ui("[权限]", "[permission]"),
+			source: "Host + TUI",
+			behavior: "local"
+		},
+		{
+			name: "workspace",
+			description: ui("管理工作区", "Manage workspaces"),
+			argumentHint: ui("[子命令|路径]", "[subcommand|path]"),
 			source: "TUI",
 			behavior: "local"
 		},
@@ -19942,28 +19985,9 @@ function tuiCommands() {
 			behavior: "local"
 		},
 		{
-			name: "workspace",
-			description: ui("管理工作区", "Manage workspaces"),
-			argumentHint: ui("[子命令|路径]", "[subcommand|path]"),
-			source: "TUI",
-			behavior: "local"
-		},
-		{
 			name: "profile",
 			description: ui("管理 Profile", "Manage Profiles"),
 			argumentHint: "[list|switch|create|copy]",
-			source: "TUI",
-			behavior: "local"
-		},
-		{
-			name: "mode",
-			description: ui("切换模式", "Switch mode"),
-			source: "TUI",
-			behavior: "local"
-		},
-		{
-			name: "model",
-			description: ui("切换模型和推理强度", "Switch model and reasoning effort"),
 			source: "TUI",
 			behavior: "local"
 		},
@@ -20035,13 +20059,6 @@ function tuiCommands() {
 			behavior: "local"
 		},
 		{
-			name: "plugins",
-			description: ui("打开插件中心", "Open plugin center"),
-			argumentHint: ui("[子命令]", "[subcommand]"),
-			source: "TUI",
-			behavior: "local"
-		},
-		{
 			name: "doctor",
 			description: ui("检查运行环境", "Check runtime environment"),
 			source: "TUI",
@@ -20105,12 +20122,6 @@ function tuiCommands() {
 		{
 			name: "help",
 			description: ui("查看帮助", "View help"),
-			source: "TUI",
-			behavior: "local"
-		},
-		{
-			name: "quit",
-			description: ui("退出", "Exit"),
 			source: "TUI",
 			behavior: "local"
 		},
@@ -21199,11 +21210,11 @@ var HarnessTuiCapabilities = class {
 		if (!hostResult.ok) throw new Error(ui(`读取 Host 命令失败：${hostResult.error.message}`, `Failed to load Host commands: ${hostResult.error.message}`));
 		if (skillResponse !== void 0 && !skillResponse.result.ok) throw new Error(ui(`读取 Skill 失败：${skillResponse.result.error.message}`, `Failed to load Skills: ${skillResponse.result.error.message}`));
 		const commands = tuiCommands();
-		const local = new Map(commands.map((command) => [command.name, command]));
+		const reserved = reservedTuiCatalogNames();
 		const merged = [...commands];
-		const names = new Set(commands.map((command) => command.name));
+		const names = new Set(reserved);
 		for (const command of hostResult.value) {
-			if (local.get(command.name) !== void 0) continue;
+			if (reserved.has(command.name)) continue;
 			names.add(command.name);
 			merged.push({
 				name: command.name,
@@ -30142,6 +30153,8 @@ function questionBatchSummary(answers) {
 * @returns the exact command candidate when registered.
 */
 function commandOf(catalog, name$1) {
+	const canonical = canonicalTuiCommandName(name$1);
+	if (canonical !== name$1) return catalog.find((candidate) => candidate.name === canonical);
 	return catalog.find((candidate) => candidate.name === name$1);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3854,9 +3854,9 @@ export function commandOf(
   catalog: readonly TuiCommandCandidate[],
   name: string,
 ): TuiCommandCandidate | undefined {
-  const exact = catalog.find(candidate => candidate.name === name)
-  if (exact !== undefined) return exact
   const canonical = canonicalTuiCommandName(name)
-  if (canonical === name) return undefined
-  return catalog.find(candidate => candidate.name === canonical)
+  if (canonical !== name) {
+    return catalog.find(candidate => candidate.name === canonical)
+  }
+  return catalog.find(candidate => candidate.name === name)
 }

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -23,7 +23,7 @@ import {
   type TuiCustomTheme,
   type TuiThemeId,
 } from '@deepseek-ai/dsh-tui-protocol'
-import { capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
+import { canonicalTuiCommandName, capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
 import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
 import { lastFencedCode } from './copy-content.ts'
 import { formatByteSize } from './byte-size.ts'
@@ -3854,5 +3854,9 @@ export function commandOf(
   catalog: readonly TuiCommandCandidate[],
   name: string,
 ): TuiCommandCandidate | undefined {
-  return catalog.find(candidate => candidate.name === name)
+  const exact = catalog.find(candidate => candidate.name === name)
+  if (exact !== undefined) return exact
+  const canonical = canonicalTuiCommandName(name)
+  if (canonical === name) return undefined
+  return catalog.find(candidate => candidate.name === canonical)
 }

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -53,6 +53,24 @@ export interface TuiCommandCandidate {
   readonly behavior: 'local' | 'host' | 'skill'
 }
 
+/**
+ * Compatible names that still execute, but stay out of `/`, Ctrl+P, and help.
+ * Hidden name → visible canonical name.
+ */
+export const TUI_HIDDEN_COMMAND_ALIASES = Object.freeze({
+  resume: 'sessions',
+  plugins: 'plugin',
+  quit: 'exit',
+} as const)
+
+/**
+ * Map a typed command token to the catalog name used for lookup.
+ * @param name - token without a leading slash.
+ */
+export function canonicalTuiCommandName(name: string): string {
+  return TUI_HIDDEN_COMMAND_ALIASES[name as keyof typeof TUI_HIDDEN_COMMAND_ALIASES] ?? name
+}
+
 /** One selectable Agent Preset from the Host directory. */
 export interface TuiModeOption {
   readonly id: string
@@ -212,17 +230,17 @@ export function shortFunctionDescription(description: string, fallback: string):
 export function tuiCommands(): readonly TuiCommandCandidate[] {
   return Object.freeze([
     { name: 'new', description: ui('新建会话', 'New session'), source: 'TUI', behavior: 'local' },
-    { name: 'resume', description: ui('恢复会话', 'Resume session'), source: 'TUI', behavior: 'local' },
     { name: 'sessions', description: ui('查看或搜索会话', 'View or search sessions'), argumentHint: ui('[搜索词]', '[query]'), source: 'TUI', behavior: 'local' },
+    { name: 'model', description: ui('切换模型和推理强度', 'Switch model and reasoning effort'), source: 'TUI', behavior: 'local' },
+    { name: 'mode', description: ui('切换模式', 'Switch mode'), source: 'TUI', behavior: 'local' },
+    { name: 'permission', description: ui('切换权限', 'Switch permission'), argumentHint: ui('[权限]', '[permission]'), source: 'Host + TUI', behavior: 'local' },
+    { name: 'workspace', description: ui('管理工作区', 'Manage workspaces'), argumentHint: ui('[子命令|路径]', '[subcommand|path]'), source: 'TUI', behavior: 'local' },
     { name: 'rename', description: ui('重命名当前会话', 'Rename current session'), argumentHint: ui('<标题>', '<title>'), source: 'TUI', behavior: 'local' },
     { name: 'fork', description: ui('从当前会话创建分支', 'Fork current session'), source: 'TUI', behavior: 'local' },
     { name: 'archive', description: ui('归档当前会话', 'Archive current session'), source: 'TUI', behavior: 'local' },
     { name: 'export', description: ui('导出当前会话', 'Export current session'), argumentHint: ui('[md] [路径]', '[md] [path]'), source: 'TUI', behavior: 'local' },
     { name: 'copy', description: ui('复制最后一条回复', 'Copy last response'), argumentHint: '[pick|code]', source: 'TUI', behavior: 'local' },
-    { name: 'workspace', description: ui('管理工作区', 'Manage workspaces'), argumentHint: ui('[子命令|路径]', '[subcommand|path]'), source: 'TUI', behavior: 'local' },
     { name: 'profile', description: ui('管理 Profile', 'Manage Profiles'), argumentHint: '[list|switch|create|copy]', source: 'TUI', behavior: 'local' },
-    { name: 'mode', description: ui('切换模式', 'Switch mode'), source: 'TUI', behavior: 'local' },
-    { name: 'model', description: ui('切换模型和推理强度', 'Switch model and reasoning effort'), source: 'TUI', behavior: 'local' },
     { name: 'language', description: ui('切换界面语言', 'Switch interface language'), argumentHint: '[auto|zh|en]', source: 'TUI', behavior: 'local' },
     { name: 'theme', description: ui('切换界面或独立代码主题', 'Switch interface or code theme'), argumentHint: '[dark|light|code|use|edit|palette|import|export|delete]', source: 'TUI', behavior: 'local' },
     { name: 'queue', description: ui('管理排队消息', 'Manage queued messages'), source: 'TUI', behavior: 'local' },
@@ -233,7 +251,6 @@ export function tuiCommands(): readonly TuiCommandCandidate[] {
     { name: 'settings', description: ui('打开设置', 'Open Settings'), argumentHint: '[namespace]', source: 'TUI', behavior: 'local' },
     { name: 'keymap', description: ui('自定义快捷键', 'Customize shortcuts'), argumentHint: '[binding [chord|reset]]', source: 'TUI', behavior: 'local' },
     { name: 'plugin', description: ui('打开插件中心', 'Open plugin center'), argumentHint: ui('[子命令]', '[subcommand]'), source: 'TUI', behavior: 'local' },
-    { name: 'plugins', description: ui('打开插件中心', 'Open plugin center'), argumentHint: ui('[子命令]', '[subcommand]'), source: 'TUI', behavior: 'local' },
     { name: 'doctor', description: ui('检查运行环境', 'Check runtime environment'), source: 'TUI', behavior: 'local' },
     { name: 'restart', description: ui('重启并恢复当前会话', 'Restart and resume current session'), source: 'TUI', behavior: 'local' },
     { name: 'tools', description: ui('查看工具', 'View tools'), argumentHint: '[display]', source: 'TUI', behavior: 'local' },
@@ -245,7 +262,6 @@ export function tuiCommands(): readonly TuiCommandCandidate[] {
     { name: 'mcp', description: ui('查看 MCP', 'View MCP'), source: 'TUI', behavior: 'local' },
     { name: 'status', description: ui('查看状态和统计', 'View status and statistics'), source: 'TUI', behavior: 'local' },
     { name: 'help', description: ui('查看帮助', 'View help'), source: 'TUI', behavior: 'local' },
-    { name: 'quit', description: ui('退出', 'Exit'), source: 'TUI', behavior: 'local' },
     { name: 'exit', description: ui('退出', 'Exit'), source: 'TUI', behavior: 'local' },
   ])
 }

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -71,6 +71,17 @@ export function canonicalTuiCommandName(name: string): string {
   return TUI_HIDDEN_COMMAND_ALIASES[name as keyof typeof TUI_HIDDEN_COMMAND_ALIASES] ?? name
 }
 
+/**
+ * Visible TUI names plus hidden aliases that must keep occupying the merged catalog.
+ * Host or Skill entries with these names must not steal typed `/resume` `/plugins` `/quit`.
+ */
+export function reservedTuiCatalogNames(): ReadonlySet<string> {
+  return new Set([
+    ...Object.keys(TUI_HIDDEN_COMMAND_ALIASES),
+    ...tuiCommands().map(command => command.name),
+  ])
+}
+
 /** One selectable Agent Preset from the Host directory. */
 export interface TuiModeOption {
   readonly id: string
@@ -1624,12 +1635,11 @@ export class HarnessTuiCapabilities {
       ))
     }
     const commands = tuiCommands()
-    const local = new Map(commands.map(command => [command.name, command]))
+    const reserved = reservedTuiCatalogNames()
     const merged = [...commands]
-    const names = new Set(commands.map(command => command.name))
+    const names = new Set(reserved)
     for (const command of hostResult.value as readonly HostCommandDescriptor[]) {
-      const localCommand = local.get(command.name)
-      if (localCommand !== undefined) continue
+      if (reserved.has(command.name)) continue
       names.add(command.name)
       merged.push({
         name: command.name,

--- a/tests/command-catalog.test.ts
+++ b/tests/command-catalog.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from 'vitest'
 import { commandOf } from '../src/client/actions.ts'
 import {
   canonicalTuiCommandName,
+  reservedTuiCatalogNames,
   shortFunctionDescription,
   tuiCommands,
+  type TuiCommandCandidate,
 } from '../src/client/capabilities.ts'
 
 const root = resolve(import.meta.dirname, '..')
@@ -24,7 +26,7 @@ describe('command catalog copy (review #60)', () => {
     const source = readFileSync(resolve(root, 'src/client/capabilities.ts'), 'utf8')
     expect(source).toMatch(/\$\{sessionId\}:\$\{uiLocale\(\)\}/u)
     expect(source).not.toMatch(/命令冲突：TUI 与 Host 都注册了/u)
-    expect(source).toMatch(/if \(localCommand !== undefined\) continue/u)
+    expect(source).toMatch(/if \(reserved\.has\(command\.name\)\) continue/u)
     const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
     expect(surface).toMatch(/invalidateCommandCatalog\(\)/u)
   })
@@ -48,5 +50,33 @@ describe('command catalog copy (review #60)', () => {
     expect(execute).toMatch(/case 'resume':/u)
     expect(execute).toMatch(/case 'plugins':/u)
     expect(execute).toMatch(/case 'quit':/u)
+  })
+
+  it('keeps hidden aliases reserved when a same-named Host command is merged', () => {
+    const reserved = reservedTuiCatalogNames()
+    expect(reserved.has('resume')).toBe(true)
+    expect(reserved.has('plugins')).toBe(true)
+    expect(reserved.has('quit')).toBe(true)
+    expect(reserved.has('sessions')).toBe(true)
+    expect(reserved.has('compact')).toBe(false)
+
+    const hostResume: TuiCommandCandidate = {
+      name: 'resume',
+      description: 'Host resume',
+      source: 'Host',
+      behavior: 'host',
+    }
+    const hostPlugins: TuiCommandCandidate = {
+      name: 'plugins',
+      description: 'Host plugins',
+      source: 'Host',
+      behavior: 'host',
+    }
+    const merged = [...tuiCommands(), hostResume, hostPlugins]
+    expect(commandOf(merged, 'resume')?.name).toBe('sessions')
+    expect(commandOf(merged, 'resume')?.behavior).toBe('local')
+    expect(commandOf(merged, 'plugins')?.name).toBe('plugin')
+    expect(commandOf(merged, 'quit')?.name).toBe('exit')
+    expect(commandOf(merged, 'sessions')?.name).toBe('sessions')
   })
 })

--- a/tests/command-catalog.test.ts
+++ b/tests/command-catalog.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { shortFunctionDescription } from '../src/client/capabilities.ts'
+import { commandOf } from '../src/client/actions.ts'
+import {
+  canonicalTuiCommandName,
+  shortFunctionDescription,
+  tuiCommands,
+} from '../src/client/capabilities.ts'
 
 const root = resolve(import.meta.dirname, '..')
 
@@ -22,5 +27,26 @@ describe('command catalog copy (review #60)', () => {
     expect(source).toMatch(/if \(localCommand !== undefined\) continue/u)
     const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
     expect(surface).toMatch(/invalidateCommandCatalog\(\)/u)
+  })
+
+  it('puts daily commands first and hides compatible aliases from the visible catalog', () => {
+    const names = tuiCommands().map(command => command.name)
+    expect(names.slice(0, 6)).toEqual(['new', 'sessions', 'model', 'mode', 'permission', 'workspace'])
+    expect(names).toContain('plugin')
+    expect(names).toContain('exit')
+    expect(names).not.toContain('resume')
+    expect(names).not.toContain('plugins')
+    expect(names).not.toContain('quit')
+    expect(canonicalTuiCommandName('resume')).toBe('sessions')
+    expect(canonicalTuiCommandName('plugins')).toBe('plugin')
+    expect(canonicalTuiCommandName('quit')).toBe('exit')
+    expect(commandOf(tuiCommands(), 'resume')?.name).toBe('sessions')
+    expect(commandOf(tuiCommands(), 'plugins')?.name).toBe('plugin')
+    expect(commandOf(tuiCommands(), 'quit')?.name).toBe('exit')
+    expect(commandOf(tuiCommands(), 'sessions')?.name).toBe('sessions')
+    const execute = readFileSync(resolve(root, 'src/client/actions.ts'), 'utf8')
+    expect(execute).toMatch(/case 'resume':/u)
+    expect(execute).toMatch(/case 'plugins':/u)
+    expect(execute).toMatch(/case 'quit':/u)
   })
 })


### PR DESCRIPTION
## Summary
- Reorder the visible slash catalog so `/new`, `/sessions`, `/model`, `/mode`, `/permission`, and `/workspace` appear first.
- Hide compatible aliases `/resume`, `/plugins`, and `/quit` from `/`, Ctrl+P, and help while keeping `execute()` resolution.
- Show `/sessions`, `/plugin`, and `/exit` as the official names.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/command-catalog.test.ts tests/i18n-en-chrome.test.ts tests/i18n-ast.test.ts`
- [ ] Type `/` and confirm the first six rows are the daily commands
- [ ] Confirm `/resume`, `/plugins`, and `/quit` still execute when typed by hand


Made with [Cursor](https://cursor.com)