### PR TITLE
feat(clarify): add optional TUI shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Models, Providers, Agent Presets, permissions, Host commands, tools, Settings, S
 The repository is public and can be installed directly from GitHub without private-repository authentication. SeekTTY supports macOS, Linux, and Windows. On Windows, install with `pnpm add --global` as shown below so PATHEXT-aware shims (`dsh.cmd`) can be resolved.
 
 ```sh
-pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2
+pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0
 deepseek
 ```
 
@@ -87,7 +87,7 @@ deepseek --update
 The native dsh entry remains available:
 
 ```sh
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 dsh --profile tui
 ```
 
@@ -124,7 +124,7 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 | Configuration and diagnostics | `/settings`, `/language`, `/theme`, `/status`, `/doctor`, `/feedback`, `/restart` |
 | Help and exit | `/help`, `/quit`, `/exit` |
 
-`/plugin`, `/workspace`, and `/profile` provide both complete interactive centers and direct subcommands. Unknown commands produce nearby suggestions instead of being sent to the model as ordinary prompts.
+`/plugin`, `/workspace`, and `/profile` provide both complete interactive centers and direct subcommands. Unknown commands produce nearby suggestions instead of being sent to the model as ordinary prompts. `/clarify` is not a stock command: it is added to the local `/` catalog only while the Clarify Remote receiver is present, writes the returned draft into the regular composer, and never auto-sends. Palette execution keeps the current composer as the seed. Typing `/clarify some text` uses that text as args after submit clears the composer; typing `/clarify` alone has no leftover body to preserve.
 
 ## Common controls
 
@@ -152,7 +152,7 @@ Replace the former global package once. The new `deepseek` launcher then uses na
 
 ```sh
 pnpm remove --global deepseek-tui
-pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2
+pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0
 deepseek
 ```
 
@@ -160,7 +160,7 @@ Custom Profiles migrate independently on first launch, for example `deepseek --p
 
 ```sh
 dsh plugin --profile tui remove deepseek-tui
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 ```
 
 ## Plug and unplug
@@ -174,7 +174,7 @@ dsh plugin --profile tui remove seektty
 Reinstall with the same native command:
 
 ```sh
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 ```
 
 Installation writes directly to the target Harness Profile dependencies, Bundle order, and pnpm lockfile. TUI `/plugin` and native `dsh plugin` operate on that same Profile state.
@@ -229,7 +229,7 @@ The interface selection, independent code selection, and named definitions live 
 ## Verified scope
 
 - Isolated install, configuration composition, and PTY boot against official stock `@deepseek-ai/dsh@0.1.0-rc.8`, plus the add/boot/remove/re-add contract against the declared minimum `@deepseek-ai/dsh@0.1.0-rc.6`.
-- `/doctor`: 95 Harness plugins running, 0 errors, 0 warnings.
+- Packaged SeekTTY `1.1.0` and Clarify `0.1.0` were installed through each official dsh `0.1.0-rc.6`, `0.1.0-rc.7`, and `0.1.0-rc.8` CLI. In every with-plugin Profile, local `/doctor` reported 98 Harness plugins running, 0 errors, and 0 warnings, and `/clarify` opened the first question. In every bare Profile, `/clarify` remained an unknown command.
 - Model listing, Provider/model/reasoning selection, request submission, and Harness error propagation.
 - First-run Provider readiness, masked API-key setup, deferral and draft restoration, Harness credential persistence, and restart without another prompt under an isolated `DSH_HOME`.
 - Real dark, light, and palette-generated PTY rendering, independent live interface/code switching, 80/120/160-column layouts, and persistence after restarting the same Profile.
@@ -248,8 +248,15 @@ SEEKTTY_SPEC=/path/to/seektty.tgz \
 pnpm test:stock
 ```
 
+Reusable cross-package doctor check:
+
+```sh
+CLARIFY_SPEC=/path/to/dsh-plugin-clarify.tgz \
+pnpm test:clarify-doctor
+```
+
 ## Compatibility and upgrades
 
-The tested compatibility baseline is official `0.1.0-rc.8`. The declared minimum host is official `0.1.0-rc.6`. A newer dsh than `tested` still boots, with a notice; older than `minimum` is rejected. A scheduled workflow scans the official npm `latest` dist-tag, upgrades the exact `@deepseek-ai/dsh-*` pins after `pnpm run check` and the isolated stock-dsh contract pass, and opens a pull request. npm `next` and GitHub harness pre-releases are not followed.
+The tested compatibility baseline is official `0.1.0-rc.8`. The declared minimum host is official `0.1.0-rc.6`. Tested hosts are official dsh `0.1.0-rc.6`, `0.1.0-rc.7`, and `0.1.0-rc.8`. A newer dsh than `tested` still boots, with a notice; older than `minimum` is rejected. Official rc.6/rc.7 graphs resolve `@deepseek-ai/dsh-attachment@0.1.0-rc.7`, whose `ImageAttachmentLimits` has `maxImageBytes`, `maxImagesPerMessage`, `maxMessageImageBytes`, `maxImagePixels`, and `mediaTypes`, but not `maxImageDimension`. SeekTTY inserts rc.8 `@deepseek-ai/dsh-host-apiproxy`, whose `imageLimits` projection requires that field. The Host plugin `seektty/attachment-compat` runs immediately before `api-gateway` and, only when the live capability is that exact valid legacy shape, derives a conservative `maxImageDimension` from `maxImagePixels` (one side cannot exceed the pixel count). Native rc.8 objects keep identity. Any other shape is left unchanged so rc.8 validation still fails closed. Future hosts are matched by that capability, not by version branching. A scheduled workflow scans the official npm `latest` dist-tag, upgrades the exact `@deepseek-ai/dsh-*` pins after `pnpm run check` and the isolated stock-dsh contract pass, and opens a pull request. npm `next` and GitHub harness pre-releases are not followed.
 
-The source repository and the stable `v1.0.2` GitHub Release are public. No npm-registry package is published; install the tagged GitHub source above or use the tarball attached to the Release.
+The source repository and its GitHub Releases are public. No npm-registry package is published; install the tagged GitHub source above or use the tarball attached to the matching Release.

--- a/README.zh.md
+++ b/README.zh.md
@@ -68,7 +68,7 @@ Markdown 围栏会直接渲染成连续代码色块。助手代码、Shell 指�
 仓库公开，可直接从 GitHub 安装，无需配置私有仓库访问权限。SeekTTY 支持 macOS、Linux 和 Windows。Windows 请用下方的 `pnpm add --global` 安装，以便解析 PATHEXT 的 `dsh.cmd` shim。
 
 ```sh
-pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2
+pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0
 deepseek
 ```
 
@@ -87,7 +87,7 @@ deepseek --update
 也可以只使用 dsh 的原生入口：
 
 ```sh
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 dsh --profile tui
 ```
 
@@ -124,7 +124,7 @@ dsh --profile tui
 | 配置与诊断 | `/settings`、`/language`、`/theme`、`/status`、`/doctor`、`/feedback`、`/restart` |
 | 帮助与退出 | `/help`、`/quit`、`/exit` |
 
-`/plugin`、`/workspace` 和 `/profile` 既有完整的交互中心，也支持直接子命令。未知命令会给出相近候选，不会被当成普通消息发给模型。
+`/plugin`、`/workspace` 和 `/profile` 既有完整的交互中心，也支持直接子命令。未知命令会给出相近候选，不会被当成普通消息发给模型。`/clarify` 不是常驻命令：仅当探测到 Clarify Remote 接收端时才会进入本地 `/` 目录，把返回的 draft 写入常规输入区，并且不会自动发送。命令面板执行会保留当前输入区作为 seed；键入 `/clarify some text` 后提交会清空输入区，因此 seed 来自参数；单独键入 `/clarify` 没有可保留的正文。
 
 ## 常用交互
 
@@ -152,7 +152,7 @@ dsh --profile tui
 
 ```sh
 pnpm remove --global deepseek-tui
-pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2
+pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0
 deepseek
 ```
 
@@ -160,7 +160,7 @@ deepseek
 
 ```sh
 dsh plugin --profile tui remove deepseek-tui
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 ```
 
 ## 直接插拔
@@ -174,7 +174,7 @@ dsh plugin --profile tui remove seektty
 重新安装使用相同命令：
 
 ```sh
-dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.0.2
+dsh plugin --profile tui add github:Hilbert-beinghappy/seektty#v1.1.0
 ```
 
 安装结果直接写入目标 Harness Profile 的依赖、Bundle 顺序和 pnpm lockfile。TUI 的 `/plugin` 与原生 `dsh plugin` 操作同一份 Profile 状态。
@@ -229,7 +229,7 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 打开完整主题中心�
 ## 已验证范围
 
 - 官方 stock `@deepseek-ai/dsh@0.1.0-rc.8` 隔离安装、配置装配和 PTY 启动；并对声明的最低版本 `@deepseek-ai/dsh@0.1.0-rc.6` 完成 add／boot／remove／re-add 插拔契约。
-- `/doctor`：95 个 Harness 插件运行，0 error，0 warning。
+- 通过官方 dsh `0.1.0-rc.6`、`0.1.0-rc.7`、`0.1.0-rc.8` 各自的 CLI 安装打包后的 SeekTTY `1.1.0` 与 Clarify `0.1.0`：三种 with-plugin Profile 的本地 `/doctor` 均为 98 个 Harness 插件运行、0 error、0 warning，`/clarify` 均进入首个问题；三种 bare Profile 的 `/clarify` 均保持“未知命令”。
 - 模型列表、Provider／模型／推理强度切换、请求提交和 Harness 错误透传。
 - 隔离 `DSH_HOME` 下的首次 Provider 就绪检查、API Key 掩码输入、跳过后的草稿恢复、Harness 凭证持久化，以及重启后不再提示。
 - 暗色、亮色及配色生成主题的真实 PTY 渲染，界面／代码主题独立即时切换，80／120／160 列布局，以及同一 Profile 重启后的主题恢复。
@@ -248,8 +248,15 @@ SEEKTTY_SPEC=/path/to/seektty.tgz \
 pnpm test:stock
 ```
 
+可复用的跨包 doctor 检查：
+
+```sh
+CLARIFY_SPEC=/path/to/dsh-plugin-clarify.tgz \
+pnpm test:clarify-doctor
+```
+
 ## 兼容和升级
 
-已测兼容基线是官方 `0.1.0-rc.8`，声明的最低 Host 是官方 `0.1.0-rc.6`。新于 `tested` 的 dsh 仍可启动并给出提示；旧于 `minimum` 会被拒绝。定时工作流会扫描官方 npm `latest` dist-tag，在 `pnpm run check` 和隔离 stock-dsh 插拔契约通过后升级精确的 `@deepseek-ai/dsh-*` 钉死版本并开 pull request。不跟 npm `next` 或 GitHub harness 预发布。
+已测兼容基线是官方 `0.1.0-rc.8`，声明的最低 Host 是官方 `0.1.0-rc.6`。已测 Host 为官方 dsh `0.1.0-rc.6`、`0.1.0-rc.7` 与 `0.1.0-rc.8`。新于 `tested` 的 dsh 仍可启动并给出提示；旧于 `minimum` 会被拒绝。官方 rc.6/rc.7 基图解析 `@deepseek-ai/dsh-attachment@0.1.0-rc.7`，其 `ImageAttachmentLimits` 含 `maxImageBytes`、`maxImagesPerMessage`、`maxMessageImageBytes`、`maxImagePixels`、`mediaTypes`，但没有 `maxImageDimension`。SeekTTY 随后插入 rc.8 的 `@deepseek-ai/dsh-host-apiproxy`，其 `imageLimits` 投影要求该字段。Host 插件 `seektty/attachment-compat` 紧挨在 `api-gateway` 之前运行：仅当现场能力正好是这份合法遗留形状时，才从 `maxImagePixels` 推导保守的 `maxImageDimension`（单边不能超过像素总数）。原生 rc.8 对象保持同一引用。其他残缺或未知形状一律不改，让 rc.8 校验继续闭包失败。未来 Host 按能力匹配，不做版本分支。定时工作流会扫描官方 npm `latest` dist-tag，在 `pnpm run check` 和隔离 stock-dsh 插拔契约通过后升级精确的 `@deepseek-ai/dsh-*` 钉死版本并开 pull request。不跟 npm `next` 或 GitHub harness 预发布。
 
-源码仓库与稳定版 `v1.0.2` GitHub Release 均已公开。当前不发布 npm Registry 包；可安装上方已锁定 Tag 的 GitHub 源码，也可使用 Release 附带的 tarball。
+源码仓库与 GitHub Releases 均公开。当前不发布 npm Registry 包；可安装上方已锁定 Tag 的 GitHub 源码，也可使用对应 Release 附带的 tarball。

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -146,6 +146,13 @@
     - id: tui-marketplace-providers
       name: 'seektty/marketplace-provider'
 
+    # Official rc.6/rc.7 attachments publish a frozen ImageAttachmentLimits
+    # without maxImageDimension. This SeekTTY-owned adapter must run after
+    # that store exists and immediately before api-gateway so the rc.8
+    # host-apiproxy projection reads a capability-normalized object.
+    - id: attachment-compat
+      name: 'seektty/attachment-compat'
+
     - id: api-gateway
       name: '@deepseek-ai/dsh-host-apiproxy'
 

--- a/docs/任务书B-seektty-shell.md
+++ b/docs/任务书B-seektty-shell.md
@@ -1,0 +1,154 @@
+# 任务书 B：SeekTTY —— TUI 基线不动、体验打磨、Clarify 薄壳
+
+> 这是一本 SeekTTY 任务书。现有 TUI 是基线，不是重写对象。本书消费任务书 A 定义的接口，把 A 的接口规范视为**已经定稿**；本书不得定义、增补或改名任何接口字段。
+
+## 1. 一段话使命
+
+保持 SeekTTY 现有轻量而功能完整的 TUI 原封不动；体验优化作为独立轨道继续（减噪、打磨，不加新功能）；在此之外只新增**一个薄壳章节**：当且仅当探测到 Clarify 插件的 Remote 时，提供一个入口，调用插件的 start / answer / cancel / fetch draft 接口，渲染其返回的 question / options / `multiple` / `allowCustom`，展示最终 draft，并把 draft 填入**常规 composer**，由用户用普通 Enter 经既有 `session.prompt` 路径自行发送。插件缺席时，SeekTTY 行为与今天**逐比特一致**。
+
+## 2. 目标
+
+- 现有 TUI 全部能力原地保留，本特性不触碰第 5 节"不动清单"中的任何组件设计。
+- 薄壳只做四件事：探测、调接口、渲染返回、填 composer。
+- 无插件 ⇒ 零行为变化：无新命令、无新按钮、无报错、无死入口。
+- 体验轨道与薄壳轨道分离：体验工作不作为新能力的载体。
+
+## 3. 非目标
+
+- 不实现推理、路由、用量、限额、取消、进程状态中的任何一项——这些全在插件与 Harness 侧。
+- 不发明 SeekTTY 专属协议或字段；接口词汇以任务书 A 为准，一字不改。
+- 不把任何现有 TUI 功能迁入插件。
+- 不做常驻顾问 chrome：不加全局快捷键、不加常显灰色建议行、不加 Form-1 式占位符、不动 F1、不动空 Enter。
+- 不为本特性重设计 overlay / keymap / 状态栏 / `/` 命令目录。
+- 不新增任何 SeekTTY 侧持久化（文件、Profile hack、`.env`、Settings 滥用）来存问答或 draft。
+
+## 4. 共享契约（两本任务书逐字一致，不得改写）
+
+插件提供一个绑定当前 Session 与某个 context version 的临时推理进程。
+
+- 模型与 Provider 路由、Profile、上下文读取、用量记录、限额、取消、错误处理全部由 Harness 拥有。插件消费这些 Host 服务；不得持有凭据、不得自行调用 Provider、不得打开隐藏 Session、不得运行常规 Agent 循环。
+- 该进程不得创建正式的用户消息或助手消息。
+- 该进程不得写入 Session transcript、input queue、pending、Plan、Goal，或 Session 分支 / fork。
+- 该进程不得调用工具、MCP、Skills 或子代理。
+- Harness（经由插件的接口）返回结构化的 question、options、是否 `multiple`、是否 `allowCustom`，以及最终整理后的 draft 文本。
+- 进程启动后，若当前 Session、模型路由或 context version 变化，Harness 必须 cancel 该进程或将结果标记为 stale。以下同样视为 context version 变化：主 Session 出现新的正式消息、compaction、recall / 上下文注入。stale 的 options 不得静默继续。
+- 草稿问答仅可作为 Harness 拥有的 TTL 进程状态存在，绝不可成为 SeekTTY 文件，绝不可进入 transcript。进程标识至少包含 `processId`、绑定的 `sessionId`、`contextVersion`（或模型可见上下文的稳定指纹）、`modelRouteId`。
+- 最终文本进入正式对话的唯一途径，是用户之后通过常规 Session 提交路径（`session.prompt` 或等价物）自行发送。插件与任何 Surface 都不得自动发送。
+- 输出仅为"待发出的用户草稿文本"，不是助手回复，也不是给 Agent 执行的计划。
+
+共享接口词汇（两本书必须使用且不得改名）：
+
+- start / answer / cancel / fetch draft
+- `processId`、`sessionId`、`contextVersion`、`modelRouteId`
+- question、options、`multiple`、`allowCustom`、最终 draft 文本
+- 状态：running / cancelled / stale / complete
+- 用量与错误走既有 Harness 通道
+
+## 5. 不动清单（Immobile Inventory）
+
+以下组件对本特性而言**不得重设计、不得为其扩展**。后续体验轨道可以打磨它们，但打磨不得成为夹带新能力的载体：
+
+- composer（输入区、草稿、历史）
+- 状态栏 / 通知板（busy-status、session-chrome）
+- overlay 体系与 keymap
+- `/` 命令目录与命令面板（Ctrl+P）
+- input queue 与 `/steer`
+- 审批 / approval 流与 Shift+Tab 权限循环
+- pending 恢复语义
+- 受控 restart 语义（工作区、会话、草稿、附件恢复）
+- `/plugin` 插件市场 UI
+- 主题体系（interface / code 双主题）
+- locale / 中英文切换
+
+薄壳允许做的唯一 UI 动作：用**既有** overlay 原语渲染一个新的 overlay 内容（单选 / 多选 / 自定义输入 / 文本展示，均为 TUI 已有的人机交互形态），以及用**既有**的 composer 草稿填充机制放入 draft。不新建交互原语。
+
+## 6. 架构与数据流（薄壳章节）
+
+### 6.1 所有权
+
+| 归属 | 内容 |
+| --- | --- |
+| 插件（任务书 A） | 进程、接口、TTL 状态、stale / cancel 规则、draft 生成 |
+| SeekTTY 薄壳 | 探测 Remote、发起接口调用、渲染 question / options / `multiple` / `allowCustom`、展示状态与 `staleReason`、把 draft 填入 composer |
+| SeekTTY 既有路径 | 用户按 Enter 后的 `session.prompt` 提交（`src/client/surface.ts` 现有路径，不改动） |
+| 用户 | 决定是否发送、是否修改 draft 后再发送 |
+
+### 6.2 数据流
+
+1. **探测**：启动或插件重载后，经既有 Host RPC 发现机制探测 Clarify Remote 是否存在。不存在 ⇒ 本章节所有代码路径静默不激活。
+2. **入口**：仅当 Remote 存在时，在 SeekTTY 本地 `/` 目录构造阶段动态加入一条命令；该条目只属于 TUI 运行时目录，不注册 Host CommandRuntime，因为 Host command 会向 Session 写入 command / run / done 事件。不加全局快捷键。
+3. **回合**：入口打开 overlay → 调 start（带当前 `sessionId`，composer 中已有的半成品文字作为 seedText 传入但**不清空 composer**）→ 循环渲染 question / options / `multiple` / `allowCustom` 并调 answer。`multiple = false` 使用既有单选原语且恰选一个；`multiple = true` 使用既有多选原语且至少选一个；customText 与 selectedOptionIds 严格异或。状态 complete 时立即另调 fetch draft；若 fetch 前已 stale，则 stale 胜出且不得读取 draft。
+4. **落地**：draft 展示给用户确认后填入常规 composer（覆盖前若 composer 非空需用户确认）。overlay 关闭。**到此为止**——发送与否、何时发送，完全是用户按 Enter 的常规动作。
+5. **取消与过期**：用户 Esc / 关闭 overlay ⇒ 调 cancel。接口返回 stale ⇒ overlay 显式展示 `staleReason`，只提供"重新开始"与"放弃"两个动作，绝不静默续用旧 options 或旧 draft。
+6. **错误**：接口错误按 TUI 既有 Host 错误呈现方式展示，不新建错误 UI。
+
+### 6.3 明确禁止
+
+- 不 auto-send：任何代码路径不得在薄壳流程中调用 `session.prompt`。
+- 不产生第二份 transcript：问答过程不写入会话记录、不写 SeekTTY 文件、不进 Settings。
+- 不缓存进程状态跨 restart：restart 后旧 `processId` 一律视为失效，从探测重新开始。
+
+## 7. 缺席行为（Absence）
+
+插件未安装或 Remote 未注册时：
+
+- `/` 目录中不出现该命令；命令面板、帮助、状态栏均无痕迹。
+- 无任何错误、警告、日志噪音、死按钮。
+- 行为与未实现本章节的 SeekTTY **逐比特一致**，以快照比对验证（见第 10 节）。
+
+## 8. 体验轨道（与薄壳分离）
+
+后续 SeekTTY 工作的定位是"轻量但完整"：
+
+- **做**：减少 chrome 与噪音、打磨既有交互的顺滑度、修正呈现缺陷（方向参考 `docs/体验优化.md`、`docs/体验优化2.md`，但那些文档不构成本书任务）。
+- **不做**：任何属于插件本体的新能力。判据：凡是需要推理、进程状态或新接口的想法，一律先进任务书 A 的接口讨论，SeekTTY 侧最多做一行壳层跟进。
+- 本书不为体验轨道排任务；体验任务另行立项，逐项对照第 5 节不动清单确认"打磨而非重设计"。
+
+## 9. 有序任务（小步、每步可验证）
+
+| # | 任务 | 验证方式 |
+| --- | --- | --- |
+| B1 | 探测与入口：Remote 存在时动态注册 `/` 命令；不存在时零注册 | 有插件环境命令出现；无插件环境用 PTY 快照与基线版本逐帧比对，零差异 |
+| B2 | 壳层 overlay：用既有 overlay 原语渲染 question / options / `multiple` / `allowCustom`，完成 answer 循环，展示 running / stale / cancelled / complete 状态 | 对着插件（或 A 书 T3 的桩 Remote）走完单选、多选、自定义输入与多轮问答；stale 时看到 `staleReason` 与“重新开始 / 放弃” |
+| B3 | draft 落地：complete 后 fetch draft，确认后填入 composer；composer 非空时先确认；不发送 | 断言 composer 内容变化且无 `session.prompt` 调用发生；用户 Enter 后走既有提交路径 |
+| B4 | 取消路径：Esc / 关闭 overlay 调 cancel；restart 后不复用旧 `processId` | 断言 cancel 被调用；restart 后入口重新从探测开始 |
+| B5 | 固化第 10 节测试为可重跑脚本 | 单命令重跑全绿 |
+
+## 10. 测试计划
+
+1. **有插件**：完整回合——探测、入口、多轮问答、draft 入 composer、用户 Enter 经既有 `session.prompt` 发送成功。
+2. **无插件**：PTY 快照与未含本章节的构建逐帧比对，零差异；`/` 目录、帮助、命令面板无新条目。
+3. **draft 只进 composer**：全程断言薄壳代码未触发任何提交；draft 出现在 composer 且可编辑。
+4. **无新增持久化**：回合前后比对 SeekTTY 可写位置（Profile、Settings 命名空间、本地文件），无新键、无新文件。
+5. **无 transcript 污染**：回合前后 Session transcript 逐字节一致（与 A 书测试 2 互为印证）。
+6. **stale 呈现**：借助 A 书 T5 的触发手段制造 stale，断言 overlay 显式提示且旧内容不可继续操作。
+7. **restart**：回合中途 `/restart`，恢复后无残留 overlay、无旧 `processId` 复用，composer 草稿按既有 restart 语义恢复。
+
+## 11. 验收清单
+
+- [ ] 第 5 节不动清单组件的设计零改动（代码审查逐项确认）。
+- [ ] 无插件环境快照比对零差异。
+- [ ] 有插件环境完整回合通过，draft 仅经用户 Enter 发送。
+- [ ] 薄壳代码中不存在对 `session.prompt` 的调用。
+- [ ] 无任何新增 SeekTTY 持久化。
+- [ ] 接口字段与状态名与任务书 A 第 6 节逐字一致，无 SeekTTY 私有字段。
+- [ ] 全部使用既有 overlay / composer / 错误呈现原语，无新交互原语。
+
+## 12. 风险与阻塞
+
+- **A 书 T0 与本书的真实关系**：stock dsh rc.6 / rc.7 / rc.8 上 T0(b)（只读上下文修订标识）与 T0(d)（usage / limits / cancel 通道）仍然阻塞，这只挡住 A 书 T4+ 的真实推理接入。T1–T3 已用公开 Typert / Gateway 契约和确定性 T3 桩 Remote 交付；本书 B2–B5 消费的就是这一份公开 Remote，**不得**因为这两道无关的 T0 闸门而停掉全部 B2+。B1 的无插件零差异仍然是硬条件。
+- **本地 `/doctor` 不是 stock doctor**：SeekTTY v1.0.2 已有本地 `/doctor`（`managementBridge().plugins.doctor()` → `ProfilePluginManager.doctor()`）。本轨道不得替换它，也不得再造一个伪造的 stock CLI / Host HTTP `/doctor`。跨项目验收是：先独立验证官方 dsh 上 Clarify 的 add/boot/remove/re-add，再在未改动的 SeekTTY 本地 doctor 接收端上要求 Clarify bundle/fiber 零 error、零 warning。`ProfilePluginManager.doctor()` 本身不检查 fiber；常规测试里的 planted 用例只证明接收端，`CLARIFY_SPEC=... pnpm test:clarify-doctor` 才是隔离安装真包后调用未改 doctor。fiber 健康仍需运行中的 Host + `/doctor` 的 `pluginInventory()`，不得假装已自动化。
+- **overlay 原语覆盖不足**：若既有单选 / 多选 / 自定义输入原语无法表达某个 question 形态，正确做法是回到任务书 A 讨论 question 形状是否过于复杂，而不是在 SeekTTY 新造原语。
+- **探测时序**：插件热装 / 热卸时命令注册需跟随既有插件重载机制；若既有机制不支持热感知，可接受"下次启动生效"，不为此新造监听。动态 `/clarify` 只在 Clarify Remote 接收端被状态无关探测证明存在时出现；探测可对不可能的 `processId` 调用 `fetchDraft`，仅精确 `PROCESS_NOT_FOUND`，或包裹错误文案同时含探测 `processId` 与紧密等价 process-not-found 消息，视为存在，`SESSION_ID_REQUIRED` / `INVALID_ANSWER` 等无关业务错误不得单独证明探测存在，transport / endpoint 不可用视为缺席。
+- **契约变更**：任何需要新字段、新状态的诉求，一律先改任务书 A，本书只做一行跟进。绝不允许反向。SeekTTY 只经 `ConnectionHandle.rpc.call('/api', 'clarify/<method>', { args }, signal)` 消费公开 Remote，不得复制或导入 Clarify 内部实现，也不得增加 `workspace:` 依赖。
+- **版本与发布**：本轨道目标版本为 `1.1.0`；不得把 Clarify 壳层锁死在单一 dsh 版本。发布前至少针对官方 dsh rc.6、rc.7、当时 npm `latest` 与不同于 `latest` 的官方 `next` 分别验证“插件缺席零差异”和“插件存在完整回合”，未知未来版本通过能力探测安全降级且不得产生死入口。2026-08-20 的标签快照为 `latest=0.1.0-rc.7`、`next=0.1.0-rc.8`。功能 PR squash merge后从 `main` 创建 annotated `v1.1.0`，GitHub Release 附带 `pnpm pack` tgz、`SHA256SUMS`、精确已测兼容矩阵与安装 / 校验说明。
+
+## 13. 附录：接口边界（两本任务书逐字一致）
+
+- 插件拥有：临时推理进程、接口（Host Remote / API）、TTL 状态、Harness 注入（router / 上下文读取 / usage / limits / cancel）、stale 与 cancel 规则、draft 文本的生成。
+- SeekTTY 拥有：现有 TUI 全部能力、后续体验打磨、可选的壳层（仅调用插件接口）。
+- Web 拥有：基于同一套接口的自己的壳层。
+- 共享：第 4 节契约块与接口词汇。
+- 禁止：SeekTTY 定义插件不存在的字段；插件调用 SeekTTY API；任何一方自动提交 draft。
+
+若某任务需要变更契约：先改任务书 A（A 书是契约与接口规范的唯一来源），任务书 B 只做一行跟进。绝不允许反向。

--- a/lib/attachment-compat.js
+++ b/lib/attachment-compat.js
@@ -1,0 +1,76 @@
+//#region src/host/attachment-compat.ts
+/** Stable Cordis plugin name. */
+const name = "seektty-attachment-compat";
+/**
+* Wait for the official attachments store. This plugin is listed immediately
+* before `api-gateway` in `cordis.patch.yml` so, once `attachments` exists, it
+* becomes ACTIVE before `@deepseek-ai/dsh-host-apiproxy` registers the rc.8
+* `imageLimits` projection that reads `ctx.attachments.imageLimits`.
+*/
+const inject = ["attachments"];
+const REQUIRED_POSITIVE_INTS = [
+	"maxImageBytes",
+	"maxImagesPerMessage",
+	"maxMessageImageBytes",
+	"maxImagePixels"
+];
+function isPositiveInt(value) {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+function isStringArray(value) {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+/**
+* True only for the exact valid legacy capability: official rc.6/rc.7
+* `ImageAttachmentLimits` fields are present and well-typed, and
+* `maxImageDimension` is absent. Any other shape is left to rc.8 schema.
+*/
+function isLegacyImageLimits(value) {
+	if (typeof value !== "object" || value === null) return false;
+	const row = value;
+	if ("maxImageDimension" in row) return false;
+	for (const key of REQUIRED_POSITIVE_INTS) if (!isPositiveInt(row[key])) return false;
+	return isStringArray(row.mediaTypes);
+}
+/**
+* Conservative per-side bound implied by a positive pixel count: a 1×N image
+* has one dimension equal to `maxImagePixels`.
+* @param maxImagePixels - already-validated positive integer pixel count.
+*/
+function deriveMaxImageDimension(maxImagePixels) {
+	return maxImagePixels;
+}
+/**
+* Return a new object only for the exact valid legacy shape. Native rc.8
+* objects and malformed/unknown shapes keep the same identity.
+* @param value - live `attachments.imageLimits`.
+*/
+function normalizeLegacyImageLimits(value) {
+	if (!isLegacyImageLimits(value)) return value;
+	return {
+		...value,
+		maxImageDimension: deriveMaxImageDimension(value.maxImagePixels)
+	};
+}
+/**
+* Replace `attachments.imageLimits` when the official store still publishes
+* the frozen rc.6/rc.7 capability. Official `LocalAttachmentStore` freezes
+* that object, so the field is replaced rather than mutated. The fiber
+* disposer restores the original reference only while `imageLimits` is
+* still strictly identical to the normalized object.
+* @param ctx - Host context that already has `attachments`.
+*/
+function apply(ctx) {
+	const attachments = ctx.get("attachments");
+	if (attachments === void 0) return;
+	const original = attachments.imageLimits;
+	const next = normalizeLegacyImageLimits(original);
+	if (next === original) return;
+	attachments.imageLimits = next;
+	ctx.effect(() => () => {
+		if (attachments.imageLimits === next) attachments.imageLimits = original;
+	}, "seektty/attachment-compat: restore imageLimits");
+}
+
+//#endregion
+export { apply, deriveMaxImageDimension, inject, isLegacyImageLimits, name, normalizeLegacyImageLimits };

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_VERSION, d as launcherCopy, f as launcherPrefersEnglish, i as PACKAGE_NAME, n as measureStartupSync, o as compareDshVersion, p as versionMessage, r as DSH_COMPATIBILITY, s as defaultPluginSpec, u as isVersionRequest } from "./startup-trace-XWhFZ-rv.js";
+import { a as PACKAGE_VERSION, d as launcherCopy, f as launcherPrefersEnglish, i as PACKAGE_NAME, n as measureStartupSync, o as compareDshVersion, p as versionMessage, r as DSH_COMPATIBILITY, s as defaultPluginSpec, u as isVersionRequest } from "./startup-trace-oQui160r.js";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DQmPrtbG.js";
-import { c as dshCompatibilityError, f as launcherPrefersEnglish, l as dshCompatibilityNotice, r as DSH_COMPATIBILITY, t as measureStartup } from "./startup-trace-XWhFZ-rv.js";
+import { c as dshCompatibilityError, f as launcherPrefersEnglish, l as dshCompatibilityNotice, r as DSH_COMPATIBILITY, t as measureStartup } from "./startup-trace-oQui160r.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-CIbYwatv.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-3S2DF29J.js";
 import { createRequire } from "node:module";
@@ -19972,6 +19972,443 @@ function resolveHarnessUserPath(rawPath, workspacePath) {
 }
 
 //#endregion
+//#region src/client/clarify-remote.ts
+/** Public Clarify Remote contract consumed through ConnectionHandle.rpc.call. */
+const CLARIFY_API_CHANNEL = "/api";
+const CLARIFY_NAMESPACE = "clarify";
+const CLARIFY_PROBE_PROCESS_ID = "__clarify_absent_probe__";
+const ABSENT_CODES = new Set([
+	"invocation-unavailable",
+	"definition-unavailable",
+	"service-unavailable",
+	"method-unavailable"
+]);
+const ABSENT_MESSAGE = /no active Remote method|invocation-unavailable|definition-unavailable|no RPC handler|transport failure|HTTP 404|^not found$/i;
+const PROBE_PRESENCE_CODES = new Set(["PROCESS_NOT_FOUND"]);
+const PROBE_PRESENCE_MESSAGE = /PROCESS_NOT_FOUND|process .+ does not exist/i;
+var ClarifyRemoteError = class extends Error {
+	code;
+	constructor(code, message) {
+		super(message);
+		this.name = "ClarifyRemoteError";
+		this.code = code;
+	}
+};
+function clarifyEndpoint(method) {
+	return `${CLARIFY_NAMESPACE}/${method}`;
+}
+function omitClarifyArgs(args) {
+	const out = {};
+	for (const [key, value] of Object.entries(args)) {
+		if (value === void 0) continue;
+		if (typeof value === "string" && value.length === 0 && key !== "sessionId" && key !== "processId" && key !== "questionId") continue;
+		if (key === "selectedOptionIds" && Array.isArray(value)) {
+			if (value.length === 0) continue;
+			out[key] = [...value];
+			continue;
+		}
+		out[key] = value;
+	}
+	return out;
+}
+function clarifyErrorParts(result) {
+	return {
+		code: result.error?.code ?? "",
+		message: result.error?.message ?? ""
+	};
+}
+function isClarifyAbsent(result) {
+	const { code, message } = clarifyErrorParts(result);
+	return ABSENT_CODES.has(code) || ABSENT_MESSAGE.test(message);
+}
+/**
+* Presence proof for the impossible-processId `fetchDraft` probe.
+* Exact PROCESS_NOT_FOUND may prove presence. A wrapped/internal error must
+* mention CLARIFY_PROBE_PROCESS_ID, not an arbitrary other process.
+*/
+function isClarifyProbePresence(result) {
+	if (isClarifyAbsent(result)) return false;
+	const { code, message } = clarifyErrorParts(result);
+	if (PROBE_PRESENCE_CODES.has(code)) return true;
+	return message.includes(CLARIFY_PROBE_PROCESS_ID) && PROBE_PRESENCE_MESSAGE.test(message);
+}
+async function callClarify(rpc, method, args, signal) {
+	const result = await rpc(CLARIFY_API_CHANNEL, clarifyEndpoint(method), { args: omitClarifyArgs(args) }, signal);
+	if (result.ok) return result.value;
+	throw new ClarifyRemoteError(result.error?.code ?? "internal", result.error?.message ?? `clarify/${method} failed`);
+}
+async function probeClarifyRemote(rpc, signal) {
+	try {
+		return isClarifyProbePresence(await rpc(CLARIFY_API_CHANNEL, clarifyEndpoint("fetchDraft"), { args: { processId: CLARIFY_PROBE_PROCESS_ID } }, signal));
+	} catch (error) {
+		return isClarifyProbePresence({
+			ok: false,
+			error: { message: error instanceof Error ? error.message : String(error) }
+		});
+	}
+}
+function parseClarifyEcho(value, options$1 = {}) {
+	if (typeof value !== "object" || value === null) throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify response must be an object");
+	const record = value;
+	if (typeof record.processId !== "string" || record.processId.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify processId must be a non-empty string");
+	if (typeof record.sessionId !== "string" || record.sessionId.trim() === "" || typeof record.contextVersion !== "string" || record.contextVersion.trim() === "" || typeof record.modelRouteId !== "string" || record.modelRouteId.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify echo is missing session binding fields");
+	if (record.status !== "running" && record.status !== "cancelled" && record.status !== "stale" && record.status !== "complete") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify status is not a shared contract value");
+	const question = record.status === "running" ? parseQuestion(record.question) : void 0;
+	const draft = record.status === "complete" && options$1.allowDraft === true && typeof record.draft === "string" ? record.draft : void 0;
+	return {
+		processId: record.processId,
+		sessionId: record.sessionId,
+		status: record.status,
+		contextVersion: record.contextVersion,
+		modelRouteId: record.modelRouteId,
+		...typeof record.staleReason === "string" ? { staleReason: record.staleReason } : {},
+		...question === void 0 || record.status !== "running" ? {} : { question },
+		...draft === void 0 || record.status !== "complete" ? {} : { draft }
+	};
+}
+function parseQuestion(value) {
+	if (value === void 0) return void 0;
+	if (typeof value !== "object" || value === null) throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify question must be an object");
+	const record = value;
+	if (typeof record.questionId !== "string" || record.questionId.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify questionId must be a non-empty string");
+	if (typeof record.text !== "string" || record.text.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify question text must be a non-empty string");
+	if (typeof record.multiple !== "boolean" || typeof record.allowCustom !== "boolean") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify question.multiple and allowCustom must be booleans");
+	if (!Array.isArray(record.options) || record.options.length === 0) throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify question must include at least one option");
+	const seen = /* @__PURE__ */ new Set();
+	const options$1 = record.options.map((option) => {
+		if (typeof option !== "object" || option === null) throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify option must be an object");
+		const row = option;
+		if (typeof row.optionId !== "string" || row.optionId.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify optionId values must be non-empty");
+		if (typeof row.text !== "string" || row.text.trim() === "") throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify option text must be a non-empty string");
+		if (seen.has(row.optionId)) throw new ClarifyRemoteError("INVALID_ANSWER", "Clarify optionId values must be unique");
+		seen.add(row.optionId);
+		return {
+			optionId: row.optionId,
+			text: row.text
+		};
+	});
+	return {
+		questionId: record.questionId,
+		text: record.text,
+		multiple: record.multiple,
+		allowCustom: record.allowCustom,
+		options: options$1
+	};
+}
+
+//#endregion
+//#region src/client/clarify-shell.ts
+function clarifyCustomChoiceId(question) {
+	const used = new Set(question.options.map((option) => option.optionId));
+	let candidate = "__custom__";
+	let n = 0;
+	while (used.has(candidate)) {
+		n += 1;
+		candidate = `__custom__:${n}`;
+	}
+	return candidate;
+}
+var ClarifyShellAbort = class extends Error {
+	constructor() {
+		super("clarify-shell-abort");
+		this.name = "ClarifyShellAbort";
+	}
+};
+function clarifyTuiCommand() {
+	return {
+		name: "clarify",
+		description: ui("澄清当前输入并生成待发送草稿", "Clarify the current input into a sendable draft"),
+		source: "TUI",
+		behavior: "local"
+	};
+}
+function mergeClarifyCatalog(commands, present) {
+	if (!present || commands.some((command) => command.name === "clarify")) return commands;
+	const entry = clarifyTuiCommand();
+	const index = commands.findIndex((command) => command.name === "doctor");
+	if (index === -1) return [...commands, entry];
+	return [
+		...commands.slice(0, index),
+		entry,
+		...commands.slice(index)
+	];
+}
+/**
+* Resolve the Clarify seed from the two invocation paths.
+* Palette execution keeps the current composer and passes empty args, so the
+* composer body is the seed. Typed `/clarify some text` is submitted after the
+* composer is cleared, so only `rawArgs` remains. Typed `/clarify` alone has
+* no leftover body to preserve.
+*/
+function clarifySeedText(composerText, rawArgs) {
+	const composer = composerText.trim();
+	if (composer === "" || /^\/clarify(?:\s|$)/iu.test(composer)) return rawArgs.trim();
+	return composer;
+}
+function buildClarifyAnswer(question, input) {
+	const hasOptions = input.selectedOptionIds !== void 0;
+	const hasCustom = input.customText !== void 0;
+	if (hasOptions === hasCustom) throw new Error("selectedOptionIds and customText are mutually exclusive and required as one of the two");
+	if (hasCustom) {
+		if (!question.allowCustom) throw new Error("customText is only valid when allowCustom is true");
+		const customText = input.customText?.trim() ?? "";
+		if (customText === "") throw new Error("customText must not be empty");
+		return { customText };
+	}
+	const selectedOptionIds = [...input.selectedOptionIds ?? []];
+	if (selectedOptionIds.length === 0) throw new Error(question.multiple ? "multiple=true requires at least one selectedOptionId" : "selectedOptionIds must not be empty");
+	if (!question.multiple && selectedOptionIds.length !== 1) throw new Error("multiple=false requires exactly one selectedOptionId");
+	const allowed = new Set(question.options.map((option) => option.optionId));
+	const unique = /* @__PURE__ */ new Set();
+	for (const optionId of selectedOptionIds) {
+		if (!allowed.has(optionId)) throw new Error(`selectedOptionId ${JSON.stringify(optionId)} is not in the current question`);
+		if (unique.has(optionId)) throw new Error("selectedOptionIds must be unique");
+		unique.add(optionId);
+	}
+	return { selectedOptionIds };
+}
+async function runClarifyShell(request) {
+	let processId;
+	try {
+		while (true) {
+			let current = await invoke(request, "start", {
+				sessionId: request.sessionId,
+				...request.seedText === "" ? {} : { seedText: request.seedText }
+			});
+			processId = current.processId;
+			if (current.status === "stale") {
+				if (await resolveStale(request, current) === "restart") {
+					processId = void 0;
+					continue;
+				}
+				return abandoned(current);
+			}
+			while (current.status === "running") {
+				const question = current.question;
+				if (question === void 0) throw new Error(ui("Clarify 进程在提问完成前结束", "Clarify returned running without a question"));
+				const answer = await collectAnswer(request.overlays, question);
+				if (answer === void 0) {
+					await cancelQuietly(request, current.processId);
+					return { kind: "cancelled" };
+				}
+				current = await invoke(request, "answer", {
+					processId: current.processId,
+					questionId: question.questionId,
+					...answer
+				});
+				processId = current.processId;
+			}
+			if (current.status === "stale") {
+				if (await resolveStale(request, current) === "restart") {
+					processId = void 0;
+					continue;
+				}
+				return abandoned(current);
+			}
+			if (current.status !== "complete") return { kind: "cancelled" };
+			const fetched = await invoke(request, "fetchDraft", { processId: current.processId });
+			if (fetched.status === "stale") {
+				if (await resolveStale(request, fetched) === "restart") {
+					processId = void 0;
+					continue;
+				}
+				return abandoned(fetched);
+			}
+			if (fetched.status !== "complete") throw new Error(ui(`Clarify fetchDraft 返回了 ${fetched.status}，不能当作 stale`, `Clarify fetchDraft returned ${fetched.status} and must not be treated as stale`));
+			if (fetched.draft === void 0) throw new Error(ui("Clarify fetchDraft 在 complete 时缺少 draft", "Clarify fetchDraft returned complete without a draft"));
+			processId = void 0;
+			return applyDraft(request, fetched.draft);
+		}
+	} catch (error) {
+		if (processId !== void 0) await cancelQuietly(request, processId);
+		if (error instanceof ClarifyShellAbort) return { kind: "cancelled" };
+		throw error;
+	}
+}
+function abandoned(echo) {
+	return {
+		kind: "abandoned",
+		...echo.staleReason === void 0 ? {} : { staleReason: echo.staleReason }
+	};
+}
+async function collectAnswer(overlays, question) {
+	const optionChoices = question.options.map((option) => ({
+		id: option.optionId,
+		label: option.text
+	}));
+	const customId = clarifyCustomChoiceId(question);
+	if (question.multiple) {
+		if (question.allowCustom) {
+			const mode = await overlays.select({
+				title: questionTitle(question),
+				detail: statusDetail("running"),
+				choices: [{
+					id: "options",
+					label: ui("从选项中选择", "Choose from options")
+				}, {
+					id: customId,
+					label: ui("自定义回答…", "Custom answer…")
+				}]
+			});
+			if (mode === void 0) return void 0;
+			if (mode.id === customId) return readCustom(overlays, question);
+		}
+		const picked$1 = await overlays.multiSelect({
+			title: questionTitle(question),
+			detail: statusDetail("running"),
+			choices: optionChoices
+		});
+		if (picked$1 === void 0) return void 0;
+		return buildClarifyAnswer(question, { selectedOptionIds: picked$1.map((choice) => choice.id) });
+	}
+	const choices = [...optionChoices, ...question.allowCustom ? [{
+		id: customId,
+		label: ui("自定义回答…", "Custom answer…")
+	}] : []];
+	const picked = await overlays.select({
+		title: questionTitle(question),
+		detail: statusDetail("running"),
+		choices
+	});
+	if (picked === void 0) return void 0;
+	if (picked.id === customId) return readCustom(overlays, question);
+	return buildClarifyAnswer(question, { selectedOptionIds: [picked.id] });
+}
+async function readCustom(overlays, question) {
+	const custom = await overlays.multilineInput({
+		title: questionTitle(question),
+		detail: statusDetail("running"),
+		placeholder: ui("输入自定义回答", "Enter a custom answer")
+	});
+	if (custom === void 0) return void 0;
+	const answer = buildClarifyAnswer(question, { customText: custom });
+	if (!("customText" in answer)) return void 0;
+	return answer;
+}
+async function resolveStale(request, echo) {
+	const selected = await request.overlays.select({
+		title: ui("Clarify 已过期", "Clarify is stale"),
+		detail: staleDetail(echo.staleReason),
+		searchable: false,
+		choices: [{
+			id: "restart",
+			label: ui("重新开始", "Start over"),
+			description: ui("丢弃过期结果并新建进程", "Discard the stale result and start a new process")
+		}, {
+			id: "abandon",
+			label: ui("放弃", "Abandon"),
+			description: ui("关闭并不再使用过期选项", "Close without using the stale options")
+		}]
+	});
+	await cancelQuietly(request, echo.processId);
+	if (selected?.id === "restart") return "restart";
+	return "abandon";
+}
+async function applyDraft(request, draft) {
+	await request.overlays.detail({
+		title: ui("Clarify 草稿", "Clarify draft"),
+		content: draft,
+		footer: ui("确认后写入输入区，不会自动发送", "Confirm to write the composer; it is not sent automatically")
+	});
+	if (!await request.overlays.confirm(ui("将草稿填入输入区？", "Insert the draft into the composer?"), ui("草稿只进入常规输入区，不会自动发送。", "The draft only enters the regular composer and is not sent automatically."), ui("填入", "Insert"))) return { kind: "cancelled" };
+	if (request.composerText.trim() !== "") {
+		if (!await request.overlays.confirm(ui("覆盖当前输入区？", "Replace the current composer text?"), ui("当前输入区已有内容，填入 Clarify 草稿将覆盖它。", "The composer already has text; inserting the Clarify draft replaces it."), ui("覆盖", "Replace"))) return {
+			kind: "kept-composer",
+			draft
+		};
+	}
+	request.writeComposer(draft);
+	return {
+		kind: "applied",
+		draft
+	};
+}
+async function invoke(request, method, args) {
+	const result = await request.overlays.progress({
+		title: ui("Clarify", "Clarify"),
+		detail: statusDetail("running"),
+		work: async (_report, signal) => {
+			if (method === "start") return invokeStartWork(request, args, signal);
+			return parseClarifyEcho(await callClarify(request.call, method, args, signal), { allowDraft: method === "fetchDraft" });
+		}
+	});
+	if (result === void 0) throw new ClarifyShellAbort();
+	return result;
+}
+/**
+* Overlay Esc aborts the progress signal and the in-process/HTTP carrier.
+* Clarify `start` has no cancellation parameter, so Gateway never injects that
+* signal into the Host method; aborting the RPC only discards the echo while
+* the process remains until TTL. Observe the overlay abort locally, keep the
+* start RPC running, and cancel the late processId.
+*/
+async function invokeStartWork(request, args, signal) {
+	if (signal.aborted) return void 0;
+	const settled = callClarify(request.call, "start", args).then((value) => ({
+		ok: true,
+		value
+	}), (error) => ({
+		ok: false,
+		error
+	}));
+	const winner = await raceUntilAbort(settled, signal);
+	if (winner === void 0) {
+		cancelLateStart(request, settled);
+		return;
+	}
+	if (!winner.ok) throw winner.error;
+	return parseClarifyEcho(winner.value);
+}
+function cancelLateStart(request, settled) {
+	return settled.then(async (result) => {
+		if (!result.ok) return;
+		const processId = processIdFromValue(result.value);
+		if (processId === void 0) return;
+		await cancelQuietly(request, processId);
+	});
+}
+function processIdFromValue(value) {
+	if (typeof value !== "object" || value === null) return void 0;
+	const processId = Reflect.get(value, "processId");
+	return typeof processId === "string" && processId.trim() !== "" ? processId : void 0;
+}
+function raceUntilAbort(pending, signal) {
+	return new Promise((resolve$1, reject) => {
+		const onAbort = () => {
+			resolve$1(void 0);
+		};
+		if (signal.aborted) {
+			resolve$1(void 0);
+			return;
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+		pending.then((value) => {
+			signal.removeEventListener("abort", onAbort);
+			resolve$1(signal.aborted ? void 0 : value);
+		}, (error) => {
+			signal.removeEventListener("abort", onAbort);
+			if (signal.aborted) resolve$1(void 0);
+			else reject(error);
+		});
+	});
+}
+async function cancelQuietly(request, processId) {
+	try {
+		await callClarify(request.call, "cancel", { processId });
+	} catch {}
+}
+function questionTitle(question) {
+	return `${ui("Clarify", "Clarify")} · ${question.text}`;
+}
+function statusDetail(status) {
+	return ui(`状态：${status}`, `Status: ${status}`);
+}
+function staleDetail(reason) {
+	const label = reason === void 0 ? ui("未知原因", "Unknown reason") : reason;
+	return ui(`Clarify 已 stale（${label}）。过期选项和草稿不能继续使用。`, `Clarify is stale (${label}). Stale options and drafts cannot be reused.`);
+}
+
+//#endregion
 //#region src/client/capabilities.ts
 /**
 * Compatible names that still execute, but stay out of `/`, Ctrl+P, and help.
@@ -20539,6 +20976,26 @@ var HarnessTuiCapabilities = class {
 			signal.throwIfAborted();
 			return catalog;
 		});
+	}
+	/**
+	* Public Connection RPC face used by optional plugin shells.
+	* @returns the mounted caller, when the Client Connection handle exists.
+	*/
+	connectionRpc() {
+		return this.connectionHandle()?.rpc;
+	}
+	/**
+	* State-free probe for the Clarify Remote receiver.
+	* @param signal - optional cancellation for the probe RPC.
+	* @returns true only when the impossible-processId probe gets PROCESS_NOT_FOUND.
+	*/
+	async clarifyRemotePresent(signal) {
+		const rpc = this.connectionRpc();
+		if (rpc === void 0) return false;
+		return probeClarifyRemote((channel, endpoint, payload, inner) => rpc.call(channel, endpoint, payload, inner), signal);
+	}
+	connectionHandle() {
+		return this.ctx.connection;
 	}
 	/** Invalidate the current command/Skill snapshot and repull on next use. */
 	invalidateCommandCatalog() {
@@ -21345,8 +21802,9 @@ var HarnessTuiCapabilities = class {
 		}) : this.ctx.remote.commands.list(sessionId), isSubagent ? Promise.resolve(void 0) : this.api.skills.list({ sessionId })]);
 		if (!hostResult.ok) throw new Error(ui(`读取 Host 命令失败：${hostResult.error.message}`, `Failed to load Host commands: ${hostResult.error.message}`));
 		if (skillResponse !== void 0 && !skillResponse.result.ok) throw new Error(ui(`读取 Skill 失败：${skillResponse.result.error.message}`, `Failed to load Skills: ${skillResponse.result.error.message}`));
-		const commands = tuiCommands();
-		const reserved = reservedTuiCatalogNames();
+		const present = await this.clarifyRemotePresent().catch(() => false);
+		const commands = mergeClarifyCatalog(tuiCommands(), present);
+		const reserved = present ? new Set([...reservedTuiCatalogNames(), "clarify"]) : reservedTuiCatalogNames();
 		const merged = [...commands];
 		const names = new Set(reserved);
 		for (const command of hostResult.value) {
@@ -23169,13 +23627,13 @@ function helpSectionText(id) {
 	return ui([
 		"输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。",
 		"启动前需要 Node、pnpm 和官方 dsh，且 dsh 需在 PATH 或 DSH_BIN 中。",
-		"安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2",
+		"安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0",
 		"然后运行 deepseek。版本与兼容范围见 deepseek --version。",
 		"更多步骤见仓库 QUICKSTART 与 README。"
 	].join("\n"), [
 		"Run /doctor to check pnpm, Profile plugins, and Bundle compatibility.",
 		"Before launch you need Node, pnpm, and official dsh on PATH or DSH_BIN.",
-		"Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2",
+		"Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0",
 		"Then run deepseek. See deepseek --version for the version and compatibility range.",
 		"More steps are in the repository QUICKSTART and README."
 	].join("\n"));
@@ -27097,6 +27555,9 @@ var TuiActions = class {
 				case "doctor":
 					await this.doctor();
 					break;
+				case "clarify":
+					await this.clarify(args);
+					break;
 				case "restart":
 					await this.restart();
 					break;
@@ -29635,6 +30096,26 @@ ${source.credentialRef === void 0 ? ui("无 Credential Ref", "No Credential Ref"
 		if (secret === void 0 || secret === "") return;
 		await bridge.setCredential(ref, secret);
 		this.host.notice(ui(`Credential ${ref} 已配置`, `Credential ${ref} configured`), "success");
+	}
+	async clarify(rawArgs) {
+		if (await this.capabilities.clarifyRemotePresent().catch(() => false) !== true) throw new Error(ui("Clarify Remote 当前不可用", "Clarify Remote is not currently available"));
+		const rpc = this.capabilities.connectionRpc();
+		if (rpc === void 0) throw new Error(ui("Clarify Remote 当前不可用", "Clarify Remote is not currently available"));
+		const active = this.capabilities.active();
+		if (active === void 0) throw new Error(ui("当前没有打开的会话", "No session is open"));
+		const composer = this.host.composerText?.() ?? "";
+		await this.overlayFlow(this.host.overlays, async (navigation) => {
+			if ((await runClarifyShell({
+				sessionId: String(active.sessionId),
+				seedText: clarifySeedText(composer, rawArgs),
+				composerText: composer,
+				overlays: navigation,
+				writeComposer: (draft) => {
+					this.host.setEditor(draft);
+				},
+				call: (channel, endpoint, payload, signal) => rpc.call(channel, endpoint, payload, signal)
+			})).kind === "applied") this.host.notice(ui("已将 Clarify 草稿填入输入区", "Clarify draft inserted into the composer"), "success");
+		});
 	}
 	async doctor(overlays = this.host.overlays) {
 		const [report, status, inventory] = await Promise.all([
@@ -33063,6 +33544,7 @@ async function startTuiSurface(options$1) {
 				focusEditor();
 				renderWhileOpen();
 			},
+			composerText: () => editor.getText(),
 			copy: (text$1) => {
 				writeClipboard(text$1, {
 					fallback: liveBehavior.get().clipboardFallback,

--- a/lib/startup-trace-oQui160r.js
+++ b/lib/startup-trace-oQui160r.js
@@ -1,6 +1,6 @@
 //#region src/dsh-compat.ts
 const PACKAGE_NAME = "seektty";
-const PACKAGE_VERSION = "1.0.2";
+const PACKAGE_VERSION = "1.1.0";
 const DSH_COMPATIBILITY = {
 	minimum: "0.1.0-rc.6",
 	tested: "0.1.0-rc.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seektty",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "description": "SeekTTY, a pluggable DeepSeek-colored terminal surface for DeepSeek Harness",
   "keywords": [
@@ -34,6 +34,7 @@
     "./startup": "./lib/startup.js",
     "./marketplace-provider": "./lib/marketplace-provider.js",
     "./in-process": "./lib/in-process.js",
+    "./attachment-compat": "./lib/attachment-compat.js",
     "./package.json": "./package.json"
   },
   "bin": {
@@ -67,6 +68,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:stock": "node scripts/stock-dsh-cycle.mjs",
+    "test:clarify-doctor": "node scripts/clarify-doctor-acceptance.mjs",
     "check": "pnpm run typecheck && pnpm run test && pnpm run build && pnpm pack --dry-run"
   },
   "dependencies": {

--- a/scripts/clarify-doctor-acceptance.mjs
+++ b/scripts/clarify-doctor-acceptance.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Opt-in Clarify × SeekTTY doctor receiver check.
+ *
+ * What this automates:
+ *   Isolated DSH_HOME + unchanged ProfilePluginManager.run(['add', CLARIFY_SPEC])
+ *   + unchanged ProfilePluginManager.doctor(). Asserts zero error/warning and a
+ *   healthy dsh-plugin-clarify bundle. This is not a stock CLI /doctor and does
+ *   not rewrite SeekTTY doctor.
+ *
+ * What this cannot prove:
+ *   doctor() does not inspect fibers. Fiber health needs a running Host and the
+ *   existing TUI /doctor path (managementBridge().plugins.doctor() plus
+ *   pluginInventory()). Do not treat this script as that acceptance.
+ *
+ * Manual fiber / official-boot plan for Codex:
+ *   1. Build or pack the sibling Clarify package (it must have lib/ and
+ *      dsh.bundle.patch). Example:
+ *        (cd /path/to/dsh-plugin-clarify && pnpm pack)
+ *   2. Isolated home, empty tui Profile (do not let a template inject missing
+ *      bundles such as @deepseek-ai/dsh-base, or doctor() will error):
+ *        CLARIFY_ACCEPT_HOME=$(mktemp -d)
+ *        mkdir -p "$CLARIFY_ACCEPT_HOME/profiles/tui"
+ *        printf '%s\n' '{"name":"dsh-profile-tui","private":true,"dependencies":{},"dsh":{"profile":{"bundles":[]}}}' \
+ *          > "$CLARIFY_ACCEPT_HOME/profiles/tui/package.json"
+ *   3. Official add + boot (requires DSH_BIN, not this repo's deepseek):
+ *        DSH_HOME="$CLARIFY_ACCEPT_HOME" "$DSH_BIN" plugin --profile tui add /path/to/dsh-plugin-clarify
+ *        DSH_HOME="$CLARIFY_ACCEPT_HOME" "$DSH_BIN" --profile tui --dump-config
+ *      dump-config must mention dsh-plugin-clarify / id: clarify.
+ *   4. Start unmodified SeekTTY against the same DSH_HOME / Profile and run
+ *      local /doctor. Require zero error, zero warning, Clarify bundle active,
+ *      and the clarify fiber not failed (pluginInventory fiberPhase).
+ *   5. Do not invent a stock HTTP/CLI /doctor. Do not stage AppleDouble files.
+ *
+ * Usage:
+ *   CLARIFY_SPEC=/path/to/dsh-plugin-clarify pnpm test:clarify-doctor
+ */
+
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const spec = process.env.CLARIFY_SPEC?.trim()
+if (!spec) {
+  process.stderr.write(`用法：CLARIFY_SPEC=/path/to/dsh-plugin-clarify pnpm test:clarify-doctor
+
+此脚本只跑未改动的 ProfilePluginManager.doctor() 接收端（真包装入隔离 DSH_HOME）。
+fiber 健康需要运行中的 SeekTTY /doctor + pluginInventory，见本文件顶部手跑步骤。
+常规 pnpm test 里的 planted 用例只验证接收端，不冒充已安装真包。
+`)
+  process.exit(2)
+}
+
+const result = spawnSync(
+  'pnpm',
+  ['exec', 'vitest', 'run', 'tests/clarify-doctor-acceptance.test.ts'],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      CLARIFY_SPEC: resolve(spec),
+    },
+  },
+)
+
+if (result.error) throw result.error
+process.exit(result.status ?? 1)

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -57,6 +57,7 @@ import type {
   SelectOverlayRequest,
 } from './overlays.ts'
 import { OverlayQueue } from './overlays.ts'
+import { clarifySeedText, runClarifyShell } from './clarify-shell.ts'
 import {
   formatSettingsValue,
   hasDedicatedSettingsEditor,
@@ -126,6 +127,7 @@ export interface TuiActionHost {
   applyLocale(locale: LocaleId): void
   applyBehavior?(behavior: TuiBehaviorSettings): void
   setEditor(text: string): void
+  composerText?(): string
   copy(text: string): void
   close(code: number): void
   restart(profile: string, notice: string): void
@@ -446,6 +448,7 @@ export class TuiActions {
         case 'plugin':
         case 'plugins': await this.plugin(args); break
         case 'doctor': await this.doctor(); break
+        case 'clarify': await this.clarify(args); break
         case 'restart': await this.restart(); break
         case 'tools': await this.tools(args); break
         case 'files': await this.files(); break
@@ -3011,6 +3014,32 @@ ${source.credentialRef === undefined ? ui('无 Credential Ref', "No Credential R
     if (secret === undefined || secret === '') return
     await bridge.setCredential(ref, secret)
     this.host.notice(ui(`Credential ${ref} 已配置`, `Credential ${ref} configured`), 'success')
+  }
+
+  private async clarify(rawArgs: string): Promise<void> {
+    if (await this.capabilities.clarifyRemotePresent().catch(() => false) !== true) {
+      throw new Error(ui('Clarify Remote 当前不可用', 'Clarify Remote is not currently available'))
+    }
+    const rpc = this.capabilities.connectionRpc()
+    if (rpc === undefined) {
+      throw new Error(ui('Clarify Remote 当前不可用', 'Clarify Remote is not currently available'))
+    }
+    const active = this.capabilities.active()
+    if (active === undefined) throw new Error(ui('当前没有打开的会话', 'No session is open'))
+    const composer = this.host.composerText?.() ?? ''
+    await this.overlayFlow(this.host.overlays, async (navigation) => {
+      const outcome = await runClarifyShell({
+        sessionId: String(active.sessionId),
+        seedText: clarifySeedText(composer, rawArgs),
+        composerText: composer,
+        overlays: navigation,
+        writeComposer: (draft) => { this.host.setEditor(draft) },
+        call: (channel, endpoint, payload, signal) => rpc.call(channel, endpoint, payload, signal),
+      })
+      if (outcome.kind === 'applied') {
+        this.host.notice(ui('已将 Clarify 草稿填入输入区', 'Clarify draft inserted into the composer'), 'success')
+      }
+    })
   }
 
   private async doctor(overlays: OverlayPrompts = this.host.overlays): Promise<void> {

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -43,6 +43,8 @@ import { flattenProducedFiles, type ProducedFileGroup } from './produced-files.t
 import { explainFailure, withRunningRetry } from './error-advice.ts'
 import { ui, uiLocale } from './locale.ts'
 import { resolveHarnessUserPath } from './workspace-path.ts'
+import { mergeClarifyCatalog } from './clarify-shell.ts'
+import { probeClarifyRemote } from './clarify-remote.ts'
 
 /** A command shown by the terminal's merged slash directory. */
 export interface TuiCommandCandidate {
@@ -622,6 +624,29 @@ export class HarnessTuiCapabilities {
       signal.throwIfAborted()
       return catalog
     })
+  }
+
+  /**
+   * Public Connection RPC face used by optional plugin shells.
+   * @returns the mounted caller, when the Client Connection handle exists.
+   */
+  connectionRpc(): ConnectionHandle['rpc'] | undefined {
+    return this.connectionHandle()?.rpc
+  }
+
+  /**
+   * State-free probe for the Clarify Remote receiver.
+   * @param signal - optional cancellation for the probe RPC.
+   * @returns true only when the impossible-processId probe gets PROCESS_NOT_FOUND.
+   */
+  async clarifyRemotePresent(signal?: AbortSignal): Promise<boolean> {
+    const rpc = this.connectionRpc()
+    if (rpc === undefined) return false
+    return probeClarifyRemote((channel, endpoint, payload, inner) => rpc.call(channel, endpoint, payload, inner), signal)
+  }
+
+  private connectionHandle(): ConnectionHandle | undefined {
+    return (this.ctx as TuiClientContext & { readonly connection?: ConnectionHandle }).connection
   }
 
   /** Invalidate the current command/Skill snapshot and repull on next use. */
@@ -1644,8 +1669,11 @@ export class HarnessTuiCapabilities {
         `Failed to load Skills: ${skillResponse.result.error.message}`,
       ))
     }
-    const commands = tuiCommands()
-    const reserved = reservedTuiCatalogNames()
+    const present = await this.clarifyRemotePresent().catch(() => false)
+    const commands = mergeClarifyCatalog(tuiCommands(), present)
+    const reserved = present
+      ? new Set<string>([...reservedTuiCatalogNames(), 'clarify'])
+      : reservedTuiCatalogNames()
     const merged = [...commands]
     const names = new Set(reserved)
     for (const command of hostResult.value as readonly HostCommandDescriptor[]) {

--- a/src/client/clarify-remote.ts
+++ b/src/client/clarify-remote.ts
@@ -1,0 +1,255 @@
+/** Public Clarify Remote contract consumed through ConnectionHandle.rpc.call. */
+
+export const CLARIFY_API_CHANNEL = '/api'
+export const CLARIFY_NAMESPACE = 'clarify'
+export const CLARIFY_METHODS = ['start', 'answer', 'cancel', 'fetchDraft'] as const
+export const CLARIFY_PROBE_PROCESS_ID = '__clarify_absent_probe__'
+
+export type ClarifyMethod = (typeof CLARIFY_METHODS)[number]
+export type ClarifyProcessStatus = 'running' | 'cancelled' | 'stale' | 'complete'
+export type ClarifyStaleReason =
+  | 'session-changed'
+  | 'route-changed'
+  | 'context-changed'
+  | 'new-official-message'
+  | 'compaction'
+  | 'recall-injection'
+  | 'ttl-expired'
+
+export interface ClarifyOption {
+  readonly optionId: string
+  readonly text: string
+}
+
+export interface ClarifyQuestion {
+  readonly questionId: string
+  readonly text: string
+  readonly options: readonly ClarifyOption[]
+  readonly multiple: boolean
+  readonly allowCustom: boolean
+}
+
+export interface ClarifyProcessEcho {
+  readonly processId: string
+  readonly sessionId: string
+  readonly status: ClarifyProcessStatus
+  readonly contextVersion: string
+  readonly modelRouteId: string
+  readonly staleReason?: ClarifyStaleReason | string
+  readonly question?: ClarifyQuestion
+  readonly draft?: string
+}
+
+export interface ClarifyRpcError {
+  readonly code?: string
+  readonly message?: string
+}
+
+export interface ClarifyRpcResult {
+  readonly ok: boolean
+  readonly value?: unknown
+  readonly error?: ClarifyRpcError
+}
+
+export type ClarifyRpcCaller = (
+  channel: string,
+  endpoint: string,
+  payload: { readonly args: Record<string, unknown> },
+  signal?: AbortSignal,
+) => Promise<ClarifyRpcResult>
+
+const BUSINESS_CODES = new Set([
+  'PROCESS_NOT_FOUND',
+  'PROCESS_BUSY',
+  'SESSION_ID_REQUIRED',
+  'INVALID_ANSWER',
+])
+
+const ABSENT_CODES = new Set([
+  'invocation-unavailable',
+  'definition-unavailable',
+  'service-unavailable',
+  'method-unavailable',
+])
+
+const BUSINESS_MESSAGE = /PROCESS_NOT_FOUND|PROCESS_BUSY|SESSION_ID_REQUIRED|INVALID_ANSWER|process .+ does not exist|sessionId is required|session .+ is not available|already inferring/i
+const ABSENT_MESSAGE = /no active Remote method|invocation-unavailable|definition-unavailable|no RPC handler|transport failure|HTTP 404|^not found$/i
+const PROBE_PRESENCE_CODES = new Set(['PROCESS_NOT_FOUND'])
+const PROBE_PRESENCE_MESSAGE = /PROCESS_NOT_FOUND|process .+ does not exist/i
+
+export interface ClarifyParseOptions {
+  /** Draft text is accepted only from a complete `fetchDraft` echo. */
+  readonly allowDraft?: boolean
+}
+
+export class ClarifyRemoteError extends Error {
+  readonly code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'ClarifyRemoteError'
+    this.code = code
+  }
+}
+
+export function clarifyEndpoint(method: ClarifyMethod): string {
+  return `${CLARIFY_NAMESPACE}/${method}`
+}
+
+export function omitClarifyArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined) continue
+    if (typeof value === 'string' && value.length === 0 && key !== 'sessionId' && key !== 'processId' && key !== 'questionId') {
+      continue
+    }
+    if (key === 'selectedOptionIds' && Array.isArray(value)) {
+      if (value.length === 0) continue
+      out[key] = [...value]
+      continue
+    }
+    out[key] = value
+  }
+  return out
+}
+
+function clarifyErrorParts(result: ClarifyRpcResult): { readonly code: string; readonly message: string } {
+  return {
+    code: result.error?.code ?? '',
+    message: result.error?.message ?? '',
+  }
+}
+
+function isClarifyAbsent(result: ClarifyRpcResult): boolean {
+  const { code, message } = clarifyErrorParts(result)
+  return ABSENT_CODES.has(code) || ABSENT_MESSAGE.test(message)
+}
+
+/** Recognize documented Clarify business failures. This is not probe presence. */
+export function isClarifyBusinessError(result: ClarifyRpcResult): boolean {
+  if (isClarifyAbsent(result)) return false
+  const { code, message } = clarifyErrorParts(result)
+  return BUSINESS_CODES.has(code) || BUSINESS_MESSAGE.test(message)
+}
+
+/**
+ * Presence proof for the impossible-processId `fetchDraft` probe.
+ * Exact PROCESS_NOT_FOUND may prove presence. A wrapped/internal error must
+ * mention CLARIFY_PROBE_PROCESS_ID, not an arbitrary other process.
+ */
+export function isClarifyProbePresence(result: ClarifyRpcResult): boolean {
+  if (isClarifyAbsent(result)) return false
+  const { code, message } = clarifyErrorParts(result)
+  if (PROBE_PRESENCE_CODES.has(code)) return true
+  return message.includes(CLARIFY_PROBE_PROCESS_ID) && PROBE_PRESENCE_MESSAGE.test(message)
+}
+
+/** Probe-only presence. Unrelated business errors do not prove the receiver. */
+export function isClarifyReceiverPresent(result: ClarifyRpcResult): boolean {
+  return isClarifyProbePresence(result)
+}
+
+export async function callClarify(
+  rpc: ClarifyRpcCaller,
+  method: ClarifyMethod,
+  args: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const result = await rpc(CLARIFY_API_CHANNEL, clarifyEndpoint(method), { args: omitClarifyArgs(args) }, signal)
+  if (result.ok) return result.value
+  throw new ClarifyRemoteError(result.error?.code ?? 'internal', result.error?.message ?? `clarify/${method} failed`)
+}
+
+export async function probeClarifyRemote(rpc: ClarifyRpcCaller, signal?: AbortSignal): Promise<boolean> {
+  try {
+    const result = await rpc(
+      CLARIFY_API_CHANNEL,
+      clarifyEndpoint('fetchDraft'),
+      { args: { processId: CLARIFY_PROBE_PROCESS_ID } },
+      signal,
+    )
+    return isClarifyProbePresence(result)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return isClarifyProbePresence({ ok: false, error: { message } })
+  }
+}
+
+export function parseClarifyEcho(value: unknown, options: ClarifyParseOptions = {}): ClarifyProcessEcho {
+  if (typeof value !== 'object' || value === null) {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify response must be an object')
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.processId !== 'string' || record.processId.trim() === '') {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify processId must be a non-empty string')
+  }
+  if (
+    typeof record.sessionId !== 'string' || record.sessionId.trim() === ''
+    || typeof record.contextVersion !== 'string' || record.contextVersion.trim() === ''
+    || typeof record.modelRouteId !== 'string' || record.modelRouteId.trim() === ''
+  ) {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify echo is missing session binding fields')
+  }
+  if (record.status !== 'running' && record.status !== 'cancelled' && record.status !== 'stale' && record.status !== 'complete') {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify status is not a shared contract value')
+  }
+  const question = record.status === 'running' ? parseQuestion(record.question) : undefined
+  const draft = record.status === 'complete' && options.allowDraft === true && typeof record.draft === 'string'
+    ? record.draft
+    : undefined
+  return {
+    processId: record.processId,
+    sessionId: record.sessionId,
+    status: record.status,
+    contextVersion: record.contextVersion,
+    modelRouteId: record.modelRouteId,
+    ...(typeof record.staleReason === 'string' ? { staleReason: record.staleReason } : {}),
+    ...(question === undefined || record.status !== 'running' ? {} : { question }),
+    ...(draft === undefined || record.status !== 'complete' ? {} : { draft }),
+  }
+}
+
+function parseQuestion(value: unknown): ClarifyQuestion | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'object' || value === null) {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify question must be an object')
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.questionId !== 'string' || record.questionId.trim() === '') {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify questionId must be a non-empty string')
+  }
+  if (typeof record.text !== 'string' || record.text.trim() === '') {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify question text must be a non-empty string')
+  }
+  if (typeof record.multiple !== 'boolean' || typeof record.allowCustom !== 'boolean') {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify question.multiple and allowCustom must be booleans')
+  }
+  if (!Array.isArray(record.options) || record.options.length === 0) {
+    throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify question must include at least one option')
+  }
+  const seen = new Set<string>()
+  const options = record.options.map((option) => {
+    if (typeof option !== 'object' || option === null) {
+      throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify option must be an object')
+    }
+    const row = option as Record<string, unknown>
+    if (typeof row.optionId !== 'string' || row.optionId.trim() === '') {
+      throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify optionId values must be non-empty')
+    }
+    if (typeof row.text !== 'string' || row.text.trim() === '') {
+      throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify option text must be a non-empty string')
+    }
+    if (seen.has(row.optionId)) {
+      throw new ClarifyRemoteError('INVALID_ANSWER', 'Clarify optionId values must be unique')
+    }
+    seen.add(row.optionId)
+    return { optionId: row.optionId, text: row.text }
+  })
+  return {
+    questionId: record.questionId,
+    text: record.text,
+    multiple: record.multiple,
+    allowCustom: record.allowCustom,
+    options,
+  }
+}

--- a/src/client/clarify-shell.ts
+++ b/src/client/clarify-shell.ts
@@ -1,0 +1,403 @@
+/** SeekTTY-owned Clarify thin shell over public Remote methods and existing overlays. */
+
+import type { TuiCommandCandidate } from './capabilities.ts'
+import {
+  callClarify,
+  parseClarifyEcho,
+  type ClarifyProcessEcho,
+  type ClarifyQuestion,
+  type ClarifyRpcCaller,
+  type ClarifyStaleReason,
+} from './clarify-remote.ts'
+import { ui } from './locale.ts'
+import type { OverlayChoice, OverlayPrompts } from './overlays.ts'
+
+function clarifyCustomChoiceId(question: ClarifyQuestion): string {
+  const used = new Set(question.options.map(option => option.optionId))
+  let candidate = '__custom__'
+  let n = 0
+  while (used.has(candidate)) {
+    n += 1
+    candidate = `__custom__:${n}`
+  }
+  return candidate
+}
+
+export type ClarifyShellOutcome =
+  | { readonly kind: 'applied'; readonly draft: string }
+  | { readonly kind: 'cancelled' }
+  | { readonly kind: 'abandoned'; readonly staleReason?: string }
+  | { readonly kind: 'kept-composer'; readonly draft: string }
+
+export interface ClarifyShellRequest {
+  readonly sessionId: string
+  readonly seedText: string
+  readonly composerText: string
+  readonly overlays: OverlayPrompts
+  readonly call: ClarifyRpcCaller
+  readonly writeComposer: (draft: string) => void
+}
+
+class ClarifyShellAbort extends Error {
+  constructor() {
+    super('clarify-shell-abort')
+    this.name = 'ClarifyShellAbort'
+  }
+}
+
+export function clarifyTuiCommand(): TuiCommandCandidate {
+  return {
+    name: 'clarify',
+    description: ui('澄清当前输入并生成待发送草稿', 'Clarify the current input into a sendable draft'),
+    source: 'TUI',
+    behavior: 'local',
+  }
+}
+
+export function mergeClarifyCatalog(
+  commands: readonly TuiCommandCandidate[],
+  present: boolean,
+): readonly TuiCommandCandidate[] {
+  if (!present || commands.some(command => command.name === 'clarify')) return commands
+  const entry = clarifyTuiCommand()
+  const index = commands.findIndex(command => command.name === 'doctor')
+  if (index === -1) return [...commands, entry]
+  return [...commands.slice(0, index), entry, ...commands.slice(index)]
+}
+
+/**
+ * Resolve the Clarify seed from the two invocation paths.
+ * Palette execution keeps the current composer and passes empty args, so the
+ * composer body is the seed. Typed `/clarify some text` is submitted after the
+ * composer is cleared, so only `rawArgs` remains. Typed `/clarify` alone has
+ * no leftover body to preserve.
+ */
+export function clarifySeedText(composerText: string, rawArgs: string): string {
+  const composer = composerText.trim()
+  if (composer === '' || /^\/clarify(?:\s|$)/iu.test(composer)) return rawArgs.trim()
+  return composer
+}
+
+export function buildClarifyAnswer(
+  question: ClarifyQuestion,
+  input: { readonly selectedOptionIds?: readonly string[]; readonly customText?: string },
+): { readonly selectedOptionIds: readonly string[] } | { readonly customText: string } {
+  const hasOptions = input.selectedOptionIds !== undefined
+  const hasCustom = input.customText !== undefined
+  if (hasOptions === hasCustom) {
+    throw new Error('selectedOptionIds and customText are mutually exclusive and required as one of the two')
+  }
+  if (hasCustom) {
+    if (!question.allowCustom) throw new Error('customText is only valid when allowCustom is true')
+    const customText = input.customText?.trim() ?? ''
+    if (customText === '') throw new Error('customText must not be empty')
+    return { customText }
+  }
+  const selectedOptionIds = [...(input.selectedOptionIds ?? [])]
+  if (selectedOptionIds.length === 0) {
+    throw new Error(question.multiple
+      ? 'multiple=true requires at least one selectedOptionId'
+      : 'selectedOptionIds must not be empty')
+  }
+  if (!question.multiple && selectedOptionIds.length !== 1) {
+    throw new Error('multiple=false requires exactly one selectedOptionId')
+  }
+  const allowed = new Set(question.options.map(option => option.optionId))
+  const unique = new Set<string>()
+  for (const optionId of selectedOptionIds) {
+    if (!allowed.has(optionId)) {
+      throw new Error(`selectedOptionId ${JSON.stringify(optionId)} is not in the current question`)
+    }
+    if (unique.has(optionId)) {
+      throw new Error('selectedOptionIds must be unique')
+    }
+    unique.add(optionId)
+  }
+  return { selectedOptionIds }
+}
+
+export async function runClarifyShell(request: ClarifyShellRequest): Promise<ClarifyShellOutcome> {
+  let processId: string | undefined
+  try {
+    while (true) {
+      let current = await invoke(request, 'start', {
+        sessionId: request.sessionId,
+        ...(request.seedText === '' ? {} : { seedText: request.seedText }),
+      })
+      processId = current.processId
+      if (current.status === 'stale') {
+        if (await resolveStale(request, current) === 'restart') {
+          processId = undefined
+          continue
+        }
+        return abandoned(current)
+      }
+      while (current.status === 'running') {
+        const question = current.question
+        if (question === undefined) {
+          throw new Error(ui('Clarify 进程在提问完成前结束', 'Clarify returned running without a question'))
+        }
+        const answer = await collectAnswer(request.overlays, question)
+        if (answer === undefined) {
+          await cancelQuietly(request, current.processId)
+          return { kind: 'cancelled' }
+        }
+        current = await invoke(request, 'answer', {
+          processId: current.processId,
+          questionId: question.questionId,
+          ...answer,
+        })
+        processId = current.processId
+      }
+      if (current.status === 'stale') {
+        if (await resolveStale(request, current) === 'restart') {
+          processId = undefined
+          continue
+        }
+        return abandoned(current)
+      }
+      if (current.status !== 'complete') return { kind: 'cancelled' }
+      const fetched = await invoke(request, 'fetchDraft', { processId: current.processId })
+      if (fetched.status === 'stale') {
+        if (await resolveStale(request, fetched) === 'restart') {
+          processId = undefined
+          continue
+        }
+        return abandoned(fetched)
+      }
+      if (fetched.status !== 'complete') {
+        throw new Error(ui(
+          `Clarify fetchDraft 返回了 ${fetched.status}，不能当作 stale`,
+          `Clarify fetchDraft returned ${fetched.status} and must not be treated as stale`,
+        ))
+      }
+      if (fetched.draft === undefined) {
+        throw new Error(ui(
+          'Clarify fetchDraft 在 complete 时缺少 draft',
+          'Clarify fetchDraft returned complete without a draft',
+        ))
+      }
+      processId = undefined
+      return applyDraft(request, fetched.draft)
+    }
+  } catch (error) {
+    if (processId !== undefined) await cancelQuietly(request, processId)
+    if (error instanceof ClarifyShellAbort) return { kind: 'cancelled' }
+    throw error
+  }
+}
+
+function abandoned(echo: ClarifyProcessEcho): ClarifyShellOutcome {
+  return {
+    kind: 'abandoned',
+    ...(echo.staleReason === undefined ? {} : { staleReason: echo.staleReason }),
+  }
+}
+
+async function collectAnswer(
+  overlays: OverlayPrompts,
+  question: ClarifyQuestion,
+): Promise<{ selectedOptionIds: readonly string[] } | { customText: string } | undefined> {
+  const optionChoices = question.options.map(option => ({ id: option.optionId, label: option.text }))
+  const customId = clarifyCustomChoiceId(question)
+  if (question.multiple) {
+    if (question.allowCustom) {
+      const mode = await overlays.select({
+        title: questionTitle(question),
+        detail: statusDetail('running'),
+        choices: [
+          { id: 'options', label: ui('从选项中选择', 'Choose from options') },
+          { id: customId, label: ui('自定义回答…', 'Custom answer…') },
+        ],
+      })
+      if (mode === undefined) return undefined
+      if (mode.id === customId) return readCustom(overlays, question)
+    }
+    const picked = await overlays.multiSelect({
+      title: questionTitle(question),
+      detail: statusDetail('running'),
+      choices: optionChoices,
+    })
+    if (picked === undefined) return undefined
+    return buildClarifyAnswer(question, { selectedOptionIds: picked.map(choice => choice.id) })
+  }
+  const choices: OverlayChoice[] = [
+    ...optionChoices,
+    ...(question.allowCustom ? [{ id: customId, label: ui('自定义回答…', 'Custom answer…') }] : []),
+  ]
+  const picked = await overlays.select({
+    title: questionTitle(question),
+    detail: statusDetail('running'),
+    choices,
+  })
+  if (picked === undefined) return undefined
+  if (picked.id === customId) return readCustom(overlays, question)
+  return buildClarifyAnswer(question, { selectedOptionIds: [picked.id] })
+}
+
+async function readCustom(
+  overlays: OverlayPrompts,
+  question: ClarifyQuestion,
+): Promise<{ customText: string } | undefined> {
+  const custom = await overlays.multilineInput({
+    title: questionTitle(question),
+    detail: statusDetail('running'),
+    placeholder: ui('输入自定义回答', 'Enter a custom answer'),
+  })
+  if (custom === undefined) return undefined
+  const answer = buildClarifyAnswer(question, { customText: custom })
+  if (!('customText' in answer)) return undefined
+  return answer
+}
+
+async function resolveStale(
+  request: ClarifyShellRequest,
+  echo: ClarifyProcessEcho,
+): Promise<'restart' | 'abandon'> {
+  const selected = await request.overlays.select({
+    title: ui('Clarify 已过期', 'Clarify is stale'),
+    detail: staleDetail(echo.staleReason),
+    searchable: false,
+    choices: [
+      { id: 'restart', label: ui('重新开始', 'Start over'), description: ui('丢弃过期结果并新建进程', 'Discard the stale result and start a new process') },
+      { id: 'abandon', label: ui('放弃', 'Abandon'), description: ui('关闭并不再使用过期选项', 'Close without using the stale options') },
+    ],
+  })
+  await cancelQuietly(request, echo.processId)
+  if (selected?.id === 'restart') return 'restart'
+  return 'abandon'
+}
+
+async function applyDraft(request: ClarifyShellRequest, draft: string): Promise<ClarifyShellOutcome> {
+  await request.overlays.detail({
+    title: ui('Clarify 草稿', 'Clarify draft'),
+    content: draft,
+    footer: ui('确认后写入输入区，不会自动发送', 'Confirm to write the composer; it is not sent automatically'),
+  })
+  const apply = await request.overlays.confirm(
+    ui('将草稿填入输入区？', 'Insert the draft into the composer?'),
+    ui('草稿只进入常规输入区，不会自动发送。', 'The draft only enters the regular composer and is not sent automatically.'),
+    ui('填入', 'Insert'),
+  )
+  if (!apply) return { kind: 'cancelled' }
+  if (request.composerText.trim() !== '') {
+    const overwrite = await request.overlays.confirm(
+      ui('覆盖当前输入区？', 'Replace the current composer text?'),
+      ui('当前输入区已有内容，填入 Clarify 草稿将覆盖它。', 'The composer already has text; inserting the Clarify draft replaces it.'),
+      ui('覆盖', 'Replace'),
+    )
+    if (!overwrite) return { kind: 'kept-composer', draft }
+  }
+  request.writeComposer(draft)
+  return { kind: 'applied', draft }
+}
+
+async function invoke(
+  request: ClarifyShellRequest,
+  method: 'start' | 'answer' | 'cancel' | 'fetchDraft',
+  args: Record<string, unknown>,
+): Promise<ClarifyProcessEcho> {
+  const result = await request.overlays.progress({
+    title: ui('Clarify', 'Clarify'),
+    detail: statusDetail('running'),
+    work: async (_report, signal) => {
+      if (method === 'start') return invokeStartWork(request, args, signal)
+      return parseClarifyEcho(await callClarify(request.call, method, args, signal), {
+        allowDraft: method === 'fetchDraft',
+      })
+    },
+  })
+  if (result === undefined) throw new ClarifyShellAbort()
+  return result
+}
+
+/**
+ * Overlay Esc aborts the progress signal and the in-process/HTTP carrier.
+ * Clarify `start` has no cancellation parameter, so Gateway never injects that
+ * signal into the Host method; aborting the RPC only discards the echo while
+ * the process remains until TTL. Observe the overlay abort locally, keep the
+ * start RPC running, and cancel the late processId.
+ */
+async function invokeStartWork(
+  request: ClarifyShellRequest,
+  args: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<ClarifyProcessEcho | undefined> {
+  if (signal.aborted) return undefined
+  const pending = callClarify(request.call, 'start', args)
+  const settled = pending.then(
+    (value): { readonly ok: true; readonly value: unknown } => ({ ok: true, value }),
+    (error: unknown): { readonly ok: false; readonly error: unknown } => ({ ok: false, error }),
+  )
+  const winner = await raceUntilAbort(settled, signal)
+  if (winner === undefined) {
+    void cancelLateStart(request, settled)
+    return undefined
+  }
+  if (!winner.ok) throw winner.error
+  return parseClarifyEcho(winner.value)
+}
+
+function cancelLateStart(
+  request: ClarifyShellRequest,
+  settled: Promise<{ readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly error: unknown }>,
+): Promise<void> {
+  return settled.then(async (result) => {
+    if (!result.ok) return
+    const processId = processIdFromValue(result.value)
+    if (processId === undefined) return
+    await cancelQuietly(request, processId)
+  })
+}
+
+function processIdFromValue(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const processId = Reflect.get(value, 'processId')
+  return typeof processId === 'string' && processId.trim() !== '' ? processId : undefined
+}
+
+function raceUntilAbort<T>(pending: Promise<T>, signal: AbortSignal): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => { resolve(undefined) }
+    if (signal.aborted) {
+      resolve(undefined)
+      return
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    pending.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(signal.aborted ? undefined : value)
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort)
+        if (signal.aborted) resolve(undefined)
+        else reject(error)
+      },
+    )
+  })
+}
+
+async function cancelQuietly(request: ClarifyShellRequest, processId: string): Promise<void> {
+  try {
+    await callClarify(request.call, 'cancel', { processId })
+  } catch {
+    // Restart and absence both treat cancel as best-effort.
+  }
+}
+
+function questionTitle(question: ClarifyQuestion): string {
+  return `${ui('Clarify', 'Clarify')} · ${question.text}`
+}
+
+function statusDetail(status: string): string {
+  return ui(`状态：${status}`, `Status: ${status}`)
+}
+
+function staleDetail(reason: ClarifyStaleReason | string | undefined): string {
+  const label = reason === undefined ? ui('未知原因', 'Unknown reason') : reason
+  return ui(
+    `Clarify 已 stale（${label}）。过期选项和草稿不能继续使用。`,
+    `Clarify is stale (${label}). Stale options and drafts cannot be reused.`,
+  )
+}

--- a/src/client/help.ts
+++ b/src/client/help.ts
@@ -41,14 +41,14 @@ export function helpSectionText(id: HelpSectionId): string {
     [
       '输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。',
       '启动前需要 Node、pnpm 和官方 dsh，且 dsh 需在 PATH 或 DSH_BIN 中。',
-      '安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2',
+      '安装：pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0',
       '然后运行 deepseek。版本与兼容范围见 deepseek --version。',
       '更多步骤见仓库 QUICKSTART 与 README。',
     ].join('\n'),
     [
       'Run /doctor to check pnpm, Profile plugins, and Bundle compatibility.',
       'Before launch you need Node, pnpm, and official dsh on PATH or DSH_BIN.',
-      'Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.0.2',
+      'Install: pnpm add --global github:Hilbert-beinghappy/seektty#v1.1.0',
       'Then run deepseek. See deepseek --version for the version and compatibility range.',
       'More steps are in the repository QUICKSTART and README.',
     ].join('\n'),

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -543,6 +543,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         focusEditor()
         renderWhileOpen()
       },
+      composerText: () => editor.getText(),
       copy: (text) => {
         void writeClipboard(text, {
           fallback: liveBehavior.get().clipboardFallback,

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -6,7 +6,7 @@ export interface DshCompatibility {
 }
 
 export const PACKAGE_NAME = 'seektty'
-export const PACKAGE_VERSION = '1.0.2'
+export const PACKAGE_VERSION = '1.1.0'
 export const DSH_COMPATIBILITY: DshCompatibility = {
   minimum: '0.1.0-rc.6',
   tested: '0.1.0-rc.8',

--- a/src/host/attachment-compat.ts
+++ b/src/host/attachment-compat.ts
@@ -1,0 +1,90 @@
+/** SeekTTY Host adapter for official dsh 0.1.0-rc.6–rc.8 imageLimits. */
+
+import type { Context } from '@deepseek-ai/cordis'
+
+/** Stable Cordis plugin name. */
+export const name = 'seektty-attachment-compat'
+
+/**
+ * Wait for the official attachments store. This plugin is listed immediately
+ * before `api-gateway` in `cordis.patch.yml` so, once `attachments` exists, it
+ * becomes ACTIVE before `@deepseek-ai/dsh-host-apiproxy` registers the rc.8
+ * `imageLimits` projection that reads `ctx.attachments.imageLimits`.
+ */
+export const inject = ['attachments']
+
+const REQUIRED_POSITIVE_INTS = [
+  'maxImageBytes',
+  'maxImagesPerMessage',
+  'maxMessageImageBytes',
+  'maxImagePixels',
+] as const
+
+interface AttachmentLimitsHost {
+  imageLimits: unknown
+}
+
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+}
+
+/**
+ * True only for the exact valid legacy capability: official rc.6/rc.7
+ * `ImageAttachmentLimits` fields are present and well-typed, and
+ * `maxImageDimension` is absent. Any other shape is left to rc.8 schema.
+ */
+export function isLegacyImageLimits(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false
+  const row = value as Record<string, unknown>
+  if ('maxImageDimension' in row) return false
+  for (const key of REQUIRED_POSITIVE_INTS) {
+    if (!isPositiveInt(row[key])) return false
+  }
+  return isStringArray(row.mediaTypes)
+}
+
+/**
+ * Conservative per-side bound implied by a positive pixel count: a 1×N image
+ * has one dimension equal to `maxImagePixels`.
+ * @param maxImagePixels - already-validated positive integer pixel count.
+ */
+export function deriveMaxImageDimension(maxImagePixels: number): number {
+  return maxImagePixels
+}
+
+/**
+ * Return a new object only for the exact valid legacy shape. Native rc.8
+ * objects and malformed/unknown shapes keep the same identity.
+ * @param value - live `attachments.imageLimits`.
+ */
+export function normalizeLegacyImageLimits<T>(value: T): T {
+  if (!isLegacyImageLimits(value)) return value
+  return {
+    ...value,
+    maxImageDimension: deriveMaxImageDimension(value.maxImagePixels as number),
+  }
+}
+
+/**
+ * Replace `attachments.imageLimits` when the official store still publishes
+ * the frozen rc.6/rc.7 capability. Official `LocalAttachmentStore` freezes
+ * that object, so the field is replaced rather than mutated. The fiber
+ * disposer restores the original reference only while `imageLimits` is
+ * still strictly identical to the normalized object.
+ * @param ctx - Host context that already has `attachments`.
+ */
+export function apply(ctx: Context): void {
+  const attachments = ctx.get('attachments') as AttachmentLimitsHost | undefined
+  if (attachments === undefined) return
+  const original = attachments.imageLimits
+  const next = normalizeLegacyImageLimits(original)
+  if (next === original) return
+  attachments.imageLimits = next
+  ctx.effect(() => () => {
+    if (attachments.imageLimits === next) attachments.imageLimits = original
+  }, 'seektty/attachment-compat: restore imageLimits')
+}

--- a/tests/attachment-compat.test.ts
+++ b/tests/attachment-compat.test.ts
@@ -1,0 +1,131 @@
+import { Context } from '@deepseek-ai/cordis'
+import { imageLimitsProjectionSchema } from '@deepseek-ai/dsh-host-apiproxy/api/sessions.schema'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import * as attachmentCompat from '../src/host/attachment-compat.ts'
+
+const OFFICIAL_MEDIA_TYPES = Object.freeze(['image/png', 'image/jpeg', 'image/webp', 'image/gif'])
+
+/** Official rc.6/rc.7 LocalAttachmentStore shape (frozen, no maxImageDimension). */
+function officialLegacyLimits(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return Object.freeze({
+    maxImageBytes: 5 * 1024 * 1024,
+    maxImagesPerMessage: 20,
+    maxMessageImageBytes: 100 * 1024 * 1024,
+    maxImagePixels: 40_000_000,
+    mediaTypes: OFFICIAL_MEDIA_TYPES,
+    ...extra,
+  })
+}
+
+function officialRc8Limits(): Record<string, unknown> {
+  return Object.freeze({
+    maxImageBytes: 5 * 1024 * 1024,
+    maxImagesPerMessage: 20,
+    maxMessageImageBytes: 100 * 1024 * 1024,
+    maxImagePixels: 40_000_000,
+    maxImageDimension: 8192,
+    mediaTypes: OFFICIAL_MEDIA_TYPES,
+  })
+}
+
+async function bootCompat(imageLimits: unknown): Promise<{
+  attachments: { imageLimits: unknown }
+  dispose: () => Promise<void>
+}> {
+  const ctx = new Context()
+  const attachments = { imageLimits }
+  ctx.provide('attachments', attachments)
+  const fiber = await ctx.plugin(attachmentCompat)
+  return { attachments, dispose: () => fiber.dispose() }
+}
+
+describe('seektty/attachment-compat', () => {
+  it('normalizes the exact valid legacy capability and derives maxImageDimension from maxImagePixels', async () => {
+    const original = officialLegacyLimits()
+    expect(imageLimitsProjectionSchema.safeParse(original).success).toBe(false)
+    const { attachments, dispose } = await bootCompat(original)
+    expect(attachments.imageLimits).not.toBe(original)
+    expect(attachments.imageLimits).toEqual({
+      ...original,
+      maxImageDimension: 40_000_000,
+    })
+    expect(imageLimitsProjectionSchema.safeParse(attachments.imageLimits).success).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(original, 'maxImageDimension')).toBe(false)
+    await dispose()
+  })
+
+  it('leaves a native rc.8 object unchanged by identity', async () => {
+    const original = officialRc8Limits()
+    const { attachments, dispose } = await bootCompat(original)
+    expect(attachments.imageLimits).toBe(original)
+    expect(imageLimitsProjectionSchema.safeParse(attachments.imageLimits).success).toBe(true)
+    await dispose()
+    expect(attachments.imageLimits).toBe(original)
+  })
+
+  it('does not normalize malformed objects missing or invalid required fields', async () => {
+    const cases: unknown[] = [
+      officialLegacyLimits({ maxImageBytes: undefined }),
+      { ...officialLegacyLimits(), maxImagePixels: undefined },
+      { ...officialLegacyLimits(), maxImagePixels: 0 },
+      { ...officialLegacyLimits(), maxImagePixels: 1.5 },
+      { ...officialLegacyLimits(), maxImagesPerMessage: '20' },
+      { ...officialLegacyLimits(), mediaTypes: 'image/png' },
+      { ...officialLegacyLimits(), mediaTypes: [1] },
+      { ...officialLegacyLimits(), maxImageDimension: undefined },
+      { ...officialLegacyLimits(), maxImageDimension: '8192' },
+      { maxImagePixels: 40_000_000, mediaTypes: [...OFFICIAL_MEDIA_TYPES] },
+      null,
+      undefined,
+      {},
+    ]
+    for (const original of cases) {
+      const { attachments, dispose } = await bootCompat(original)
+      expect(attachments.imageLimits, JSON.stringify(original)).toBe(original)
+      expect(imageLimitsProjectionSchema.safeParse(attachments.imageLimits).success).toBe(false)
+      await dispose()
+      expect(attachments.imageLimits).toBe(original)
+    }
+  })
+
+  it('restores the exact original imageLimits on cleanup', async () => {
+    const original = officialLegacyLimits()
+    const { attachments, dispose } = await bootCompat(original)
+    expect(attachments.imageLimits).not.toBe(original)
+    await dispose()
+    expect(attachments.imageLimits).toBe(original)
+    expect(Object.prototype.hasOwnProperty.call(original, 'maxImageDimension')).toBe(false)
+  })
+
+  it('does not clobber a newer imageLimits owner on cleanup', async () => {
+    const original = officialLegacyLimits()
+    const { attachments, dispose } = await bootCompat(original)
+    expect(attachments.imageLimits).not.toBe(original)
+    const newer = officialRc8Limits()
+    attachments.imageLimits = newer
+    await dispose()
+    expect(attachments.imageLimits).toBe(newer)
+  })
+
+  it('preserves unknown future extra fields on a valid legacy object', async () => {
+    const original = officialLegacyLimits({ futureFlag: true, extraLimit: 3 })
+    const { attachments, dispose } = await bootCompat(original)
+    const next = attachments.imageLimits as Record<string, unknown>
+    expect(next).not.toBe(original)
+    expect(next.futureFlag).toBe(true)
+    expect(next.extraLimit).toBe(3)
+    expect(next.maxImageDimension).toBe(40_000_000)
+    expect(next.mediaTypes).toBe(OFFICIAL_MEDIA_TYPES)
+    expect(original.futureFlag).toBe(true)
+    await dispose()
+    expect(attachments.imageLimits).toBe(original)
+  })
+
+  it('matches hosts by capability shape and does not branch on dsh versions', () => {
+    const source = readFileSync(resolve(import.meta.dirname, '../src/host/attachment-compat.ts'), 'utf8')
+    expect(source).not.toContain('compareDshVersion')
+    expect(source).not.toMatch(/from ['"]\.\.\/dsh-compat/u)
+  })
+})

--- a/tests/clarify-doctor-acceptance.test.ts
+++ b/tests/clarify-doctor-acceptance.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ProfilePluginManager, type ProfileDoctorResult } from '../src/host/profile-plugin-manager.ts'
+
+const clarifySpec = process.env.CLARIFY_SPEC?.trim()
+
+function writeEmptyTuiProfile(home: string): string {
+  const dir = join(home, 'profiles', 'tui')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), `${JSON.stringify({
+    name: 'dsh-profile-tui',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: [] as string[] } },
+  }, null, 2)}\n`)
+  writeFileSync(join(dir, 'pnpm-workspace.yaml'), `packages:
+  - .
+
+nodeLinker: hoisted
+autoInstallPeers: false
+`)
+  writeFileSync(join(dir, 'cordis.patch.yml'), '[]\n')
+  return dir
+}
+
+function plantClarifyBundle(profileDir: string): void {
+  const pkg = join(profileDir, 'node_modules', 'dsh-plugin-clarify')
+  mkdirSync(pkg, { recursive: true })
+  writeFileSync(join(pkg, 'package.json'), `${JSON.stringify({
+    name: 'dsh-plugin-clarify',
+    version: '0.0.0-test',
+    description: 'planted Clarify bundle for the unchanged doctor receiver',
+    dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2)}\n`)
+  writeFileSync(join(pkg, 'cordis.patch.yml'), `- insert:
+    - id: clarify
+      name: dsh-plugin-clarify
+`)
+  const manifestPath = join(profileDir, 'package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    dependencies?: Record<string, string>
+    dsh?: { profile?: { bundles?: string[] } }
+  }
+  manifest.dependencies = { 'dsh-plugin-clarify': 'file:./planted-clarify' }
+  manifest.dsh = { profile: { bundles: ['dsh-plugin-clarify'] } }
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function assertClarifyDoctorHealthy(report: ProfileDoctorResult): void {
+  expect(report.diagnostics.filter(item => item.level === 'error')).toEqual([])
+  expect(report.diagnostics.filter(item => item.level === 'warning')).toEqual([])
+  expect(report.snapshot.bundles).toContain('dsh-plugin-clarify')
+  const clarify = report.snapshot.plugins.find(plugin => plugin.name === 'dsh-plugin-clarify')
+  expect(clarify).toMatchObject({
+    name: 'dsh-plugin-clarify',
+    bundle: true,
+    active: true,
+    patchValid: true,
+    diagnostics: [],
+  })
+}
+
+describe('unchanged SeekTTY doctor receiver for Clarify', () => {
+  it('reports a planted Clarify bundle as healthy without rewriting doctor', () => {
+    const home = mkdtempSync(join(tmpdir(), 'seektty-clarify-doctor-'))
+    try {
+      const profileDir = writeEmptyTuiProfile(home)
+      plantClarifyBundle(profileDir)
+      const report = new ProfilePluginManager({
+        profile: 'tui',
+        installAnchor: home,
+        home,
+      }).doctor()
+      assertClarifyDoctorHealthy(report)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(clarifySpec === undefined)(
+    'installs the local Clarify package into isolated DSH_HOME and doctor stays clean',
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), 'seektty-clarify-install-'))
+      try {
+        writeEmptyTuiProfile(home)
+        const manager = new ProfilePluginManager({
+          profile: 'tui',
+          installAnchor: home,
+          home,
+          invokingCwd: process.cwd(),
+        })
+        const result = await manager.run(['add', resolve(clarifySpec as string)])
+        expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0)
+        assertClarifyDoctorHealthy(manager.doctor())
+      } finally {
+        rmSync(home, { recursive: true, force: true })
+      }
+    },
+    120_000,
+  )
+})

--- a/tests/clarify-remote.test.ts
+++ b/tests/clarify-remote.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CLARIFY_API_CHANNEL,
+  CLARIFY_PROBE_PROCESS_ID,
+  callClarify,
+  isClarifyBusinessError,
+  isClarifyProbePresence,
+  isClarifyReceiverPresent,
+  parseClarifyEcho,
+  probeClarifyRemote,
+  type ClarifyRpcCaller,
+} from '../src/client/clarify-remote.ts'
+
+function caller(impl: ClarifyRpcCaller): ClarifyRpcCaller {
+  return impl
+}
+
+describe('Clarify Remote probe and public RPC wrapper', () => {
+  it('probes with fetchDraft and an impossible processId, wrapping args only', async () => {
+    const rpc = vi.fn<ClarifyRpcCaller>(async (channel, endpoint, payload) => {
+      expect(channel).toBe(CLARIFY_API_CHANNEL)
+      expect(endpoint).toBe('clarify/fetchDraft')
+      expect(payload).toEqual({ args: { processId: CLARIFY_PROBE_PROCESS_ID } })
+      return { ok: false, error: { code: 'PROCESS_NOT_FOUND', message: `process ${CLARIFY_PROBE_PROCESS_ID} does not exist` } }
+    })
+    await expect(probeClarifyRemote(caller(rpc))).resolves.toBe(true)
+    expect(rpc).toHaveBeenCalledOnce()
+  })
+
+  it('treats gateway-wrapped PROCESS_NOT_FOUND text as presence', async () => {
+    const present = isClarifyProbePresence({
+      ok: false,
+      error: { code: 'internal', message: `process ${CLARIFY_PROBE_PROCESS_ID} does not exist` },
+    })
+    expect(present).toBe(true)
+    expect(isClarifyReceiverPresent({
+      ok: false,
+      error: { code: 'PROCESS_NOT_FOUND', message: 'PROCESS_NOT_FOUND' },
+    })).toBe(true)
+    expect(isClarifyProbePresence({
+      ok: false,
+      error: { code: 'internal', message: 'process other-proc-1 does not exist' },
+    })).toBe(false)
+  })
+
+  it('does not treat unrelated business errors or a successful echo as probe presence', () => {
+    const sessionRequired = { ok: false, error: { code: 'SESSION_ID_REQUIRED', message: 'sessionId is required' } }
+    const invalidAnswer = { ok: false, error: { code: 'INVALID_ANSWER', message: 'INVALID_ANSWER' } }
+    const busy = { ok: false, error: { code: 'PROCESS_BUSY', message: 'already inferring' } }
+    const okEcho = { ok: true, value: { processId: 'should-not-prove-presence' } }
+    expect(isClarifyBusinessError(sessionRequired)).toBe(true)
+    expect(isClarifyBusinessError(invalidAnswer)).toBe(true)
+    expect(isClarifyBusinessError(busy)).toBe(true)
+    expect(isClarifyProbePresence(sessionRequired)).toBe(false)
+    expect(isClarifyProbePresence(invalidAnswer)).toBe(false)
+    expect(isClarifyProbePresence(busy)).toBe(false)
+    expect(isClarifyProbePresence(okEcho)).toBe(false)
+    expect(isClarifyReceiverPresent(sessionRequired)).toBe(false)
+  })
+
+  it('treats transport and endpoint unavailability as absence', async () => {
+    expect(isClarifyReceiverPresent({
+      ok: false,
+      error: { code: 'invocation-unavailable', message: 'no active Remote method exports this endpoint' },
+    })).toBe(false)
+    expect(isClarifyReceiverPresent({
+      ok: false,
+      error: { code: 'internal', message: 'connection: no RPC handler for "/api/clarify/fetchDraft"' },
+    })).toBe(false)
+    await expect(probeClarifyRemote(async () => {
+      throw new Error('transport failure for /api/clarify/fetchDraft: HTTP 404')
+    })).resolves.toBe(false)
+  })
+
+  it('calls start/answer/cancel/fetchDraft through ConnectionHandle.rpc.call shape', async () => {
+    const seen: Array<{ endpoint: string; payload: unknown }> = []
+    const rpc: ClarifyRpcCaller = async (channel, endpoint, payload) => {
+      expect(channel).toBe('/api')
+      seen.push({ endpoint, payload })
+      return {
+        ok: true,
+        value: {
+          processId: 'p1',
+          sessionId: 's1',
+          status: 'running',
+          contextVersion: 'ctx',
+          modelRouteId: 'route',
+        },
+      }
+    }
+    await callClarify(rpc, 'start', { sessionId: 's1', seedText: 'half' })
+    await callClarify(rpc, 'answer', { processId: 'p1', questionId: 'q1', selectedOptionIds: ['o1'] })
+    await callClarify(rpc, 'cancel', { processId: 'p1' })
+    await callClarify(rpc, 'fetchDraft', { processId: 'p1' })
+    expect(seen.map(item => item.endpoint)).toEqual([
+      'clarify/start',
+      'clarify/answer',
+      'clarify/cancel',
+      'clarify/fetchDraft',
+    ])
+    expect(seen[0]?.payload).toEqual({ args: { sessionId: 's1', seedText: 'half' } })
+    expect(seen[1]?.payload).toEqual({
+      args: { processId: 'p1', questionId: 'q1', selectedOptionIds: ['o1'] },
+    })
+  })
+
+  it('omits empty optional seed and empty selectedOptionIds from the wire args', async () => {
+    const rpc = vi.fn<ClarifyRpcCaller>(async () => ({
+      ok: true,
+      value: { processId: 'p1', sessionId: 's1', status: 'running', contextVersion: 'c', modelRouteId: 'r' },
+    }))
+    await callClarify(rpc, 'start', { sessionId: 's1', seedText: '' })
+    expect(rpc.mock.calls[0]?.[2]).toEqual({ args: { sessionId: 's1' } })
+  })
+
+  it('snapshots selectedOptionIds so later caller mutation cannot change an in-flight RPC', async () => {
+    const selected = ['o1']
+    let release!: () => void
+    const held = new Promise<void>(resolve => { release = resolve })
+    const seen: unknown[] = []
+    const pending = callClarify(async (_channel, _endpoint, payload) => {
+      seen.push(payload)
+      await held
+      return {
+        ok: true,
+        value: { processId: 'p1', sessionId: 's1', status: 'complete', contextVersion: 'c', modelRouteId: 'r' },
+      }
+    }, 'answer', { processId: 'p1', questionId: 'q1', selectedOptionIds: selected })
+    selected[0] = 'mutated'
+    selected.push('extra')
+    release()
+    await pending
+    expect(seen[0]).toEqual({
+      args: { processId: 'p1', questionId: 'q1', selectedOptionIds: ['o1'] },
+    })
+  })
+
+  it('rejects duplicate remote optionIds and copies question options away from the caller', () => {
+    const options = [{ optionId: 'o1', text: 'A' }]
+    const question = {
+      questionId: 'q1',
+      text: 'Choose one',
+      multiple: false,
+      allowCustom: false,
+      options,
+    }
+    const value = {
+      processId: 'p1',
+      sessionId: 's1',
+      status: 'running',
+      contextVersion: 'c',
+      modelRouteId: 'r',
+      question,
+      draft: 'must-not-be-read-from-running',
+    }
+    const parsed = parseClarifyEcho(value)
+    options.push({ optionId: 'o2', text: 'B' })
+    options[0]!.text = 'mutated'
+    expect(parsed.question?.options).toEqual([{ optionId: 'o1', text: 'A' }])
+    expect(parsed.draft).toBeUndefined()
+    expect(() => parseClarifyEcho({
+      ...value,
+      question: {
+        ...question,
+        options: [
+          { optionId: 'dup', text: 'One' },
+          { optionId: 'dup', text: 'Two' },
+        ],
+      },
+    })).toThrow(/unique/i)
+  })
+
+  it('reads draft only from a complete fetchDraft echo', () => {
+    const complete = {
+      processId: 'p1',
+      sessionId: 's1',
+      status: 'complete',
+      contextVersion: 'c',
+      modelRouteId: 'r',
+      draft: 'from-answer',
+      answer: { draft: 'nested-answer-must-be-ignored' },
+    }
+    expect(parseClarifyEcho(complete).draft).toBeUndefined()
+    expect(parseClarifyEcho(complete, { allowDraft: false }).draft).toBeUndefined()
+    expect(parseClarifyEcho(complete, { allowDraft: true }).draft).toBe('from-answer')
+    expect(parseClarifyEcho({ ...complete, status: 'stale' }, { allowDraft: true }).draft).toBeUndefined()
+  })
+
+  it('lets stale and complete dominate malformed question and leaked draft fields', () => {
+    const malformedQuestion = {
+      questionId: '',
+      text: '',
+      multiple: 'legacy',
+      options: 'not-an-array',
+    }
+    const stale = parseClarifyEcho({
+      processId: 'p1',
+      sessionId: 's1',
+      status: 'stale',
+      contextVersion: 'c',
+      modelRouteId: 'r',
+      staleReason: 'ttl-expired',
+      question: malformedQuestion,
+      draft: 'LEAKED-STALE',
+    }, { allowDraft: true })
+    expect(stale).toMatchObject({
+      processId: 'p1',
+      status: 'stale',
+      staleReason: 'ttl-expired',
+    })
+    expect(stale.question).toBeUndefined()
+    expect(stale.draft).toBeUndefined()
+
+    const complete = parseClarifyEcho({
+      processId: 'p1',
+      sessionId: 's1',
+      status: 'complete',
+      contextVersion: 'c',
+      modelRouteId: 'r',
+      question: malformedQuestion,
+      draft: 'LEAKED-COMPLETE',
+    })
+    expect(complete.status).toBe('complete')
+    expect(complete.question).toBeUndefined()
+    expect(complete.draft).toBeUndefined()
+  })
+
+  it('rejects empty session binding fields', () => {
+    const base = {
+      processId: 'p1',
+      sessionId: 's1',
+      status: 'complete',
+      contextVersion: 'c',
+      modelRouteId: 'r',
+    }
+    expect(() => parseClarifyEcho({ ...base, sessionId: '' })).toThrow(/binding/i)
+    expect(() => parseClarifyEcho({ ...base, contextVersion: '   ' })).toThrow(/binding/i)
+    expect(() => parseClarifyEcho({ ...base, modelRouteId: '' })).toThrow(/binding/i)
+  })
+})

--- a/tests/clarify-shell.test.ts
+++ b/tests/clarify-shell.test.ts
@@ -1,0 +1,982 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { commandOf, paletteFillsEditor, TuiActions, type TuiActionHost } from '../src/client/actions.ts'
+import {
+  reservedTuiCatalogNames,
+  tuiCommands,
+  type HarnessTuiCapabilities,
+  type TuiCommandCandidate,
+} from '../src/client/capabilities.ts'
+import {
+  buildClarifyAnswer,
+  clarifySeedText,
+  clarifyTuiCommand,
+  mergeClarifyCatalog,
+  runClarifyShell,
+} from '../src/client/clarify-shell.ts'
+import type { ClarifyQuestion, ClarifyRpcCaller } from '../src/client/clarify-remote.ts'
+import { helpSectionText } from '../src/client/help.ts'
+import type { OverlayChoice, OverlayNavigation, OverlayQueue } from '../src/client/overlays.ts'
+import type { Transcript } from '../src/client/transcript.ts'
+
+const root = resolve(import.meta.dirname, '..')
+
+const single: ClarifyQuestion = {
+  questionId: 'q-goal',
+  text: 'What is the main thing you want to accomplish?',
+  options: [
+    { optionId: 'o-feature', text: 'Add a feature' },
+    { optionId: 'o-bugfix', text: 'Fix a bug' },
+  ],
+  multiple: false,
+  allowCustom: true,
+}
+
+const multiple: ClarifyQuestion = {
+  questionId: 'q-constraints',
+  text: 'Which constraints should the draft respect?',
+  options: [
+    { optionId: 'o-time', text: 'Timeboxed' },
+    { optionId: 'o-compat', text: 'Compatibility' },
+  ],
+  multiple: true,
+  allowCustom: false,
+}
+
+function echo(status: string, extra: Record<string, unknown> = {}) {
+  return {
+    processId: 'proc-1',
+    sessionId: 'session-1',
+    status,
+    contextVersion: 'ctx-v1',
+    modelRouteId: 'route-v1',
+    ...extra,
+  }
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T | PromiseLike<T>) => void
+  readonly reject: (error: unknown) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+async function waitOrAbort(hold: Promise<void>, signal?: AbortSignal): Promise<void> {
+  if (signal === undefined) {
+    await hold
+    return
+  }
+  signal.throwIfAborted()
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(signal.reason instanceof Error ? signal.reason : new Error('connection request aborted'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    hold.then(
+      () => {
+        signal.removeEventListener('abort', onAbort)
+        if (signal.aborted) onAbort()
+        else resolve()
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
+function stubRemote(script: Array<{ endpoint: string; result: unknown } | { endpoint: string; error: { code: string; message: string } }>): {
+  readonly rpc: ClarifyRpcCaller
+  readonly calls: Array<{ endpoint: string; args: Record<string, unknown> }>
+} {
+  const calls: Array<{ endpoint: string; args: Record<string, unknown> }> = []
+  const queue = [...script]
+  const rpc: ClarifyRpcCaller = async (channel, endpoint, payload) => {
+    expect(channel).toBe('/api')
+    const args = (payload as { args: Record<string, unknown> }).args
+    calls.push({ endpoint, args })
+    const next = queue.shift()
+    if (next === undefined) throw new Error(`unexpected ${endpoint}`)
+    expect(next.endpoint).toBe(endpoint)
+    if ('error' in next) return { ok: false, error: next.error }
+    return { ok: true, value: next.result }
+  }
+  return { rpc, calls }
+}
+
+function overlays(script: {
+  select?: Array<OverlayChoice | undefined | 'custom-answer'>
+  multiSelect?: Array<readonly OverlayChoice[] | undefined>
+  input?: Array<string | undefined>
+  confirm?: boolean[]
+}, signal: AbortSignal = new AbortController().signal): OverlayQueue & {
+  readonly selectTitles: string[]
+  readonly selectChoices: OverlayChoice[][]
+} {
+  const select = [...(script.select ?? [])]
+  const multiSelect = [...(script.multiSelect ?? [])]
+  const input = [...(script.input ?? [])]
+  const confirm = [...(script.confirm ?? [])]
+  const selectTitles: string[] = []
+  const selectChoices: OverlayChoice[][] = []
+  const prompts = {
+    select: async (request: { title?: string; choices?: readonly OverlayChoice[] }) => {
+      if (request.title !== undefined) selectTitles.push(request.title)
+      const choices = request.choices === undefined ? [] : [...request.choices]
+      selectChoices.push(choices)
+      const next = select.shift()
+      if (next === 'custom-answer') {
+        return [...choices].reverse().find(choice => /自定义回答|Custom answer/i.test(choice.label))
+      }
+      return next
+    },
+    multiSelect: async () => multiSelect.shift(),
+    input: async () => input.shift(),
+    multilineInput: async () => input.shift(),
+    secretInput: async () => undefined,
+    detail: async () => undefined,
+    confirm: async () => confirm.shift() ?? true,
+    progress: async (request: { work(report: (chunk: string) => void, signal: AbortSignal): Promise<unknown> }) => {
+      try {
+        return await request.work(() => undefined, signal)
+      } catch (error) {
+        if (signal.aborted) return undefined
+        throw error
+      }
+    },
+  }
+  return {
+    ...prompts,
+    navigate: async (run: (navigation: OverlayNavigation) => Promise<void>) => {
+      await run({
+        ...prompts,
+        selectPage: async () => undefined,
+        replaceSelectPage: () => undefined,
+        updateChoices: () => undefined,
+        back: () => undefined,
+        finish: () => undefined,
+        signal: new AbortController().signal,
+      } as OverlayNavigation)
+      return undefined
+    },
+    selectTitles,
+    selectChoices,
+  } as unknown as OverlayQueue & { readonly selectTitles: string[]; readonly selectChoices: OverlayChoice[][] }
+}
+
+function host(overlayQueue: OverlayQueue, composer = ''): TuiActionHost & {
+  readonly setEditor: ReturnType<typeof vi.fn<(text: string) => void>>
+  readonly composerText: ReturnType<typeof vi.fn<() => string>>
+} {
+  return {
+    overlays: overlayQueue,
+    transcript: { followLatest: vi.fn() } as unknown as Transcript,
+    notice: vi.fn(),
+    refresh: vi.fn(),
+    refreshHeader: vi.fn(),
+    applyTheme: vi.fn(),
+    applyLocale: vi.fn(),
+    setEditor: vi.fn<(text: string) => void>(),
+    composerText: vi.fn(() => composer),
+    copy: vi.fn(),
+    close: vi.fn(),
+    restart: vi.fn(),
+    requireRestart: vi.fn(),
+  }
+}
+
+describe('Clarify catalog absence stays zero-diff', () => {
+  it('does not register /clarify on the static TUI catalog, help, or reserved names', () => {
+    expect(tuiCommands().map(command => command.name)).not.toContain('clarify')
+    expect(reservedTuiCatalogNames().has('clarify')).toBe(false)
+    expect(commandOf(tuiCommands(), 'clarify')).toBeUndefined()
+    expect(helpSectionText('doctor')).not.toContain('/clarify')
+    expect(helpSectionText('flows')).not.toContain('/clarify')
+    expect(mergeClarifyCatalog(tuiCommands(), false)).toEqual(tuiCommands())
+  })
+
+  it('inserts a local /clarify entry only when the Remote is present', () => {
+    const merged = mergeClarifyCatalog(tuiCommands(), true)
+    const command = commandOf(merged, 'clarify')
+    expect(command).toEqual(clarifyTuiCommand())
+    expect(command?.behavior).toBe('local')
+    expect(command?.source).toBe('TUI')
+    expect(merged.map(item => item.name)).toContain('doctor')
+    expect(merged.findIndex(item => item.name === 'clarify'))
+      .toBeLessThan(merged.findIndex(item => item.name === 'doctor'))
+    expect(paletteFillsEditor(command as TuiCommandCandidate)).toBe(false)
+  })
+})
+
+describe('Clarify answer XOR and seed text', () => {
+  it('rejects selectedOptionIds and customText together, empty selection, and wrong cardinality', () => {
+    expect(() => buildClarifyAnswer(single, { selectedOptionIds: ['o-feature'], customText: 'also' }))
+      .toThrow(/mutually exclusive/i)
+    expect(() => buildClarifyAnswer(single, {})).toThrow(/required/i)
+    expect(() => buildClarifyAnswer(single, { selectedOptionIds: [] })).toThrow(/empty/i)
+    expect(() => buildClarifyAnswer(single, { selectedOptionIds: ['o-feature', 'o-bugfix'] }))
+      .toThrow(/exactly one/i)
+    expect(() => buildClarifyAnswer(multiple, { selectedOptionIds: [] })).toThrow(/at least one/i)
+    expect(() => buildClarifyAnswer(single, { customText: '   ' })).toThrow(/empty/i)
+    expect(buildClarifyAnswer(single, { selectedOptionIds: ['o-feature'] }))
+      .toEqual({ selectedOptionIds: ['o-feature'] })
+    expect(buildClarifyAnswer(single, { customText: 'ship it' })).toEqual({ customText: 'ship it' })
+    expect(buildClarifyAnswer(multiple, { selectedOptionIds: ['o-time', 'o-compat'] }))
+      .toEqual({ selectedOptionIds: ['o-time', 'o-compat'] })
+  })
+
+  it('rejects unknown and duplicate selectedOptionIds before RPC', () => {
+    expect(() => buildClarifyAnswer(single, { selectedOptionIds: ['ghost'] }))
+      .toThrow(/not in the current question/i)
+    expect(() => buildClarifyAnswer(multiple, { selectedOptionIds: ['o-time', 'o-time'] }))
+      .toThrow(/unique/i)
+    const selected = ['o-time', 'o-compat']
+    const built = buildClarifyAnswer(multiple, { selectedOptionIds: selected })
+    selected[0] = 'mutated'
+    expect(built).toEqual({ selectedOptionIds: ['o-time', 'o-compat'] })
+  })
+
+  it('keeps palette composer as seed and uses typed /clarify args after submit clears the composer', () => {
+    expect(clarifySeedText('half-written ask', '')).toBe('half-written ask')
+    expect(clarifySeedText('', 'some text')).toBe('some text')
+    expect(clarifySeedText('/clarify some text', 'some text')).toBe('some text')
+    expect(clarifySeedText('', '')).toBe('')
+    expect(clarifySeedText('/clarify', '')).toBe('')
+    expect(clarifySeedText('/clarify leftover', '')).toBe('')
+  })
+})
+
+describe('Clarify overlay loop', () => {
+  it('walks single, multiple, then fetches draft into the composer only', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/answer', result: echo('running', { question: multiple }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Ready draft' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'half-written ask',
+      composerText: 'half-written ask',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({
+        select: [{ id: 'o-feature', label: 'Add a feature' }],
+        multiSelect: [[{ id: 'o-time', label: 'Timeboxed' }, { id: 'o-compat', label: 'Compatibility' }]],
+        confirm: [true, true],
+      }),
+    })
+    expect(outcome).toEqual({ kind: 'applied', draft: 'Ready draft' })
+    expect(writeComposer).toHaveBeenCalledWith('Ready draft')
+    expect(calls[0]?.args).toEqual({ sessionId: 'session-1', seedText: 'half-written ask' })
+    expect(calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-goal',
+      selectedOptionIds: ['o-feature'],
+    })
+    expect(calls[2]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-constraints',
+      selectedOptionIds: ['o-time', 'o-compat'],
+    })
+    expect(calls.map(item => item.endpoint)).not.toContain('session.prompt')
+  })
+
+  it('sends customText alone when allowCustom is chosen', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Custom draft' }) },
+    ])
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: rpc,
+      overlays: overlays({
+        select: [{ id: '__custom__', label: 'Custom' }],
+        input: ['ship a clarify plugin'],
+        confirm: [true],
+      }),
+    })
+    expect(calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-goal',
+      customText: 'ship a clarify plugin',
+    })
+    expect(calls[1]?.args).not.toHaveProperty('selectedOptionIds')
+  })
+
+  it('selects an optionId of __custom__ as that option and still reaches custom input', async () => {
+    const colliding: ClarifyQuestion = {
+      questionId: 'q-sentinel',
+      text: 'Which path?',
+      options: [
+        { optionId: '__custom__', text: 'Looks reserved' },
+        { optionId: 'o-other', text: 'Other' },
+      ],
+      multiple: false,
+      allowCustom: true,
+    }
+    const asOption = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: colliding }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Option draft' }) },
+    ])
+    const optionPrompts = overlays({
+      select: [{ id: '__custom__', label: 'Looks reserved' }],
+      confirm: [true],
+    })
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: asOption.rpc,
+      overlays: optionPrompts,
+    })
+    const presentedIds = optionPrompts.selectChoices[0]?.map(choice => choice.id) ?? []
+    expect(presentedIds).toContain('__custom__')
+    expect(presentedIds.some(id => id !== '__custom__' && id !== 'o-other')).toBe(true)
+    expect(asOption.calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-sentinel',
+      selectedOptionIds: ['__custom__'],
+    })
+    expect(asOption.calls[1]?.args).not.toHaveProperty('customText')
+
+    const asCustom = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: colliding }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Custom draft' }) },
+    ])
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: asCustom.rpc,
+      overlays: overlays({
+        select: ['custom-answer'],
+        input: ['not the reserved option'],
+        confirm: [true],
+      }),
+    })
+    expect(asCustom.calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-sentinel',
+      customText: 'not the reserved option',
+    })
+    expect(asCustom.calls[1]?.args).not.toHaveProperty('selectedOptionIds')
+  })
+
+  it('uses the same collision-free custom choice in multiple allowCustom', async () => {
+    const colliding: ClarifyQuestion = {
+      questionId: 'q-multi-sentinel',
+      text: 'Which constraints?',
+      options: [
+        { optionId: '__custom__', text: 'Looks reserved' },
+        { optionId: 'o-time', text: 'Timeboxed' },
+      ],
+      multiple: true,
+      allowCustom: true,
+    }
+    const asOptions = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: colliding }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Multi option draft' }) },
+    ])
+    const optionPrompts = overlays({
+      select: [{ id: 'options', label: 'Choose from options' }],
+      multiSelect: [[{ id: '__custom__', label: 'Looks reserved' }]],
+      confirm: [true],
+    })
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: asOptions.rpc,
+      overlays: optionPrompts,
+    })
+    const modeIds = optionPrompts.selectChoices[0]?.map(choice => choice.id) ?? []
+    expect(modeIds).toContain('options')
+    expect(modeIds).not.toContain('__custom__')
+    expect(asOptions.calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-multi-sentinel',
+      selectedOptionIds: ['__custom__'],
+    })
+    expect(asOptions.calls[1]?.args).not.toHaveProperty('customText')
+
+    const asCustom = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: colliding }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Multi custom draft' }) },
+    ])
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: asCustom.rpc,
+      overlays: overlays({
+        select: ['custom-answer'],
+        input: ['custom multi'],
+        confirm: [true],
+      }),
+    })
+    expect(asCustom.calls[1]?.args).toEqual({
+      processId: 'proc-1',
+      questionId: 'q-multi-sentinel',
+      customText: 'custom multi',
+    })
+    expect(asCustom.calls[1]?.args).not.toHaveProperty('selectedOptionIds')
+  })
+
+  it('cancels the process when the overlay is dismissed and does not persist the id', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled') },
+    ])
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: rpc,
+      overlays: overlays({ select: [undefined] }),
+    })
+    expect(outcome).toEqual({ kind: 'cancelled' })
+    expect(calls.at(-1)).toEqual({ endpoint: 'clarify/cancel', args: { processId: 'proc-1' } })
+    const again = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single, processId: 'proc-2' }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled', { processId: 'proc-2' }) },
+    ])
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: again.rpc,
+      overlays: overlays({ select: [undefined] }),
+    })
+    expect(again.calls[0]?.args).not.toHaveProperty('processId')
+    expect(again.calls[1]?.args).toEqual({ processId: 'proc-2' })
+  })
+
+  it('shows staleReason and refuses to fetch or reuse old options', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      {
+        endpoint: 'clarify/answer',
+        result: echo('stale', { staleReason: 'context-changed', question: single }),
+      },
+      { endpoint: 'clarify/cancel', result: echo('stale', { staleReason: 'context-changed' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({
+        select: [
+          { id: 'o-feature', label: 'Add a feature' },
+          { id: 'abandon', label: '放弃' },
+        ],
+      }),
+    })
+    expect(outcome).toEqual({ kind: 'abandoned', staleReason: 'context-changed' })
+    expect(writeComposer).not.toHaveBeenCalled()
+    expect(calls.map(item => item.endpoint)).not.toContain('clarify/fetchDraft')
+  })
+
+  it('lets stale win over a later draft and can restart without reusing the old processId', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      {
+        endpoint: 'clarify/fetchDraft',
+        result: echo('stale', { staleReason: 'ttl-expired', draft: 'should-not-apply' }),
+      },
+      { endpoint: 'clarify/cancel', result: echo('cancelled') },
+      { endpoint: 'clarify/start', result: echo('running', { processId: 'proc-9', question: single }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled', { processId: 'proc-9' }) },
+    ])
+    const writeComposer = vi.fn()
+    await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'seed',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({
+        select: [
+          { id: 'o-feature', label: 'Add a feature' },
+          { id: 'restart', label: '重新开始' },
+          undefined,
+        ],
+      }),
+    })
+    expect(writeComposer).not.toHaveBeenCalled()
+    expect(calls.map(item => item.endpoint)).toEqual([
+      'clarify/start',
+      'clarify/answer',
+      'clarify/fetchDraft',
+      'clarify/cancel',
+      'clarify/start',
+      'clarify/cancel',
+    ])
+    expect(calls[3]?.args).toEqual({ processId: 'proc-1' })
+    expect(calls[4]?.endpoint).toBe('clarify/start')
+    expect(calls[4]?.args).toEqual({ sessionId: 'session-1', seedText: 'seed' })
+    expect(calls[4]?.args).not.toEqual(expect.objectContaining({ processId: 'proc-1' }))
+  })
+
+  it('cancels the stale process before the second start and swallows cancel errors', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('stale', { staleReason: 'ttl-expired' }) },
+      { endpoint: 'clarify/cancel', error: { code: 'PROCESS_NOT_FOUND', message: 'already gone' } },
+      { endpoint: 'clarify/start', result: echo('running', { processId: 'proc-2', question: single }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled', { processId: 'proc-2' }) },
+    ])
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'seed',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: rpc,
+      overlays: overlays({
+        select: [
+          { id: 'restart', label: '重新开始' },
+          undefined,
+        ],
+      }),
+    })
+    expect(outcome).toEqual({ kind: 'cancelled' })
+    expect(calls.map(item => item.endpoint)).toEqual([
+      'clarify/start',
+      'clarify/cancel',
+      'clarify/start',
+      'clarify/cancel',
+    ])
+    expect(calls[1]?.args).toEqual({ processId: 'proc-1' })
+    expect(calls[2]?.args).toEqual({ sessionId: 'session-1', seedText: 'seed' })
+    expect(calls[2]?.args).not.toHaveProperty('processId')
+  })
+
+  it('asks before overwriting a non-empty composer and never prompts the session', async () => {
+    const { rpc } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'New draft' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'old',
+      composerText: 'old composer',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({ confirm: [true, false] }),
+    })
+    expect(outcome).toEqual({ kind: 'kept-composer', draft: 'New draft' })
+    expect(writeComposer).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate remote options before overlay or answer RPC', async () => {
+    const { rpc, calls } = stubRemote([
+      {
+        endpoint: 'clarify/start',
+        result: echo('running', {
+          question: {
+            ...single,
+            options: [
+              { optionId: 'dup', text: 'One' },
+              { optionId: 'dup', text: 'Two' },
+            ],
+          },
+        }),
+      },
+      { endpoint: 'clarify/cancel', result: echo('cancelled') },
+    ])
+    const prompts = overlays({})
+    await expect(runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: rpc,
+      overlays: prompts,
+    })).rejects.toThrow(/unique/i)
+    expect(prompts.selectTitles).toEqual([])
+    expect(calls.map(item => item.endpoint)).toEqual(['clarify/start'])
+  })
+
+  it('rejects unknown and duplicate overlay selections before answer RPC', async () => {
+    const unknown = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled') },
+    ])
+    await expect(runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: unknown.rpc,
+      overlays: overlays({ select: [{ id: 'ghost', label: 'Ghost' }] }),
+    })).rejects.toThrow(/not in the current question/i)
+    expect(unknown.calls.map(item => item.endpoint)).toEqual(['clarify/start', 'clarify/cancel'])
+
+    const duplicated = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: multiple }) },
+      { endpoint: 'clarify/cancel', result: echo('cancelled') },
+    ])
+    await expect(runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer: vi.fn(),
+      call: duplicated.rpc,
+      overlays: overlays({
+        multiSelect: [[{ id: 'o-time', label: 'Timeboxed' }, { id: 'o-time', label: 'Timeboxed' }]],
+      }),
+    })).rejects.toThrow(/unique/i)
+    expect(duplicated.calls.map(item => item.endpoint)).toEqual(['clarify/start', 'clarify/cancel'])
+  })
+
+  it('does not open stale restart UI for malformed fetchDraft and cancels best-effort', async () => {
+    for (const result of [
+      echo('complete'),
+      echo('running', { question: single }),
+      echo('cancelled'),
+    ]) {
+      const { rpc, calls } = stubRemote([
+        { endpoint: 'clarify/start', result: echo('complete') },
+        { endpoint: 'clarify/fetchDraft', result },
+        { endpoint: 'clarify/cancel', result: echo('cancelled') },
+      ])
+      const prompts = overlays({
+        select: [{ id: 'restart', label: '重新开始' }],
+        confirm: [true],
+      })
+      const writeComposer = vi.fn()
+      await expect(runClarifyShell({
+        sessionId: 'session-1',
+        seedText: '',
+        composerText: '',
+        writeComposer,
+        call: rpc,
+        overlays: prompts,
+      })).rejects.toThrow(/fetchDraft|draft/i)
+      expect(prompts.selectTitles.some(title => /stale|过期/i.test(title))).toBe(false)
+      expect(writeComposer).not.toHaveBeenCalled()
+      expect(calls.map(item => item.endpoint)).toEqual([
+        'clarify/start',
+        'clarify/fetchDraft',
+        'clarify/cancel',
+      ])
+    }
+  })
+
+  it('treats stale as dominant when the echo carries a malformed question and leaked draft', async () => {
+    const { rpc, calls } = stubRemote([
+      {
+        endpoint: 'clarify/start',
+        result: echo('stale', {
+          staleReason: 'ttl-expired',
+          question: { questionId: '', options: 'legacy' },
+          draft: 'LEAKED-STALE',
+        }),
+      },
+      { endpoint: 'clarify/cancel', result: echo('stale', { staleReason: 'ttl-expired' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({ select: [{ id: 'abandon', label: '放弃' }] }),
+    })
+    expect(outcome).toEqual({ kind: 'abandoned', staleReason: 'ttl-expired' })
+    expect(writeComposer).not.toHaveBeenCalled()
+    expect(calls.map(item => item.endpoint)).toEqual(['clarify/start', 'clarify/cancel'])
+  })
+
+  it('ignores malformed question and leaked draft on a complete non-fetch echo and still fetchDrafts', async () => {
+    const { rpc, calls } = stubRemote([
+      {
+        endpoint: 'clarify/start',
+        result: echo('complete', {
+          question: { questionId: '', options: 'legacy' },
+          draft: 'LEAKED-COMPLETE',
+        }),
+      },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'MANDATORY-DRAFT' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({ confirm: [true] }),
+    })
+    expect(outcome).toEqual({ kind: 'applied', draft: 'MANDATORY-DRAFT' })
+    expect(writeComposer).toHaveBeenCalledWith('MANDATORY-DRAFT')
+    expect(writeComposer).not.toHaveBeenCalledWith('LEAKED-COMPLETE')
+    expect(calls.map(item => item.endpoint)).toEqual(['clarify/start', 'clarify/fetchDraft'])
+  })
+
+  it('uses fetchDraft draft and ignores a draft field on start or answer', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single, draft: 'LEAKED-START' }) },
+      { endpoint: 'clarify/answer', result: echo('complete', { draft: 'LEAKED-ANSWER' }) },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'REAL-DRAFT' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: '',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({
+        select: [{ id: 'o-feature', label: 'Add a feature' }],
+        confirm: [true],
+      }),
+    })
+    expect(outcome).toEqual({ kind: 'applied', draft: 'REAL-DRAFT' })
+    expect(writeComposer).toHaveBeenCalledWith('REAL-DRAFT')
+    expect(writeComposer).not.toHaveBeenCalledWith('LEAKED-START')
+    expect(writeComposer).not.toHaveBeenCalledWith('LEAKED-ANSWER')
+    expect(calls.map(item => item.endpoint)).toEqual([
+      'clarify/start',
+      'clarify/answer',
+      'clarify/fetchDraft',
+    ])
+  })
+})
+
+describe('Clarify start abort does not leave a Host process', () => {
+  it('cancels the late start processId once and never answers, fetches, or writes the composer', async () => {
+    const hold = deferred<void>()
+    const calls: Array<{ endpoint: string; args: Record<string, unknown>; signal?: AbortSignal | undefined }> = []
+    const rpc: ClarifyRpcCaller = async (_channel, endpoint, payload, signal) => {
+      const args = (payload as { args: Record<string, unknown> }).args
+      calls.push({ endpoint, args, signal })
+      if (endpoint === 'clarify/start') {
+        await waitOrAbort(hold.promise, signal)
+        return { ok: true, value: echo('running', { question: single, draft: 'LEAKED-START' }) }
+      }
+      if (endpoint === 'clarify/cancel') {
+        return { ok: true, value: echo('cancelled') }
+      }
+      throw new Error(`unexpected ${endpoint}`)
+    }
+    const controller = new AbortController()
+    const prompts = overlays({}, controller.signal)
+    const writeComposer = vi.fn()
+    const pending = runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'seed',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: prompts,
+    })
+    await vi.waitFor(() => {
+      expect(calls.map(item => item.endpoint)).toEqual(['clarify/start'])
+    })
+    controller.abort()
+    await expect(pending).resolves.toEqual({ kind: 'cancelled' })
+    expect(calls[0]?.signal).toBeUndefined()
+    expect(writeComposer).not.toHaveBeenCalled()
+    expect(prompts.selectTitles).toEqual([])
+    hold.resolve()
+    await vi.waitFor(() => {
+      expect(calls.map(item => item.endpoint)).toEqual(['clarify/start', 'clarify/cancel'])
+    })
+    expect(calls[1]?.args).toEqual({ processId: 'proc-1' })
+    expect(calls[1]?.signal).toBeUndefined()
+    expect(calls.filter(item => item.endpoint === 'clarify/cancel')).toHaveLength(1)
+    expect(calls.map(item => item.endpoint)).not.toContain('clarify/answer')
+    expect(calls.map(item => item.endpoint)).not.toContain('clarify/fetchDraft')
+  })
+
+  it('swallows a start failure after Esc without cancel, composer write, or unhandled rejection', async () => {
+    const hold = deferred<void>()
+    const calls: Array<{ endpoint: string }> = []
+    const rejections: unknown[] = []
+    let startFinished = false
+    const onUnhandled = (reason: unknown): void => {
+      rejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    const rpc: ClarifyRpcCaller = async (_channel, endpoint, _payload, signal) => {
+      calls.push({ endpoint })
+      if (endpoint === 'clarify/start') {
+        await waitOrAbort(hold.promise, signal)
+        startFinished = true
+        return { ok: false, error: { code: 'internal', message: 'start boom' } }
+      }
+      throw new Error(`unexpected ${endpoint}`)
+    }
+    const controller = new AbortController()
+    try {
+      const pending = runClarifyShell({
+        sessionId: 'session-1',
+        seedText: '',
+        composerText: '',
+        writeComposer: vi.fn(),
+        call: rpc,
+        overlays: overlays({}, controller.signal),
+      })
+      await vi.waitFor(() => {
+        expect(calls.map(item => item.endpoint)).toEqual(['clarify/start'])
+      })
+      controller.abort()
+      await expect(pending).resolves.toEqual({ kind: 'cancelled' })
+      expect(startFinished).toBe(false)
+      hold.resolve()
+      await vi.waitFor(() => {
+        expect(startFinished).toBe(true)
+      })
+      expect(calls.map(item => item.endpoint)).toEqual(['clarify/start'])
+      expect(rejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+      hold.resolve()
+    }
+  })
+
+  it('leaves a successful start unchanged and still answers after the first question', async () => {
+    const { rpc, calls } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('running', { question: single }) },
+      { endpoint: 'clarify/answer', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Ready draft' }) },
+    ])
+    const writeComposer = vi.fn()
+    const outcome = await runClarifyShell({
+      sessionId: 'session-1',
+      seedText: 'half-written ask',
+      composerText: '',
+      writeComposer,
+      call: rpc,
+      overlays: overlays({
+        select: [{ id: 'o-feature', label: 'Add a feature' }],
+        confirm: [true],
+      }),
+    })
+    expect(outcome).toEqual({ kind: 'applied', draft: 'Ready draft' })
+    expect(writeComposer).toHaveBeenCalledWith('Ready draft')
+    expect(calls.map(item => item.endpoint)).toEqual([
+      'clarify/start',
+      'clarify/answer',
+      'clarify/fetchDraft',
+    ])
+  })
+})
+
+describe('Clarify surface wiring and existing doctor boundary', () => {
+  it('keeps local /doctor on the Profile manager bridge and does not add a stock doctor', () => {
+    const actions = readFileSync(resolve(root, 'src/client/actions.ts'), 'utf8')
+    const capabilities = readFileSync(resolve(root, 'src/client/capabilities.ts'), 'utf8')
+    const shell = readFileSync(resolve(root, 'src/client/clarify-shell.ts'), 'utf8')
+    const remote = readFileSync(resolve(root, 'src/client/clarify-remote.ts'), 'utf8')
+    expect(actions).toMatch(/managementBridge\(\)\.plugins\.doctor\(\)/u)
+    expect(actions).toMatch(/case 'doctor': await this\.doctor\(\)/u)
+    expect(actions).not.toMatch(/rpc\.call\([^)]*doctor/u)
+    expect(capabilities).toContain("name: 'doctor'")
+    expect(`${shell}\n${remote}`).not.toMatch(/session\.prompt\(/u)
+    expect(`${shell}\n${remote}`).not.toMatch(/writeFile|mkdirSync|settings\.mutate/u)
+    expect(tuiCommands().some(command => command.name === 'doctor')).toBe(true)
+  })
+
+  it('executes /clarify through the public RPC face and writes only the composer', async () => {
+    const { rpc } = stubRemote([
+      { endpoint: 'clarify/start', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Palette draft' }) },
+    ])
+    const overlayQueue = overlays({ confirm: [true] })
+    const actionHost = host(overlayQueue, 'composer seed')
+    const capabilities = {
+      active: () => ({ sessionId: 'session-1', session: { prompt: vi.fn() } }),
+      connectionRpc: () => ({ call: rpc }),
+      clarifyRemotePresent: async () => true,
+    } as unknown as HarnessTuiCapabilities
+    const actions = new TuiActions(capabilities, actionHost)
+    await actions.execute('clarify', '')
+    expect(actionHost.setEditor).toHaveBeenCalledWith('Palette draft')
+    expect(capabilities.active()?.session.prompt).not.toHaveBeenCalled()
+  })
+
+  it('warns when a cached /clarify is executed after the Remote disappears', async () => {
+    const rpc = vi.fn<ClarifyRpcCaller>(async () => {
+      throw new Error('should not call')
+    })
+    const actionHost = host(overlays({}))
+    const actions = new TuiActions({
+      active: () => ({ sessionId: 'session-1' }),
+      connectionRpc: () => ({ call: rpc }),
+      clarifyRemotePresent: async () => false,
+    } as unknown as HarnessTuiCapabilities, actionHost)
+    await actions.execute('clarify', '')
+    expect(rpc).not.toHaveBeenCalled()
+    expect(actionHost.setEditor).not.toHaveBeenCalled()
+    expect(actionHost.notice).toHaveBeenCalledWith(expect.stringMatching(/Clarify Remote/), 'error')
+  })
+
+  it('seeds palette execution from the composer and typed /clarify from args', async () => {
+    const palette = stubRemote([
+      { endpoint: 'clarify/start', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Palette draft' }) },
+    ])
+    const paletteHost = host(overlays({ confirm: [true] }), 'half-written ask')
+    await new TuiActions({
+      active: () => ({ sessionId: 'session-1', session: { prompt: vi.fn() } }),
+      connectionRpc: () => ({ call: palette.rpc }),
+      clarifyRemotePresent: async () => true,
+    } as unknown as HarnessTuiCapabilities, paletteHost).execute('clarify', '')
+    expect(palette.calls[0]?.args).toEqual({ sessionId: 'session-1', seedText: 'half-written ask' })
+
+    const typed = stubRemote([
+      { endpoint: 'clarify/start', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Typed draft' }) },
+    ])
+    const typedHost = host(overlays({ confirm: [true] }), '')
+    await new TuiActions({
+      active: () => ({ sessionId: 'session-1', session: { prompt: vi.fn() } }),
+      connectionRpc: () => ({ call: typed.rpc }),
+      clarifyRemotePresent: async () => true,
+    } as unknown as HarnessTuiCapabilities, typedHost).execute('clarify', 'some text')
+    expect(typed.calls[0]?.args).toEqual({ sessionId: 'session-1', seedText: 'some text' })
+
+    const lone = stubRemote([
+      { endpoint: 'clarify/start', result: echo('complete') },
+      { endpoint: 'clarify/fetchDraft', result: echo('complete', { draft: 'Empty draft' }) },
+    ])
+    const loneHost = host(overlays({ confirm: [true] }), '')
+    await new TuiActions({
+      active: () => ({ sessionId: 'session-1', session: { prompt: vi.fn() } }),
+      connectionRpc: () => ({ call: lone.rpc }),
+      clarifyRemotePresent: async () => true,
+    } as unknown as HarnessTuiCapabilities, loneHost).execute('clarify', '')
+    expect(lone.calls[0]?.args).toEqual({ sessionId: 'session-1' })
+  })
+})

--- a/tests/i18n-ast.test.ts
+++ b/tests/i18n-ast.test.ts
@@ -38,6 +38,7 @@ const GATED = [
   'client/pending-status.ts',
   'client/surface.ts',
   'client/capabilities.ts',
+  'client/clarify-shell.ts',
   'client/transcript.ts',
   'client/actions.ts',
   'client/error-advice.ts',

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -127,7 +127,7 @@ describe('launcher provisioning', () => {
     expect(launch([], { DSH_BIN: '/stock/dsh' }, execute)).toBe(0)
     expect(calls.map(call => call.args)).toEqual([
       ['plugin', '--profile', 'tui', 'remove', 'deepseek-tui'],
-      ['plugin', '--profile', 'tui', 'add', 'github:Hilbert-beinghappy/seektty#v1.0.2'],
+      ['plugin', '--profile', 'tui', 'add', 'github:Hilbert-beinghappy/seektty#v1.1.0'],
       ['--profile', 'tui'],
     ])
   })
@@ -152,7 +152,7 @@ describe('launcher provisioning', () => {
     const chunks: string[] = []
     expect(launch(['--version'], { LANG: 'en_US.UTF-8' }, execute, chunk => { chunks.push(chunk) })).toBe(0)
     expect(execute).not.toHaveBeenCalled()
-    expect(chunks.join('')).toContain('seektty 1.0.2')
+    expect(chunks.join('')).toContain('seektty 1.1.0')
     expect(chunks.join('')).toContain('Requires dsh >= 0.1.0-rc.6')
   })
 })

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -39,9 +39,14 @@ describe('out-of-tree Bundle contract', () => {
     expect(Array.isArray(patch)).toBe(true)
     expect(patchText).toContain("name: 'seektty/marketplace-provider'")
     expect(patchText).toContain("name: '@deepseek-ai/dsh-client-locale'")
+    expect(patchText).toContain("name: 'seektty/attachment-compat'")
     expect(patchText).toContain("name: 'seektty/in-process'")
     expect(patchText).toContain("name: 'seektty/startup'")
     expect(patchText).toContain("name: 'seektty'")
+    const insert = (patch as { insert?: { name?: string }[] }[]).find(row => Array.isArray(row.insert))
+    const names = (insert?.insert ?? []).map(row => row.name)
+    expect(names.indexOf('seektty/attachment-compat')).toBe(names.indexOf('@deepseek-ai/dsh-host-apiproxy') - 1)
+    expect(manifest.exports).toMatchObject({ './attachment-compat': './lib/attachment-compat.js' })
   })
 
   it('pins official dsh packages to the tested Harness baseline when that version exists', () => {
@@ -109,7 +114,7 @@ describe('out-of-tree Bundle contract', () => {
     expect(candidate.bundle).toBe(true)
     expect(candidate.patchValid).toBe(true)
     expect(candidate.diagnostics).toEqual([
-      '安装包声明脚本：build、typecheck、test、test:stock、check',
+      '安装包声明脚本：build、typecheck、test、test:stock、test:clarify-doctor、check',
     ])
   })
 })

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
     startup: 'src/host/startup.ts',
     'marketplace-provider': 'src/host/marketplace-provider.ts',
     'in-process': 'src/host/in-process.ts',
+    'attachment-compat': 'src/host/attachment-compat.ts',
     bin: 'src/bin.ts',
   },
   outDir: 'lib',


### PR DESCRIPTION
## Summary

- dynamically expose /clarify only after a state-free public Remote probe proves the receiver exists
- render the shared start, answer, cancel, and fetchDraft contract with existing overlays and write only the confirmed draft into the regular composer
- preserve the existing local /doctor path and add packaged cross-project acceptance coverage
- normalize the exact official rc.6/rc.7 legacy imageLimits capability before the rc.8 API projection
- bump SeekTTY to 1.1.0 and document the official rc.6, rc.7, rc.8 compatibility matrix

## Verification

- pnpm run check: 79 files passed, 451 tests passed, 1 conditional skip; typecheck, build, and pack dry-run passed
- focused final regression: 55 tests passed
- packaged SeekTTY 1.1.0 plus Clarify 0.1.0: official dsh rc.6, rc.7, rc.8 with-plugin Profiles reached /clarify and local /doctor reported 98 active, 0 errors, 0 warnings
- bare Profiles on rc.6, rc.7, rc.8 kept /clarify unknown
- final packaged smoke repeated on official rc.6 and rc.8

## Release

Squash merge, then create annotated v1.1.0 from merged main. Publish pnpm pack tgz plus SHA256SUMS in GitHub Releases. No npm publication.