### PR TITLE
fix(tui): show generation progress only in the context bar

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-CnWu_5tm.js";
+import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-BaJMdZkh.js";
 import { r as DSH_COMPATIBILITY, s as dshCompatibilityError, t as measureStartup, u as launcherPrefersEnglish } from "./startup-trace-BYa9XU45.js";
-import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-CkGM8FUO.js";
-import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-lP5i4UGS.js";
+import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-CPgV7Ky0.js";
+import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-BiAn_mh8.js";
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import * as fs from "node:fs";
@@ -30477,7 +30477,7 @@ var ContextBar = class {
 			const facts = this.state.facts;
 			const context = facts.context?.split(" · ", 1)[0];
 			const elapsed = facts.running && facts.statusElapsed !== false && facts.runningSince !== void 0 ? ` ${formatElapsed(Date.now() - facts.runningSince)}` : "";
-			const runtime = facts.running ? color.accent(`${ui("● 生成中", "● Generating")}${elapsed}`) : color.muted(ui("就绪", "Ready"));
+			const runtime = facts.running ? color.accent(`${ui("● 生成中", "● Generating")}${elapsed}${ui(" · Ctrl+C 停止", " · Ctrl+C to stop")}`) : color.muted(ui("就绪", "Ready"));
 			return [`${prefix}${columns("", context === void 0 ? runtime : `${color.muted(context)} · ${runtime}`, innerWidth)}`];
 		}
 		return [`${prefix}${columns("", this.state.kind === "error" ? color.danger(translateUiText(this.state.message)) : color.muted(this.state.kind === "loading" ? ui("正在连接 Harness…", "Connecting to Harness…") : ui("未打开会话", "No session open")), innerWidth)}`];
@@ -32630,7 +32630,6 @@ async function startTuiSurface(options$1) {
 				if (elapsedTimer === void 0 && liveBehavior.get().statusElapsed) elapsedTimer = setInterval(() => {
 					if (stopping !== void 0) return;
 					if (sessionChrome.of(latestSessionId).runningSince === void 0 || !liveBehavior.get().statusElapsed) return;
-					updateStatus();
 					renderWhileOpen();
 				}, 500);
 			} else {
@@ -32664,7 +32663,6 @@ async function startTuiSurface(options$1) {
 			chrome.notify = currentNotify;
 			chrome.notifyPrimed = true;
 			const pendingCount = snapshot.pending.length;
-			const generating = liveBehavior.get().statusElapsed && chrome.runningSince !== void 0 ? ui(`生成中 · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C 停止`, `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`) : ui("生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop");
 			const facts = [];
 			if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`));
 			const jobCount = (active === void 0 ? void 0 : capabilities.jobs())?.filter((job) => job.status === "running" || job.status === "stopping").length ?? 0;
@@ -32685,7 +32683,6 @@ async function startTuiSurface(options$1) {
 				})) } : noticeView.error === void 0 ? {} : { error: noticeText(noticeView.error.message, "error") },
 				...pendingCount > 0 ? { pending: color.warning(pendingInteractionStatus(snapshot.pending) ?? ui(`等待 ${String(pendingCount)} 项交互`, `Waiting for ${String(pendingCount)} interaction(s)`)) } : {},
 				...restartRequired ? { restart: color.warning(restartRequiredFact()) } : {},
-				...snapshot.running ? { running: color.accent(generating) } : {},
 				...noticeView.warning === void 0 ? {} : { warning: noticeText(noticeView.warning.message, "warning") },
 				...facts.length === 0 ? {} : { facts: color.muted(facts.join(" · ")) },
 				...noticeView.toast === void 0 ? {} : { notice: noticeText(noticeView.toast.message, noticeView.toast.tone) }

--- a/lib/locale-BaJMdZkh.js
+++ b/lib/locale-BaJMdZkh.js
@@ -70,6 +70,7 @@ const ENGLISH_TEXT = new Map([
 	["等待回答问题", "Waiting for a question"],
 	["正在连接 Harness…", "Connecting to Harness…"],
 	["● 生成中", "● Generating"],
+	[" · Ctrl+C 停止", " · Ctrl+C to stop"],
 	["生成中 · Ctrl+C 停止", "Generating · Ctrl+C to stop"],
 	["未打开会话", "No session open"],
 	["会话已删除", "Session deleted"],

--- a/lib/marketplace-provider.js
+++ b/lib/marketplace-provider.js
@@ -1,5 +1,5 @@
-import { c as ui } from "./locale-CnWu_5tm.js";
-import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CkGM8FUO.js";
+import { c as ui } from "./locale-BaJMdZkh.js";
+import { n as assertCredentialFreeUrl } from "./plugin-marketplace-CPgV7Ky0.js";
 import { Service } from "@deepseek-ai/cordis";
 
 //#region src/host/marketplace-provider.ts

--- a/lib/plugin-marketplace-CPgV7Ky0.js
+++ b/lib/plugin-marketplace-CPgV7Ky0.js
@@ -1,4 +1,4 @@
-import { c as ui } from "./locale-CnWu_5tm.js";
+import { c as ui } from "./locale-BaJMdZkh.js";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { gunzip } from "node:zlib";

--- a/lib/startup-BiAn_mh8.js
+++ b/lib/startup-BiAn_mh8.js
@@ -1,4 +1,4 @@
-import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-CnWu_5tm.js";
+import { c as ui, n as localeFromEnvironment, o as setUiLocale } from "./locale-BaJMdZkh.js";
 import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,4 +1,4 @@
-import "./locale-CnWu_5tm.js";
-import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-lP5i4UGS.js";
+import "./locale-BaJMdZkh.js";
+import { i as name, n as apply, r as inject, t as TUI_STARTUP_SERVICE } from "./startup-BiAn_mh8.js";
 
 export { TUI_STARTUP_SERVICE, apply, inject, name };

--- a/src/client/chrome.ts
+++ b/src/client/chrome.ts
@@ -227,7 +227,7 @@ export class ContextBar implements Component {
         ? ` ${formatElapsed(Date.now() - facts.runningSince)}`
         : ''
       const runtime = facts.running
-        ? color.accent(`${ui('● 生成中', '● Generating')}${elapsed}`)
+        ? color.accent(`${ui('● 生成中', '● Generating')}${elapsed}${ui(' · Ctrl+C 停止', ' · Ctrl+C to stop')}`)
         : color.muted(ui('就绪', 'Ready'))
       const right = context === undefined ? runtime : `${color.muted(context)} · ${runtime}`
       return [`${prefix}${columns('', right, innerWidth)}`]

--- a/src/client/locale.ts
+++ b/src/client/locale.ts
@@ -86,6 +86,7 @@ const ENGLISH_TEXT = new Map<string, string>([
   ['等待回答问题', 'Waiting for a question'],
   ['正在连接 Harness…', 'Connecting to Harness…'],
   ['● 生成中', '● Generating'],
+  [' · Ctrl+C 停止', ' · Ctrl+C to stop'],
   ['生成中 · Ctrl+C 停止', 'Generating · Ctrl+C to stop'],
   ['未打开会话', 'No session open'],
   ['会话已删除', 'Session deleted'],

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -55,7 +55,6 @@ import {
 import { adoptSyntaxHighlighter, SyntaxHighlighter } from './syntax-highlighter.ts'
 import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
-import { formatElapsed } from './elapsed.ts'
 import { writeClipboard } from './clipboard.ts'
 import {
   captureClipboardImage,
@@ -351,7 +350,6 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
             if (stopping !== undefined) return
             const elapsed = sessionChrome.of(latestSessionId)
             if (elapsed.runningSince === undefined || !liveBehavior.get().statusElapsed) return
-            updateStatus()
             renderWhileOpen()
           }, 500)
         }
@@ -382,12 +380,6 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       chrome.notify = currentNotify
       chrome.notifyPrimed = true
       const pendingCount = snapshot.pending.length
-      const generating = liveBehavior.get().statusElapsed && chrome.runningSince !== undefined
-        ? ui(
-          `生成中 · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C 停止`,
-          `Generating · ${formatElapsed(Date.now() - chrome.runningSince)} · Ctrl+C to stop`,
-        )
-        : ui('生成中 · Ctrl+C 停止', 'Generating · Ctrl+C to stop')
       const facts: string[] = []
       if (snapshot.queue.length > 0) facts.push(ui(`队列 ${String(snapshot.queue.length)}`, `Queue ${String(snapshot.queue.length)}`))
       const jobs = active === undefined ? undefined : capabilities.jobs()
@@ -422,7 +414,6 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
           }
           : {}),
         ...(restartRequired ? { restart: color.warning(restartRequiredFact()) } : {}),
-        ...(snapshot.running ? { running: color.accent(generating) } : {}),
         ...(noticeView.warning === undefined
           ? {}
           : { warning: noticeText(noticeView.warning.message, 'warning') }),

--- a/tests/chrome.test.ts
+++ b/tests/chrome.test.ts
@@ -1,7 +1,9 @@
+import { readFileSync } from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { visibleWidth, type Component, type TUI } from '@mariozechner/pi-tui'
 import {
   BottomAnchoredLayout,
+  ContextBar,
   PromptEditor,
   transcriptViewportRows,
 } from '../src/client/chrome.ts'
@@ -189,5 +191,31 @@ describe('composer chrome', () => {
     })
 
     expect(composer.render(60).at(-1)).toMatch(/v4-pro · 最大推理 · 标准$/u)
+  })
+})
+
+describe('context bar running indicator', () => {
+  it('puts the Ctrl+C stop hint on the context bar only', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const bar = new ContextBar('tui', '/workspace')
+    bar.setFacts({
+      hostVersion: '0.1.0',
+      nodeVersion: '24.0.0',
+      platform: 'darwin',
+      architecture: 'arm64',
+      profile: 'tui',
+      workspace: '/workspace',
+      session: 'session',
+      mode: 'standard',
+      model: 'deepseek-v4-pro',
+      permission: 'workspace-write',
+      running: true,
+      runningSince: Date.now() - 1_000,
+    })
+    const rendered = bar.render(80).join('\n')
+    expect(rendered).toContain('生成中')
+    expect(rendered).toContain('Ctrl+C')
+    const surface = readFileSync(new URL('../src/client/surface.ts', import.meta.url), 'utf8')
+    expect(surface).not.toMatch(/status\.setDetail\(color\.accent\(ui\(\s*`生成中/u)
   })
 })


### PR DESCRIPTION
## Summary
- ContextBar is the only running indicator and now includes the Ctrl+C hint.
- StatusBar no longer repeats “生成中” while a turn is running.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/chrome.test.ts tests/i18n-en-chrome.test.ts tests/i18n-ast.test.ts`
- [ ] Start a generation and confirm only the top row says “生成中 · Ctrl+C 停止”


Made with [Cursor](https://cursor.com)