### PR TITLE
fix(tui): keep failure advice on one status-bar line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-Cx6Oq8rk.js";
+import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DdrrhFA6.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-BYa9XU45.js";
-import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-Di2x50P-.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-C08eAhrI.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-BJ_NQKbH.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-BMYr9ihZ.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import * as fs from "node:fs";
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -19792,6 +19792,10 @@ function unwrapTransport(message) {
 	const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message);
 	return match === null ? void 0 : match[1]?.trim();
 }
+/** Collapse Host text so StatusBar never receives an embedded newline. */
+function oneLine(text$1) {
+	return text$1.replace(/[\r\n]+/gu, " ").replace(/[ \t]+/gu, " ").trim();
+}
 /**
 * Build the language-agnostic timeout Error thrown by snapshot waits.
 * @param label - startup phase already chosen by the caller.
@@ -19812,17 +19816,16 @@ function pluginFailureDetail(result) {
 	return chunks.length === 0 ? ui("无 pnpm 输出", "No pnpm output") : chunks.join("\n");
 }
 /**
-* Rewrite a raw failure message into what happened plus a next action.
+* Rewrite a raw failure into a single action-first StatusBar line.
 * @param message - original Error.message or stringified failure.
 */
 function explainFailure(message) {
-	const inner = unwrapTransport(message);
-	if (inner !== void 0) return ui(`内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`, `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`);
-	if (message.includes(STARTUP_TIMEOUT_MARK)) return ui(`${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, "").replace(/。下一步：.*$/u, "")}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`, "Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
-	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui("pnpm 不在 PATH 中；请安装 pnpm 后重试。下一步：安装 pnpm 并确保它在 PATH 中，然后重试。", "pnpm is not on PATH; install pnpm and retry.\nNext: install pnpm, keep it on PATH, then retry.");
-	if (/\bENOENT\b/u.test(message)) return ui(`${message}\n下一步：确认路径存在且当前进程有权读取。`, `${message}\nNext: confirm the path exists and this process can read it.`);
-	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui(`${message}\n下一步：检查文件权限，或换一个可写目录。`, `${message}\nNext: check file permissions, or use a writable directory.`);
-	return message;
+	if (unwrapTransport(message) !== void 0) return ui("重试当前操作，再次失败运行 /doctor", "Retry this action; if it fails again, run /doctor");
+	if (message.includes(STARTUP_TIMEOUT_MARK)) return ui("确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek", "Confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.");
+	if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) return ui("安装 pnpm 并确保它在 PATH 中后重试", "Install pnpm; it is not on PATH, then retry");
+	if (/\bENOENT\b/u.test(message)) return ui("确认路径存在且可读后重试", "Confirm the path exists and is readable, then retry");
+	if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) return ui("权限不足，检查当前权限后重试", "Check the current permission and retry");
+	return oneLine(message);
 }
 
 //#endregion

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/lib/locale-DdrrhFA6.js
+++ b/lib/locale-DdrrhFA6.js
@@ -673,6 +673,7 @@ const ENGLISH_TEXT = new Map([
 	["tarball package.json 缺少包名", "The tarball package.json has no package name"],
 	["pnpm 不可用；Profile 插件操作需要 PATH 中的 pnpm", "pnpm is unavailable; Profile plugin operations require pnpm on PATH"],
 	["pnpm 不在 PATH 中；请安装 pnpm 后重试", "pnpm is not on PATH; install pnpm and retry"],
+	["安装 pnpm 并确保它在 PATH 中后重试", "Install pnpm; it is not on PATH, then retry"],
 	["Profile Bundle 结构可解析", "Profile Bundle structure is valid"],
 	["位于 Bundle 顺序中但未声明 dsh.bundle.patch", "Listed in Bundle order but does not declare dsh.bundle.patch"],
 	["TUI Bundle 必须通过 dsh --profile <name> 启动", "The TUI Bundle must be started through dsh --profile <name>"],

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
-import { c as ui } from "./locale-Cx6Oq8rk.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-Di2x50P-.js";
+import { c as ui } from "./locale-DdrrhFA6.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-BJ_NQKbH.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-BJ_NQKbH.js
+++ b/lib/plugin-marketplace-BJ_NQKbH.js
@@ -1,4 +1,4 @@
-import { c as ui } from "./locale-Cx6Oq8rk.js";
+import { c as ui } from "./locale-DdrrhFA6.js";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { gunzip } from "node:zlib";

--- a/lib/startup-BMYr9ihZ.js
+++ b/lib/startup-BMYr9ihZ.js
@@ -1,4 +1,4 @@
-import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-Cx6Oq8rk.js";
+import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-DdrrhFA6.js";
 import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
-import "./locale-Cx6Oq8rk.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-C08eAhrI.js";
+import "./locale-DdrrhFA6.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-BMYr9ihZ.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -55,13 +55,13 @@ export function explainFailure(message: string): string {
   if (message.includes(STARTUP_TIMEOUT_MARK)) {
     return ui(
       '确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek',
-      'Startup timed out; confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
+      'Confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
     )
   }
   if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) {
     return ui(
       '安装 pnpm 并确保它在 PATH 中后重试',
-      'pnpm is not on PATH; install pnpm and retry',
+      'Install pnpm and keep it on PATH, then retry',
     )
   }
   if (/\bENOENT\b/u.test(message)) {
@@ -73,7 +73,7 @@ export function explainFailure(message: string): string {
   if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) {
     return ui(
       '权限不足，检查当前权限后重试',
-      'Permission denied; check the current permission and retry',
+      'Check the current permission and retry',
     )
   }
   return oneLine(message)

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -61,7 +61,7 @@ export function explainFailure(message: string): string {
   if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) {
     return ui(
       '安装 pnpm 并确保它在 PATH 中后重试',
-      'Install pnpm and keep it on PATH, then retry',
+      'Install pnpm; it is not on PATH, then retry',
     )
   }
   if (/\bENOENT\b/u.test(message)) {

--- a/src/client/error-advice.ts
+++ b/src/client/error-advice.ts
@@ -1,4 +1,4 @@
-/** Map opaque Host/runtime failures into what happened plus a next step. */
+/** Map opaque Host/runtime failures into one status-bar line, action first. */
 
 import { ui } from './locale.ts'
 
@@ -15,6 +15,11 @@ export interface PluginFailureOutput {
 function unwrapTransport(message: string): string | undefined {
   const match = /^transport failure for .+?: handler failure: ([\s\S]+)$/u.exec(message)
   return match === null ? undefined : match[1]?.trim()
+}
+
+/** Collapse Host text so StatusBar never receives an embedded newline. */
+function oneLine(text: string): string {
+  return text.replace(/[\r\n]+/gu, ' ').replace(/[ \t]+/gu, ' ').trim()
 }
 
 /**
@@ -37,40 +42,39 @@ export function pluginFailureDetail(result: PluginFailureOutput): string {
 }
 
 /**
- * Rewrite a raw failure message into what happened plus a next action.
+ * Rewrite a raw failure into a single action-first StatusBar line.
  * @param message - original Error.message or stringified failure.
  */
 export function explainFailure(message: string): string {
-  const inner = unwrapTransport(message)
-  if (inner !== undefined) {
+  if (unwrapTransport(message) !== undefined) {
     return ui(
-      `内部调用失败：${inner}\n下一步：重试当前操作；若反复出现，运行 /doctor 或 /restart。`,
-      `An internal call failed: ${inner}\nNext: retry this action; if it keeps happening, run /doctor or /restart.`,
+      '重试当前操作，再次失败运行 /doctor',
+      'Retry this action; if it fails again, run /doctor',
     )
   }
   if (message.includes(STARTUP_TIMEOUT_MARK)) {
     return ui(
-      `${message.replace(/，请运行 \/doctor 检查 Harness 状态$/u, '').replace(/。下一步：.*$/u, '')}。下一步：确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek。`,
-      'Startup timed out. Next: confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
+      '确认 dsh 在 PATH 或 DSH_BIN 中，检查 Profile 后重新运行 deepseek',
+      'Startup timed out; confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.',
     )
   }
   if (/pnpm 不在 PATH/u.test(message) || /exit 127/u.test(message)) {
     return ui(
-      'pnpm 不在 PATH 中；请安装 pnpm 后重试。下一步：安装 pnpm 并确保它在 PATH 中，然后重试。',
-      'pnpm is not on PATH; install pnpm and retry.\nNext: install pnpm, keep it on PATH, then retry.',
+      '安装 pnpm 并确保它在 PATH 中后重试',
+      'pnpm is not on PATH; install pnpm and retry',
     )
   }
   if (/\bENOENT\b/u.test(message)) {
     return ui(
-      `${message}\n下一步：确认路径存在且当前进程有权读取。`,
-      `${message}\nNext: confirm the path exists and this process can read it.`,
+      '确认路径存在且可读后重试',
+      'Confirm the path exists and is readable, then retry',
     )
   }
   if (/\bEACCES\b/u.test(message) || /\bEPERM\b/u.test(message)) {
     return ui(
-      `${message}\n下一步：检查文件权限，或换一个可写目录。`,
-      `${message}\nNext: check file permissions, or use a writable directory.`,
+      '权限不足，检查当前权限后重试',
+      'Permission denied; check the current permission and retry',
     )
   }
-  return message
+  return oneLine(message)
 }

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -689,6 +689,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['tarball package.json 缺少包名', 'The tarball package.json has no package name'],
   ['pnpm 不可用；Profile 插件操作需要 PATH 中的 pnpm', 'pnpm is unavailable; Profile plugin operations require pnpm on PATH'],
   ['pnpm 不在 PATH 中；请安装 pnpm 后重试', 'pnpm is not on PATH; install pnpm and retry'],
+  ['安装 pnpm 并确保它在 PATH 中后重试', 'Install pnpm; it is not on PATH, then retry'],
   ['Profile Bundle 结构可解析', 'Profile Bundle structure is valid'],
   ['位于 Bundle 顺序中但未声明 dsh.bundle.patch', 'Listed in Bundle order but does not declare dsh.bundle.patch'],
   ['TUI Bundle 必须通过 dsh --profile <name> 启动', 'The TUI Bundle must be started through dsh --profile <name>'],

--- a/tests/error-advice.test.ts
+++ b/tests/error-advice.test.ts
@@ -28,10 +28,33 @@ describe('actionable failure text', () => {
     const message = startupTimeoutError('Reading workspace').message
     expect(message).toContain('超时')
     const explained = explainFailure(message)
-    expect(explained).toContain('Startup timed out')
+    expect(explained).toBe('Confirm dsh is on PATH or DSH_BIN, check the Profile, then run deepseek again.')
+    expect(explained).not.toContain('Startup timed out')
     expect(explained).not.toMatch(/\p{Script=Han}/u)
     const source = readFileSync(resolve(root, 'src/client/client-runtime.ts'), 'utf8')
     expect(source).toMatch(/startupTimeoutError\(label\)/u)
     expect(source).not.toMatch(/reject\(new Error\(ui\(/u)
+  })
+
+  it('keeps every English branch on one action-first line', () => {
+    setUiLocale('en')
+    const cases = [
+      explainFailure('transport failure for /api/foo: handler failure: boom'),
+      explainFailure(startupTimeoutError('Reading workspace').message),
+      explainFailure('pnpm 不在 PATH 中；请安装 pnpm 后重试'),
+      explainFailure('ENOENT: no such file'),
+      explainFailure('EACCES: permission denied'),
+      explainFailure('EPERM: operation not permitted'),
+    ]
+    for (const explained of cases) {
+      expect(explained).not.toContain('\n')
+      expect(explained).not.toMatch(/\p{Script=Han}/u)
+    }
+    expect(cases[0]).toBe('Retry this action; if it fails again, run /doctor')
+    expect(cases[1]).toMatch(/^Confirm dsh is on PATH/)
+    expect(cases[2]).toMatch(/^Install pnpm/)
+    expect(cases[3]).toMatch(/^Confirm the path exists/)
+    expect(cases[4]).toMatch(/^Check the current permission/)
+    expect(cases[5]).toMatch(/^Check the current permission/)
   })
 })

--- a/tests/error-advice.test.ts
+++ b/tests/error-advice.test.ts
@@ -10,8 +10,9 @@ afterEach(() => { setUiLocale('zh') })
 
 describe('actionable failure text', () => {
   it('unwraps in-process transport failures and keeps installer warnings', () => {
-    expect(explainFailure('transport failure for /api/foo: handler failure: boom')).toContain('内部调用失败：boom')
-    expect(explainFailure('transport failure for /api/foo: handler failure: boom')).toContain('下一步')
+    const transport = explainFailure('transport failure for /api/foo: handler failure: boom')
+    expect(transport).not.toContain('\n')
+    expect(transport).toContain('重试当前操作，再次失败运行 /doctor')
     expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).not.toContain('/doctor')
     expect(explainFailure('读取工作区与会话超时，请运行 /doctor 检查 Harness 状态')).toContain('重新运行 deepseek')
     expect(explainFailure('读取工作区与会话超时')).toContain('重新运行 deepseek')

--- a/tests/i18n-en-chrome.test.ts
+++ b/tests/i18n-en-chrome.test.ts
@@ -132,14 +132,14 @@ describe('i18n English chrome gate (task 7)', () => {
     expect(rendered).toContain('Run the linter on changed files')
     expect(rendered).toContain('Remove demo from tui?')
     expect(rendered).toContain('another surface')
-    expect(rendered).toContain('Startup timed out')
+    expect(rendered).toContain('Confirm dsh is on PATH or DSH_BIN')
     expect(rendered).toContain('Switch permission')
   })
 
   it('re-localizes chrome constructed in zh after switching to en, and the reverse', () => {
     const fromZh = englishChromeFrom('zh')
     expect(fromZh).not.toMatch(HAN)
-    expect(fromZh).toContain('Startup timed out')
+    expect(fromZh).toContain('Confirm dsh is on PATH or DSH_BIN')
     expect(fromZh).toContain('DeepSeek dark')
     expect(fromZh).toContain('The interface theme currently used by SeekTTY')
     expect(fromZh).toContain('Remove demo from tui?')


### PR DESCRIPTION
## Summary
- Collapse `explainFailure()` into one action-first StatusBar line so the next step is not truncated.
- Use fixed bilingual copy for transport failures, permission errors, missing paths, pnpm PATH / exit 127, and startup timeouts; do not add an error center or history.

## Test plan
- [x] `tests/error-advice.test.ts` — transport advice is one line and action-first; timeout still contains `重新运行 deepseek` and does not mention `/doctor`
- [x] `tests/i18n-en-chrome.test.ts` — English chrome stays Han-free, including timeout copy
- [x] `tests/settings-schema-i18n.test.ts` — pnpm PATH machine string still localizes


Made with [Cursor](https://cursor.com)