### PR TITLE
fix(tui): stop treating Tab as confirm inside selectors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30724,10 +30724,6 @@ var SearchSelectOverlay = class {
 		return modalFrame(this.request.title, lines, width);
 	}
 	handleInput(data) {
-		if (matchesKey(data, Key.tab)) {
-			this.choose();
-			return;
-		}
 		if (matchesKey(data, Key.home)) {
 			this.list.setSelectedIndex(0);
 			return;

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -305,10 +305,6 @@ class SearchSelectOverlay implements Component {
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.tab)) {
-      this.choose()
-      return
-    }
     if (matchesKey(data, Key.home)) {
       this.list.setSelectedIndex(0)
       return

--- a/tests/overlays-navigation.test.ts
+++ b/tests/overlays-navigation.test.ts
@@ -114,6 +114,33 @@ describe('overlay navigation', () => {
     expect(signal?.aborted).toBe(true)
   })
 
+  it('does not treat Tab as confirm inside a selector', async () => {
+    const harness = overlayHarness()
+    const selected = harness.overlays.select({
+      title: 'pick a model',
+      choices: [
+        { id: 'alpha', label: 'alpha model' },
+        { id: 'bravo', label: 'bravo model' },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(plain(harness.component().render(80))).toContain('pick a model')
+    })
+
+    harness.component().handleInput('\t')
+    expect(plain(harness.component().render(80))).toContain('pick a model')
+    expect(harness.hide).not.toHaveBeenCalled()
+    await expect(Promise.race([
+      selected.then(() => 'resolved'),
+      Promise.resolve('pending'),
+    ])).resolves.toBe('pending')
+
+    harness.component().handleInput(ENTER)
+    await expect(selected).resolves.toEqual({ id: 'alpha', label: 'alpha model' })
+    expect(harness.hide).toHaveBeenCalledOnce()
+  })
+
   it('treats Escape as Back even when a searchable page contains a query', async () => {
     const harness = overlayHarness()
     const selected = harness.overlays.select({


### PR DESCRIPTION
## Summary
- Remove the Tab-equals-Enter shortcut in `SearchSelectOverlay` so Tab no longer submits models, settings, or approvals.
- Leave Enter as the only confirm path through the existing SelectList/`onSelect` handler.
- Add an overlay navigation test that Tab keeps the selector open and Enter still submits the current choice.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/overlays-navigation.test.ts`
- [ ] Open a model/settings/approval selector and press Tab — overlay stays open
- [ ] Press Enter — current choice is submitted
- [ ] Confirm footer copy and `surface.ts` are unchanged


Made with [Cursor](https://cursor.com)