### PR TITLE
fix(tui): keep tool approval on one navigation stack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -29998,53 +29998,58 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 			fallback: ui(`调用 ${wait.payload.callId ?? wait.payload.approvalId}`, `Invoke ${wait.payload.callId ?? wait.payload.approvalId}`),
 			preview: toolApprovalPreview(call)
 		});
-		while (true) {
-			const selected = await this.host.overlays.select({
+		const options$1 = {
+			width: "95%",
+			maxHeight: "90%",
+			anchor: "bottom-center",
+			margin: 1
+		};
+		let decision;
+		await this.overlayFlow(this.host.overlays, async (navigation) => {
+			await navigation.selectPage({
 				title: ui(`工具审批 · ${wait.payload.toolName}`, `Tool approval · ${wait.payload.toolName}`),
 				detail: composed.detail,
 				searchable: false,
+				initialChoiceId: "reject",
 				choices: [
 					{
 						id: "allow",
 						label: ui("仅本次允许", "Allow this time"),
 						description: ui("只允许这一次工具调用", "Allow only this tool call")
 					},
-					{
-						id: "reject",
-						label: ui("拒绝", "Reject"),
-						description: ui("本次工具调用不会执行", "This tool call will not run")
-					},
 					...composed.full === void 0 ? [] : [{
 						id: "inspect",
 						label: ui("查看完整参数", "View full arguments"),
 						description: ui("打开只读子页，不批准也不拒绝", "Open a read-only page; does not approve or reject")
-					}]
+					}],
+					{
+						id: "reject",
+						label: ui("拒绝", "Reject"),
+						description: ui("本次工具调用不会执行", "This tool call will not run")
+					}
 				],
 				footer: ui("Enter 确认 · Esc 安全拒绝", "Enter to confirm · Esc rejects safely"),
-				options: {
-					width: "95%",
-					maxHeight: "90%",
-					anchor: "bottom-center",
-					margin: 1
+				options: options$1
+			}, async (selected) => {
+				if (selected.id === "inspect" && composed.full !== void 0) {
+					await navigation.detail({
+						title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
+						content: composed.full,
+						options: {
+							width: "95%",
+							maxHeight: "90%",
+							anchor: "center",
+							margin: 1
+						}
+					});
+					return;
 				}
+				decision = selected.id === "allow" ? "allowed-once" : "rejected";
+				navigation.finish();
 			});
-			if (selected?.id === "inspect" && composed.full !== void 0) {
-				await this.host.overlays.detail({
-					title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
-					content: composed.full,
-					options: {
-						width: "95%",
-						maxHeight: "90%",
-						anchor: "center",
-						margin: 1
-					}
-				});
-				continue;
-			}
-			this.host.transcript.followLatest();
-			await this.capabilities.answerApproval(wait, selected?.id === "reject" || selected === void 0 ? "rejected" : "allowed-once");
-			return;
-		}
+		}, options$1);
+		this.host.transcript.followLatest();
+		await this.capabilities.answerApproval(wait, decision ?? "rejected");
 	}
 	async question(wait) {
 		const answers = [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -151,7 +151,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -606,7 +606,7 @@ var CombinedAutocompleteProvider = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup-data.js
 const ambiguousMinimalCodePoint = 161;
 const ambiguousMaximumCodePoint = 1114109;
 const ambiguousRanges = [
@@ -1229,7 +1229,7 @@ const wideRanges = [
 ];
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/utilities.js
 /**
 Binary search on a sorted flat array of [start, end] pairs.
 
@@ -1251,7 +1251,7 @@ const isInRange = (ranges, codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/lookup.js
 const commonCjkCodePoint = 19968;
 const [wideFastPathStart, wideFastPathEnd] = /* @__PURE__ */ findWideFastPathRange(wideRanges);
 function findWideFastPathRange(ranges) {
@@ -1283,7 +1283,7 @@ const isWide = (codePoint) => {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
+//#region node_modules/.pnpm/get-east-asian-width@1.6.0/node_modules/get-east-asian-width/index.js
 function validate(codePoint) {
 	if (!Number.isSafeInteger(codePoint)) throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
 }
@@ -1294,7 +1294,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2110,7 +2110,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2188,7 +2188,7 @@ var Box = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2862,7 +2862,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3080,7 +3080,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3156,7 +3156,7 @@ var Text = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3198,7 +3198,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3470,7 +3470,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4254,7 +4254,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4281,7 +4281,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4408,7 +4408,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5871,7 +5871,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5935,7 +5935,7 @@ var Image = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -6264,7 +6264,7 @@ var Input = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
+//#region node_modules/.pnpm/marked@15.0.12/node_modules/marked/lib/marked.esm.js
 /**
 * marked v15.0.12 - a markdown parser
 * Copyright (c) 2011-2025, Christopher Jeffrey. (MIT Licensed)
@@ -8098,7 +8098,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8595,7 +8595,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8829,7 +8829,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region ../deepseek-tui/node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=7d95e956b3ba0dca9460ba312b126b864bf4b49bf880b095158948f20f74e7de/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3672,35 +3672,40 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
       fallback: ui(`调用 ${wait.payload.callId ?? wait.payload.approvalId}`, `Invoke ${wait.payload.callId ?? wait.payload.approvalId}`),
       preview: toolApprovalPreview(call),
     })
-    while (true) {
-      const selected = await this.host.overlays.select({
+    const options = { width: '95%', maxHeight: '90%', anchor: 'bottom-center' as const, margin: 1 }
+    let decision: 'allowed-once' | 'rejected' | undefined
+    await this.overlayFlow(this.host.overlays, async (navigation) => {
+      await navigation.selectPage({
         title: ui(`工具审批 · ${wait.payload.toolName}`, `Tool approval · ${wait.payload.toolName}`),
         detail: composed.detail,
         searchable: false,
+        initialChoiceId: 'reject',
         choices: [
           { id: 'allow', label: ui('仅本次允许', 'Allow this time'), description: ui('只允许这一次工具调用', 'Allow only this tool call') },
-          { id: 'reject', label: ui('拒绝', 'Reject'), description: ui('本次工具调用不会执行', 'This tool call will not run') },
           ...(composed.full === undefined ? [] : [{
             id: 'inspect',
             label: ui('查看完整参数', 'View full arguments'),
             description: ui('打开只读子页，不批准也不拒绝', 'Open a read-only page; does not approve or reject'),
           }]),
+          { id: 'reject', label: ui('拒绝', 'Reject'), description: ui('本次工具调用不会执行', 'This tool call will not run') },
         ],
         footer: ui('Enter 确认 · Esc 安全拒绝', 'Enter to confirm · Esc rejects safely'),
-        options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
+        options,
+      }, async (selected) => {
+        if (selected.id === 'inspect' && composed.full !== undefined) {
+          await navigation.detail({
+            title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
+            content: composed.full,
+            options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+          })
+          return
+        }
+        decision = selected.id === 'allow' ? 'allowed-once' : 'rejected'
+        navigation.finish()
       })
-      if (selected?.id === 'inspect' && composed.full !== undefined) {
-        await this.host.overlays.detail({
-          title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
-          content: composed.full,
-          options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
-        })
-        continue
-      }
-      this.host.transcript.followLatest()
-      await this.capabilities.answerApproval(wait, selected?.id === 'reject' || selected === undefined ? 'rejected' : 'allowed-once')
-      return
-    }
+    }, options)
+    this.host.transcript.followLatest()
+    await this.capabilities.answerApproval(wait, decision ?? 'rejected')
   }
 
   private async question(wait: PendingWait<'question'>): Promise<void> {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3672,7 +3672,7 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
       fallback: ui(`调用 ${wait.payload.callId ?? wait.payload.approvalId}`, `Invoke ${wait.payload.callId ?? wait.payload.approvalId}`),
       preview: toolApprovalPreview(call),
     })
-    const options = { width: '95%', maxHeight: '90%', anchor: 'bottom-center' as const, margin: 1 }
+    const options = { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 } as const
     let decision: 'allowed-once' | 'rejected' | undefined
     await this.overlayFlow(this.host.overlays, async (navigation) => {
       await navigation.selectPage({
@@ -3696,7 +3696,7 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
           await navigation.detail({
             title: ui(`完整参数 · ${wait.payload.toolName}`, `Full arguments · ${wait.payload.toolName}`),
             content: composed.full,
-            options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 },
+            options: { width: '95%', maxHeight: '90%', anchor: 'center', margin: 1 } as const,
           })
           return
         }

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -14,7 +14,7 @@ import type {
   HarnessTuiCapabilities,
   TuiActiveSession,
 } from '../src/client/capabilities.ts'
-import { OverlayQueue } from '../src/client/overlays.ts'
+import { OverlayQueue, type OverlayNavigation } from '../src/client/overlays.ts'
 import type { Transcript } from '../src/client/transcript.ts'
 
 const ESCAPE = '\u001B'
@@ -48,7 +48,10 @@ function liveOverlays(): {
   }
 }
 
-function host(overlays: Partial<OverlayQueue>, transcript: Partial<Transcript>): TuiActionHost {
+function host(
+  overlays: Partial<OverlayQueue> & Partial<OverlayNavigation>,
+  transcript: Partial<Transcript>,
+): TuiActionHost {
   return {
     overlays: overlays as OverlayQueue,
     transcript: transcript as Transcript,
@@ -84,7 +87,7 @@ function questionBatch(count: number): PendingWait<'question'> {
 
 function pendingActions(
   wait: PendingWait<'question'>,
-  overlays: Partial<OverlayQueue>,
+  overlays: Partial<OverlayQueue> & Partial<OverlayNavigation>,
 ): {
   readonly actions: TuiActions
   readonly answerQuestion: ReturnType<typeof vi.fn>

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -201,9 +201,16 @@ describe('pending interaction continuation', () => {
     } as unknown as ConversationSnapshot
     const followLatest = vi.fn()
     const answerApproval = vi.fn(async () => undefined)
-    const select = vi.fn(async (request: { detail?: string }) => {
+    const finish = vi.fn()
+    const detail = vi.fn(async () => undefined)
+    const selectPage = vi.fn(async (
+      request: { detail?: string; initialChoiceId?: string; choices: readonly { id: string }[] },
+      onSelect: (choice: { id: string; label: string }) => Promise<void>,
+    ) => {
       expect(request.detail).toContain('$ ls -la src')
-      return { id: 'reject', label: '拒绝' }
+      expect(request.initialChoiceId).toBe('reject')
+      expect(request.choices.map(choice => choice.id)).toEqual(['allow', 'reject'])
+      await onSelect({ id: 'reject', label: '拒绝' })
     })
     const active = {
       session: { getSnapshot: () => snapshot },
@@ -212,10 +219,58 @@ describe('pending interaction continuation', () => {
       active: () => active,
       answerApproval,
     } as unknown as HarnessTuiCapabilities
-    const actions = new TuiActions(capabilities, host({ select }, { followLatest }))
+    const actions = new TuiActions(capabilities, host({ selectPage, detail, finish }, { followLatest }))
 
     actions.syncPending(snapshot)
     await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
+    expect(selectPage).toHaveBeenCalledOnce()
+    expect(detail).not.toHaveBeenCalled()
+    expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
+  })
+
+  it('opens full arguments as a child page and keeps the approval selector', async () => {
+    const approval = {
+      key: 'approval:long',
+      kind: 'approval',
+      sessionId: 'session' as SessionId,
+      payload: {
+        toolName: 'shell',
+        callId: 'call-long',
+        approvalId: 'appr-2',
+        reason: '需要执行命令',
+      },
+    } as unknown as PendingWait<'approval'>
+    const longCommand = `printf '${'x'.repeat(1_300)}'`
+    const snapshot = {
+      pending: [approval],
+      runningCalls: [{
+        callId: 'call-long',
+        name: 'shell',
+        argsRaw: JSON.stringify({ command: longCommand }),
+        callView: { card: 'terminal', title: longCommand },
+      }],
+    } as unknown as ConversationSnapshot
+    const answerApproval = vi.fn(async () => undefined)
+    const finish = vi.fn()
+    const detail = vi.fn(async () => undefined)
+    const selectPage = vi.fn(async (
+      request: { initialChoiceId?: string; choices: readonly { id: string }[] },
+      onSelect: (choice: { id: string; label: string }) => Promise<void>,
+    ) => {
+      expect(request.initialChoiceId).toBe('reject')
+      expect(request.choices.map(choice => choice.id)).toEqual(['allow', 'inspect', 'reject'])
+      await onSelect({ id: 'inspect', label: '查看完整参数' })
+      await onSelect({ id: 'reject', label: '拒绝' })
+    })
+    const actions = new TuiActions({
+      active: () => ({ session: { getSnapshot: () => snapshot } }) as unknown as TuiActiveSession,
+      answerApproval,
+    } as unknown as HarnessTuiCapabilities, host({ selectPage, detail, finish }, { followLatest: vi.fn() }))
+
+    actions.syncPending(snapshot as ConversationSnapshot)
+    await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
+    expect(selectPage).toHaveBeenCalledOnce()
+    expect(detail).toHaveBeenCalledOnce()
     expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
   })
 

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
 import type {
   ConversationSnapshot,
   PendingWait,
@@ -13,8 +14,39 @@ import type {
   HarnessTuiCapabilities,
   TuiActiveSession,
 } from '../src/client/capabilities.ts'
-import type { OverlayQueue } from '../src/client/overlays.ts'
+import { OverlayQueue } from '../src/client/overlays.ts'
 import type { Transcript } from '../src/client/transcript.ts'
+
+const ESCAPE = '\u001B'
+const ENTER = '\r'
+const UP = '\u001B[A'
+const DOWN = '\u001B[B'
+
+function plain(lines: readonly string[]): string {
+  return lines.join('\n').replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+function liveOverlays(): {
+  readonly overlays: OverlayQueue
+  component(): Component & { handleInput(data: string): void }
+} {
+  let mounted: Component | undefined
+  const tui = {
+    showOverlay: vi.fn((component: Component) => {
+      mounted = component
+      return { hide: vi.fn() } as unknown as OverlayHandle
+    }),
+    requestRender: vi.fn(),
+    terminal: { rows: 24, cols: 80 },
+  } as unknown as TUI
+  return {
+    overlays: new OverlayQueue(tui),
+    component: () => {
+      if (mounted === undefined) throw new Error('overlay has not mounted')
+      return mounted as Component & { handleInput(data: string): void }
+    },
+  }
+}
 
 function host(overlays: Partial<OverlayQueue>, transcript: Partial<Transcript>): TuiActionHost {
   return {
@@ -288,5 +320,93 @@ describe('pending interaction continuation', () => {
 
     expect(cancelQuestion).toHaveBeenCalledWith(wait)
     expect(answerQuestion).not.toHaveBeenCalled()
+  })
+
+  it('defaults to reject and submits rejected when Escape closes the root page', async () => {
+    const approval = {
+      key: 'approval:root-esc',
+      kind: 'approval',
+      sessionId: 'session' as SessionId,
+      payload: {
+        toolName: 'shell',
+        callId: 'call-esc',
+        approvalId: 'appr-esc',
+        reason: '需要执行命令',
+      },
+    } as unknown as PendingWait<'approval'>
+    const snapshot = {
+      pending: [approval],
+      runningCalls: [{
+        callId: 'call-esc',
+        name: 'shell',
+        argsRaw: '{"command":"ls"}',
+        callView: { card: 'terminal', title: 'ls -la src' },
+      }],
+    } as unknown as ConversationSnapshot
+    const answerApproval = vi.fn(async () => undefined)
+    const live = liveOverlays()
+    const actions = new TuiActions({
+      active: () => ({ session: { getSnapshot: () => snapshot } }) as unknown as TuiActiveSession,
+      answerApproval,
+    } as unknown as HarnessTuiCapabilities, host(live.overlays, { followLatest: vi.fn() }))
+
+    actions.syncPending(snapshot)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('工具审批') })
+    expect(plain(live.component().render(80))).toContain('拒绝')
+
+    live.component().handleInput(ESCAPE)
+    await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
+    expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
+  })
+
+  it('returns from argument detail onto the same selector with inspect still selected', async () => {
+    const approval = {
+      key: 'approval:inspect',
+      kind: 'approval',
+      sessionId: 'session' as SessionId,
+      payload: {
+        toolName: 'shell',
+        callId: 'call-inspect',
+        approvalId: 'appr-inspect',
+        reason: '需要执行命令',
+      },
+    } as unknown as PendingWait<'approval'>
+    const longCommand = `printf '${'x'.repeat(1_300)}'`
+    const snapshot = {
+      pending: [approval],
+      runningCalls: [{
+        callId: 'call-inspect',
+        name: 'shell',
+        argsRaw: JSON.stringify({ command: longCommand }),
+        callView: { card: 'terminal', title: longCommand },
+      }],
+    } as unknown as ConversationSnapshot
+    const answerApproval = vi.fn(async () => undefined)
+    const live = liveOverlays()
+    const actions = new TuiActions({
+      active: () => ({ session: { getSnapshot: () => snapshot } }) as unknown as TuiActiveSession,
+      answerApproval,
+    } as unknown as HarnessTuiCapabilities, host(live.overlays, { followLatest: vi.fn() }))
+
+    actions.syncPending(snapshot)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('查看完整参数') })
+
+    live.component().handleInput(UP)
+    live.component().handleInput(ENTER)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('完整参数') })
+
+    live.component().handleInput(ESCAPE)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('工具审批') })
+
+    live.component().handleInput(ENTER)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('完整参数') })
+    expect(answerApproval).not.toHaveBeenCalled()
+
+    live.component().handleInput(ESCAPE)
+    await vi.waitFor(() => { expect(plain(live.component().render(80))).toContain('工具审批') })
+    live.component().handleInput(DOWN)
+    live.component().handleInput(ENTER)
+    await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
+    expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
   })
 })

--- a/tests/actions-theme.test.ts
+++ b/tests/actions-theme.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
 import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
-import type { OverlayQueue } from '../src/client/overlays.ts'
+import type { OverlayNavigation, OverlayQueue } from '../src/client/overlays.ts'
 import type { Transcript } from '../src/client/transcript.ts'
 import { BUILT_IN_THEMES, editableTheme } from '../src/client/theme-config.ts'
 import {
@@ -58,7 +58,7 @@ function settingsState(initial: TuiAppearanceSettings): {
 
 function actionHarness(
   settings: TuiManagementBridge['settings'],
-  overlays: Partial<OverlayQueue> = {},
+  overlays: Partial<OverlayQueue> & Partial<OverlayNavigation> = {},
 ): {
   readonly actions: TuiActions
   readonly host: TuiActionHost
@@ -144,7 +144,7 @@ describe('/theme commands', () => {
       .mockResolvedValueOnce('Ocean')
       .mockResolvedValueOnce('#071426 #F4F8FF #6682FF #37C99B #E7AE5B #F0717F')
     const select = vi.fn().mockResolvedValue({ id: 'apply', label: '应用并保存' })
-    const { actions, host } = actionHarness(state.settings, { input, select } as Partial<OverlayQueue>)
+    const { actions, host } = actionHarness(state.settings, { input, select } as Partial<OverlayQueue> & Partial<OverlayNavigation>)
 
     await actions.execute('theme', 'palette')
 
@@ -171,7 +171,7 @@ describe('/theme commands', () => {
       .mockResolvedValueOnce('Ocean')
       .mockResolvedValueOnce('#071426 #F4F8FF #6682FF')
     const select = vi.fn().mockResolvedValue({ id: 'cancel', label: '取消' })
-    const { actions, host } = actionHarness(state.settings, { input, select } as Partial<OverlayQueue>)
+    const { actions, host } = actionHarness(state.settings, { input, select } as Partial<OverlayQueue> & Partial<OverlayNavigation>)
 
     await actions.execute('theme', 'palette')
 
@@ -196,7 +196,7 @@ describe('/theme commands', () => {
       }`, 'utf8')
       const state = settingsState({ theme: 'light', codeTheme: 'auto', customThemes: [] })
       const select = vi.fn().mockResolvedValue({ id: 'apply', label: '应用并保存' })
-      const { actions, host } = actionHarness(state.settings, { select } as Partial<OverlayQueue>)
+      const { actions, host } = actionHarness(state.settings, { select } as Partial<OverlayQueue> & Partial<OverlayNavigation>)
 
       await actions.execute('theme', `import "${path}"`)
 
@@ -223,7 +223,7 @@ describe('/theme commands', () => {
     const state = settingsState({ theme: 'custom:ocean', codeTheme: 'custom:ocean', customThemes: [custom] })
     const confirm = vi.fn().mockResolvedValue(false)
     const select = vi.fn()
-    const { actions } = actionHarness(state.settings, { confirm, select } as Partial<OverlayQueue>)
+    const { actions } = actionHarness(state.settings, { confirm, select } as Partial<OverlayQueue> & Partial<OverlayNavigation>)
 
     await actions.execute('theme', 'edit Ocean')
 
@@ -240,7 +240,7 @@ describe('/theme commands', () => {
     const custom = editableTheme(BUILT_IN_THEMES.dark, 'ocean', 'Ocean')
     const state = settingsState({ theme: 'custom:ocean', codeTheme: 'custom:ocean', customThemes: [custom] })
     const confirm = vi.fn().mockResolvedValue(true)
-    const { actions, host } = actionHarness(state.settings, { confirm } as Partial<OverlayQueue>)
+    const { actions, host } = actionHarness(state.settings, { confirm } as Partial<OverlayQueue> & Partial<OverlayNavigation>)
 
     await actions.execute('theme', 'delete Ocean')
 

--- a/tests/session-allowlist.test.ts
+++ b/tests/session-allowlist.test.ts
@@ -12,10 +12,13 @@ import type {
   HarnessTuiCapabilities,
   TuiActiveSession,
 } from '../src/client/capabilities.ts'
-import type { OverlayQueue, SelectOverlayRequest } from '../src/client/overlays.ts'
+import type { OverlayNavigation, OverlayQueue } from '../src/client/overlays.ts'
 import type { Transcript } from '../src/client/transcript.ts'
 
-function host(overlays: Partial<OverlayQueue>, transcript: Partial<Transcript> = {}): TuiActionHost {
+function host(
+  overlays: Partial<OverlayQueue> & Partial<OverlayNavigation>,
+  transcript: Partial<Transcript> = {},
+): TuiActionHost {
   return {
     overlays: overlays as OverlayQueue,
     transcript: { followLatest: vi.fn(), ...transcript } as Transcript,
@@ -42,9 +45,13 @@ describe('session tool approvals', () => {
     } as unknown as PendingWait<'approval'>
     const snapshot = { pending: [wait] } as unknown as ConversationSnapshot
     const answerApproval = vi.fn(async () => undefined)
-    const select = vi.fn(async (request: SelectOverlayRequest) => {
+    const selectPage = vi.fn(async (
+      request: { initialChoiceId?: string; choices: readonly { id: string }[] },
+      onSelect: (choice: { id: string; label: string }) => Promise<void>,
+    ) => {
+      expect(request.initialChoiceId).toBe('reject')
       expect(request.choices.map(choice => choice.id)).toEqual(['allow', 'reject'])
-      return { id: 'allow', label: 'Allow this time' }
+      await onSelect({ id: 'allow', label: 'Allow this time' })
     })
     const active = {
       sessionId: 'session' as SessionId,
@@ -54,10 +61,10 @@ describe('session tool approvals', () => {
       active: () => active,
       answerApproval,
     } as unknown as HarnessTuiCapabilities
-    const actions = new TuiActions(capabilities, host({ select }))
+    const actions = new TuiActions(capabilities, host({ selectPage, finish: vi.fn() }))
     actions.syncPending(snapshot)
     await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
-    expect(select).toHaveBeenCalledOnce()
+    expect(selectPage).toHaveBeenCalledOnce()
     expect(answerApproval).toHaveBeenCalledWith(wait, 'allowed-once')
   })
 })


### PR DESCRIPTION
## Summary
- Tool approval now uses one `OverlayNavigation` session: allow / inspect / reject, default focus on reject.
- “查看完整参数” is a child page; Esc returns to the same selector. Esc on the root page still rejects.
- No session-permanent allow; Harness still only has `allowed-once` and `rejected`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Test plan
- [x] `vitest run tests/actions-interaction.test.ts tests/approval-preview.test.ts`
- [ ] Open an approval, press Enter, and confirm it rejects by default
- [ ] Open full arguments, press Esc, and confirm the same approval page and selection remain


Made with [Cursor](https://cursor.com)