### PR TITLE
fix(tui): focus /queue on messages instead of bulk actions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22894,6 +22894,21 @@ function createLiveBehavior(initial) {
 }
 
 //#endregion
+//#region src/client/queue-order.ts
+/**
+* Message rows first, bulk actions last, so Enter targets a queued message.
+* @param rowIds - snapshot queue ids in Host order.
+* @param queuedCount - number of rows still in `queued` placement.
+*/
+function queueListChoiceOrder(rowIds, queuedCount) {
+	return [
+		...rowIds,
+		...queuedCount > 1 ? ["__all_steer__"] : [],
+		...queuedCount > 0 ? ["__clear__"] : []
+	];
+}
+
+//#endregion
 //#region src/client/byte-size.ts
 /** Human-readable byte counts for export notices. */
 const UNITS = [
@@ -28016,24 +28031,29 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 				id: "__empty__",
 				label: ui("当前队列为空", "The queue is empty"),
 				disabledReason: ui("等待新的排队消息，或 Esc 关闭", "Waiting for a queued message, or Esc to close")
-			}] : [
-				...queued.length > 1 ? [{
-					id: "__all_steer__",
+			}] : queueListChoiceOrder(rows.map((row) => row.id), queued.length).map((id) => {
+				if (id === "__all_steer__") return {
+					id,
 					label: ui("整队引导", "Steer entire queue"),
 					description: ui(`按当前顺序处理 ${queued.length} 条排队消息`, `Process ${queued.length} queued message(s) in the current order`)
-				}] : [],
-				...queued.length > 0 ? [{
-					id: "__clear__",
+				};
+				if (id === "__clear__") return {
+					id,
 					label: ui("清空全部", "Clear all"),
 					description: ui("删除所有排队消息，不影响当前轮次", "Remove every queued message; the current turn is unchanged")
-				}] : [],
-				...rows.map((row) => ({
+				};
+				const row = rows.find((candidate) => candidate.id === id);
+				if (row === void 0) return {
+					id,
+					label: id
+				};
+				return {
 					id: row.id,
 					label: row.preview === "" ? ui("(空消息)", "(empty message)") : row.preview,
 					description: queuePlacementLabel(row.placement),
 					...row.placement === "queued" ? {} : { disabledReason: ui("当前状态不接受队列修改", "The queue cannot be changed in the current state") }
-				}))
-			],
+				};
+			}),
 			searchable: rows.length > 8,
 			options: {
 				width: "95%",

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -26,6 +26,7 @@ import {
 import { canonicalTuiCommandName, capabilityError, HarnessTuiCapabilities, type TuiCommandCandidate, type TuiModelOption, type TuiPermissionOption, type TuiToolOption } from './capabilities.ts'
 import { behaviorFromSettings, behaviorSettings } from './behavior.ts'
 import { lastFencedCode } from './copy-content.ts'
+import { queueListChoiceOrder } from './queue-order.ts'
 import { formatByteSize } from './byte-size.ts'
 import { helpSectionChoices, helpSectionText, type HelpSectionId } from './help.ts'
 import {
@@ -1789,20 +1790,30 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       detail: ui('查看、编辑或提前处理排队消息 · 打开期间自动刷新', "View, edit, or promote queued messages · refreshes while open"),
       choices: rows.length === 0
         ? [{ id: '__empty__', label: ui('当前队列为空', "The queue is empty"), disabledReason: ui('等待新的排队消息，或 Esc 关闭', "Waiting for a queued message, or Esc to close") }]
-        : [
-          ...(queued.length > 1
-            ? [{ id: '__all_steer__', label: ui('整队引导', "Steer entire queue"), description: ui(`按当前顺序处理 ${queued.length} 条排队消息`, `Process ${queued.length} queued message(s) in the current order`) }]
-            : []),
-          ...(queued.length > 0
-            ? [{ id: '__clear__', label: ui('清空全部', "Clear all"), description: ui('删除所有排队消息，不影响当前轮次', "Remove every queued message; the current turn is unchanged") }]
-            : []),
-          ...rows.map(row => ({
+        : queueListChoiceOrder(rows.map(row => row.id), queued.length).map((id) => {
+          if (id === '__all_steer__') {
+            return {
+              id,
+              label: ui('整队引导', "Steer entire queue"),
+              description: ui(`按当前顺序处理 ${queued.length} 条排队消息`, `Process ${queued.length} queued message(s) in the current order`),
+            }
+          }
+          if (id === '__clear__') {
+            return {
+              id,
+              label: ui('清空全部', "Clear all"),
+              description: ui('删除所有排队消息，不影响当前轮次', "Remove every queued message; the current turn is unchanged"),
+            }
+          }
+          const row = rows.find(candidate => candidate.id === id)
+          if (row === undefined) return { id, label: id }
+          return {
             id: row.id,
             label: row.preview === '' ? ui('(空消息)', "(empty message)") : row.preview,
             description: queuePlacementLabel(row.placement),
             ...(row.placement === 'queued' ? {} : { disabledReason: ui('当前状态不接受队列修改', "The queue cannot be changed in the current state") }),
-          })),
-        ],
+          }
+        }),
       searchable: rows.length > 8,
       options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
     }

--- a/src/client/queue-order.ts
+++ b/src/client/queue-order.ts
@@ -15,3 +15,16 @@ export function moveIndex<T>(items: readonly T[], index: number, direction: -1 |
   copy.splice(next, 0, row)
   return copy
 }
+
+/**
+ * Message rows first, bulk actions last, so Enter targets a queued message.
+ * @param rowIds - snapshot queue ids in Host order.
+ * @param queuedCount - number of rows still in `queued` placement.
+ */
+export function queueListChoiceOrder(rowIds: readonly string[], queuedCount: number): readonly string[] {
+  return [
+    ...rowIds,
+    ...(queuedCount > 1 ? ['__all_steer__'] : []),
+    ...(queuedCount > 0 ? ['__clear__'] : []),
+  ]
+}

--- a/tests/queue-order.test.ts
+++ b/tests/queue-order.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { moveIndex } from '../src/client/queue-order.ts'
+import { moveIndex, queueListChoiceOrder } from '../src/client/queue-order.ts'
 
 describe('queue reorder', () => {
   it('moves an item up or down and no-ops at the ends', () => {
@@ -18,5 +18,11 @@ describe('queue reorder', () => {
     expect(source.includes('reorderQueued')).toBe(false)
     expect(source.includes('与上一条排队消息对调')).toBe(false)
     expect(source.includes('Swap with the previous queued message')).toBe(false)
+  })
+
+  it('puts queued messages before bulk actions so Enter targets a message', () => {
+    expect(queueListChoiceOrder(['m1'], 1)).toEqual(['m1', '__clear__'])
+    expect(queueListChoiceOrder(['m1', 'm2'], 2)).toEqual(['m1', 'm2', '__all_steer__', '__clear__'])
+    expect(queueListChoiceOrder([], 0)).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- `/queue` now lists queued messages first.
- Bulk actions (`整队引导`, `清空全部`) stay at the bottom so Enter does not immediately clear or steer the whole queue.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/queue-order.test.ts`
- [ ] Queue one message, open `/queue`, press Enter, and confirm the message action page opens
- [ ] Queue two messages and confirm bulk actions are after the message rows


Made with [Cursor](https://cursor.com)