### PR TITLE
fix(tui): keep question answers when continuing after Esc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30054,125 +30054,46 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 	async question(wait) {
 		const answers = [];
 		const questions = wait.payload.questions;
-		let index = 0;
-		while (index < questions.length) {
-			const question = questions[index];
-			if (question === void 0) break;
-			const planReview = question.intent?.kind === "plan-review" ? question.intent : void 0;
-			const title = `${planReview === void 0 ? question.header ?? ui("问题", "Question") : ui("计划审查", "Plan review")} · ${index + 1}/${questions.length}`;
-			const escapeDecision = async () => this.confirmQuestionEscape(index, questions.length, answers.length);
-			const presentation = (option) => {
-				if (planReview === void 0) return option;
-				return option.label === planReview.approve ? {
-					label: ui("批准计划", "Approve plan"),
-					description: ui("按此计划继续", "Continue with this plan")
-				} : {
-					label: ui("继续规划", "Continue planning"),
-					description: ui("返回并修改计划", "Return and revise the plan")
-				};
-			};
-			if (question.multiSelect === true) {
-				const picked$1 = await this.host.overlays.multiSelect({
-					title,
-					detail: question.detail ?? question.question,
-					choices: (question.options ?? []).map((option) => {
-						const display = presentation(option);
-						return {
-							id: option.label,
-							label: display.label,
-							...display.description === void 0 ? {} : { description: display.description }
-						};
-					}),
-					options: {
-						width: "95%",
-						maxHeight: "90%",
-						anchor: "bottom-center",
-						margin: 1
-					}
-				});
-				if (picked$1 === void 0) {
-					const decision = await escapeDecision();
-					if (decision === "cancel") {
-						this.host.transcript.followLatest();
-						await this.capabilities.cancelQuestion(wait);
-						return;
-					}
-					if (decision === "skip") {
-						answers.push({
-							id: question.id,
-							selected: []
-						});
-						index += 1;
-					}
-					continue;
-				}
-				answers.push({
-					id: question.id,
-					selected: picked$1.map((option) => option.id)
-				});
-				index += 1;
-				continue;
-			}
-			const choices = [...(question.options ?? []).map((option) => {
-				const display = presentation(option);
-				return {
-					id: `option:${option.label}`,
-					label: display.label,
-					...display.description === void 0 ? {} : { description: display.description }
-				};
-			}), ...planReview === void 0 ? [{
-				id: "__custom__",
-				label: ui("自定义回答…", "Custom answer…")
-			}, {
-				id: "__skip__",
-				label: ui("跳过", "Skip"),
-				description: ui("提交空选择", "Submit an empty selection")
-			}] : []];
-			const picked = await this.host.overlays.select({
-				title,
-				detail: question.detail ?? question.question,
-				choices,
-				searchable: planReview === void 0,
-				options: {
-					width: "95%",
-					maxHeight: "90%",
-					anchor: "bottom-center",
-					margin: 1
-				}
-			});
-			if (picked === void 0) {
-				const decision = await escapeDecision();
-				if (decision === "cancel") {
+		const options$1 = {
+			width: "95%",
+			maxHeight: "90%",
+			anchor: "bottom-center",
+			margin: 1
+		};
+		await this.overlayFlow(this.host.overlays, async (navigation) => {
+			let index = 0;
+			while (index < questions.length) {
+				const question = questions[index];
+				if (question === void 0) break;
+				if (navigation.signal.aborted) {
 					this.host.transcript.followLatest();
 					await this.capabilities.cancelQuestion(wait);
 					return;
 				}
-				if (decision === "skip") {
-					answers.push({
-						id: question.id,
-						selected: []
-					});
-					index += 1;
-				}
-				continue;
-			}
-			if (picked.id === "__custom__") {
-				const custom = await this.host.overlays.multilineInput({
-					title: question.question,
-					...question.detail === void 0 ? {} : { detail: question.detail },
-					options: {
-						width: "95%",
-						maxHeight: "90%",
-						anchor: "bottom-center",
-						margin: 1
+				const planReview = question.intent?.kind === "plan-review" ? question.intent : void 0;
+				const title = `${planReview === void 0 ? question.header ?? ui("问题", "Question") : ui("计划审查", "Plan review")} · ${index + 1}/${questions.length}`;
+				let escapeHandled;
+				const escapeDecision = async () => {
+					const decision = await this.confirmQuestionEscape(navigation, index, questions.length, answers.length);
+					escapeHandled = decision;
+					return decision;
+				};
+				const onEscape = async () => {
+					if (await escapeDecision() === "continue") return;
+					navigation.back();
+				};
+				const resolveEscape = async () => {
+					if (navigation.signal.aborted) {
+						this.host.transcript.followLatest();
+						await this.capabilities.cancelQuestion(wait);
+						return false;
 					}
-				});
-				if (custom === void 0) {
-					const decision = await escapeDecision();
+					const decision = escapeHandled ?? await this.confirmQuestionEscape(navigation, index, questions.length, answers.length);
+					escapeHandled = void 0;
 					if (decision === "cancel") {
 						this.host.transcript.followLatest();
 						await this.capabilities.cancelQuestion(wait);
-						return;
+						return false;
 					}
 					if (decision === "skip") {
 						answers.push({
@@ -30181,29 +30102,109 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 						});
 						index += 1;
 					}
+					return true;
+				};
+				const presentation = (option) => {
+					if (planReview === void 0) return option;
+					return option.label === planReview.approve ? {
+						label: ui("批准计划", "Approve plan"),
+						description: ui("按此计划继续", "Continue with this plan")
+					} : {
+						label: ui("继续规划", "Continue planning"),
+						description: ui("返回并修改计划", "Return and revise the plan")
+					};
+				};
+				if (question.multiSelect === true) {
+					const picked$1 = await navigation.multiSelect({
+						title,
+						detail: question.detail ?? question.question,
+						choices: (question.options ?? []).map((option) => {
+							const display = presentation(option);
+							return {
+								id: option.label,
+								label: display.label,
+								...display.description === void 0 ? {} : { description: display.description }
+							};
+						}),
+						onEscape,
+						options: options$1
+					});
+					if (picked$1 === void 0) {
+						if (!await resolveEscape()) return;
+						continue;
+					}
+					answers.push({
+						id: question.id,
+						selected: picked$1.map((option) => option.id)
+					});
+					index += 1;
 					continue;
 				}
-				answers.push({
-					id: question.id,
-					selected: [],
-					custom
+				const choices = [...(question.options ?? []).map((option) => {
+					const display = presentation(option);
+					return {
+						id: `option:${option.label}`,
+						label: display.label,
+						...display.description === void 0 ? {} : { description: display.description }
+					};
+				}), ...planReview === void 0 ? [{
+					id: "__custom__",
+					label: ui("自定义回答…", "Custom answer…")
+				}, {
+					id: "__skip__",
+					label: ui("跳过", "Skip"),
+					description: ui("提交空选择", "Submit an empty selection")
+				}] : []];
+				const picked = await navigation.select({
+					title,
+					detail: question.detail ?? question.question,
+					choices,
+					searchable: planReview === void 0,
+					onEscape,
+					options: options$1
 				});
-			} else if (picked.id === "__skip__") answers.push({
-				id: question.id,
-				selected: []
-			});
-			else answers.push({
-				id: question.id,
-				selected: [picked.id.slice(7)]
-			});
-			index += 1;
-		}
-		this.host.transcript.followLatest();
-		await this.capabilities.answerQuestion(wait, { answers });
-		this.host.notice(questionBatchSummary(answers), "info");
+				if (picked === void 0) {
+					if (!await resolveEscape()) return;
+					continue;
+				}
+				if (picked.id === "__custom__") {
+					const custom = await navigation.multilineInput({
+						title: question.question,
+						...question.detail === void 0 ? {} : { detail: question.detail },
+						onEscape,
+						options: options$1
+					});
+					if (custom === void 0) {
+						if (!await resolveEscape()) return;
+						continue;
+					}
+					answers.push({
+						id: question.id,
+						selected: [],
+						custom
+					});
+				} else if (picked.id === "__skip__") answers.push({
+					id: question.id,
+					selected: []
+				});
+				else answers.push({
+					id: question.id,
+					selected: [picked.id.slice(7)]
+				});
+				index += 1;
+			}
+			if (navigation.signal.aborted) {
+				this.host.transcript.followLatest();
+				await this.capabilities.cancelQuestion(wait);
+				return;
+			}
+			this.host.transcript.followLatest();
+			await this.capabilities.answerQuestion(wait, { answers });
+			this.host.notice(questionBatchSummary(answers), "info");
+		}, options$1);
 	}
-	async confirmQuestionEscape(index, total, answered) {
-		const selected = await this.host.overlays.select({
+	async confirmQuestionEscape(overlays, index, total, answered) {
+		const selected = await overlays.select({
 			title: ui("取消这批问题？", "Cancel this question batch?"),
 			detail: ui(`已回答 ${String(answered)}/${String(total)} · 当前第 ${String(index + 1)} 题`, `Answered ${String(answered)}/${String(total)} · currently question ${String(index + 1)}`),
 			searchable: false,
@@ -31182,6 +31183,10 @@ var NavigationOverlay = class {
 				this.pendingBack = current;
 				return;
 			}
+			if (current.escapeHandler !== void 0) {
+				this.dispatch(current, current.escapeHandler);
+				return;
+			}
 			if (this.stack.length <= 1) this.finish();
 			else this.back();
 			return;
@@ -31199,7 +31204,8 @@ var NavigationOverlay = class {
 				}),
 				dismiss: resolve$1,
 				busy: false,
-				active: true
+				active: true,
+				escapeHandler: request.onEscape
 			};
 			this.stack.push(entry);
 			this.requestRender();
@@ -31223,19 +31229,19 @@ var NavigationOverlay = class {
 		this.requestRender();
 	}
 	select(request) {
-		return this.prompt((submit) => new SearchSelectOverlay(request, submit));
+		return this.prompt((submit) => new SearchSelectOverlay(request, submit), request.onEscape);
 	}
 	input(request) {
-		return this.prompt((submit) => new TextInputOverlay(request, submit));
+		return this.prompt((submit) => new TextInputOverlay(request, submit), request.onEscape);
 	}
 	multilineInput(request) {
-		return this.prompt((submit) => new MultilineEditorOverlay(this.tui, request, submit));
+		return this.prompt((submit) => new MultilineEditorOverlay(this.tui, request, submit), request.onEscape);
 	}
 	secretInput(request) {
-		return this.prompt((submit) => new SecretInputOverlay(request, submit));
+		return this.prompt((submit) => new SecretInputOverlay(request, submit), request.onEscape);
 	}
 	multiSelect(request) {
-		return this.prompt((submit) => new MultiSelectOverlay(request, submit));
+		return this.prompt((submit) => new MultiSelectOverlay(request, submit), request.onEscape);
 	}
 	async detail(request) {
 		await this.prompt((submit) => new ScrollableDetailOverlay(request, () => {
@@ -31305,7 +31311,7 @@ var NavigationOverlay = class {
 		this.pendingBack = void 0;
 		this.dismissAll();
 	}
-	prompt(create) {
+	prompt(create, escapeHandler) {
 		if (this.closed) return Promise.resolve(void 0);
 		return new Promise((resolve$1) => {
 			let entry;
@@ -31318,7 +31324,8 @@ var NavigationOverlay = class {
 					resolve$1(void 0);
 				},
 				busy: false,
-				active: true
+				active: true,
+				escapeHandler
 			};
 			this.stack.push(entry);
 			this.requestRender();

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3711,129 +3711,151 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
   private async question(wait: PendingWait<'question'>): Promise<void> {
     const answers: QuestionResponsePayload['answer']['answers'] = []
     const questions = wait.payload.questions
-    let index = 0
-    while (index < questions.length) {
-      const question = questions[index]
-      if (question === undefined) break
-      const planReview = question.intent?.kind === 'plan-review' ? question.intent : undefined
-      const title = `${planReview === undefined ? question.header ?? ui('问题', "Question") : ui('计划审查', "Plan review")} · ${index + 1}/${questions.length}`
-      const escapeDecision = async (): Promise<'cancel' | 'skip' | 'continue'> => (
-        this.confirmQuestionEscape(index, questions.length, answers.length)
-      )
-      const presentation = (option: NonNullable<typeof question.options>[number]): {
-        readonly label: string
-        readonly description?: string
-      } => {
-        if (planReview === undefined) return option
-        return option.label === planReview.approve
-          ? { label: ui('批准计划', "Approve plan"), description: ui('按此计划继续', "Continue with this plan") }
-          : { label: ui('继续规划', "Continue planning"), description: ui('返回并修改计划', "Return and revise the plan") }
-      }
-      if (question.multiSelect === true) {
-        const picked = await this.host.overlays.multiSelect({
-          title,
-          detail: question.detail ?? question.question,
-          choices: (question.options ?? []).map((option) => {
-            const display = presentation(option)
-            return {
-              id: option.label,
-              label: display.label,
-              ...(display.description === undefined ? {} : { description: display.description }),
-            }
-          }),
-          options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
-        })
-        if (picked === undefined) {
-          const decision = await escapeDecision()
-          if (decision === 'cancel') {
-            this.host.transcript.followLatest()
-            await this.capabilities.cancelQuestion(wait)
-            return
-          }
-          if (decision === 'skip') {
-            answers.push({ id: question.id, selected: [] })
-            index += 1
-          }
-          continue
-        }
-        answers.push({ id: question.id, selected: picked.map(option => option.id) })
-        index += 1
-        continue
-      }
-      const choices: OverlayChoice[] = [
-        ...(question.options ?? []).map((option) => {
-          const display = presentation(option)
-          return {
-            id: `option:${option.label}`,
-            label: display.label,
-            ...(display.description === undefined ? {} : { description: display.description }),
-          }
-        }),
-        ...(planReview === undefined
-          ? [
-            { id: '__custom__', label: ui('自定义回答…', "Custom answer…") },
-            { id: '__skip__', label: ui('跳过', "Skip"), description: ui('提交空选择', "Submit an empty selection") },
-          ]
-          : []),
-      ]
-      const picked = await this.host.overlays.select({
-        title,
-        detail: question.detail ?? question.question,
-        choices,
-        searchable: planReview === undefined,
-        options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
-      })
-      if (picked === undefined) {
-        const decision = await escapeDecision()
-        if (decision === 'cancel') {
+    const options = { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 } as const
+    await this.overlayFlow(this.host.overlays, async (navigation) => {
+      let index = 0
+      while (index < questions.length) {
+        const question = questions[index]
+        if (question === undefined) break
+        if (navigation.signal.aborted) {
           this.host.transcript.followLatest()
           await this.capabilities.cancelQuestion(wait)
           return
         }
-        if (decision === 'skip') {
-          answers.push({ id: question.id, selected: [] })
-          index += 1
+        const planReview = question.intent?.kind === 'plan-review' ? question.intent : undefined
+        const title = `${planReview === undefined ? question.header ?? ui('问题', "Question") : ui('计划审查', "Plan review")} · ${index + 1}/${questions.length}`
+        let escapeHandled: 'cancel' | 'skip' | 'continue' | undefined
+        const escapeDecision = async (): Promise<'cancel' | 'skip' | 'continue'> => {
+          const decision = await this.confirmQuestionEscape(navigation, index, questions.length, answers.length)
+          escapeHandled = decision
+          return decision
         }
-        continue
-      }
-      if (picked.id === '__custom__') {
-        const custom = await this.host.overlays.multilineInput({
-          title: question.question,
-          ...(question.detail === undefined ? {} : { detail: question.detail }),
-          options: { width: '95%', maxHeight: '90%', anchor: 'bottom-center', margin: 1 },
-        })
-        if (custom === undefined) {
+        const onEscape = async (): Promise<void> => {
           const decision = await escapeDecision()
+          if (decision === 'continue') return
+          navigation.back()
+        }
+        const resolveEscape = async (): Promise<boolean> => {
+          if (navigation.signal.aborted) {
+            this.host.transcript.followLatest()
+            await this.capabilities.cancelQuestion(wait)
+            return false
+          }
+          const decision = escapeHandled ?? await this.confirmQuestionEscape(
+            navigation,
+            index,
+            questions.length,
+            answers.length,
+          )
+          escapeHandled = undefined
           if (decision === 'cancel') {
             this.host.transcript.followLatest()
             await this.capabilities.cancelQuestion(wait)
-            return
+            return false
           }
           if (decision === 'skip') {
             answers.push({ id: question.id, selected: [] })
             index += 1
           }
+          return true
+        }
+        const presentation = (option: NonNullable<typeof question.options>[number]): {
+          readonly label: string
+          readonly description?: string
+        } => {
+          if (planReview === undefined) return option
+          return option.label === planReview.approve
+            ? { label: ui('批准计划', "Approve plan"), description: ui('按此计划继续', "Continue with this plan") }
+            : { label: ui('继续规划', "Continue planning"), description: ui('返回并修改计划', "Return and revise the plan") }
+        }
+        if (question.multiSelect === true) {
+          const picked = await navigation.multiSelect({
+            title,
+            detail: question.detail ?? question.question,
+            choices: (question.options ?? []).map((option) => {
+              const display = presentation(option)
+              return {
+                id: option.label,
+                label: display.label,
+                ...(display.description === undefined ? {} : { description: display.description }),
+              }
+            }),
+            onEscape,
+            options,
+          })
+          if (picked === undefined) {
+            if (!await resolveEscape()) return
+            continue
+          }
+          answers.push({ id: question.id, selected: picked.map(option => option.id) })
+          index += 1
           continue
         }
-        answers.push({ id: question.id, selected: [], custom })
-      } else if (picked.id === '__skip__') {
-        answers.push({ id: question.id, selected: [] })
-      } else {
-        answers.push({ id: question.id, selected: [picked.id.slice('option:'.length)] })
+        const choices: OverlayChoice[] = [
+          ...(question.options ?? []).map((option) => {
+            const display = presentation(option)
+            return {
+              id: `option:${option.label}`,
+              label: display.label,
+              ...(display.description === undefined ? {} : { description: display.description }),
+            }
+          }),
+          ...(planReview === undefined
+            ? [
+              { id: '__custom__', label: ui('自定义回答…', "Custom answer…") },
+              { id: '__skip__', label: ui('跳过', "Skip"), description: ui('提交空选择', "Submit an empty selection") },
+            ]
+            : []),
+        ]
+        const picked = await navigation.select({
+          title,
+          detail: question.detail ?? question.question,
+          choices,
+          searchable: planReview === undefined,
+          onEscape,
+          options,
+        })
+        if (picked === undefined) {
+          if (!await resolveEscape()) return
+          continue
+        }
+        if (picked.id === '__custom__') {
+          const custom = await navigation.multilineInput({
+            title: question.question,
+            ...(question.detail === undefined ? {} : { detail: question.detail }),
+            onEscape,
+            options,
+          })
+          if (custom === undefined) {
+            if (!await resolveEscape()) return
+            continue
+          }
+          answers.push({ id: question.id, selected: [], custom })
+        } else if (picked.id === '__skip__') {
+          answers.push({ id: question.id, selected: [] })
+        } else {
+          answers.push({ id: question.id, selected: [picked.id.slice('option:'.length)] })
+        }
+        index += 1
       }
-      index += 1
-    }
-    this.host.transcript.followLatest()
-    await this.capabilities.answerQuestion(wait, { answers })
-    this.host.notice(questionBatchSummary(answers), 'info')
+      if (navigation.signal.aborted) {
+        this.host.transcript.followLatest()
+        await this.capabilities.cancelQuestion(wait)
+        return
+      }
+      this.host.transcript.followLatest()
+      await this.capabilities.answerQuestion(wait, { answers })
+      this.host.notice(questionBatchSummary(answers), 'info')
+    }, options)
   }
 
   private async confirmQuestionEscape(
+    overlays: OverlayPrompts,
     index: number,
     total: number,
     answered: number,
   ): Promise<'cancel' | 'skip' | 'continue'> {
-    const selected = await this.host.overlays.select({
+    const selected = await overlays.select({
       title: ui('取消这批问题？', 'Cancel this question batch?'),
       detail: ui(
         `已回答 ${String(answered)}/${String(total)} · 当前第 ${String(index + 1)} 题`,

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -75,6 +75,8 @@ export interface SelectOverlayRequest {
   readonly searchable?: boolean
   readonly maxVisible?: number
   readonly options?: OverlayOptions
+  /** When set, Escape runs this instead of Back/close so a child page can open. */
+  readonly onEscape?: () => void | Promise<void>
 }
 
 /** Text input request. */
@@ -85,6 +87,8 @@ export interface InputOverlayRequest {
   readonly placeholder?: string
   readonly footer?: string
   readonly options?: OverlayOptions
+  /** When set, Escape runs this instead of Back/close so a child page can open. */
+  readonly onEscape?: () => void | Promise<void>
 }
 
 /** Scrollable read-only detail request. */
@@ -154,6 +158,7 @@ interface NavigationEntry {
   readonly dismiss: () => void
   busy: boolean
   active: boolean
+  escapeHandler?: (() => void | Promise<void>) | undefined
 }
 
 function rowOf(choice: OverlayChoice, descriptionWidth: number): SelectItem {
@@ -733,6 +738,10 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
         this.pendingBack = current
         return
       }
+      if (current.escapeHandler !== undefined) {
+        this.dispatch(current, current.escapeHandler)
+        return
+      }
       if (this.stack.length <= 1) this.finish()
       else this.back()
       return
@@ -755,6 +764,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
         dismiss: resolve,
         busy: false,
         active: true,
+        escapeHandler: request.onEscape,
       }
       this.stack.push(entry)
       this.requestRender()
@@ -786,23 +796,23 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
   }
 
   select(request: SelectOverlayRequest): Promise<OverlayChoice | undefined> {
-    return this.prompt(submit => new SearchSelectOverlay(request, submit))
+    return this.prompt(submit => new SearchSelectOverlay(request, submit), request.onEscape)
   }
 
   input(request: InputOverlayRequest): Promise<string | undefined> {
-    return this.prompt(submit => new TextInputOverlay(request, submit))
+    return this.prompt(submit => new TextInputOverlay(request, submit), request.onEscape)
   }
 
   multilineInput(request: InputOverlayRequest): Promise<string | undefined> {
-    return this.prompt(submit => new MultilineEditorOverlay(this.tui, request, submit))
+    return this.prompt(submit => new MultilineEditorOverlay(this.tui, request, submit), request.onEscape)
   }
 
   secretInput(request: InputOverlayRequest): Promise<string | undefined> {
-    return this.prompt(submit => new SecretInputOverlay(request, submit))
+    return this.prompt(submit => new SecretInputOverlay(request, submit), request.onEscape)
   }
 
   multiSelect(request: SelectOverlayRequest): Promise<readonly OverlayChoice[] | undefined> {
-    return this.prompt(submit => new MultiSelectOverlay(request, submit))
+    return this.prompt(submit => new MultiSelectOverlay(request, submit), request.onEscape)
   }
 
   async detail(request: DetailOverlayRequest): Promise<void> {
@@ -869,7 +879,10 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
     this.dismissAll()
   }
 
-  private prompt<T>(create: (submit: (value: T) => void) => DisposableComponent): Promise<T | undefined> {
+  private prompt<T>(
+    create: (submit: (value: T) => void) => DisposableComponent,
+    escapeHandler?: (() => void | Promise<void>) | undefined,
+  ): Promise<T | undefined> {
     if (this.closed) return Promise.resolve(undefined)
     return new Promise<T | undefined>((resolve) => {
       let entry: NavigationEntry
@@ -881,6 +894,7 @@ class NavigationOverlay<TResult> implements Component, OverlayNavigation<TResult
         dismiss: () => { resolve(undefined) },
         busy: false,
         active: true,
+        escapeHandler,
       }
       this.stack.push(entry)
       this.requestRender()

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
 import type {
@@ -65,6 +67,76 @@ function host(
     close: vi.fn(),
     restart: vi.fn(),
     requireRestart: vi.fn(),
+  }
+}
+
+function questionOverlays(
+  select: OverlayQueue['select'],
+  extra: Partial<OverlayQueue> = {},
+): Partial<OverlayQueue> {
+  const overlays: Partial<OverlayQueue> = { select, ...extra }
+  overlays.navigate = async (run) => {
+    await run({
+      select: overlays.select!,
+      multiSelect: overlays.multiSelect ?? (async () => undefined),
+      multilineInput: overlays.multilineInput ?? (async () => undefined),
+      input: async () => undefined,
+      secretInput: async () => undefined,
+      detail: async () => undefined,
+      confirm: async () => false,
+      progress: async () => undefined,
+      selectPage: async () => undefined,
+      replaceSelectPage: () => undefined,
+      updateChoices: () => undefined,
+      back: () => undefined,
+      finish: () => undefined,
+      signal: new AbortController().signal,
+    } as OverlayNavigation<never>)
+    return undefined
+  }
+  return overlays
+}
+
+function liveQuestionHarness(wait: PendingWait<'question'>): {
+  readonly hide: ReturnType<typeof vi.fn>
+  readonly answerQuestion: ReturnType<typeof vi.fn>
+  readonly cancelQuestion: ReturnType<typeof vi.fn>
+  component(): Component & { handleInput(data: string): void }
+  plain(): string
+} {
+  let mounted: Component | undefined
+  const hide = vi.fn()
+  const tui = {
+    showOverlay: vi.fn((component: Component) => {
+      mounted = component
+      return { hide } as unknown as OverlayHandle
+    }),
+    requestRender: vi.fn(),
+    terminal: { rows: 24, cols: 80 },
+  } as unknown as TUI
+  const overlays = new OverlayQueue(tui)
+  const snapshot = { pending: [wait] } as unknown as ConversationSnapshot
+  const answerQuestion = vi.fn(async () => undefined)
+  const cancelQuestion = vi.fn(async () => undefined)
+  const capabilities = {
+    active: () => ({ session: { getSnapshot: () => snapshot } }),
+    answerQuestion,
+    cancelQuestion,
+  } as unknown as HarnessTuiCapabilities
+  const actions = new TuiActions(capabilities, host(overlays, { followLatest: vi.fn() }))
+  actions.syncPending(snapshot)
+  return {
+    hide,
+    answerQuestion,
+    cancelQuestion,
+    component: () => {
+      if (mounted === undefined) throw new Error('overlay has not mounted')
+      return mounted as Component & { handleInput(data: string): void }
+    },
+    plain: () => {
+      if (mounted === undefined) throw new Error('overlay has not mounted')
+      return mounted.render(90).join('\n').replace(/\u001B\[[0-9;:]*m/gu, '')
+    },
   }
 }
 
@@ -139,7 +211,7 @@ describe('pending interaction continuation', () => {
       answerQuestion,
       cancelQuestion: vi.fn(),
     } as unknown as HarnessTuiCapabilities
-    const actions = new TuiActions(capabilities, host({ select }, { followLatest }))
+    const actions = new TuiActions(capabilities, host(questionOverlays(select), { followLatest }))
 
     actions.syncPending(snapshot)
     await vi.waitFor(() => { expect(answerQuestion).toHaveBeenCalledOnce() })
@@ -176,7 +248,7 @@ describe('pending interaction continuation', () => {
       if (thirdShows === 1) return undefined
       return { id: 'option:选项3', label: '选项3' }
     })
-    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, questionOverlays(select))
 
     actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
     await vi.waitFor(() => { expect(answerQuestion).toHaveBeenCalledOnce() })
@@ -199,7 +271,7 @@ describe('pending interaction continuation', () => {
       if (request.title.includes('取消')) return { id: 'skip', label: '仅跳过本题' }
       return { id: 'option:选项2', label: '选项2' }
     })
-    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, questionOverlays(select))
 
     actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
     await vi.waitFor(() => { expect(answerQuestion).toHaveBeenCalledOnce() })
@@ -316,7 +388,7 @@ describe('pending interaction continuation', () => {
       if (request.title.includes('2/2')) return undefined
       return { id: 'cancel', label: '取消全部' }
     })
-    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, { select })
+    const { actions, answerQuestion, cancelQuestion } = pendingActions(wait, questionOverlays(select))
 
     actions.syncPending({ pending: [wait] } as unknown as ConversationSnapshot)
     await vi.waitFor(() => { expect(cancelQuestion).toHaveBeenCalledOnce() })
@@ -411,5 +483,89 @@ describe('pending interaction continuation', () => {
     live.component().handleInput(ENTER)
     await vi.waitFor(() => { expect(answerApproval).toHaveBeenCalledOnce() })
     expect(answerApproval).toHaveBeenCalledWith(approval, 'rejected')
+  })
+
+  it('asks to cancel a question batch on the same navigator', () => {
+    const source = readFileSync(resolve(import.meta.dirname, '../src/client/actions.ts'), 'utf8')
+    expect(source).toMatch(/private async confirmQuestionEscape\(\s*overlays: OverlayPrompts/)
+    expect(source).toMatch(/const selected = await overlays\.select\(\{/)
+    expect(source).not.toMatch(/this\.host\.overlays\.select\(\{\s*title: ui\('取消这批问题？'/)
+  })
+
+  it('keeps multi-select checks when continuing after Escape', async () => {
+    const wait = {
+      key: 'question:multi',
+      kind: 'question',
+      sessionId: 'session' as SessionId,
+      payload: {
+        questions: [{
+          id: 'q1',
+          header: '问题',
+          question: '选择多项',
+          options: [{ label: 'Alpha' }, { label: 'Bravo' }],
+          multiSelect: true,
+        }],
+      },
+    } as unknown as PendingWait<'question'>
+    const harness = liveQuestionHarness(wait)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/Alpha/)
+    })
+    harness.component().handleInput(' ')
+    expect(harness.plain()).toContain('[x]')
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/取消这批问题|Cancel this question batch/)
+    })
+    expect(harness.hide).not.toHaveBeenCalled()
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/Alpha/)
+    })
+    expect(harness.plain()).toContain('[x]')
+    expect(harness.plain()).not.toMatch(/取消这批问题|Cancel this question batch/)
+    expect(harness.hide).not.toHaveBeenCalled()
+    expect(harness.answerQuestion).not.toHaveBeenCalled()
+    expect(harness.cancelQuestion).not.toHaveBeenCalled()
+  })
+
+  it('keeps unsubmitted custom text when continuing after Escape', async () => {
+    const wait = {
+      key: 'question:custom',
+      kind: 'question',
+      sessionId: 'session' as SessionId,
+      payload: {
+        questions: [{
+          id: 'q1',
+          header: '问题',
+          question: '请说明',
+          options: [{ label: '现成选项' }],
+          multiSelect: false,
+        }],
+      },
+    } as unknown as PendingWait<'question'>
+    const harness = liveQuestionHarness(wait)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/现成选项/)
+    })
+    harness.component().handleInput('\u001B[B')
+    harness.component().handleInput('\r')
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/请说明/)
+      expect(harness.plain()).toMatch(/Ctrl\+Enter/)
+    })
+    harness.component().handleInput('draft-answer')
+    expect(harness.plain()).toContain('draft-answer')
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toMatch(/取消这批问题|Cancel this question batch/)
+    })
+    harness.component().handleInput(ESCAPE)
+    await vi.waitFor(() => {
+      expect(harness.plain()).toContain('draft-answer')
+    })
+    expect(harness.plain()).toMatch(/Ctrl\+Enter/)
+    expect(harness.hide).not.toHaveBeenCalled()
+    expect(harness.answerQuestion).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Run the whole question batch on one `overlays.navigate()` session so the current select / multi-select / editor stays mounted.
- Open cancel-confirm as a child page of that question. Choosing 继续作答 (or Esc on the confirm) `back()`s to the same component, so checks, search, and unsubmitted text are kept.
- Skip-this-question and cancel-all keep the existing `cancelQuestion` / empty-selected semantics. Approval is unchanged.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/actions-interaction.test.ts tests/overlay-backstack.test.ts`
- [ ] Multi-select: toggle items, Esc, 继续作答 — checks still present
- [ ] Custom answer: type text, Esc, continue — editor text still present
- [ ] Esc → 仅跳过本题 still submits an empty selection and advances
- [ ] Esc → 取消全部 still discards the batch


Made with [Cursor](https://cursor.com)