### PR TITLE
docs(readme): clarify plugin-backed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@
 
 Run `deepseek` from a project directory to use the native Agent, Session, model, permission, Settings, Profile, plugin, and persistence services of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) from one terminal workspace. Prompts, code changes, tool calls, sessions, model routes, permissions, plugins, subagents, and diagnostics all operate on the same Harness state.
 
-When an idea still needs definition, `/clarify` reads the active Session and composer draft, follows the real model route, and generates Socratic questions, contextual options, and a live draft preview that evolves after every answer. Accepting the preview places a complete Draft back in the ordinary composer for review and manual submission. Harness native `/plan` can then turn the clarified requirement into an implementation plan.
+When an idea still needs definition, the optional plugin-backed `/clarify` workflow reads the active Session and composer draft, follows the real model route, and generates Socratic questions, contextual options, and a live draft preview that evolves after every answer. Accepting the preview places a complete Draft back in the ordinary composer for review and manual submission. Harness native `/plan` can then turn the clarified requirement into an implementation plan.
+
+The [Clarify Host plugin](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) owns the Session-bound clarification process, model-generated questions, options, previews, and six-method Remote. When that compatible plugin capability is active, SeekTTY detects it and adds the local `/clarify` command plus its keyboard-first TUI surface. SeekTTY passes the current Session and draft to the plugin, then writes an accepted Draft back into the composer.
 
 Clarify model calls run through [Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) and are recorded in its dedicated `auxiliary_runtime` ledger. Official Agent-loop usage remains in `tokenUsage`; SeekTTY `/status` shows separately sourced Official, Auxiliary, and derived Combined totals while the snapshot contract is healthy.
 
@@ -54,19 +56,29 @@ The live view fills the terminal and keeps the composer and status at the bottom
 
 ## Clarify and Plan
 
-[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) and Plan cover consecutive parts of one workflow.
+[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) is an optional DeepSeek Harness Host plugin, and SeekTTY is its keyboard-first terminal consumer. Plugin-backed Clarify and Harness-native Plan cover consecutive parts of one workflow.
 
 Clarify handles the stage where the desired outcome still needs definition. It uses the current Session and draft to ask one focused question at a time, carries accepted decisions forward, and updates a reviewable Draft after every answer. Accepting returns that Draft to the composer. You can edit it and press Enter when it represents what you want.
 
 Plan handles the stage where the requirement is ready for implementation. Harness native `/plan` turns the submitted requirement into an implementation proposal and opens the normal plan-review flow.
+
+### Where `/clarify` comes from
+
+| Component | Responsibility |
+| --- | --- |
+| **SeekTTY** | Probes the Clarify Remote, dynamically adds `/clarify` to the local command catalog, renders the terminal interaction, supplies the current Session and composer seed, and returns an accepted Draft to the composer. |
+| **dsh-plugin-clarify** | Publishes `start`, `answer`, `accept`, `refine`, `cancel`, and `fetchDraft` over `clarify.wire/1`; owns the temporary clarification process and generates questions, options, and evolving Draft previews. |
+| **dsh-plugin-auxiliary-runtime** | Provides Clarify's same-process model execution, limits, cancellation, and separately sourced auxiliary usage. |
+
+The standalone SeekTTY shell presents its core command catalog. Activating the two Host plugins in the same Profile expands that catalog with the complete `/clarify` workflow.
 
 ```text
 [Active Session + composer draft]
               |
               v
      +------------------+      clarify Remote      +------------------+
-     | SeekTTY          | -----------------------> | Clarify          |
-     | /clarify surface | <----------------------- | question/options |
+     | SeekTTY consumer | -----------------------> | Clarify plugin   |
+     | /clarify adapter | <----------------------- | process / model  |
      +--------+---------+   live Draft preview     +--------+---------+
               |                                            |
               |                                            | same-process run
@@ -105,9 +117,9 @@ Questions, options, preview revisions, and refine feedback live in a temporary c
 
 Each Clarify model call is recorded by Auxiliary Runtime in the official `storageDomain` under `auxiliary_runtime`. Official `tokenUsage` continues to represent Agent-loop calls. Auxiliary derives Combined values from the four disjoint buckets—`uncachedInputTokens`, `outputTokens`, `cacheReadTokens`, and `cacheWriteTokens`—at read time, and SeekTTY `/status` validates and displays the snapshot. The auxiliary ledger stores call identity, purpose, status, token buckets, normalized failures, and timestamps; prompts, message text, model output, custom answers, credentials, and filesystem paths stay outside the ledger.
 
-### Start Clarify from the composer
+### Start plugin-backed Clarify from the composer
 
-SeekTTY adds `/clarify` to its local command catalog while a compatible six-method Clarify Remote with `clarify.wire/1` is active. The current recommended installation is Clarify `0.2.1`; `0.2.0` remains an available rollback artifact.
+SeekTTY adds `/clarify` to its local command catalog while the `dsh-plugin-clarify` Host plugin exposes a compatible six-method Remote with `clarify.wire/1`. The current recommended installation is Clarify `0.2.1`; `0.2.0` remains an available rollback artifact.
 
 - Run it from the command palette to keep the whole composer as the seed.
 - Type `/clarify some text` to use the argument as the seed.
@@ -174,7 +186,7 @@ dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/dsh-plugin-cl
 dsh --profile tui
 ```
 
-This path consumes packed artifacts and avoids Git-source `prepare` / `allowBuilds`. Installing only the first Bundle gives you the standalone SeekTTY shell; Clarify appears when the two optional Host plugins are active in the same Profile.
+This path consumes packed artifacts and avoids Git-source `prepare` / `allowBuilds`. The first package installs the standalone SeekTTY shell, the second provides Auxiliary model execution, and the third provides the Clarify Host service and Remote. Once both Host plugins are active in the same Profile, SeekTTY discovers the Remote and adds `/clarify` to the terminal command catalog.
 
 ### Bare `deepseek` launcher
 
@@ -236,10 +248,11 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 | Runtime interaction | `/queue`, `/steer`, `/attach`, `/attachments`, `/pending` |
 | Runtime content | `/tools`, `/files`, `/jobs`, `/subagents`, `/trajectory` |
 | Extensions | `/plugin`, `/plugins`, `/skills`, `/mcp` |
+| Plugin-backed workflow | `/clarify` appears when `dsh-plugin-clarify` and its Auxiliary Runtime dependency are active in the current Profile |
 | Configuration and diagnostics | `/settings`, `/language`, `/theme`, `/status`, `/doctor`, `/feedback`, `/restart`; when `dsh-plugin-auxiliary-runtime@0.1.0` is healthy, `/status` shows separately labeled Official, Auxiliary, and Combined (derived) whole-Session usage without changing the official `tokenUsage` projection |
 | Help and exit | `/help`, `/quit`, `/exit` |
 
-`/plugin`, `/workspace`, and `/profile` provide both complete interactive centers and direct subcommands. Unknown commands produce nearby suggestions and stay within the command surface. A compatible six-method Clarify Remote with `clarify.wire/1` contributes `/clarify` to the local `/` catalog. Its model-generated questions, contextual options, and evolving preview lead to a reviewed Draft in the ordinary composer; you decide when to submit it. See [Clarify and Plan](#clarify-and-plan) for the full journey.
+`/plugin`, `/workspace`, and `/profile` provide both complete interactive centers and direct subcommands. Unknown commands produce nearby suggestions and stay within the command surface. SeekTTY detects the Clarify plugin's compatible six-method Remote with `clarify.wire/1` and dynamically adds `/clarify` to the local `/` catalog. The plugin's model-generated questions, contextual options, and evolving preview lead to a reviewed Draft in the ordinary composer; you decide when to submit it. See [Clarify and Plan](#clarify-and-plan) for the full journey.
 
 ## Common controls
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -36,7 +36,9 @@
 
 进入项目目录运行 `deepseek`，就能在一个终端工作台里使用 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 原生的 Agent、Session、模型、权限、Settings、Profile、插件与持久化能力。提问、代码修改、工具调用、会话管理、模型路由、权限切换、插件、子 Agent 和运行诊断都落在同一套 Harness 状态上。
 
-想法还没有写完整时，运行 `/clarify`：Clarify 读取当前 Session 与输入区草稿，沿真实模型路由逐题生成苏格拉底式问题、上下文选项和 live Draft preview。每回答一题，预览稿都会吸收新的决定。采用后，完整 Draft 回到普通输入框，等你审阅、修改并自行发送。需求明确之后，再用 Harness 原生 `/plan` 把它写成实施方案。
+想法还没有写完整时，可以进入由插件提供的 `/clarify` 工作流：Clarify 读取当前 Session 与输入区草稿，沿真实模型路由逐题生成苏格拉底式问题、上下文选项和 live Draft preview。每回答一题，预览稿都会吸收新的决定。采用后，完整 Draft 回到普通输入框，等你审阅、修改并自行发送。需求明确之后，再用 Harness 原生 `/plan` 把它写成实施方案。
+
+[Clarify Host 插件](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 持有绑定 Session 的澄清进程、模型生成的问题、选项、预览稿和六方法 Remote。兼容的插件能力激活后，SeekTTY 会自动探测它，并加入本地 `/clarify` 命令与键盘优先的 TUI 界面。SeekTTY 把当前 Session 和草稿交给插件，再把用户采用的 Draft 写回输入框。
 
 Clarify 的模型调用由 [Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) 承接，用量写入独立的 `auxiliary_runtime` 账本。官方 Agent 循环继续使用 `tokenUsage`；快照合同健康时，SeekTTY `/status` 分别展示来源清楚的 Official、Auxiliary 和派生 Combined 总量。
 
@@ -54,19 +56,29 @@ Clarify 的模型调用由 [Auxiliary Runtime](https://github.com/Hilbert-beingh
 
 ## Clarify 与 Plan
 
-[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 和 Plan 位于同一条工作流的前后两段。
+[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 是可选的 DeepSeek Harness Host 插件，SeekTTY 是它的键盘优先终端消费者。插件提供的 Clarify 与 Harness 原生 Plan 位于同一条工作流的前后两段。
 
 Clarify 处理“要做什么还需要问清”的阶段。它根据当前 Session 和草稿一次提出一个聚焦问题，把已经确认的决定带入后续问题，并在每一答之后更新可审阅的 Draft。采用后，这份 Draft 回到输入框；你可以继续改字，在它准确表达真实意图时按 Enter 发送。
 
 Plan 处理“需求已经明确、需要决定怎么做”的阶段。Harness 原生 `/plan` 把已经提交的需求整理为实施方案，并进入正常的计划审查流程。
+
+### `/clarify` 来自哪里
+
+| 组件 | 职责 |
+| --- | --- |
+| **SeekTTY** | 探测 Clarify Remote，动态把 `/clarify` 加入本地命令目录，渲染终端交互，提供当前 Session 与输入草稿，并把采用后的 Draft 写回输入框。 |
+| **dsh-plugin-clarify** | 通过 `clarify.wire/1` 发布 `start`、`answer`、`accept`、`refine`、`cancel` 和 `fetchDraft`，持有临时澄清进程，生成问题、选项与持续演进的 Draft preview。 |
+| **dsh-plugin-auxiliary-runtime** | 为 Clarify 提供同进程模型执行、限额、取消和来源独立的辅助用量。 |
+
+SeekTTY 单独运行时展示核心命令目录；两个 Host 插件在同一 Profile 激活后，命令目录会扩展出完整的 `/clarify` 工作流。
 
 ```text
 [当前 Session + 输入草稿]
               |
               v
      +------------------+      clarify Remote      +------------------+
-     | SeekTTY          | -----------------------> | Clarify          |
-     | /clarify 界面    | <----------------------- | 问题 / 选项      |
+     | SeekTTY 消费端   | -----------------------> | Clarify 插件     |
+     | /clarify 适配器  | <----------------------- | 进程 / 模型生成  |
      +--------+---------+   live Draft preview     +--------+---------+
               |                                            |
               |                                            | 同进程 run
@@ -105,9 +117,9 @@ Auxiliary snapshot ---------------------> SeekTTY /status
 
 每一次 Clarify 模型调用都由 Auxiliary Runtime 记入官方 `storageDomain` 下的 `auxiliary_runtime` 域。官方 `tokenUsage` 继续表示 Agent 循环调用。Combined 在读取时按四个互不重叠的 Token 桶相加。辅助账本保存调用标识、purpose、状态、Token 桶、规范化失败和时间戳；prompt、消息正文、模型输出、自定义回答、凭据和文件路径不会进入账本。
 
-### 从输入框启动 Clarify
+### 从输入框启动插件提供的 Clarify
 
-兼容的 Clarify 六方法 Remote 与 `clarify.wire/1` 激活后，SeekTTY 会把 `/clarify` 加入本地命令目录。当前推荐安装 Clarify `0.2.1`；`0.2.0` 保留为已发布回滚工件。
+`dsh-plugin-clarify` Host 插件暴露兼容的六方法 Remote 与 `clarify.wire/1` 后，SeekTTY 会把 `/clarify` 加入本地命令目录。当前推荐安装 Clarify `0.2.1`；`0.2.0` 保留为已发布回滚工件。
 
 - 从命令面板执行：保留整个输入区作为 seed。
 - 输入 `/clarify some text`：以参数文本作为 seed。
@@ -174,7 +186,7 @@ dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/dsh-plugin-cl
 dsh --profile tui
 ```
 
-这条路径直接使用打包产物，可以避开 Git 源的 `prepare` / `allowBuilds`。只安装第一项 Bundle 就能单独使用 SeekTTY；后两个 Host 插件在同一 Profile 激活后，终端会自动出现 Clarify 工作流。
+这条路径直接使用打包产物，可以避开 Git 源的 `prepare` / `allowBuilds`。第一项安装 SeekTTY 终端壳，第二项提供 Auxiliary 模型执行，第三项提供 Clarify Host 服务与 Remote。两个 Host 插件在同一 Profile 激活后，SeekTTY 会发现 Remote，并把 `/clarify` 加入终端命令目录。
 
 ### 裸 `deepseek` 启动器
 
@@ -236,10 +248,11 @@ deepseek --update
 | 运行交互 | `/queue`、`/steer`、`/attach`、`/attachments`、`/pending` |
 | 运行内容 | `/tools`、`/files`、`/jobs`、`/subagents`、`/trajectory` |
 | 扩展 | `/plugin`、`/plugins`、`/skills`、`/mcp` |
+| 插件工作流 | 当前 Profile 中的 `dsh-plugin-clarify` 及其 Auxiliary Runtime 依赖激活后出现 `/clarify` |
 | 配置与诊断 | `/settings`、`/language`、`/theme`、`/status`、`/doctor`、`/feedback`、`/restart`；当 `dsh-plugin-auxiliary-runtime@0.1.0` 健康可用时，`/status` 分别显示标明来源的官方、辅助和组合（派生）会话总用量，且不修改官方 `tokenUsage` 投影 |
 | 帮助与退出 | `/help`、`/quit`、`/exit` |
 
-`/plugin`、`/workspace` 和 `/profile` 既有完整的交互中心，也支持直接子命令。未知命令会给出相近候选，不会被当成普通消息发给模型。兼容的 Clarify 六方法 Remote 与 `clarify.wire/1` 会把 `/clarify` 加入本地 `/` 目录，用模型生成的问题、上下文选项和持续演进的预览稿，引导你得到一份进入普通输入框的 Draft；何时发送由你决定。完整旅程见 [Clarify 与 Plan](#clarify-与-plan)。
+`/plugin`、`/workspace` 和 `/profile` 既有完整的交互中心，也支持直接子命令。未知命令会给出相近候选，不会被当成普通消息发给模型。SeekTTY 探测 Clarify 插件兼容的六方法 Remote 与 `clarify.wire/1`，再把 `/clarify` 动态加入本地 `/` 目录。插件生成的问题、上下文选项和持续演进的预览稿会引导你得到一份进入普通输入框的 Draft；何时发送由你决定。完整旅程见 [Clarify 与 Plan](#clarify-与-plan)。
 
 ## 常用交互
 


### PR DESCRIPTION
## Summary

- state in the bilingual project overview that /clarify is an optional plugin-backed workflow
- document the ownership split between SeekTTY, dsh-plugin-clarify, and dsh-plugin-auxiliary-runtime
- label SeekTTY as the conditional terminal consumer and Clarify as the Host plugin in the architecture
- explain dynamic command discovery in installation steps and the slash-command table

## Verification

- git diff --check
- product-language contrast scan: no matches
- pnpm pack --dry-run: passed
- pnpm exec vitest run tests/clarify-shell.test.ts tests/clarify-composer-boundary.test.ts: 65 tests passed

## Evidence

The static SeekTTY catalog excludes clarify. SeekTTY probes the six-method clarify.wire/1 Remote and dynamically inserts the local command and TUI adapter only while the compatible Clarify Host plugin capability is active.
