### PR TITLE
fix(tui): keep important status above ephemeral notices

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -32133,6 +32133,102 @@ function nextTitleWrite(previous, next) {
 }
 
 //#endregion
+//#region src/client/status-priority.ts
+/**
+* Pick one status-bar line. Order: error, pending, restart, running, warning, facts, toast.
+* @param input - already-colored or plain candidates; omitted keys are skipped.
+*/
+function pickStatusLine(input) {
+	return input.error ?? input.pending ?? input.restart ?? input.running ?? input.warning ?? input.facts ?? input.notice;
+}
+/** Success and info toasts leave the status bar after this many milliseconds. */
+const EPHEMERAL_NOTICE_MS = 2e3;
+/**
+* Keep error, warning, and 2s success/info toasts in separate slots.
+* A later warning must not delete an error; a later toast must not delete either.
+*/
+var NoticeBoard = class {
+	error;
+	warning;
+	toast;
+	seq = 0;
+	timer;
+	onExpire;
+	/**
+	* @param onExpire - called after an ephemeral toast leaves on its own.
+	*/
+	constructor(onExpire) {
+		this.onExpire = onExpire;
+	}
+	/** Replace the expire callback after surrounding status refresh exists. */
+	setOnExpire(onExpire) {
+		this.onExpire = onExpire;
+	}
+	/**
+	* Record a notice. Error and warning occupy independent persistent slots.
+	* @param message - canonical or Chinese status text; `view()` translates at render time.
+	* @param tone - notice severity.
+	*/
+	set(message, tone) {
+		if (tone === "error") {
+			this.error = message;
+			return;
+		}
+		if (tone === "warning") {
+			this.warning = message;
+			return;
+		}
+		this.seq += 1;
+		const seq = this.seq;
+		this.toast = {
+			message,
+			tone,
+			seq
+		};
+		this.clearTimer();
+		this.timer = setTimeout(() => {
+			if (this.toast?.seq !== seq) return;
+			this.toast = void 0;
+			this.timer = void 0;
+			this.onExpire?.();
+		}, EPHEMERAL_NOTICE_MS);
+		this.timer.unref();
+	}
+	/** Clear persistent and toast slots, including any pending expire timer. */
+	dismiss() {
+		this.error = void 0;
+		this.warning = void 0;
+		this.toast = void 0;
+		this.seq += 1;
+		this.clearTimer();
+	}
+	/** True when Esc should consume the key to clear status-bar notices. */
+	hasVisible() {
+		return this.error !== void 0 || this.warning !== void 0 || this.toast !== void 0;
+	}
+	/** Current slots for `pickStatusLine`, re-presented in the active locale. */
+	view() {
+		return {
+			...this.error === void 0 ? {} : { error: { message: translateUiText(this.error) } },
+			...this.warning === void 0 ? {} : { warning: { message: translateUiText(this.warning) } },
+			...this.toast === void 0 ? {} : { toast: {
+				message: translateUiText(this.toast.message),
+				tone: this.toast.tone
+			} }
+		};
+	}
+	/** Drop the expire timer when the surface closes. */
+	dispose() {
+		this.clearTimer();
+	}
+	clearTimer() {
+		if (this.timer === void 0) return;
+		clearTimeout(this.timer);
+		this.timer = void 0;
+	}
+};
+
+//#endregion
 //#region src/client/terminal-title.ts
 /** OSC window-title text derived from the current Session facts. */
 const DEFAULT_TERMINAL_TITLE = "DeepSeek Harness";
@@ -32395,7 +32491,7 @@ async function startTuiSurface(options$1) {
 		});
 		let exitArmedUntil = 0;
 		let latestSessionId = "";
-		let notice;
+		const notices = new NoticeBoard();
 		let restartRequired;
 		let headerGeneration = 0;
 		let elapsedTimer;
@@ -32419,12 +32515,12 @@ async function startTuiSurface(options$1) {
 		};
 		const setNotice = (message, tone = "info") => {
 			if (stopping !== void 0) return;
-			notice = {
-				message,
-				tone
-			};
+			notices.set(message, tone);
 			updateStatus();
 			renderWhileOpen();
+		};
+		const dismissNotice = () => {
+			notices.dismiss();
 		};
 		const onboarding = new ProviderOnboardingGate(options$1.api, overlays, (message, tone) => {
 			setNotice(message, tone);
@@ -32452,9 +32548,8 @@ async function startTuiSurface(options$1) {
 				chrome.runningSince ??= Date.now();
 				if (elapsedTimer === void 0 && liveBehavior.get().statusElapsed) elapsedTimer = setInterval(() => {
 					if (stopping !== void 0) return;
-					const elapsed = sessionChrome.of(latestSessionId);
-					if (elapsed.runningSince === void 0 || !liveBehavior.get().statusElapsed) return;
-					status.setDetail(color.accent(ui(`生成中 · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C to stop`)));
+					if (sessionChrome.of(latestSessionId).runningSince === void 0 || !liveBehavior.get().statusElapsed) return;
+					updateStatus();
 					renderWhileOpen();
 				}, 500);
 			} else {
@@ -32489,7 +32584,6 @@ async function startTuiSurface(options$1) {
 			chrome.notifyPrimed = true;
 			const pendingCount = snapshot.pending.length;
 			const generating = liveBehavior.get().statusElapsed && chrome.runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
-			const primary = snapshot.removed ? color.danger(ui("会话已删除", "Session deleted")) : snapshot.promptError !== null ? color.danger(ui(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`, `${snapshot.promptError.op === "send" ? "Send" : "Stop"} failed: ${snapshot.promptError.error.message}`)) : pendingCount > 0 ? color.warning(ui(`/pending 处理 ${String(pendingCount)} 项交互`, `/pending handles ${String(pendingCount)} interaction(s)`)) : snapshot.running ? color.accent(generating) : void 0;
 			const facts = [];
 			if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`));
 			const jobCount = (active === void 0 ? void 0 : capabilities.jobs())?.filter((job) => job.status === "running" || job.status === "stopping").length ?? 0;
@@ -32502,11 +32596,22 @@ async function startTuiSurface(options$1) {
 			if (goal !== null && goal !== void 0) facts.push(ui("目标", "Goal"));
 			const attachmentCount = capabilities.draftAttachments().length;
 			if (attachmentCount > 0) facts.push(ui(`图片 ${String(attachmentCount)}`, `Images ${String(attachmentCount)}`));
-			if (restartRequired !== void 0) facts.push(ui("需要重启", "Restart required"));
-			const secondary = notice === void 0 ? [primary, facts.length === 0 ? void 0 : color.muted(facts.join(" · "))].filter((value) => value !== void 0).join(" · ") || void 0 : noticeText(notice.message, notice.tone);
-			status.setDetail(secondary);
+			const noticeView = notices.view();
+			status.setDetail(pickStatusLine({
+				...snapshot.removed ? { error: color.danger(ui("会话已删除", "Session deleted")) } : snapshot.promptError !== null ? { error: color.danger(ui(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`, `${snapshot.promptError.op === "send" ? "Send" : "Stop"} failed: ${snapshot.promptError.error.message}`)) } : noticeView.error === void 0 ? {} : { error: noticeText(noticeView.error.message, "error") },
+				...pendingCount > 0 ? { pending: color.warning(ui(`/pending 处理 ${String(pendingCount)} 项交互`, `/pending handles ${String(pendingCount)} interaction(s)`)) } : {},
+				...restartRequired === void 0 ? {} : { restart: color.warning(ui("需要重启", "Restart required")) },
+				...snapshot.running ? { running: color.accent(generating) } : {},
+				...noticeView.warning === void 0 ? {} : { warning: noticeText(noticeView.warning.message, "warning") },
+				...facts.length === 0 ? {} : { facts: color.muted(facts.join(" · ")) },
+				...noticeView.toast === void 0 ? {} : { notice: noticeText(noticeView.toast.message, noticeView.toast.tone) }
+			}));
 			applyTerminalTitle();
 		};
+		notices.setOnExpire(() => {
+			updateStatus();
+			renderWhileOpen();
+		});
 		const refreshHeader = (forceModel = false) => {
 			const generation = ++headerGeneration;
 			capabilities.headerFacts(forceModel).then((facts) => {
@@ -32564,6 +32669,7 @@ async function startTuiSurface(options$1) {
 					clearInterval(elapsedTimer);
 					elapsedTimer = void 0;
 				}
+				notices.dispose();
 				overlays.dispose();
 				transcript.dispose();
 				setCodeHighlighter(void 0);
@@ -32701,7 +32807,7 @@ async function startTuiSurface(options$1) {
 			editor.disableSubmit = false;
 			if (latestSessionId !== current.sessionId) {
 				latestSessionId = current.sessionId;
-				notice = void 0;
+				dismissNotice();
 				refreshHeader(true);
 			} else refreshHeader(false);
 			updateStatus();
@@ -32731,7 +32837,7 @@ async function startTuiSurface(options$1) {
 				return false;
 			}
 			capabilities.clearAttachments();
-			notice = void 0;
+			dismissNotice();
 			updateStatus();
 			return true;
 		});
@@ -32929,8 +33035,8 @@ async function startTuiSurface(options$1) {
 				actions.execute("settings", "");
 				return { consume: true };
 			}
-			if (matchesKey(data, Key.escape) && notice !== void 0 && editor.getText() === "") {
-				notice = void 0;
+			if (matchesKey(data, Key.escape) && notices.hasVisible()) {
+				dismissNotice();
 				updateStatus();
 				renderWhileOpen();
 				return { consume: true };

--- a/src/client/status-priority.ts
+++ b/src/client/status-priority.ts
@@ -26,3 +26,91 @@ export function pickStatusLine(input: StatusPriorityInput): string | undefined {
 
 /** Success and info toasts leave the status bar after this many milliseconds. */
 export const EPHEMERAL_NOTICE_MS = 2_000
+
+export type NoticeTone = 'info' | 'success' | 'warning' | 'error'
+
+export interface NoticeBoardView {
+  readonly error?: { readonly message: string }
+  readonly warning?: { readonly message: string }
+  readonly toast?: { readonly message: string; readonly tone: 'success' | 'info' }
+}
+
+/**
+ * Keep persistent error/warning notices in a separate slot from 2s success/info toasts.
+ * A later toast must not delete a higher-priority notice.
+ */
+export class NoticeBoard {
+  private persistent: { message: string; tone: 'error' | 'warning' } | undefined
+  private toast: { message: string; tone: 'success' | 'info'; seq: number } | undefined
+  private seq = 0
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private onExpire: (() => void) | undefined
+
+  /**
+   * @param onExpire - called after an ephemeral toast leaves on its own.
+   */
+  constructor(onExpire?: () => void) {
+    this.onExpire = onExpire
+  }
+
+  /** Replace the expire callback after surrounding status refresh exists. */
+  setOnExpire(onExpire: () => void): void {
+    this.onExpire = onExpire
+  }
+
+  /**
+   * Record a notice. Error/warning persist; success/info expire without clearing them.
+   * @param message - already localized status text.
+   * @param tone - notice severity.
+   */
+  set(message: string, tone: NoticeTone): void {
+    if (tone === 'error' || tone === 'warning') {
+      this.persistent = { message, tone }
+      return
+    }
+    this.seq += 1
+    const seq = this.seq
+    this.toast = { message, tone, seq }
+    this.clearTimer()
+    this.timer = setTimeout(() => {
+      if (this.toast?.seq !== seq) return
+      this.toast = undefined
+      this.timer = undefined
+      this.onExpire?.()
+    }, EPHEMERAL_NOTICE_MS)
+    this.timer.unref()
+  }
+
+  /** Clear persistent and toast slots, including any pending expire timer. */
+  dismiss(): void {
+    this.persistent = undefined
+    this.toast = undefined
+    this.seq += 1
+    this.clearTimer()
+  }
+
+  /** True when Esc should consume the key to clear status-bar notices. */
+  hasVisible(): boolean {
+    return this.persistent !== undefined || this.toast !== undefined
+  }
+
+  /** Current slots for `pickStatusLine`. */
+  view(): NoticeBoardView {
+    return {
+      ...(this.persistent?.tone === 'error' ? { error: { message: this.persistent.message } } : {}),
+      ...(this.persistent?.tone === 'warning' ? { warning: { message: this.persistent.message } } : {}),
+      ...(this.toast === undefined ? {} : { toast: { message: this.toast.message, tone: this.toast.tone } }),
+    }
+  }
+
+  /** Drop the expire timer when the surface closes. */
+  dispose(): void {
+    this.clearTimer()
+  }
+
+  private clearTimer(): void {
+    if (this.timer === undefined) return
+    clearTimeout(this.timer)
+    this.timer = undefined
+  }
+}

--- a/src/client/status-priority.ts
+++ b/src/client/status-priority.ts
@@ -1,0 +1,28 @@
+/** Status-bar line priority: important state is never replaced by a toast. */
+
+export interface StatusPriorityInput {
+  readonly error?: string
+  readonly pending?: string
+  readonly restart?: string
+  readonly running?: string
+  readonly warning?: string
+  readonly facts?: string
+  readonly notice?: string
+}
+
+/**
+ * Pick one status-bar line. Order: error, pending, restart, running, warning, facts, toast.
+ * @param input - already-colored or plain candidates; omitted keys are skipped.
+ */
+export function pickStatusLine(input: StatusPriorityInput): string | undefined {
+  return input.error
+    ?? input.pending
+    ?? input.restart
+    ?? input.running
+    ?? input.warning
+    ?? input.facts
+    ?? input.notice
+}
+
+/** Success and info toasts leave the status bar after this many milliseconds. */
+export const EPHEMERAL_NOTICE_MS = 2_000

--- a/src/client/status-priority.ts
+++ b/src/client/status-priority.ts
@@ -1,5 +1,7 @@
 /** Status-bar line priority: important state is never replaced by a toast. */
 
+import { translateUiText } from './locale.ts'
+
 export interface StatusPriorityInput {
   readonly error?: string
   readonly pending?: string
@@ -36,11 +38,12 @@ export interface NoticeBoardView {
 }
 
 /**
- * Keep persistent error/warning notices in a separate slot from 2s success/info toasts.
- * A later toast must not delete a higher-priority notice.
+ * Keep error, warning, and 2s success/info toasts in separate slots.
+ * A later warning must not delete an error; a later toast must not delete either.
  */
 export class NoticeBoard {
-  private persistent: { message: string; tone: 'error' | 'warning' } | undefined
+  private error: string | undefined
+  private warning: string | undefined
   private toast: { message: string; tone: 'success' | 'info'; seq: number } | undefined
   private seq = 0
   private timer: ReturnType<typeof setTimeout> | undefined
@@ -59,13 +62,17 @@ export class NoticeBoard {
   }
 
   /**
-   * Record a notice. Error/warning persist; success/info expire without clearing them.
-   * @param message - already localized status text.
+   * Record a notice. Error and warning occupy independent persistent slots.
+   * @param message - canonical or Chinese status text; `view()` translates at render time.
    * @param tone - notice severity.
    */
   set(message: string, tone: NoticeTone): void {
-    if (tone === 'error' || tone === 'warning') {
-      this.persistent = { message, tone }
+    if (tone === 'error') {
+      this.error = message
+      return
+    }
+    if (tone === 'warning') {
+      this.warning = message
       return
     }
     this.seq += 1
@@ -83,7 +90,8 @@ export class NoticeBoard {
 
   /** Clear persistent and toast slots, including any pending expire timer. */
   dismiss(): void {
-    this.persistent = undefined
+    this.error = undefined
+    this.warning = undefined
     this.toast = undefined
     this.seq += 1
     this.clearTimer()
@@ -91,15 +99,17 @@ export class NoticeBoard {
 
   /** True when Esc should consume the key to clear status-bar notices. */
   hasVisible(): boolean {
-    return this.persistent !== undefined || this.toast !== undefined
+    return this.error !== undefined || this.warning !== undefined || this.toast !== undefined
   }
 
-  /** Current slots for `pickStatusLine`. */
+  /** Current slots for `pickStatusLine`, re-presented in the active locale. */
   view(): NoticeBoardView {
     return {
-      ...(this.persistent?.tone === 'error' ? { error: { message: this.persistent.message } } : {}),
-      ...(this.persistent?.tone === 'warning' ? { warning: { message: this.persistent.message } } : {}),
-      ...(this.toast === undefined ? {} : { toast: { message: this.toast.message, tone: this.toast.tone } }),
+      ...(this.error === undefined ? {} : { error: { message: translateUiText(this.error) } }),
+      ...(this.warning === undefined ? {} : { warning: { message: translateUiText(this.warning) } }),
+      ...(this.toast === undefined
+        ? {}
+        : { toast: { message: translateUiText(this.toast.message), tone: this.toast.tone } }),
     }
   }
 

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -62,6 +62,7 @@ import {
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
 import { createSessionChromeStore, nextTitleWrite } from './session-chrome.ts'
+import { EPHEMERAL_NOTICE_MS, pickStatusLine } from './status-priority.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
 import { attachFatalGuards, fatalLogHint, restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
@@ -267,6 +268,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     let exitArmedUntil = 0
     let latestSessionId = ''
     let notice: { message: string; tone: NoticeTone } | undefined
+    let noticeSeq = 0
+    let noticeTimer: ReturnType<typeof setTimeout> | undefined
     let restartRequired: string | undefined
     let headerGeneration = 0
     let elapsedTimer: ReturnType<typeof setInterval> | undefined
@@ -298,8 +301,33 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const setNotice = (message: string, tone: NoticeTone = 'info'): void => {
       if (stopping !== undefined) return
       notice = { message, tone }
+      noticeSeq += 1
+      const seq = noticeSeq
+      if (noticeTimer !== undefined) {
+        clearTimeout(noticeTimer)
+        noticeTimer = undefined
+      }
+      if (tone === 'success' || tone === 'info') {
+        noticeTimer = setTimeout(() => {
+          if (seq !== noticeSeq) return
+          notice = undefined
+          noticeTimer = undefined
+          updateStatus()
+          renderWhileOpen()
+        }, EPHEMERAL_NOTICE_MS)
+        noticeTimer.unref()
+      }
       updateStatus()
       renderWhileOpen()
+    }
+
+    const dismissNotice = (): void => {
+      notice = undefined
+      noticeSeq += 1
+      if (noticeTimer !== undefined) {
+        clearTimeout(noticeTimer)
+        noticeTimer = undefined
+      }
     }
 
     const onboarding = new ProviderOnboardingGate(
@@ -337,10 +365,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
             if (stopping !== undefined) return
             const elapsed = sessionChrome.of(latestSessionId)
             if (elapsed.runningSince === undefined || !liveBehavior.get().statusElapsed) return
-            status.setDetail(color.accent(ui(
-              `生成中 · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C 停止`,
-              `Generating · ${formatElapsed(Date.now() - elapsed.runningSince)} · Ctrl+C to stop`,
-            )))
+            updateStatus()
             renderWhileOpen()
           }, 500)
         }
@@ -377,21 +402,6 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`,
         )
         : ui('生成中 · Ctrl+C 停止', 'Generating · Ctrl+C to stop')
-      const primary = snapshot.removed
-        ? color.danger(ui('会话已删除', 'Session deleted'))
-        : snapshot.promptError !== null
-          ? color.danger(ui(
-            `${snapshot.promptError.op === 'send' ? '发送' : '停止'}失败：${snapshot.promptError.error.message}`,
-            `${snapshot.promptError.op === 'send' ? 'Send' : 'Stop'} failed: ${snapshot.promptError.error.message}`,
-          ))
-          : pendingCount > 0
-            ? color.warning(ui(
-              `/pending 处理 ${String(pendingCount)} 项交互`,
-              `/pending handles ${String(pendingCount)} interaction(s)`,
-            ))
-            : snapshot.running
-              ? color.accent(generating)
-              : undefined
       const facts: string[] = []
       if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`))
       const jobs = active === undefined ? undefined : capabilities.jobs()
@@ -405,13 +415,35 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (goal !== null && goal !== undefined) facts.push(ui('目标', 'Goal'))
       const attachmentCount = capabilities.draftAttachments().length
       if (attachmentCount > 0) facts.push(ui(`图片 ${String(attachmentCount)}`, `Images ${String(attachmentCount)}`))
-      if (restartRequired !== undefined) facts.push(ui('需要重启', 'Restart required'))
-      const secondary = notice === undefined
-        ? [primary, facts.length === 0 ? undefined : color.muted(facts.join(' · '))]
-          .filter((value): value is string => value !== undefined)
-          .join(' · ') || undefined
-        : noticeText(notice.message, notice.tone)
-      status.setDetail(secondary)
+      status.setDetail(pickStatusLine({
+        ...(snapshot.removed
+          ? { error: color.danger(ui('会话已删除', 'Session deleted')) }
+          : snapshot.promptError !== null
+            ? {
+              error: color.danger(ui(
+                `${snapshot.promptError.op === 'send' ? '发送' : '停止'}失败：${snapshot.promptError.error.message}`,
+                `${snapshot.promptError.op === 'send' ? 'Send' : 'Stop'} failed: ${snapshot.promptError.error.message}`,
+              )),
+            }
+            : notice?.tone === 'error'
+              ? { error: noticeText(notice.message, notice.tone) }
+              : {}),
+        ...(pendingCount > 0
+          ? {
+            pending: color.warning(ui(
+              `/pending 处理 ${String(pendingCount)} 项交互`,
+              `/pending handles ${String(pendingCount)} interaction(s)`,
+            )),
+          }
+          : {}),
+        ...(restartRequired === undefined ? {} : { restart: color.warning(ui('需要重启', 'Restart required')) }),
+        ...(snapshot.running ? { running: color.accent(generating) } : {}),
+        ...(notice?.tone === 'warning' ? { warning: noticeText(notice.message, notice.tone) } : {}),
+        ...(facts.length === 0 ? {} : { facts: color.muted(facts.join(' · ')) }),
+        ...(notice !== undefined && (notice.tone === 'success' || notice.tone === 'info')
+          ? { notice: noticeText(notice.message, notice.tone) }
+          : {}),
+      }))
       applyTerminalTitle()
     }
 
@@ -602,7 +634,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       editor.disableSubmit = false
       if (latestSessionId !== current.sessionId) {
         latestSessionId = current.sessionId
-        notice = undefined
+        dismissNotice()
         refreshHeader(true)
       } else {
         refreshHeader(false)
@@ -645,7 +677,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           return false
         }
         capabilities.clearAttachments()
-        notice = undefined
+        dismissNotice()
         updateStatus()
         return true
       },
@@ -879,7 +911,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         return { consume: true }
       }
       if (matchesKey(data, Key.escape) && notice !== undefined && editor.getText() === '') {
-        notice = undefined
+        dismissNotice()
         updateStatus()
         renderWhileOpen()
         return { consume: true }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -62,7 +62,7 @@ import {
   type DesktopNotifySnapshot,
 } from './desktop-notify.ts'
 import { createSessionChromeStore, nextTitleWrite } from './session-chrome.ts'
-import { EPHEMERAL_NOTICE_MS, pickStatusLine } from './status-priority.ts'
+import { NoticeBoard, pickStatusLine } from './status-priority.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
 import { attachFatalGuards, fatalLogHint, restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
@@ -267,9 +267,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const closed = new Promise<TuiSurfaceOutcome>((resolve) => { resolveClosed = resolve })
     let exitArmedUntil = 0
     let latestSessionId = ''
-    let notice: { message: string; tone: NoticeTone } | undefined
-    let noticeSeq = 0
-    let noticeTimer: ReturnType<typeof setTimeout> | undefined
+    const notices = new NoticeBoard()
     let restartRequired: string | undefined
     let headerGeneration = 0
     let elapsedTimer: ReturnType<typeof setInterval> | undefined
@@ -300,34 +298,13 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
 
     const setNotice = (message: string, tone: NoticeTone = 'info'): void => {
       if (stopping !== undefined) return
-      notice = { message, tone }
-      noticeSeq += 1
-      const seq = noticeSeq
-      if (noticeTimer !== undefined) {
-        clearTimeout(noticeTimer)
-        noticeTimer = undefined
-      }
-      if (tone === 'success' || tone === 'info') {
-        noticeTimer = setTimeout(() => {
-          if (seq !== noticeSeq) return
-          notice = undefined
-          noticeTimer = undefined
-          updateStatus()
-          renderWhileOpen()
-        }, EPHEMERAL_NOTICE_MS)
-        noticeTimer.unref()
-      }
+      notices.set(message, tone)
       updateStatus()
       renderWhileOpen()
     }
 
     const dismissNotice = (): void => {
-      notice = undefined
-      noticeSeq += 1
-      if (noticeTimer !== undefined) {
-        clearTimeout(noticeTimer)
-        noticeTimer = undefined
-      }
+      notices.dismiss()
     }
 
     const onboarding = new ProviderOnboardingGate(
@@ -415,6 +392,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       if (goal !== null && goal !== undefined) facts.push(ui('目标', 'Goal'))
       const attachmentCount = capabilities.draftAttachments().length
       if (attachmentCount > 0) facts.push(ui(`图片 ${String(attachmentCount)}`, `Images ${String(attachmentCount)}`))
+      const noticeView = notices.view()
       status.setDetail(pickStatusLine({
         ...(snapshot.removed
           ? { error: color.danger(ui('会话已删除', 'Session deleted')) }
@@ -425,9 +403,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
                 `${snapshot.promptError.op === 'send' ? 'Send' : 'Stop'} failed: ${snapshot.promptError.error.message}`,
               )),
             }
-            : notice?.tone === 'error'
-              ? { error: noticeText(notice.message, notice.tone) }
-              : {}),
+            : noticeView.error === undefined
+              ? {}
+              : { error: noticeText(noticeView.error.message, 'error') }),
         ...(pendingCount > 0
           ? {
             pending: color.warning(ui(
@@ -438,14 +416,21 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           : {}),
         ...(restartRequired === undefined ? {} : { restart: color.warning(ui('需要重启', 'Restart required')) }),
         ...(snapshot.running ? { running: color.accent(generating) } : {}),
-        ...(notice?.tone === 'warning' ? { warning: noticeText(notice.message, notice.tone) } : {}),
+        ...(noticeView.warning === undefined
+          ? {}
+          : { warning: noticeText(noticeView.warning.message, 'warning') }),
         ...(facts.length === 0 ? {} : { facts: color.muted(facts.join(' · ')) }),
-        ...(notice !== undefined && (notice.tone === 'success' || notice.tone === 'info')
-          ? { notice: noticeText(notice.message, notice.tone) }
-          : {}),
+        ...(noticeView.toast === undefined
+          ? {}
+          : { notice: noticeText(noticeView.toast.message, noticeView.toast.tone) }),
       }))
       applyTerminalTitle()
     }
+
+    notices.setOnExpire(() => {
+      updateStatus()
+      renderWhileOpen()
+    })
 
     const refreshHeader = (forceModel = false): void => {
       const generation = ++headerGeneration
@@ -501,6 +486,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           clearInterval(elapsedTimer)
           elapsedTimer = undefined
         }
+        notices.dispose()
         overlays.dispose()
         transcript.dispose()
         setCodeHighlighter(undefined)
@@ -910,7 +896,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         void actions.execute('settings', '')
         return { consume: true }
       }
-      if (matchesKey(data, Key.escape) && notice !== undefined && editor.getText() === '') {
+      if (matchesKey(data, Key.escape) && notices.hasVisible()) {
         dismissNotice()
         updateStatus()
         renderWhileOpen()

--- a/tests/status-priority.test.ts
+++ b/tests/status-priority.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { pickStatusLine } from '../src/client/status-priority.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+describe('status line priority', () => {
+  it('keeps errors, pending, and restart above a success toast', () => {
+    expect(pickStatusLine({
+      error: 'send failed',
+      pending: 'waiting',
+      notice: 'copied',
+    })).toBe('send failed')
+    expect(pickStatusLine({
+      pending: 'waiting',
+      notice: 'copied',
+    })).toBe('waiting')
+    expect(pickStatusLine({
+      restart: 'restart',
+      running: 'generating',
+      facts: 'queue 1',
+      notice: 'copied',
+    })).toBe('restart')
+    expect(pickStatusLine({
+      running: 'generating',
+      facts: 'queue 1',
+      notice: 'copied',
+    })).toBe('generating')
+    expect(pickStatusLine({
+      warning: 'need restart',
+      facts: 'queue 1',
+      notice: 'copied',
+    })).toBe('need restart')
+    expect(pickStatusLine({
+      facts: 'queue 1',
+      notice: 'copied',
+    })).toBe('queue 1')
+    expect(pickStatusLine({ notice: 'copied' })).toBe('copied')
+  })
+
+  it('expires success and info notices in the surface listener', () => {
+    const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
+    expect(surface).toContain('EPHEMERAL_NOTICE_MS')
+    expect(surface).toContain('pickStatusLine')
+    expect(surface).toMatch(/tone === 'success' \|\| tone === 'info'/u)
+  })
+})

--- a/tests/status-priority.test.ts
+++ b/tests/status-priority.test.ts
@@ -1,9 +1,9 @@
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
-import { pickStatusLine } from '../src/client/status-priority.ts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EPHEMERAL_NOTICE_MS, NoticeBoard, pickStatusLine } from '../src/client/status-priority.ts'
 
-const root = resolve(import.meta.dirname, '..')
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('status line priority', () => {
   it('keeps errors, pending, and restart above a success toast', () => {
@@ -38,11 +38,68 @@ describe('status line priority', () => {
     })).toBe('queue 1')
     expect(pickStatusLine({ notice: 'copied' })).toBe('copied')
   })
+})
 
-  it('expires success and info notices in the surface listener', () => {
-    const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
-    expect(surface).toContain('EPHEMERAL_NOTICE_MS')
-    expect(surface).toContain('pickStatusLine')
-    expect(surface).toMatch(/tone === 'success' \|\| tone === 'info'/u)
+describe('notice board slots', () => {
+  it('keeps a persistent error after a success toast expires', () => {
+    vi.useFakeTimers()
+    const board = new NoticeBoard()
+    board.set('send failed', 'error')
+    board.set('copied', 'success')
+    expect(board.view()).toEqual({
+      error: { message: 'send failed' },
+      toast: { message: 'copied', tone: 'success' },
+    })
+    expect(pickStatusLine({
+      error: board.view().error?.message,
+      notice: board.view().toast?.message,
+    })).toBe('send failed')
+
+    vi.advanceTimersByTime(EPHEMERAL_NOTICE_MS)
+    expect(board.view()).toEqual({ error: { message: 'send failed' } })
+    board.dispose()
+  })
+
+  it('keeps a warning after an info toast and does not let the first timer clear a newer toast', () => {
+    vi.useFakeTimers()
+    const board = new NoticeBoard()
+    board.set('need restart', 'warning')
+    board.set('first', 'info')
+    vi.advanceTimersByTime(1_000)
+    board.set('second', 'info')
+    vi.advanceTimersByTime(1_000)
+    expect(board.view()).toEqual({
+      warning: { message: 'need restart' },
+      toast: { message: 'second', tone: 'info' },
+    })
+    vi.advanceTimersByTime(1_000)
+    expect(board.view()).toEqual({ warning: { message: 'need restart' } })
+    board.dispose()
+  })
+
+  it('dismisses persistent and toast slots together even when the editor has a draft', () => {
+    vi.useFakeTimers()
+    const board = new NoticeBoard()
+    board.set('send failed', 'error')
+    board.set('copied', 'success')
+    expect(board.hasVisible()).toBe(true)
+    board.dismiss()
+    vi.advanceTimersByTime(EPHEMERAL_NOTICE_MS)
+    expect(board.hasVisible()).toBe(false)
+    expect(board.view()).toEqual({})
+    board.dispose()
+  })
+
+  it('lets elapsed-style callbacks coexist with the toast timer', () => {
+    vi.useFakeTimers()
+    let ticks = 0
+    const elapsed = setInterval(() => { ticks += 1 }, 500)
+    const board = new NoticeBoard()
+    board.set('copied', 'success')
+    vi.advanceTimersByTime(EPHEMERAL_NOTICE_MS)
+    expect(ticks).toBe(4)
+    expect(board.view().toast).toBeUndefined()
+    clearInterval(elapsed)
+    board.dispose()
   })
 })

--- a/tests/status-priority.test.ts
+++ b/tests/status-priority.test.ts
@@ -1,8 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { EPHEMERAL_NOTICE_MS, NoticeBoard, pickStatusLine } from '../src/client/status-priority.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import {
+  EPHEMERAL_NOTICE_MS,
+  NoticeBoard,
+  pickStatusLine,
+  type StatusPriorityInput,
+} from '../src/client/status-priority.ts'
+
+function lineOf(board: NoticeBoard, extra: StatusPriorityInput = {}): string | undefined {
+  const view = board.view()
+  return pickStatusLine({
+    ...(view.error === undefined ? {} : { error: view.error.message }),
+    ...(view.warning === undefined ? {} : { warning: view.warning.message }),
+    ...(view.toast === undefined ? {} : { notice: view.toast.message }),
+    ...extra,
+  })
+}
 
 afterEach(() => {
   vi.useRealTimers()
+  setUiLocale('zh')
 })
 
 describe('status line priority', () => {
@@ -50,10 +67,7 @@ describe('notice board slots', () => {
       error: { message: 'send failed' },
       toast: { message: 'copied', tone: 'success' },
     })
-    expect(pickStatusLine({
-      error: board.view().error?.message,
-      notice: board.view().toast?.message,
-    })).toBe('send failed')
+    expect(lineOf(board)).toBe('send failed')
 
     vi.advanceTimersByTime(EPHEMERAL_NOTICE_MS)
     expect(board.view()).toEqual({ error: { message: 'send failed' } })
@@ -74,6 +88,36 @@ describe('notice board slots', () => {
     })
     vi.advanceTimersByTime(1_000)
     expect(board.view()).toEqual({ warning: { message: 'need restart' } })
+    board.dispose()
+  })
+
+  it('keeps a persistent error after a later warning is recorded', () => {
+    const board = new NoticeBoard()
+    board.set('send failed', 'error')
+    board.set('need restart', 'warning')
+    expect(board.view()).toEqual({
+      error: { message: 'send failed' },
+      warning: { message: 'need restart' },
+    })
+    expect(lineOf(board)).toBe('send failed')
+    board.dispose()
+  })
+
+  it('re-presents lasting error and warning copy after the locale switches', () => {
+    setUiLocale('zh')
+    const board = new NoticeBoard()
+    board.set('未打开会话', 'error')
+    board.set('需要重启', 'warning')
+    expect(board.view()).toEqual({
+      error: { message: '未打开会话' },
+      warning: { message: '需要重启' },
+    })
+    setUiLocale('en')
+    expect(board.view()).toEqual({
+      error: { message: 'No session open' },
+      warning: { message: 'Restart required' },
+    })
+    setUiLocale('zh')
     board.dispose()
   })
 


### PR DESCRIPTION
## Summary
- Status-bar priority is now error → pending → restart → running → warning → facts → success/info toast.
- Success and info notices disappear after 2 seconds; warnings and errors stay until cleared or Esc.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/status-priority.test.ts tests/chrome.test.ts tests/session-chrome.test.ts tests/i18n-en-chrome.test.ts`
- [ ] Trigger a send error, then copy text, and confirm the error remains
- [ ] Confirm a “copied” toast disappears after about two seconds when nothing more important is showing


Made with [Cursor](https://cursor.com)