### PR TITLE
fix(tui): run local palette commands without a second Enter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -26739,7 +26739,7 @@ var TuiActions = class {
 			else this.host.notice(capabilityError(nextError), "error");
 		}
 	}
-	/** Open the complete merged command palette and place the selection in the editor. */
+	/** Open the merged command palette and run local actions immediately. */
 	async commandPalette() {
 		try {
 			const catalog = await this.capabilities.commandCatalog();
@@ -26761,7 +26761,11 @@ var TuiActions = class {
 			if (choice === void 0) return;
 			const command = catalog.find((candidate) => candidate.name === choice.id);
 			if (command === void 0) return;
-			this.host.setEditor(`/${command.name}${command.argumentHint !== void 0 || command.behavior === "skill" ? " " : ""}`);
+			if (paletteFillsEditor(command)) {
+				this.host.setEditor(`/${command.name}${command.argumentHint !== void 0 || command.behavior === "skill" ? " " : ""}`);
+				return;
+			}
+			await this.execute(command.name, "");
 		} catch (error) {
 			this.host.notice(capabilityError(error), "error");
 		}
@@ -30156,6 +30160,22 @@ function commandOf(catalog, name$1) {
 	const canonical = canonicalTuiCommandName(name$1);
 	if (canonical !== name$1) return catalog.find((candidate) => candidate.name === canonical);
 	return catalog.find((candidate) => candidate.name === name$1);
+}
+/** Local commands that still need the user to type required arguments. */
+const PALETTE_REQUIRED_ARGUMENT_COMMANDS = new Set([
+	"rename",
+	"steer",
+	"attach"
+]);
+/**
+* Host, Skill, quit/exit, and required-argument commands stay in the editor.
+* Other TUI-local commands run through `execute()` after a palette choice.
+* Argument-hint punctuation is display copy and must not decide this.
+*/
+function paletteFillsEditor(command) {
+	if (command.behavior !== "local") return true;
+	if (command.name === "quit" || command.name === "exit") return true;
+	return PALETTE_REQUIRED_ARGUMENT_COMMANDS.has(command.name);
 }
 
 //#endregion

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -489,7 +489,7 @@ export class TuiActions {
     }
   }
 
-  /** Open the complete merged command palette and place the selection in the editor. */
+  /** Open the merged command palette and run local actions immediately. */
   async commandPalette(): Promise<void> {
     try {
       const catalog = await this.capabilities.commandCatalog()
@@ -506,7 +506,11 @@ export class TuiActions {
       if (choice === undefined) return
       const command = catalog.find(candidate => candidate.name === choice.id)
       if (command === undefined) return
-      this.host.setEditor(`/${command.name}${command.argumentHint !== undefined || command.behavior === 'skill' ? ' ' : ''}`)
+      if (paletteFillsEditor(command)) {
+        this.host.setEditor(`/${command.name}${command.argumentHint !== undefined || command.behavior === 'skill' ? ' ' : ''}`)
+        return
+      }
+      await this.execute(command.name, '')
     } catch (error) {
       this.host.notice(capabilityError(error), 'error')
     }
@@ -3859,4 +3863,14 @@ export function commandOf(
     return catalog.find(candidate => candidate.name === canonical)
   }
   return catalog.find(candidate => candidate.name === name)
+}
+
+/**
+ * Host, Skill, quit/exit, and required-argument commands stay in the editor.
+ * Other TUI-local commands run through `execute()` after a palette choice.
+ */
+export function paletteFillsEditor(command: TuiCommandCandidate): boolean {
+  if (command.behavior !== 'local') return true
+  if (command.name === 'quit' || command.name === 'exit') return true
+  return command.argumentHint?.includes('<') === true
 }

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3865,12 +3865,16 @@ export function commandOf(
   return catalog.find(candidate => candidate.name === name)
 }
 
+/** Local commands that still need the user to type required arguments. */
+const PALETTE_REQUIRED_ARGUMENT_COMMANDS = new Set(['rename', 'steer', 'attach'])
+
 /**
  * Host, Skill, quit/exit, and required-argument commands stay in the editor.
  * Other TUI-local commands run through `execute()` after a palette choice.
+ * Argument-hint punctuation is display copy and must not decide this.
  */
 export function paletteFillsEditor(command: TuiCommandCandidate): boolean {
   if (command.behavior !== 'local') return true
   if (command.name === 'quit' || command.name === 'exit') return true
-  return command.argumentHint?.includes('<') === true
+  return PALETTE_REQUIRED_ARGUMENT_COMMANDS.has(command.name)
 }

--- a/tests/actions-palette.test.ts
+++ b/tests/actions-palette.test.ts
@@ -41,11 +41,14 @@ function host(overlays: Partial<OverlayQueue>): TuiActionHost & {
 describe('command palette execution', () => {
   it('fills the editor only for Host, Skill, quit, and required-argument commands', () => {
     expect(paletteFillsEditor(command('model', 'local'))).toBe(false)
+    expect(paletteFillsEditor(command('model', 'local', '<unused hint>'))).toBe(false)
     expect(paletteFillsEditor(command('sessions', 'local', '[query]'))).toBe(false)
     expect(paletteFillsEditor(command('help', 'local'))).toBe(false)
     expect(paletteFillsEditor(command('quit', 'local'))).toBe(true)
     expect(paletteFillsEditor(command('exit', 'local'))).toBe(true)
-    expect(paletteFillsEditor(command('steer', 'local', '<message>'))).toBe(true)
+    expect(paletteFillsEditor(command('rename', 'local'))).toBe(true)
+    expect(paletteFillsEditor(command('steer', 'local'))).toBe(true)
+    expect(paletteFillsEditor(command('attach', 'local'))).toBe(true)
     expect(paletteFillsEditor(command('compact', 'host'))).toBe(true)
     expect(paletteFillsEditor(command('review', 'skill'))).toBe(true)
   })
@@ -67,17 +70,26 @@ describe('command palette execution', () => {
     execute.mockRestore()
   })
 
-  it('still fills the editor for quit and Host commands', async () => {
-    const catalog = [command('quit', 'local'), command('compact', 'host', '[text]')]
-    const quitHost = host({
-      select: vi.fn(async () => ({ id: 'quit', label: '/quit' })),
-    })
-    const actions = new TuiActions({
-      commandCatalog: async () => catalog,
-    } as unknown as HarnessTuiCapabilities, quitHost)
+  it('still fills the editor for quit, exit, rename, steer, attach, and Host commands', async () => {
+    const catalog = [
+      command('quit', 'local'),
+      command('exit', 'local'),
+      command('rename', 'local'),
+      command('steer', 'local'),
+      command('attach', 'local'),
+      command('compact', 'host', '[text]'),
+    ]
+    const execute = vi.spyOn(TuiActions.prototype, 'execute').mockResolvedValue(undefined)
 
-    await actions.commandPalette()
-    expect(quitHost.setEditor).toHaveBeenCalledWith('/quit')
+    for (const name of ['quit', 'exit', 'rename', 'steer', 'attach'] as const) {
+      const paletteHost = host({
+        select: vi.fn(async () => ({ id: name, label: `/${name}` })),
+      })
+      await new TuiActions({
+        commandCatalog: async () => catalog,
+      } as unknown as HarnessTuiCapabilities, paletteHost).commandPalette()
+      expect(paletteHost.setEditor).toHaveBeenCalledWith(`/${name}`)
+    }
 
     const hostCommand = host({
       select: vi.fn(async () => ({ id: 'compact', label: '/compact' })),
@@ -86,5 +98,7 @@ describe('command palette execution', () => {
       commandCatalog: async () => catalog,
     } as unknown as HarnessTuiCapabilities, hostCommand).commandPalette()
     expect(hostCommand.setEditor).toHaveBeenCalledWith('/compact ')
+    expect(execute).not.toHaveBeenCalled()
+    execute.mockRestore()
   })
 })

--- a/tests/actions-palette.test.ts
+++ b/tests/actions-palette.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { paletteFillsEditor, TuiActions, type TuiActionHost } from '../src/client/actions.ts'
+import type { HarnessTuiCapabilities, TuiCommandCandidate } from '../src/client/capabilities.ts'
+import type { OverlayQueue } from '../src/client/overlays.ts'
+import type { Transcript } from '../src/client/transcript.ts'
+
+function command(
+  name: string,
+  behavior: TuiCommandCandidate['behavior'],
+  argumentHint?: string,
+): TuiCommandCandidate {
+  return {
+    name,
+    description: name,
+    source: behavior === 'local' ? 'TUI' : behavior === 'skill' ? 'Skill' : 'Host',
+    behavior,
+    ...(argumentHint === undefined ? {} : { argumentHint }),
+  }
+}
+
+function host(overlays: Partial<OverlayQueue>): TuiActionHost & {
+  readonly setEditor: ReturnType<typeof vi.fn>
+} {
+  const setEditor = vi.fn()
+  return {
+    overlays: overlays as OverlayQueue,
+    transcript: { followLatest: vi.fn() } as unknown as Transcript,
+    notice: vi.fn(),
+    refresh: vi.fn(),
+    refreshHeader: vi.fn(),
+    applyTheme: vi.fn(),
+    applyLocale: vi.fn(),
+    setEditor,
+    copy: vi.fn(),
+    close: vi.fn(),
+    restart: vi.fn(),
+    requireRestart: vi.fn(),
+  }
+}
+
+describe('command palette execution', () => {
+  it('fills the editor only for Host, Skill, quit, and required-argument commands', () => {
+    expect(paletteFillsEditor(command('model', 'local'))).toBe(false)
+    expect(paletteFillsEditor(command('sessions', 'local', '[query]'))).toBe(false)
+    expect(paletteFillsEditor(command('help', 'local'))).toBe(false)
+    expect(paletteFillsEditor(command('quit', 'local'))).toBe(true)
+    expect(paletteFillsEditor(command('exit', 'local'))).toBe(true)
+    expect(paletteFillsEditor(command('steer', 'local', '<message>'))).toBe(true)
+    expect(paletteFillsEditor(command('compact', 'host'))).toBe(true)
+    expect(paletteFillsEditor(command('review', 'skill'))).toBe(true)
+  })
+
+  it('executes a local interactive command instead of copying it back to the editor', async () => {
+    const catalog = [command('help', 'local'), command('quit', 'local')]
+    const setEditorHost = host({
+      select: vi.fn(async () => ({ id: 'help', label: '/help' })),
+    })
+    const execute = vi.spyOn(TuiActions.prototype, 'execute').mockResolvedValue(undefined)
+    const actions = new TuiActions({
+      commandCatalog: async () => catalog,
+    } as unknown as HarnessTuiCapabilities, setEditorHost)
+
+    await actions.commandPalette()
+
+    expect(execute).toHaveBeenCalledWith('help', '')
+    expect(setEditorHost.setEditor).not.toHaveBeenCalled()
+    execute.mockRestore()
+  })
+
+  it('still fills the editor for quit and Host commands', async () => {
+    const catalog = [command('quit', 'local'), command('compact', 'host', '[text]')]
+    const quitHost = host({
+      select: vi.fn(async () => ({ id: 'quit', label: '/quit' })),
+    })
+    const actions = new TuiActions({
+      commandCatalog: async () => catalog,
+    } as unknown as HarnessTuiCapabilities, quitHost)
+
+    await actions.commandPalette()
+    expect(quitHost.setEditor).toHaveBeenCalledWith('/quit')
+
+    const hostCommand = host({
+      select: vi.fn(async () => ({ id: 'compact', label: '/compact' })),
+    })
+    await new TuiActions({
+      commandCatalog: async () => catalog,
+    } as unknown as HarnessTuiCapabilities, hostCommand).commandPalette()
+    expect(hostCommand.setEditor).toHaveBeenCalledWith('/compact ')
+  })
+})


### PR DESCRIPTION
## Summary
- Selecting a TUI-local command in Ctrl+P now calls `TuiActions.execute()` immediately.
- Host commands, Skills, `/quit`/`/exit`, and commands that require arguments still fill the editor.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/actions-palette.test.ts`
- [ ] Open Ctrl+P, choose `/model` or `/sessions`, and confirm the selector opens without a second Enter
- [ ] Choose a Host command or `/quit` and confirm the editor is filled


Made with [Cursor](https://cursor.com)