### PR TITLE
fix(tui): describe pending work instead of teaching /pending

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DdrrhFA6.js";
+import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-BiJhiFlO.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-BYa9XU45.js";
-import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-BJ_NQKbH.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-BMYr9ihZ.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-o9F9PRXo.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-BY6SqJI_.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import * as fs from "node:fs";
@@ -32246,6 +32246,22 @@ function sessionTerminalTitle(facts) {
 }
 
 //#endregion
+//#region src/client/pending-status.ts
+/**
+* Describe waiting approvals/questions. `/pending` is reserved for retry failures.
+* @param pending - current snapshot pending rows.
+*/
+function pendingInteractionStatus(pending) {
+	const approvals = pending.filter((item) => item.kind === "approval").length;
+	const questions = pending.filter((item) => item.kind === "question").length;
+	const total = approvals + questions;
+	if (total === 0) return void 0;
+	if (questions === 0) return approvals === 1 ? ui("等待工具审批", "Waiting for tool approval") : ui(`等待 ${String(approvals)} 项工具审批`, `Waiting for ${String(approvals)} tool approval(s)`);
+	if (approvals === 0) return questions === 1 ? ui("等待回答问题", "Waiting for a question") : ui(`等待 ${String(questions)} 项问题`, `Waiting for ${String(questions)} question(s)`);
+	return ui(`等待 ${String(total)} 项交互`, `Waiting for ${String(total)} interaction(s)`);
+}
+
+//#endregion
 //#region src/process-guards.ts
 /** Synchronous terminal restore used before any async Surface teardown. */
 const SHOW_CURSOR = "\x1B[?25h";
@@ -32599,7 +32615,7 @@ async function startTuiSurface(options$1) {
 			const noticeView = notices.view();
 			status.setDetail(pickStatusLine({
 				...snapshot.removed ? { error: color.danger(ui("会话已删除", "Session deleted")) } : snapshot.promptError !== null ? { error: color.danger(ui(`${snapshot.promptError.op === "send" ? "发送" : "停止"}失败：${snapshot.promptError.error.message}`, `${snapshot.promptError.op === "send" ? "Send" : "Stop"} failed: ${snapshot.promptError.error.message}`)) } : noticeView.error === void 0 ? {} : { error: noticeText(noticeView.error.message, "error") },
-				...pendingCount > 0 ? { pending: color.warning(ui(`/pending 处理 ${String(pendingCount)} 项交互`, `/pending handles ${String(pendingCount)} interaction(s)`)) } : {},
+				...pendingCount > 0 ? { pending: color.warning(pendingInteractionStatus(snapshot.pending) ?? ui(`等待 ${String(pendingCount)} 项交互`, `Waiting for ${String(pendingCount)} interaction(s)`)) } : {},
 				...restartRequired === void 0 ? {} : { restart: color.warning(ui("需要重启", "Restart required")) },
 				...snapshot.running ? { running: color.accent(generating) } : {},
 				...noticeView.warning === void 0 ? {} : { warning: noticeText(noticeView.warning.message, "warning") },

--- a/lib/locale-BiJhiFlO.js
+++ b/lib/locale-BiJhiFlO.js
@@ -65,6 +65,8 @@ const ENGLISH_TEXT = new Map([
 	["创建新会话", "Create new session"],
 	["重新启动 deepseek？", "Restart deepseek?"],
 	["需要重启", "Restart required"],
+	["等待工具审批", "Waiting for tool approval"],
+	["等待回答问题", "Waiting for a question"],
 	["正在连接 Harness…", "Connecting to Harness…"],
 	["● 生成中", "● Generating"],
 	["生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop"],
@@ -1245,6 +1247,18 @@ const ENGLISH_PATTERNS = [
 	{
 		pattern: /^查找 (.+) · 无匹配 · Esc 取消$/u,
 		replace: (query) => `Find ${query} · no matches · Esc cancel`
+	},
+	{
+		pattern: /^等待 (\d+) 项工具审批$/u,
+		replace: (count) => `Waiting for ${count} tool approval(s)`
+	},
+	{
+		pattern: /^等待 (\d+) 项问题$/u,
+		replace: (count) => `Waiting for ${count} question(s)`
+	},
+	{
+		pattern: /^等待 (\d+) 项交互$/u,
+		replace: (count) => `Waiting for ${count} interaction(s)`
 	}
 ];
 function requestedEnvironmentLocale(env) {

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
-import { c as ui } from "./locale-DdrrhFA6.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-BJ_NQKbH.js";
+import { c as ui } from "./locale-BiJhiFlO.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-o9F9PRXo.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-o9F9PRXo.js
+++ b/lib/plugin-marketplace-o9F9PRXo.js
@@ -1,4 +1,4 @@
-import { c as ui } from "./locale-DdrrhFA6.js";
+import { c as ui } from "./locale-BiJhiFlO.js";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { gunzip } from "node:zlib";

--- a/lib/startup-BY6SqJI_.js
+++ b/lib/startup-BY6SqJI_.js
@@ -1,4 +1,4 @@
-import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-DdrrhFA6.js";
+import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-BiJhiFlO.js";
 import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
-import "./locale-DdrrhFA6.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-BMYr9ihZ.js";
+import "./locale-BiJhiFlO.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-BY6SqJI_.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -81,6 +81,8 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['创建新会话', 'Create new session'],
   ['重新启动 deepseek？', 'Restart deepseek?'],
   ['需要重启', 'Restart required'],
+  ['等待工具审批', 'Waiting for tool approval'],
+  ['等待回答问题', 'Waiting for a question'],
   ['正在连接 Harness…', 'Connecting to Harness…'],
   ['● 生成中', '● Generating'],
   ['生成中 · Ctrl+C 停止', 'Generating · Ctrl+C to stop'],
@@ -850,6 +852,9 @@ const ENGLISH_PATTERNS: readonly {
   { pattern: /^查找 (.+) · (\d+) 处 · Enter 确认 · Esc 取消$/u, replace: (query, count) => `Find ${query} · ${count} match(es) · Enter confirm · Esc cancel` },
   { pattern: /^查找 (.+) · (\d+)\/(\d+) · n 下一个 · N 上一个 · Esc 取消$/u, replace: (query, current, total) => `Find ${query} · ${current}/${total} · n next · N previous · Esc cancel` },
   { pattern: /^查找 (.+) · 无匹配 · Esc 取消$/u, replace: query => `Find ${query} · no matches · Esc cancel` },
+  { pattern: /^等待 (\d+) 项工具审批$/u, replace: count => `Waiting for ${count} tool approval(s)` },
+  { pattern: /^等待 (\d+) 项问题$/u, replace: count => `Waiting for ${count} question(s)` },
+  { pattern: /^等待 (\d+) 项交互$/u, replace: count => `Waiting for ${count} interaction(s)` },
 ]
 
 function requestedEnvironmentLocale(env: NodeJS.ProcessEnv): LocaleId {

--- a/src/client/pending-status.ts
+++ b/src/client/pending-status.ts
@@ -1,0 +1,27 @@
+/** Status-bar copy for automatically presented pending interactions. */
+
+import { ui } from './locale.ts'
+
+/**
+ * Describe waiting approvals/questions. `/pending` is reserved for retry failures.
+ * @param pending - current snapshot pending rows.
+ */
+export function pendingInteractionStatus(
+  pending: readonly { readonly kind: string }[],
+): string | undefined {
+  const approvals = pending.filter(item => item.kind === 'approval').length
+  const questions = pending.filter(item => item.kind === 'question').length
+  const total = approvals + questions
+  if (total === 0) return undefined
+  if (questions === 0) {
+    return approvals === 1
+      ? ui('等待工具审批', 'Waiting for tool approval')
+      : ui(`等待 ${String(approvals)} 项工具审批`, `Waiting for ${String(approvals)} tool approval(s)`)
+  }
+  if (approvals === 0) {
+    return questions === 1
+      ? ui('等待回答问题', 'Waiting for a question')
+      : ui(`等待 ${String(questions)} 项问题`, `Waiting for ${String(questions)} question(s)`)
+  }
+  return ui(`等待 ${String(total)} 项交互`, `Waiting for ${String(total)} interaction(s)`)
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -65,6 +65,7 @@ import { createSessionChromeStore, nextTitleWrite } from './session-chrome.ts'
 import { NoticeBoard, pickStatusLine } from './status-priority.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
+import { pendingInteractionStatus } from './pending-status.ts'
 import { attachFatalGuards, fatalLogHint, restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
 
@@ -408,10 +409,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
               : { error: noticeText(noticeView.error.message, 'error') }),
         ...(pendingCount > 0
           ? {
-            pending: color.warning(ui(
-              `/pending 处理 ${String(pendingCount)} 项交互`,
-              `/pending handles ${String(pendingCount)} interaction(s)`,
-            )),
+            pending: color.warning(pendingInteractionStatus(snapshot.pending)
+              ?? ui(`等待 ${String(pendingCount)} 项交互`, `Waiting for ${String(pendingCount)} interaction(s)`)),
           }
           : {}),
         ...(restartRequired === undefined ? {} : { restart: color.warning(ui('需要重启', 'Restart required')) }),

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -35,6 +35,7 @@ const GATED = [
   'client/theme-import.ts',
   'client/composer-draft.ts',
   'client/provider-onboarding.ts',
+  'client/pending-status.ts',
   'client/surface.ts',
   'client/capabilities.ts',
   'client/transcript.ts',

--- a/tests/pending-status.test.ts
+++ b/tests/pending-status.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setUiLocale } from '../src/client/locale.ts'
+import { pendingInteractionStatus } from '../src/client/pending-status.ts'
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('pending status copy', () => {
+  it('describes waiting work without teaching /pending', () => {
+    expect(pendingInteractionStatus([{ kind: 'approval' }])).toBe('等待工具审批')
+    expect(pendingInteractionStatus([{ kind: 'question' }])).toBe('等待回答问题')
+    expect(pendingInteractionStatus([
+      { kind: 'approval' },
+      { kind: 'approval' },
+    ])).toBe('等待 2 项工具审批')
+    expect(pendingInteractionStatus([
+      { kind: 'approval' },
+      { kind: 'question' },
+    ])).toBe('等待 2 项交互')
+    expect(pendingInteractionStatus([])).toBeUndefined()
+    expect(pendingInteractionStatus([{ kind: 'approval' }])).not.toContain('/pending')
+  })
+})


### PR DESCRIPTION
## Summary
- Pending status copy is now “等待工具审批” / “等待回答问题” (or a count), not “输入 /pending”.
- `/pending` remains the retry command when automatic handling fails.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/pending-status.test.ts tests/locale.test.ts tests/i18n-en-chrome.test.ts tests/i18n-ast.test.ts`
- [ ] Trigger a tool approval and confirm the status bar does not tell you to type `/pending`


Made with [Cursor](https://cursor.com)