### PR TITLE
fix(tui): keep attachments when Ctrl+C clears draft text

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30484,7 +30484,8 @@ var PromptEditor = class extends Editor {
 //#region src/client/composer-draft.ts
 /**
 * Preserve composer text in editor history and the durable Settings-backed
-* history, then clear the draft and attachments.
+* history, then clear the text draft. Attachments stay unless the composer
+* is already empty, so Up can restore words without silently dropping images.
 * @param editor - focused prompt editor.
 * @param clearAttachments - pending image attachment sink.
 * @param remember - durable history sink (revisioned Settings path).
@@ -30495,10 +30496,12 @@ function clearIdleComposerDraft(editor, clearAttachments, remember = () => void 
 	if (text$1 !== "") {
 		editor.addToHistory(text$1);
 		remember(text$1);
+		editor.setText("");
+		return ui("已清空文字草稿，按 ↑ 可找回；图片仍保留", "Text draft cleared; press ↑ to restore. Images were kept.");
 	}
 	editor.setText("");
 	clearAttachments();
-	return text$1 !== "" ? ui("已清空草稿，按 ↑ 可找回", "Draft cleared; press ↑ to restore") : ui("已清空输入草稿", "Draft cleared");
+	return ui("已清除待发送图片", "Pending images cleared");
 }
 
 //#endregion

--- a/src/client/composer-draft.ts
+++ b/src/client/composer-draft.ts
@@ -10,7 +10,8 @@ interface ComposerDraftEditor {
 
 /**
  * Preserve composer text in editor history and the durable Settings-backed
- * history, then clear the draft and attachments.
+ * history, then clear the text draft. Attachments stay unless the composer
+ * is already empty, so Up can restore words without silently dropping images.
  * @param editor - focused prompt editor.
  * @param clearAttachments - pending image attachment sink.
  * @param remember - durable history sink (revisioned Settings path).
@@ -25,10 +26,13 @@ export function clearIdleComposerDraft(
   if (text !== '') {
     editor.addToHistory(text)
     remember(text)
+    editor.setText('')
+    return ui(
+      '已清空文字草稿，按 ↑ 可找回；图片仍保留',
+      'Text draft cleared; press ↑ to restore. Images were kept.',
+    )
   }
   editor.setText('')
   clearAttachments()
-  return text !== ''
-    ? ui('已清空草稿，按 ↑ 可找回', 'Draft cleared; press ↑ to restore')
-    : ui('已清空输入草稿', 'Draft cleared')
+  return ui('已清除待发送图片', 'Pending images cleared')
 }

--- a/tests/surface-draft.test.ts
+++ b/tests/surface-draft.test.ts
@@ -21,10 +21,12 @@ describe('idle Ctrl+C draft recovery (review #6)', () => {
     composer.render(80)
 
     const remembered: string[] = []
-    const notice = clearIdleComposerDraft(composer, () => undefined, (text) => { remembered.push(text) })
-    expect(notice).toBe('已清空草稿，按 ↑ 可找回')
+    const clearAttachments = vi.fn()
+    const notice = clearIdleComposerDraft(composer, clearAttachments, (text) => { remembered.push(text) })
+    expect(notice).toBe('已清空文字草稿，按 ↑ 可找回；图片仍保留')
     expect(composer.getText()).toBe('')
     expect(remembered).toEqual([draft])
+    expect(clearAttachments).not.toHaveBeenCalled()
 
     composer.handleInput(UP)
     expect(composer.getText()).toBe(draft)
@@ -37,9 +39,23 @@ describe('idle Ctrl+C draft recovery (review #6)', () => {
 
     const notice = clearIdleComposerDraft(composer, clearAttachments, remember)
 
-    expect(notice).toBe('已清空输入草稿')
+    expect(notice).toBe('已清除待发送图片')
     expect(clearAttachments).toHaveBeenCalledOnce()
     expect(remember).not.toHaveBeenCalled()
+    expect(composer.getText()).toBe('')
+  })
+
+  it('keeps pending attachments when Ctrl+C clears non-empty draft text', () => {
+    const composer = editor()
+    composer.setText('还没发出去的提示')
+    const clearAttachments = vi.fn()
+    const remember = vi.fn()
+
+    const notice = clearIdleComposerDraft(composer, clearAttachments, remember)
+
+    expect(notice).toBe('已清空文字草稿，按 ↑ 可找回；图片仍保留')
+    expect(clearAttachments).not.toHaveBeenCalled()
+    expect(remember).toHaveBeenCalledOnce()
     expect(composer.getText()).toBe('')
   })
 


### PR DESCRIPTION
## Summary
- Idle Ctrl+C now stashes composer text without calling `clearAttachments()`, so pending images stay when Up restores the draft.
- Empty composer + pending images still clears attachments, with an explicit `已清除待发送图片` / `Pending images cleared` notice.
- When text is cleared, the notice says images were kept so users are not told the whole draft will come back.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/surface-draft.test.ts`
- [ ] Idle Ctrl+C with typed text and attached images: text clears, images remain, notice mentions images were kept; Up restores text only
- [ ] Idle Ctrl+C with only pending images: images are removed and notice says pending images were cleared
- [ ] Idle Ctrl+C with empty composer and no images: still uses the existing exit-arm path (helper is not called)


Made with [Cursor](https://cursor.com)