### PR TITLE
fix(tui): keep first-open examples and F1 on daily work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22947,7 +22947,7 @@ function helpSectionChoices() {
 		{
 			id: "flows",
 			label: ui("常用流程", "Common workflows"),
-			description: ui("审批、粘贴、导出和查找", "Approvals, paste, export, and search")
+			description: ui("输入、停止、会话、审批和浏览", "Input, stop, sessions, approvals, and browsing")
 		},
 		{
 			id: "doctor",
@@ -22959,21 +22959,19 @@ function helpSectionChoices() {
 function helpSectionText(id) {
 	if (id === "keys") return helpKeymapText();
 	if (id === "flows") return ui([
-		"审批工具：弹窗里查看命令或 diff，再选仅本次允许或拒绝。",
-		"粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。",
-		"查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。",
-		"导出会话：/export 保存 ZIP，/export md 保存 Markdown。",
-		"导出主题：/theme export Ocean ./ocean.json，文件必须还不存在。",
-		"自定义快捷键：/keymap commandPalette Ctrl+K，或 /keymap commandPalette reset 恢复默认。",
-		"命令面板：Ctrl+P；完整帮助：F1 或 /help。"
+		"输入：在底部输入区写消息，Enter 发送。",
+		"换行：Shift+Enter 在输入区插入换行。",
+		"停止：Ctrl+C 停止当前轮次；再按一次退出。",
+		"会话：Ctrl+S 打开会话列表，新建或切换会话。",
+		"审批：弹窗里查看命令或 diff，再选仅本次允许或拒绝。",
+		"浏览对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。"
 	].join("\n"), [
-		"Approve tools: inspect the command or diff in the overlay, then allow once or reject.",
-		"Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.",
-		"Search the transcript: Tab into browse mode, press / to search, then n/N to jump.",
-		"Export: /export saves a ZIP; /export md saves Markdown.",
-		"Export a theme: /theme export Ocean ./ocean.json; the file must not already exist.",
-		"Custom shortcuts: /keymap commandPalette Ctrl+K, or /keymap commandPalette reset to restore.",
-		"Command palette: Ctrl+P. Full help: F1 or /help."
+		"Input: type in the composer and press Enter to send.",
+		"Newline: Shift+Enter inserts a newline in the composer.",
+		"Stop: Ctrl+C stops the active turn; press again to exit.",
+		"Sessions: Ctrl+S opens the session list to create or switch sessions.",
+		"Approvals: inspect the command or diff in the overlay, then allow once or reject.",
+		"Browse the transcript: Tab into browse mode, press / to search, then n/N to jump."
 	].join("\n"));
 	return ui([
 		"输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。",
@@ -23383,24 +23381,16 @@ function parseSettingsRootChoice(id) {
 
 //#endregion
 //#region src/client/empty-examples.ts
-/** Two or three tasks a coding session can send without typing. */
-const EMPTY_SESSION_EXAMPLES = [
-	{
-		id: "review",
-		zh: "审查当前改动并指出风险",
-		en: "Review the current changes and call out risks"
-	},
-	{
-		id: "test",
-		zh: "为刚才改过的文件补测试",
-		en: "Add tests for the files just changed"
-	},
-	{
-		id: "boot",
-		zh: "解释这个仓库怎么启动和验证",
-		en: "Explain how this repo starts and how to verify it"
-	}
-];
+/** Two tasks a coding session can send without typing. */
+const EMPTY_SESSION_EXAMPLES = [{
+	id: "review",
+	zh: "概览当前仓库，并指出最值得先处理的问题",
+	en: "Give an overview of this repo and name the problems worth handling first"
+}, {
+	id: "boot",
+	zh: "说明这个仓库如何启动和验证",
+	en: "Explain how this repo starts and how to verify it"
+}];
 /**
 * Localized prompt text for one empty-session example.
 * @param example - catalog entry.

--- a/src/client/empty-examples.ts
+++ b/src/client/empty-examples.ts
@@ -8,21 +8,16 @@ export interface EmptySessionExample {
   readonly en: string
 }
 
-/** Two or three tasks a coding session can send without typing. */
+/** Two tasks a coding session can send without typing. */
 export const EMPTY_SESSION_EXAMPLES: readonly EmptySessionExample[] = [
   {
     id: 'review',
-    zh: '审查当前改动并指出风险',
-    en: 'Review the current changes and call out risks',
-  },
-  {
-    id: 'test',
-    zh: '为刚才改过的文件补测试',
-    en: 'Add tests for the files just changed',
+    zh: '概览当前仓库，并指出最值得先处理的问题',
+    en: 'Give an overview of this repo and name the problems worth handling first',
   },
   {
     id: 'boot',
-    zh: '解释这个仓库怎么启动和验证',
+    zh: '说明这个仓库如何启动和验证',
     en: 'Explain how this repo starts and how to verify it',
   },
 ]

--- a/src/client/help.ts
+++ b/src/client/help.ts
@@ -8,7 +8,7 @@ export type HelpSectionId = 'keys' | 'flows' | 'doctor'
 export function helpSectionChoices(): readonly { id: HelpSectionId; label: string; description: string }[] {
   return [
     { id: 'keys', label: ui('键位速查', 'Keyboard shortcuts'), description: ui('与当前 TUI 绑定共用一张表', 'Same table as the live TUI bindings') },
-    { id: 'flows', label: ui('常用流程', 'Common workflows'), description: ui('审批、粘贴、导出和查找', 'Approvals, paste, export, and search') },
+    { id: 'flows', label: ui('常用流程', 'Common workflows'), description: ui('输入、停止、会话、审批和浏览', 'Input, stop, sessions, approvals, and browsing') },
     { id: 'doctor', label: ui('/doctor 与安装', '/doctor and setup'), description: ui('环境检查和 QUICKSTART', 'Environment checks and QUICKSTART') },
   ]
 }
@@ -18,22 +18,20 @@ export function helpSectionText(id: HelpSectionId): string {
   if (id === 'flows') {
     return ui(
       [
-        '审批工具：弹窗里查看命令或 diff，再选仅本次允许或拒绝。',
-        '粘贴图片：粘贴文件路径，或在空粘贴时从系统剪贴板读取位图。',
-        '查找对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。',
-        '导出会话：/export 保存 ZIP，/export md 保存 Markdown。',
-        '导出主题：/theme export Ocean ./ocean.json，文件必须还不存在。',
-        '自定义快捷键：/keymap commandPalette Ctrl+K，或 /keymap commandPalette reset 恢复默认。',
-        '命令面板：Ctrl+P；完整帮助：F1 或 /help。',
+        '输入：在底部输入区写消息，Enter 发送。',
+        '换行：Shift+Enter 在输入区插入换行。',
+        '停止：Ctrl+C 停止当前轮次；再按一次退出。',
+        '会话：Ctrl+S 打开会话列表，新建或切换会话。',
+        '审批：弹窗里查看命令或 diff，再选仅本次允许或拒绝。',
+        '浏览对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。',
       ].join('\n'),
       [
-        'Approve tools: inspect the command or diff in the overlay, then allow once or reject.',
-        'Paste images: paste a file path, or capture a clipboard bitmap on an empty paste.',
-        'Search the transcript: Tab into browse mode, press / to search, then n/N to jump.',
-        'Export: /export saves a ZIP; /export md saves Markdown.',
-        'Export a theme: /theme export Ocean ./ocean.json; the file must not already exist.',
-        'Custom shortcuts: /keymap commandPalette Ctrl+K, or /keymap commandPalette reset to restore.',
-        'Command palette: Ctrl+P. Full help: F1 or /help.',
+        'Input: type in the composer and press Enter to send.',
+        'Newline: Shift+Enter inserts a newline in the composer.',
+        'Stop: Ctrl+C stops the active turn; press again to exit.',
+        'Sessions: Ctrl+S opens the session list to create or switch sessions.',
+        'Approvals: inspect the command or diff in the overlay, then allow once or reject.',
+        'Browse the transcript: Tab into browse mode, press / to search, then n/N to jump.',
       ].join('\n'),
     )
   }

--- a/tests/empty-examples.test.ts
+++ b/tests/empty-examples.test.ts
@@ -55,11 +55,12 @@ afterEach(() => {
 })
 
 describe('empty session examples', () => {
-  it('lists three sendable starter prompts on an empty session', () => {
+  it('lists two sendable starter prompts on an empty session', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 20)
     transcript.update(snapshot())
     const rendered = stripAnsi(transcript.render(80).join('\n'))
+    expect(EMPTY_SESSION_EXAMPLES).toHaveLength(2)
     expect(rendered).toContain('探索未至之境')
     for (const example of EMPTY_SESSION_EXAMPLES) {
       expect(rendered).toContain(emptyExampleText(example))
@@ -83,8 +84,8 @@ describe('empty session examples', () => {
     transcript.update(snapshot())
     const rendered = stripAnsi(transcript.render(80).join('\n'))
     expect(rendered).toContain('Explore beyond the known')
-    expect(rendered).toContain('Review the current changes and call out risks')
-    expect(rendered).not.toContain('审查当前改动并指出风险')
+    expect(rendered).toContain('Give an overview of this repo and name the problems worth handling first')
+    expect(rendered).not.toContain('概览当前仓库，并指出最值得先处理的问题')
   })
 
   it('keeps the selected empty-session example inside a short viewport', () => {
@@ -93,8 +94,7 @@ describe('empty session examples', () => {
     transcript.update(snapshot())
     transcript.focused = true
     transcript.handleInput('\u001b[B')
-    transcript.handleInput('\u001b[B')
-    const last = emptyExampleText(EMPTY_SESSION_EXAMPLES[2]!)
+    const last = emptyExampleText(EMPTY_SESSION_EXAMPLES[1]!)
     expect(transcript.activateFocused()).toEqual({ kind: 'example', text: last })
     const visible = stripAnsi(transcript.render(80).join('\n'))
     expect(visible).toContain(last)

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { helpSectionText } from '../src/client/help.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import { helpSectionChoices, helpSectionText } from '../src/client/help.ts'
 import { SURFACE_KEYMAP, helpKeymapText, matchesBinding } from '../src/client/keymap.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+
+afterEach(() => {
+  setUiLocale('zh')
+})
 
 describe('in-app help keymap', () => {
   it('lists F1 help and Ctrl+P palette from the same table surface matches', () => {
@@ -10,5 +15,25 @@ describe('in-app help keymap', () => {
     expect(helpKeymapText()).toContain('F1')
     expect(helpKeymapText()).toContain('Ctrl+P')
     expect(helpSectionText('doctor')).toContain('/doctor')
+  })
+
+  it('keeps F1 flows on daily work, not theme export or keymap setup', () => {
+    for (const locale of ['zh', 'en'] as const) {
+      setUiLocale(locale)
+      const flows = helpSectionText('flows')
+      expect(flows).not.toContain('/theme export')
+      expect(flows).not.toContain('/keymap commandPalette')
+    }
+
+    setUiLocale('en')
+    const flows = helpSectionText('flows')
+    expect(flows.toLowerCase()).toMatch(/input/)
+    expect(flows.toLowerCase()).toMatch(/stop/)
+    expect(flows.toLowerCase()).toMatch(/session/)
+    expect(flows.toLowerCase()).toMatch(/approv/)
+    expect(flows.toLowerCase()).toMatch(/brows/)
+
+    const description = helpSectionChoices().find(choice => choice.id === 'flows')?.description ?? ''
+    expect(description.toLowerCase()).not.toMatch(/export|shortcut/)
   })
 })

--- a/tests/i18n-en-chrome.test.ts
+++ b/tests/i18n-en-chrome.test.ts
@@ -124,7 +124,7 @@ describe('i18n English chrome gate (task 7)', () => {
   it('keeps renderable chrome, help, and launcher copy free of Chinese in en mode', () => {
     const rendered = englishChromeFrom('en')
     expect(rendered).not.toMatch(HAN)
-    expect(rendered).toContain('Command palette')
+    expect(rendered).toContain('Open the command palette')
     expect(rendered).toContain('New session')
     expect(rendered).toContain('Enter a message below')
     expect(rendered).toContain('The interface theme currently used by SeekTTY')


### PR DESCRIPTION
## Summary
- Keep first-open empty-session examples to two daily tasks (repo overview, start/verify) instead of a three-item feature catalog.
- Rewrite F1 common-workflows help so it covers input, newline, stop, sessions, approvals, and transcript browsing; theme export and keymap setup stay on `/theme`, `/keymap`, and README.
- Update empty-session, help, and English-chrome tests to match the shorter daily-work copy.

## Test plan
- [ ] Open a new empty session and confirm only two starter prompts appear (zh/en).
- [ ] Press F1 → Common workflows and confirm it describes input/newline/stop/sessions/approvals/browse, with no `/theme export` or `/keymap commandPalette`.
- [ ] Confirm `/theme`, `/keymap`, and README still document theme export and custom shortcuts.
- [ ] `./node_modules/.bin/vitest run tests/empty-examples.test.ts tests/help.test.ts tests/i18n-en-chrome.test.ts tests/i18n-ast.test.ts`


Made with [Cursor](https://cursor.com)