### PR TITLE
docs: streamline bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1>SeekTTY</h1>
 
-<p>A keyboard-first terminal workspace for DeepSeek Harness, from an early idea to an executable plan.</p>
+<p>A keyboard-first terminal workspace for DeepSeek Harness.</p>
 
 <p>
   <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.1-orange" alt="Version 1.2.1"></a>
@@ -15,15 +15,15 @@
 </p>
 
 <p>
-  <a href="#project-overview">Project overview</a>
-  ·
-  <a href="#clarify-and-plan">Clarify and Plan</a>
-  ·
-  <a href="#harness-capabilities-available-in-the-tui">Terminal capabilities</a>
+  <a href="#overview">Overview</a>
   ·
   <a href="#quick-start">Quick start</a>
   ·
-  <a href="#verified-scope">Verification</a>
+  <a href="#clarify-and-plan">Clarify and Plan</a>
+  ·
+  <a href="#features">Features</a>
+  ·
+  <a href="#compatibility-and-verification">Compatibility</a>
 </p>
 
 <p>English · <a href="README.zh.md">中文</a></p>
@@ -32,149 +32,17 @@
 
 ---
 
-## Project overview
+## Overview
 
-Run `deepseek` from a project directory to use the native Agent, Session, model, permission, Settings, Profile, plugin, and persistence services of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) from one terminal workspace. Prompts, code changes, tool calls, sessions, model routes, permissions, plugins, subagents, and diagnostics all operate on the same Harness state.
+Run `deepseek` from a project directory to use the native Agent, Session, model, permission, Settings, Profile, plugin, and persistence services of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) in one terminal workspace. SeekTTY is the terminal surface; Harness remains the owner of runtime state.
 
-When an idea still needs definition, the optional plugin-backed `/clarify` workflow reads the active Session and composer draft, follows the real model route, and generates Socratic questions, contextual options, and a live draft preview that evolves after every answer. Accepting the preview places a complete Draft back in the ordinary composer for review and manual submission. Harness native `/plan` can then turn the clarified requirement into an implementation plan.
+Models, Providers, Agent Presets, permissions, commands, tools, Settings, Skills, MCP servers, and marketplace sources are discovered from the running Harness. Capabilities added by upstream or third-party Bundles therefore appear without being hard-coded into SeekTTY.
 
-The [Clarify Host plugin](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) owns the Session-bound clarification process, model-generated questions, options, previews, and six-method Remote. When that compatible plugin capability is active, SeekTTY detects it and adds the local `/clarify` command plus its keyboard-first TUI surface. SeekTTY passes the current Session and draft to the plugin, then writes an accepted Draft back into the composer.
-
-Clarify model calls run through [Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) and are recorded in its dedicated `auxiliary_runtime` ledger. Official Agent-loop usage remains in `tokenUsage`; SeekTTY `/status` shows separately sourced Official, Auxiliary, and derived Combined totals while the snapshot contract is healthy.
-
-## DeepSeek light and dark interfaces
-
-### Light theme
-
-![SeekTTY DeepSeek light start screen](assets/seektty-tui.png)
-
-### Dark theme
-
-![SeekTTY DeepSeek dark start screen](assets/seektty-tui-dark.png)
-
-The live view fills the terminal and keeps the composer and status at the bottom. Unused rows remain inside the conversation viewport and disappear as output grows; longer conversations continue into native terminal scrollback.
-
-## Clarify and Plan
-
-[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) is an optional DeepSeek Harness Host plugin, and SeekTTY is its keyboard-first terminal consumer. Plugin-backed Clarify and Harness-native Plan cover consecutive parts of one workflow.
-
-Clarify handles the stage where the desired outcome still needs definition. It uses the current Session and draft to ask one focused question at a time, carries accepted decisions forward, and updates a reviewable Draft after every answer. Accepting returns that Draft to the composer. You can edit it and press Enter when it represents what you want.
-
-Plan handles the stage where the requirement is ready for implementation. Harness native `/plan` turns the submitted requirement into an implementation proposal and opens the normal plan-review flow.
-
-### Where `/clarify` comes from
-
-| Component | Responsibility |
-| --- | --- |
-| **SeekTTY** | Probes the Clarify Remote, dynamically adds `/clarify` to the local command catalog, renders the terminal interaction, supplies the current Session and composer seed, and returns an accepted Draft to the composer. |
-| **dsh-plugin-clarify** | Publishes `start`, `answer`, `accept`, `refine`, `cancel`, and `fetchDraft` over `clarify.wire/1`; owns the temporary clarification process and generates questions, options, and evolving Draft previews. |
-| **dsh-plugin-auxiliary-runtime** | Provides Clarify's same-process model execution, limits, cancellation, and separately sourced auxiliary usage. |
-
-The standalone SeekTTY shell presents its core command catalog. Activating the two Host plugins in the same Profile expands that catalog with the complete `/clarify` workflow.
-
-```text
-[Active Session + composer draft]
-              |
-              v
-     +------------------+      clarify Remote      +------------------+
-     | SeekTTY consumer | -----------------------> | Clarify plugin   |
-     | /clarify adapter | <----------------------- | process / model  |
-     +--------+---------+   live Draft preview     +--------+---------+
-              |                                            |
-              |                                            | same-process run
-              |                                            v
-              |                                   +-------------------+
-              |                                   | Auxiliary Runtime |
-              |                                   | limits / cancel   |
-              |                                   | usage ledger      |
-              |                                   +---------+---------+
-              |                                             |
-              |                                             v
-              |                                   [official model route]
-              |                                   off-transcript, no-tools
-              |
-              | accept: Draft returns to the composer
-              v
-        [review and edit]
-              |
-              | press Enter
-              v
-     [formal Session message]
-              |
-              | /plan when an implementation plan is useful
-              v
-     [plan review -> Agent execution]
-
-Auxiliary snapshot ---------------------> SeekTTY /status
-                                          Official | Auxiliary | Combined
-```
-
-### Main Session transcript
-
-Questions, options, preview revisions, and refine feedback live in a temporary clarification process held in Host memory. It enters `stale` after 15 minutes without interaction by default and reports `staleReason=ttl-expired`. The main Session transcript receives the formal user message only after you submit the accepted Draft. Clarification state stays out of the input queue, pending interactions, Plan, Goal, Profile files, and SeekTTY local files.
-
-### Auxiliary model usage
-
-Each Clarify model call is recorded by Auxiliary Runtime in the official `storageDomain` under `auxiliary_runtime`. Official `tokenUsage` continues to represent Agent-loop calls. Auxiliary derives Combined values from the four disjoint buckets—`uncachedInputTokens`, `outputTokens`, `cacheReadTokens`, and `cacheWriteTokens`—at read time, and SeekTTY `/status` validates and displays the snapshot. The auxiliary ledger stores call identity, purpose, status, token buckets, normalized failures, and timestamps; prompts, message text, model output, custom answers, credentials, and filesystem paths stay outside the ledger.
-
-### Start plugin-backed Clarify from the composer
-
-SeekTTY adds `/clarify` to its local command catalog while the `dsh-plugin-clarify` Host plugin exposes a compatible six-method Remote with `clarify.wire/1`. The last jointly accepted Release still installs Clarify `0.2.1`; `0.2.0` remains an available rollback artifact. The unpublished trio SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` has Lane A no-key PTY evidence and 2026-08-22 Lane B live-provider observations on `candidate4`. This is not a Release or complete joint acceptance. Details are in [Verified scope](#verified-scope).
-
-- Run it from the command palette to keep the whole composer as the seed.
-- Type `/clarify some text` to use the argument as the seed.
-- End an existing draft with a standalone `/clarify` token or line to use the preceding draft as the seed.
-
-Every answer refreshes the live Draft preview. The number of questions follows the unresolved decisions in the current Session: Clarify usually asks one focused question at a time and moves directly to review when the preview is ready to send. You can answer, refine the preview directly, accept it, or cancel. Accepting writes the reviewed Draft into the ordinary composer; Enter remains the explicit send action.
-
-## Custom interface and code themes, including VS Code imports
-
-Theme customization is a first-class SeekTTY feature: interface background and text colors are editable, code-block colors and syntax styles are independently editable, and `/theme import` accepts local VS Code JSON/JSONC themes with portable TextMate token colors. A palette of 3–16 colors can also generate a complete light or dark theme for preview and further adjustment.
-
-### TypeScript in the DeepSeek light interface
-
-![SeekTTY light TypeScript syntax highlighting](assets/seektty-code-light.png)
-
-### Tool parameters, file reads, and Diff in the DeepSeek dark interface
-
-![SeekTTY dark tool and Diff syntax highlighting](assets/seektty-code-dark.png)
-
-Markdown fences disappear into continuous code surfaces. Assistant code, Shell commands, structured tool parameters, file reads, JSON, and Diff use the same active code theme; ordinary conversation text keeps the interface style. Every code background occupies continuous terminal cells and forms one uninterrupted surface.
-
-## Harness capabilities available in the TUI
-
-The current release covers these capabilities:
-
-| Area | Available operations |
-| --- | --- |
-| Conversation and runs | Streaming responses, Markdown/GFM, fence-free theme-aware syntax-highlighted code blocks, links, tables, reasoning visibility, collapsed/expanded/hidden tool cards, model retries, compaction, output-limit and error states, and Ctrl+C cancellation |
-| Sessions | Create, resume, list, full-text search, rename, fork, archive, copy the last answer, export ZIP, or `/export md` Markdown |
-| Workspaces | Start from the current directory; add, select, rename, unregister, reorder, and reorder sessions within a workspace; unregistering never deletes files or session logs |
-| Agent modes | Standard, Code/PTC, Minimal, and Cordis/Create baseline modes plus dynamically registered Agent Presets; switching an active conversation creates a new session in the same workspace |
-| Models and Providers | Dynamic Provider, model, and supported reasoning-effort discovery; current route display; per-session switching; catalog, credential, and routing diagnostics |
-| Permissions and approvals | Inspect and switch Host permission presets, cycle with Shift+Tab, confirm risky upgrades, allow one tool call, skip further prompts for a tool in this session, or reject |
-| Input queue and steering | Queue prompts while the Agent runs, inspect/edit/remove entries, steer one entry or the entire queue into the active turn, and send `/steer` directly |
-| Human interaction | Single choice, multi-select, custom answers, skip, cancel, and plan review; submitting an interaction returns to the latest output while the blocked turn resumes, with `/pending` recovery when retrying is needed |
-| Image attachments | Add PNG, JPEG, GIF, or WebP by pasting an image or file path, or with `/attach`; macOS reads the clipboard via `osascript` (optional `pngpaste`), Linux via `wl-paste`/`xclip`, Windows via PowerShell; pending images appear under the composer; enforce the live Host `imageLimits` catalog (count, bytes, pixels, optional side length); render inline when supported and fall back to file metadata otherwise. Image-capable models come from that same live catalog. Official dsh `0.1.1-rc.2` Vision-Exp must be selected explicitly in `/model`. Lane A observed it listed and selectable; Lane B on `candidate4` observed PNG send-and-clear and JFIF via the official Host PNG variant. See [Verified scope](#verified-scope) |
-| Plan, Goal, Todo, and compaction | Native `/plan`, `/goal`, and `/compact` commands with plan review, goal state, Todo counts, and compaction records in the transcript |
-| Tools and produced files | `◆ action · duration` headers with live elapsed time and connected invocation code, dynamic tool catalog, parameters, execution-boundary guidance, line-numbered highlighted file reads, highlighted Shell/JSON/Diff views, safe native terminal ANSI, generic fallback cards, session-wide produced-file listing grouped by turn, in-TUI view, path copy, and confirmed external open |
-| Subagents | Inspect direct children, activity, tree state, token use, and duration; open continuable or read-only sessions and stop an active child turn |
-| Background jobs and workflows | Job type, status, start/end times, duration, and detail views; workflow phases, members, results, and failure states in the transcript |
-| Statistics and trajectory | Per-turn steps, LLM/tool time, first-token latency, throughput, cache hit, input/output tokens, model requests, running calls, and structured trajectory inspection |
-| Profiles | List, create, copy, switch, and diagnose terminal compatibility; controlled restart restores the workspace, session, unsent draft, and attachments |
-| Settings and credentials | First-run API-key setup when no usable Provider exists; enumerate every Settings namespace in the active Profile; dedicated default-model, permission, Agent-mode, and marketplace-source controls; Schema fallback for all other fields; write-only secrets |
-| Plugins and marketplace | `/plugin` center, installed list, search, details, install, remove, update, Bundle ordering, source management, and diagnostics; npm, Git, tarball, and local-path specs |
-| Skills and MCP | Dynamic user-invocable Skill discovery and native command insertion; MCP tools, instances, settings, load state, and separate process/remote-service risk information |
-| Feedback | Session feedback plus positive/negative Assistant-message ratings, optional notes, and feedback removal |
-| Status and diagnostics | Harness, Node, platform, Profile, workspace, session, mode, model, permission, pnpm, plugin state, and actionable diagnostics |
-| Themes | Independent interface and code-block themes; automatic code colors follow DeepSeek dark/light; named custom themes, manual colors, 3–16-color generation, and local VS Code JSON/JSONC import with TextMate colors and portable token styles; live preview, contrast warnings, terminal-color fallbacks, and `NO_COLOR` |
-| Interface language | Live Chinese/English switching through `/language`; the explicit preference is shared with Harness Web through the official `locale.preference` Settings value, while `auto` follows the terminal locale |
-
-Models, Providers, Agent Presets, permissions, Host commands, tools, Settings, Skills, MCP, and marketplace sources are discovered from the running Harness. New capabilities registered by upstream or third-party Bundles enter the dynamic catalogs, with Schema controls, structured details, and actionable diagnostics available while dedicated views evolve.
+For requirements that still need definition, the optional [Clarify Host plugin](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) adds a guided `/clarify` workflow. It asks focused questions, updates a reviewable Draft after each answer, and returns the accepted Draft to the composer. Harness-native `/plan` can then turn the submitted requirement into an implementation plan.
 
 ## Quick start
 
-The repositories and GitHub Releases are public. The last jointly accepted Clarify workflow remains official DeepSeek Harness `0.1.0-rc.8` with SeekTTY `1.2.0`, Auxiliary Runtime `0.1.0`, and Clarify `0.2.1`. Install those published tarballs through the native `dsh plugin` command:
+The last jointly accepted Clarify stack uses official DeepSeek Harness `0.1.0-rc.8`, SeekTTY `1.2.0`, [Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) `0.1.0`, and Clarify `0.2.1`:
 
 ```sh
 pnpm add --global @deepseek-ai/dsh@0.1.0-rc.8
@@ -186,13 +54,11 @@ dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/dsh-plugin-cl
 dsh --profile tui
 ```
 
-This path consumes packed artifacts and avoids Git-source `prepare` / `allowBuilds`. The first package installs the standalone SeekTTY shell, the second provides Auxiliary model execution, and the third provides the Clarify Host service and Remote. Once both Host plugins are active in the same Profile, SeekTTY discovers the Remote and adds `/clarify` to the terminal command catalog.
-
-SeekTTY `1.2.1` currently tests official `0.1.1-rc.2`. The unpublished trio SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` has Lane A no-key PTY evidence and 2026-08-22 Lane B live-provider observations on `candidate4`. This is not a Release or complete joint acceptance. Details are in [Verified scope](#verified-scope). There is no `v1.2.1` Release asset yet; install this candidate from a locally packed tarball, or from a future GitHub Release listed at https://github.com/Hilbert-beinghappy/seektty/releases. Do not invent a download URL.
+These commands install prebuilt tarballs through native `dsh plugin` reconciliation. SeekTTY works on its own; the two Host plugins add `/clarify` and its separately accounted model runtime.
 
 ### Bare `deepseek` launcher
 
-SeekTTY supports macOS, Linux, and Windows. Install the same Release tarball globally; on Windows, `pnpm add --global` creates PATHEXT-aware shims for `dsh.cmd`.
+After installing `dsh`, install the same SeekTTY release globally and pin Profile reconciliation to that tarball:
 
 ```sh
 pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
@@ -200,7 +66,7 @@ export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/downl
 deepseek
 ```
 
-PowerShell uses the same URL:
+PowerShell uses the same package URL:
 
 ```powershell
 pnpm add --global 'https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz'
@@ -208,7 +74,7 @@ $env:SEEKTTY_SPEC='https://github.com/Hilbert-beinghappy/seektty/releases/downlo
 deepseek
 ```
 
-`deepseek` requires `dsh` on `PATH`, or `DSH_BIN` pointing at the executable. `SEEKTTY_SPEC` pins Profile reconciliation to the same prebuilt tarball. Without that override, this source tree's default spec is `github:Hilbert-beinghappy/seektty#v1.2.1`; that Git tag exists only after the Release is created. Until then, pack `seektty-1.2.1.tgz` and set `SEEKTTY_SPEC` to that file. Later runs boot the same Profile. Initial tasks, workspaces, Session resume, and custom Profiles are supported:
+`deepseek` requires `dsh` on `PATH`, or `DSH_BIN` pointing to its executable. Common launch forms include:
 
 ```sh
 deepseek "check this project"
@@ -220,27 +86,78 @@ deepseek --version
 deepseek --update
 ```
 
-`deepseek --update` force-scans and installs at most one permitted component. Default `SEEKTTY_UPDATE=auto`: on launch it fetches official dsh npm `latest` (discovery only; not `next` or GitHub pre-releases) and the newest SeekTTY GitHub Release. SeekTTY is self-first: a SeekTTY update wins the round and skips dsh. Otherwise dsh installs only when `latest` is in the peer-aligned auto range (legacy rc.6–rc.8 or the exact current tested Host) and is newer than the installed `dsh --version`. Future or gap Hosts such as `0.1.1-rc.1` are mentioned but never installed. `DSH_BIN` pins skip dsh. Local `link:`/`file:` installs and `SEEKTTY_SPEC` overrides are left alone. Network or install failures never block boot. Set `SEEKTTY_UPDATE=check` to restore a post-session notice, or `SEEKTTY_UPDATE=0` to disable.
+`deepseek --update` checks the latest SeekTTY release first, installs at most one compatible component per run, and never installs an untested gap or future Host. `DSH_BIN`, local installs, and `SEEKTTY_SPEC` overrides are left unchanged. Update failures do not block startup. Set `SEEKTTY_UPDATE=check` for a post-session notice or `SEEKTTY_UPDATE=0` to disable checks.
+
+SeekTTY `1.2.1` is currently a source candidate tested with official Harness `0.1.1-rc.2`; no `v1.2.1` release tarball is published. Build it with `pnpm run build && pnpm pack` and point `SEEKTTY_SPEC` to the resulting tarball, or use a later asset listed on the [Releases page](https://github.com/Hilbert-beinghappy/seektty/releases).
+
+## Interface
+
+| DeepSeek light | DeepSeek dark |
+| --- | --- |
+| ![SeekTTY DeepSeek light start screen](assets/seektty-tui.png) | ![SeekTTY DeepSeek dark start screen](assets/seektty-tui-dark.png) |
+
+| TypeScript in the light interface | Tools, file reads, and Diff in the dark interface |
+| --- | --- |
+| ![SeekTTY light TypeScript syntax highlighting](assets/seektty-code-light.png) | ![SeekTTY dark tool and Diff syntax highlighting](assets/seektty-code-dark.png) |
+
+The live view fills the terminal, keeps the composer and status at the bottom, and lets longer conversations continue into native scrollback. Assistant code, Shell commands, tool parameters, file reads, JSON, and Diff share the active code theme while ordinary conversation text keeps the interface theme.
+
+## Clarify and Plan
+
+Clarify and Plan cover consecutive stages of one workflow: Clarify helps decide **what** should be built; Harness-native Plan proposes **how** to build it.
+
+| Component | Responsibility |
+| --- | --- |
+| **SeekTTY** | Detects the Clarify Remote, adds `/clarify`, renders the terminal interaction, supplies the active Session and draft, and returns an accepted Draft to the composer. |
+| **dsh-plugin-clarify** | Owns the temporary clarification process and publishes `start`, `answer`, `accept`, `refine`, `cancel`, and `fetchDraft` over `clarify.wire/1`. |
+| **dsh-plugin-auxiliary-runtime** | Runs Clarify model calls through the active model route with limits, cancellation, and a separate usage ledger. |
+
+Start Clarify in any of these ways:
+
+- Choose `/clarify` from the command palette to use the whole composer as the seed.
+- Type `/clarify some text` to use its argument as the seed.
+- End an existing draft with a standalone `/clarify` token or line to use the preceding text as the seed.
+
+Clarify asks one focused question at a time, carries accepted decisions forward, and refreshes the Draft preview after every answer. You can answer, refine, accept, or cancel. Accepting only writes the Draft into the ordinary composer; Enter remains the explicit send action. Run `/plan` after submission when an implementation proposal is useful.
+
+Questions, options, previews, and refine feedback remain in Host memory and become stale after 15 minutes without interaction by default. The main Session receives only the Draft you explicitly submit. Auxiliary usage is stored in the official `storageDomain` under `auxiliary_runtime`; prompts, answers, model output, credentials, and filesystem paths are excluded. `/status` displays validated Official, Auxiliary, and derived Combined totals without changing official Agent `tokenUsage`.
+
+See [Compatibility and verification](#compatibility-and-verification) for the accepted release stack and current candidate boundary.
+
+## Features
+
+| Area | Available operations |
+| --- | --- |
+| Conversation | Streaming Markdown/GFM, syntax-highlighted code, links, tables, reasoning visibility, tool-card display modes, retries, compaction, cancellation, and error states |
+| Sessions and workspaces | Create, resume, search, rename, fork, archive, reorder, copy, export, and switch workspaces without deleting project files or logs |
+| Agents, models, and permissions | Dynamic Agent Presets, Providers, models, reasoning efforts, and permission presets with per-session switching and diagnostics |
+| Queue and interaction | Queue or steer prompts during a run; edit queue entries; answer single-choice, multi-select, custom, skip, cancel, and plan-review prompts |
+| Images | Paste or attach PNG, JPEG, GIF, or WebP; enforce live Host limits; restore pending attachments; render inline when the terminal supports it |
+| Plan, Goal, Todo, and compaction | Native `/plan`, `/goal`, and `/compact` with plan review, goal state, Todo counts, and transcript records |
+| Tools and files | Live tool duration, highlighted parameters and results, file reads with source line numbers, Shell/JSON/Diff views, produced-file browsing, path copy, and confirmed external open |
+| Subagents and background work | Inspect or stop direct subagents; view jobs, workflow phases, results, failures, token use, duration, and structured trajectory data |
+| Profiles and Settings | Create, copy, switch, and diagnose Profiles; edit every registered Settings namespace with Schema fallbacks, revision checks, and write-only secrets |
+| Plugins, Skills, and MCP | Plugin center, native Bundle reconciliation, dynamic Skill commands, MCP instances, load state, settings, and risk information |
+| Themes and language | Independent interface/code themes, palette generation, VS Code theme import, contrast checks, `NO_COLOR`, and live Chinese/English switching |
+| Diagnostics and feedback | Runtime status, actionable `/doctor` checks, Session feedback, Assistant-message ratings, and feedback removal |
+
+SeekTTY reads these catalogs from the active Harness Profile. Unsupported optional capabilities degrade safely while dedicated terminal views continue to evolve.
 
 ## First-run API key setup
 
-When the active Profile has no usable model Provider, and the official DeepSeek Provider exposes a missing writable credential reference, SeekTTY opens a centered write-only prompt before the first interface frame. An existing environment credential, a credential already stored by Harness, or another active Provider that uses ambient or keyless authentication skips the prompt.
+| Dark | Light |
+| --- | --- |
+| ![SeekTTY dark first-run API key prompt](assets/seektty-onboarding-dark.png) | ![SeekTTY light first-run API key prompt](assets/seektty-onboarding-light.png) |
 
-### Dark first-run prompt
+When the active Profile has no usable model Provider and the official DeepSeek Provider exposes a writable missing credential, SeekTTY opens a centered, write-only prompt. Existing environment credentials, stored Harness credentials, and ambient or keyless Providers skip it.
 
-![SeekTTY dark first-run API key prompt](assets/seektty-onboarding-dark.png)
+Input is masked and passed directly to Harness `credentials.set`. SeekTTY does not read it back or put it in Settings, logs, screenshots, or Session data. Saving does not make a paid validation request; authentication errors follow the normal Provider path on the first real request.
 
-### Light first-run prompt
-
-![SeekTTY light first-run API key prompt](assets/seektty-onboarding-light.png)
-
-Paste only the API key. Input is masked, and Enter passes the normalized value directly to Harness `credentials.set`; SeekTTY does not read it back, write a credential file, or place it in settings, logs, screenshots, or Session data. Saving does not send a paid validation request—the first real model request reports any authentication failure through the normal Harness Provider error path.
-
-Escape defers setup without blocking `/settings`, `/plugin`, or other local surfaces. Sending a normal prompt, a Skill command, or a prompt with attachments opens the same setup again. An initial `deepseek "task"`, submitted text, and draft attachments remain intact; after a successful save the pending prompt continues automatically, while another deferral restores it to the composer. If Provider inspection is unavailable, the official adapter is absent, or the credential layer is read-only, SeekTTY avoids an unusable form and points to `/settings` and `/doctor` while preserving Harness behavior.
+Escape defers setup without blocking local surfaces such as `/settings` or `/plugin`. Pending text and attachments are preserved, and the request continues automatically after a successful save. If credentials cannot be inspected or written, SeekTTY points to `/settings` and `/doctor` instead of showing an unusable form.
 
 ## Slash commands
 
-Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands, Host commands registered for the active Agent, and user-invocable Skills.
+Typing `/` opens a searchable menu that merges SeekTTY commands, Host commands for the active Agent, and user-invocable Skills.
 
 | Category | Commands |
 | --- | --- |
@@ -250,93 +167,33 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 | Runtime interaction | `/queue`, `/steer`, `/attach`, `/attachments`, `/pending` |
 | Runtime content | `/tools`, `/files`, `/jobs`, `/subagents`, `/trajectory` |
 | Extensions | `/plugin`, `/plugins`, `/skills`, `/mcp` |
-| Plugin-backed workflow | `/clarify` appears when `dsh-plugin-clarify` and its Auxiliary Runtime dependency are active in the current Profile |
-| Configuration and diagnostics | `/settings`, `/language`, `/theme`, `/status`, `/doctor`, `/feedback`, `/restart`; when last-accepted Auxiliary Runtime `0.1.0` or the current `0.1.1` candidate is healthy, `/status` shows separately labeled Official, Auxiliary, and Combined (derived) whole-Session usage without changing the official `tokenUsage` projection |
+| Plugin workflow | `/clarify` appears when a compatible Clarify Remote and Auxiliary Runtime are active |
+| Configuration and diagnostics | `/settings`, `/language`, `/theme`, `/status`, `/doctor`, `/feedback`, `/restart` |
 | Help and exit | `/help`, `/quit`, `/exit` |
 
-`/plugin`, `/workspace`, and `/profile` provide both complete interactive centers and direct subcommands. Unknown commands produce nearby suggestions and stay within the command surface. SeekTTY detects the Clarify plugin's compatible six-method Remote with `clarify.wire/1` and dynamically adds `/clarify` to the local `/` catalog. The plugin's model-generated questions, contextual options, and evolving preview lead to a reviewed Draft in the ordinary composer; you decide when to submit it. See [Clarify and Plan](#clarify-and-plan) for the full journey.
+`/plugin`, `/workspace`, and `/profile` provide interactive centers and direct subcommands. Unknown commands stay inside the command surface and show nearby suggestions.
 
 ## Common controls
 
 | Input | Action |
 | --- | --- |
-| Left-button drag, then the terminal copy shortcut | Use the terminal's native selection and copy for any visible TUI text (`Command+C` on macOS; normally `Ctrl+Shift+C` on Linux and Windows terminals) |
-| Mouse wheel / trackpad | Browse the native terminal scrollback while the composer remains active |
+| Left-button drag, then the terminal copy shortcut | Select and copy visible TUI text using the terminal (`Command+C` on macOS; usually `Ctrl+Shift+C` on Linux and Windows) |
+| Mouse wheel / trackpad | Browse native terminal scrollback while the composer remains active |
 | `/` | Open command and Skill candidates |
 | Enter / Shift+Enter | Submit or confirm / insert a newline |
 | Tab / Escape | Switch between composer and transcript / return or close the active overlay |
 | PgUp / PgDn / Home / End | Page through the transcript, jump to the oldest content, or return to the latest |
-| Shift+Tab | Cycle the current permission, confirming full access first |
+| Shift+Tab | Cycle permission presets, confirming full access first |
 | Shift+Left / Shift+Right | Jump to the previous or next user turn |
-| F1 | Open in-app help |
-| Ctrl+P | Open the complete command palette |
-| Ctrl+M | Open model selection when the terminal exposes an extended keyboard protocol |
-| Ctrl+S | Open session resume |
+| F1 / Ctrl+P | Open help / open the command palette |
+| Ctrl+M / Ctrl+S | Open model selection / open Session resume |
 | Ctrl+O / Ctrl+T | Cycle tool-card display / show or hide reasoning |
 | F2 / Ctrl+, / Cmd+, | Open Settings |
 | Ctrl+C | Stop the active turn, clear a draft, or confirm exit with a second press |
 
-## Migrate from deepseek-tui
+## Themes and language
 
-Replace the former global package once. The new `deepseek` launcher then uses native `dsh plugin` commands to replace the legacy Bundle identity in the target Profile with `seektty`:
-
-```sh
-pnpm remove --global deepseek-tui
-pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-deepseek
-```
-
-Custom Profiles migrate independently on first launch, for example `deepseek --profile team-tui`. Native dsh-only installations can migrate explicitly:
-
-```sh
-dsh plugin --profile tui remove deepseek-tui
-dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-```
-
-## Plug and unplug
-
-Removal changes only the target Profile, never the dsh installation:
-
-```sh
-dsh plugin --profile tui remove seektty
-```
-
-Reinstall with the same native command:
-
-```sh
-dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-```
-
-Installation writes directly to the target Harness Profile dependencies, Bundle order, and pnpm lockfile. TUI `/plugin` and native `dsh plugin` operate on that same Profile state.
-
-## Plugin center
-
-Bare `/plugin` opens the current Profile's plugin center, and `/plugins` is an alias. Direct subcommands include `list`, `search`, `info`, `install`, `remove`, `update`, `reorder`, `source`, and `doctor`.
-
-- Search npm Registry by default, add JSON/HTTP Catalogs, and consume sources registered by other Harness Bundles.
-- Install npm names, Git URLs, tarballs, file URLs, and local directories.
-- Preflight `dsh.bundle.patch`, packed files, the final install spec, build scripts, and the target Profile.
-- Restart immediately after install, removal, update, or reorder while restoring the workspace, session, draft, and attachments.
-- Inspect version, source, publisher, Bundle state, load order, and actionable diagnostics.
-
-## Models, settings, and themes
-
-`/model` discovers Providers, models, and reasoning efforts from Harness and immediately refreshes the effective model shown in the composer. `/mode` manages Agent Presets, while `/permission` manages the active session permission; each has a separate runtime meaning.
-
-`/settings` lists every Settings namespace registered in the current Profile. Default model, default permission, default Agent mode, and marketplace sources have dedicated selectors. Boolean, enum, number, text, JSON, Secret, Credential Ref, and other fields remain editable through the generic Schema UI. It shows inherited values, user overrides, reset actions, and live/restart timing; revision checks protect concurrent writes. Secrets expose only whether a value is configured and use masked input.
-
-SeekTTY terminal copy ships in Chinese and English. `/language` opens the language selector, and direct forms are available for scripts or quick switching:
-
-```text
-/language auto
-/language zh
-/language en
-```
-
-The selection is stored by the official `@deepseek-ai/dsh-client-locale` Host plugin as `locale.preference`, so the TUI and Harness Web use the same explicit preference. `auto` removes that override: SeekTTY then checks `LC_ALL`, `LC_MESSAGES`, `LANGUAGE`, and `LANG`, while the browser keeps using its own platform-language fallback. Switching is live and rebuilds the terminal chrome and transcript presentation without changing model, tool, user, Provider, or plugin-authored content.
-
-SeekTTY starts with its DeepSeek dark theme. `/theme` opens a complete theme center; built-in and named themes can also be managed directly:
+SeekTTY starts with its DeepSeek dark theme. `/theme` opens the theme center; direct forms include:
 
 ```text
 /theme dark
@@ -349,51 +206,85 @@ SeekTTY starts with its DeepSeek dark theme. `/theme` opens a complete theme cen
 /theme delete <name>
 ```
 
-The interface theme and code-block theme are independent. `/theme light`, `/theme dark`, and `/theme use <name>` select a complete matching interface/code pair. With `/theme code auto`, code background, foreground, syntax colors, and dark/light direction follow the active interface theme, so DeepSeek light uses light code blocks. `/theme code dark`, `/theme code light`, or `/theme code <name>` explicitly overrides only code until another complete interface theme is selected. `/theme edit` changes a complete named theme, while `/theme palette` accepts 3–16 HEX/RGB color codes and builds dark and light candidates.
+Interface and code themes are independent. A palette of 3–16 HEX/RGB colors can generate light and dark candidates. `/theme import` reads local VS Code JSON/JSONC themes, resolves relative `include` files, and preserves portable TextMate colors and styles. Every customization path previews changes and flags low contrast before saving. Definitions live in the revision-protected `seektty-appearance` Harness Settings namespace.
 
-`/theme import` reads a local VS Code JSON/JSONC theme, recursively resolves relative `include` files, maps editor and semantic-token colors, and preserves portable TextMate foreground, background, bold, italic, underline, and strikethrough rules. An imported VS Code theme becomes the active code theme without replacing the current interface theme. Every customization path opens a live preview before saving. Low-contrast colors are never silently replaced; the preview identifies the affected roles and asks for a second confirmation.
+Use `/language` or a direct command to switch the terminal copy live:
 
-Custom themes cover the terminal canvas, panels, selection, text, border, brand and status colors, code background and foreground, and semantic roles for comments, keywords, strings, numbers, constants, functions, types, variables, properties, parameters, operators, punctuation, tags, attributes, and regular expressions. Assistant Markdown code, Shell invocations, structured tool parameters, file reads, JSON, and Diff all use the same code theme. Tool calls render as a compact action/duration header followed by `⎿`-connected invocation code; the duration advances from the Harness call timestamp while the tool is active and freezes at settlement. Collapsed cards retain the invocation while expanded cards add results. Common grammars are ready at startup; other supported grammars load on demand and redraw in place. Theme changes recolor existing messages without moving the transcript, losing expanded state, or changing the draft.
+```text
+/language auto
+/language zh
+/language en
+```
 
-The interface selection, independent code selection, and named definitions live in the `seektty-appearance` Harness Settings namespace under revision protection. `/settings` can therefore edit the same data through its generic Schema UI. Theme names are case-insensitively unique; overwrites and deletion require confirmation. Deleting an active interface theme returns the interface to DeepSeek dark, while deleting an active code theme returns code to automatic pairing. VS Code font families and sizes are deliberately ignored because the terminal owns the character-grid font; imported bold/italic and related styles apply only to code tokens and never restyle ordinary Chinese, English, system text, or tool titles.
+The explicit preference is stored by the official locale plugin as `locale.preference` and shared with Harness Web. `auto` removes the override and follows the terminal locale. Switching changes SeekTTY chrome and transcript presentation without rewriting model, tool, user, Provider, or plugin-authored content.
 
-## Verified scope
+## Plugin center
 
-- Isolated install, configuration composition, and PTY boot against official stock `@deepseek-ai/dsh@0.1.0-rc.8`, plus the add/boot/remove/re-add contract against the declared minimum `@deepseek-ai/dsh@0.1.0-rc.6`.
-- SeekTTY `1.2.1` currently tests official `@deepseek-ai/dsh@0.1.1-rc.2` at the shell, unit, and typecheck layer. Lane A (2026-08-21, unmodified stock `0.1.1-rc.2`, isolated `DSH_HOME`, real PTY, unpublished SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`): `/doctor` 0 error / 0 warning, 99 plugins running; `/status` healthy; `/clarify` routed through Auxiliary, returned `MISSING_CREDENTIAL` without a key, and kept the composer; Vision-Exp was visible and selectable; a PNG attachment restored after `/restart`. Missing-source restore: unit tests keep the failure copy to a basename, cover both notice orders, and keep absolute paths out of the text; a real-PTY hardcopy/visible scan found only the ASCII basename `vision-logo.png` and none of `private/tmp`, `/tmp`, `Users`, or `Volumes`. That does not prove the restore error stayed visible after dismissing the no-key onboarding modal (Esc also clears notices). Lane B (2026-08-22, unmodified stock `0.1.1-rc.2`, isolated `DSH_HOME`, `candidate4`): Vision-Exp was selected explicitly; a PNG image-only send succeeded, cleared attachments on send, and recognized the logo, but the image-only prompt with no question led the model to call `read_image` again; a real JFIF JPEG queued through SeekTTY was converted by the official Host to a PNG variant as usual, then OCR succeeded without tools; Clarify via Auxiliary completed 6 dynamic rounds, a 41-line full review, and a second-confirm accept back into the composer without auto-send; `/status` showed Official, Auxiliary, and Combined usage; an 895-file scan found 0 secret literals. This is not a Release or complete joint acceptance. It does not prove Web UI, GIF/WebP, over-limit rejection, JPEG original-byte passthrough, PNG without any tool use, this-round interruption recovery, or a cost/cache A/B.
-- Last jointly accepted Release installation: Clarify `0.2.1` with SeekTTY `1.2.0`, Auxiliary Runtime `0.1.0`, and official dsh `0.1.0-rc.8`. Clarify `0.2.1` preserves the six-method Remote, `clarify.wire/1`, and exact rc.8 compatibility boundary of `0.2.0`.
-- Clarify `0.2.0` live-provider acceptance covered model-generated questions/options/previews, multi-round preview evolution, review-and-accept into the composer without automatic submission, interruption recovery, usage provenance, and privacy.
-- Clarify `0.2.1` post-release no-key acceptance re-downloaded and verified all three Release assets, passed stock add/boot/remove/re-add and `/doctor` with 0 errors, 0 warnings, and 99 plugins, then reached `running`, routed through Auxiliary, and returned the expected isolated-environment `MISSING_CREDENTIAL` result. Version `0.2.1` has not rerun live-provider multi-round acceptance or a cache/cost A/B.
-- Historical standalone Clarify lifecycle evidence covers official dsh rc.6/rc.7/rc.8; the complete dynamic production boundary remains exact rc.8 with Auxiliary Runtime `0.1.0`.
-- Auxiliary calls persist usage/limits/cancel only in the `auxiliary_runtime` storage domain. Official Agent `tokenUsage` remains unchanged, while `/status` displays validated `Official`, `Auxiliary`, and derived `Combined` buckets only when the optional snapshot contract is healthy.
-- Model listing, Provider/model/reasoning selection, request submission, and Harness error propagation.
-- First-run Provider readiness, masked API-key setup, deferral and draft restoration, Harness credential persistence, and restart without another prompt under an isolated `DSH_HOME`.
-- Real dark, light, and palette-generated PTY rendering, independent live interface/code switching, 80/120/160-column layouts, and persistence after restarting the same Profile.
-- Chinese/English locale resolution, revision-protected shared preference writes, live terminal switching, and preservation of unknown external content.
-- Native removal clears the dependency, Bundle, and config entries; re-add boots again.
-- A fresh packed global install, with no workspace development dependencies or duplicate `@deepseek-ai/*` packages, exposes bare `deepseek`, provisions the `tui` Profile, and boots through the official dsh module fallback.
-- A real native `todo_write` journey passes after installation; the package gate also rejects Profile-local copies of official identity-bearing Host packages and verifies that Cordis, API proxy, Session, and tool runtime resolve to the official fallback instance.
-- Installation, startup, keyboard navigation, and terminal interaction are supported on macOS, Linux, and Windows.
+`/plugin` opens the active Profile's plugin center; `/plugins` is an alias. Direct subcommands include `list`, `search`, `info`, `install`, `remove`, `update`, `reorder`, `source`, and `doctor`.
 
-A real first-run session was verified with a valid DeepSeek credential pasted into the masked overlay under an isolated `DSH_HOME`: `v4-flash` returned `REALCHECK_58597`, then used that answer in the next turn to return `REALCHECK_58598`. Restarting the same Profile did not reopen setup, the Harness credential file was mode `0600`, and the credential never appeared in terminal output, screenshots, or the repository. The isolated credential store was removed after verification.
+- Search npm by default, add JSON/HTTP catalogs, or use sources registered by other Bundles.
+- Install npm names, Git URLs, tarballs, file URLs, and local directories.
+- Preflight `dsh.bundle.patch`, packed files, install specs, build scripts, and the target Profile.
+- Restart after a mutation while restoring the workspace, Session, draft, and attachments.
+- Inspect versions, sources, publishers, Bundle order, load state, and actionable diagnostics.
 
-Reusable stock-dsh contract check:
+TUI `/plugin` and native `dsh plugin` reconcile the same Profile dependencies, Bundle order, and pnpm lockfile.
+
+## Migration and removal
+
+Replace the former `deepseek-tui` global package once:
 
 ```sh
+pnpm remove --global deepseek-tui
+pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+deepseek
+```
+
+Custom Profiles migrate independently on first launch. Native dsh-only installations can replace the Bundle explicitly:
+
+```sh
+dsh plugin --profile tui remove deepseek-tui
+dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+```
+
+Removing SeekTTY changes only the target Profile, never the dsh installation:
+
+```sh
+dsh plugin --profile tui remove seektty
+```
+
+## Compatibility and verification
+
+| Boundary | Version |
+| --- | --- |
+| Node.js | `^22.19.0 || >=24` |
+| Declared minimum Harness Host | `0.1.0-rc.6` |
+| Current tested Harness Host | `0.1.1-rc.2` |
+| Last jointly accepted Clarify release stack | dsh `0.1.0-rc.8` + SeekTTY `1.2.0` + Auxiliary Runtime `0.1.0` + Clarify `0.2.1` |
+| Current source candidate | SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`; not a Release or complete joint acceptance |
+
+Hosts older than the declared minimum are rejected. Newer-than-tested Hosts may boot with a notice, but automatic updates install only an explicitly compatible range. The published Bundle does not install Cordis or identity-bearing `@deepseek-ai/dsh-*` packages into a Profile: optional peers describe the Host contract, and runtime imports resolve through the official Harness installation. The attachment compatibility adapter handles only the exact tested legacy image-limit shape and fails closed for unknown shapes.
+
+Verification includes:
+
+- Isolated stock-dsh add, boot, remove, and re-add lifecycle checks, including the declared minimum.
+- Type checking, unit tests, production build, packed-content checks, and duplicate-Host-package rejection.
+- Real PTY coverage for startup, navigation, dark/light/custom themes, 80/120/160-column layouts, locale switching, and restart restoration; installation and terminal interaction are supported on macOS, Linux, and Windows.
+- First-run credential setup and a real multi-turn Provider session without credential leakage into output, screenshots, or the repository.
+- Candidate observations on stock `0.1.1-rc.2` for Clarify, separate usage, PNG/JFIF attachments, Vision-Exp selection, and restart restoration. These observations do not establish full Web UI, GIF/WebP, over-limit, interruption-recovery, or cost/cache coverage.
+
+Reusable checks:
+
+```sh
+pnpm run check
+
 DSH_BIN=/path/to/dsh \
 SEEKTTY_SPEC=/path/to/seektty.tgz \
 pnpm test:stock
-```
 
-Reusable cross-package doctor check:
-
-```sh
 CLARIFY_SPEC=/path/to/dsh-plugin-clarify.tgz \
 pnpm test:clarify-doctor
 ```
 
-## Compatibility and upgrades
-
-The current tested Host is official `0.1.1-rc.2`. The shell's declared minimum remains official `0.1.0-rc.6`, with shell lifecycle coverage on the legacy rc.6/rc.7/rc.8 line. The last jointly accepted Clarify + Auxiliary production combination is still exact `0.1.0-rc.8` with SeekTTY `1.2.0`, Auxiliary Runtime `0.1.0`, and Clarify `0.2.1`. The unpublished trio SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` has Lane A no-key PTY evidence and 2026-08-22 Lane B live-provider observations on `candidate4`; this is not a Release or complete joint acceptance (see [Verified scope](#verified-scope)). A newer dsh than `tested` still boots the shell with a notice; older than the shell minimum is rejected. The updater judges the actually installed `dsh --version`, prefers a SeekTTY self-first update, installs at most one component per round, and never installs a future or gap Host. The published Bundle does not install a second copy of Cordis or any `@deepseek-ai/dsh-*` Host package into a Profile: optional peers describe the host contract, while runtime imports resolve through the official `$DSH_HOME/profiles/node_modules` fallback. This preserves identity-bearing symbols such as the native tool scheduler. Pure client helpers that the official fallback does not ship are bundled instead. The Host plugin `seektty/attachment-compat` still runs immediately before `api-gateway` and adapts only the exact valid legacy image-limit capability shape; all other shapes fail closed. Future hosts are matched by capability and unsupported optional features degrade safely. A scheduled workflow scans the official npm `latest` dist-tag, upgrades development baselines only after `pnpm run check`, packed-launcher isolation, and the stock-dsh contract pass, then opens a pull request. npm `next` and GitHub harness pre-releases are not followed.
-
-The source repository and its GitHub Releases are public. User packages come from the prebuilt tarball attached to the matching Release; there is currently no npm Registry release.
+User packages are distributed as prebuilt tarballs attached to matching GitHub Releases. There is currently no npm Registry release.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ deepseek --version
 deepseek --update
 ```
 
-`deepseek --update` checks the latest SeekTTY release first, installs at most one compatible component per run, and never installs an untested gap or future Host. `DSH_BIN`, local installs, and `SEEKTTY_SPEC` overrides are left unchanged. Update failures do not block startup. Set `SEEKTTY_UPDATE=check` for a post-session notice or `SEEKTTY_UPDATE=0` to disable checks.
+`deepseek --update` is self-first: it checks SeekTTY before dsh, installs at most one compatible component per run, and never installs an untested gap or future Host. `DSH_BIN`, local installs, and `SEEKTTY_SPEC` overrides are left unchanged. Update failures do not block startup. Set `SEEKTTY_UPDATE=check` for a post-session notice or `SEEKTTY_UPDATE=0` to disable checks.
 
 SeekTTY `1.2.1` is currently a source candidate tested with official Harness `0.1.1-rc.2`; no `v1.2.1` release tarball is published. Build it with `pnpm run build && pnpm pack` and point `SEEKTTY_SPEC` to the resulting tarball, or use a later asset listed on the [Releases page](https://github.com/Hilbert-beinghappy/seektty/releases).
 
@@ -255,6 +255,8 @@ dsh plugin --profile tui remove seektty
 ```
 
 ## Compatibility and verification
+
+The current tested Host is official `0.1.1-rc.2`; the complete compatibility boundary is summarized below.
 
 | Boundary | Version |
 | --- | --- |

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,7 +86,7 @@ deepseek --version
 deepseek --update
 ```
 
-`deepseek --update` 优先检查 SeekTTY，每轮最多安装一个兼容组件，绝不自动安装未测试的 gap 或未来 Host。`DSH_BIN`、本地安装和 `SEEKTTY_SPEC` 覆盖不会被改写，更新失败也不会阻止启动。设置 `SEEKTTY_UPDATE=check` 可改为会话后提示，设置 `SEEKTTY_UPDATE=0` 可关闭检查。
+`deepseek --update` 采用 SeekTTY 自更新优先策略：先检查 SeekTTY，再检查 dsh；每轮最多安装一个兼容组件，绝不自动安装未测试的 gap 或未来 Host。`DSH_BIN`、本地安装和 `SEEKTTY_SPEC` 覆盖不会被改写，更新失败也不会阻止启动。设置 `SEEKTTY_UPDATE=check` 可改为会话后提示，设置 `SEEKTTY_UPDATE=0` 可关闭检查。
 
 SeekTTY `1.2.1` 目前是已在官方 Harness `0.1.1-rc.2` 上测试的源码候选版，尚未发布 `v1.2.1` tarball。请运行 `pnpm run build && pnpm pack`，把 `SEEKTTY_SPEC` 指向生成的 tarball，或使用 [Releases 页面](https://github.com/Hilbert-beinghappy/seektty/releases)中后续列出的工件。
 
@@ -255,6 +255,8 @@ dsh plugin --profile tui remove seektty
 ```
 
 ## 兼容与验证
+
+当前已测 Host 是官方 `0.1.1-rc.2`；完整兼容边界汇总如下。
 
 | 边界 | 版本 |
 | --- | --- |

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 <h1>SeekTTY</h1>
 
-<p>DeepSeek Harness 的键盘优先终端工作台，陪你把一个想法推进到可执行方案。</p>
+<p>DeepSeek Harness 的键盘优先终端工作台。</p>
 
 <p>
   <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.1-orange" alt="Version 1.2.1"></a>
@@ -17,13 +17,13 @@
 <p>
   <a href="#项目概览">项目概览</a>
   ·
-  <a href="#clarify-与-plan">Clarify 与 Plan</a>
-  ·
-  <a href="#已经接入的-harness-能力">终端能力</a>
-  ·
   <a href="#快速开始">快速开始</a>
   ·
-  <a href="#已验证范围">验证</a>
+  <a href="#clarify-与-plan">Clarify 与 Plan</a>
+  ·
+  <a href="#功能">功能</a>
+  ·
+  <a href="#兼容与验证">兼容性</a>
 </p>
 
 <p><a href="README.md">English</a> · 中文</p>
@@ -34,147 +34,15 @@
 
 ## 项目概览
 
-进入项目目录运行 `deepseek`，就能在一个终端工作台里使用 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 原生的 Agent、Session、模型、权限、Settings、Profile、插件与持久化能力。提问、代码修改、工具调用、会话管理、模型路由、权限切换、插件、子 Agent 和运行诊断都落在同一套 Harness 状态上。
+进入项目目录运行 `deepseek`，即可在一个终端工作台中使用 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 原生的 Agent、Session、模型、权限、Settings、Profile、插件与持久化服务。SeekTTY 只负责终端界面；运行状态始终由 Harness 持有。
 
-想法还没有写完整时，可以进入由插件提供的 `/clarify` 工作流：Clarify 读取当前 Session 与输入区草稿，沿真实模型路由逐题生成苏格拉底式问题、上下文选项和 live Draft preview。每回答一题，预览稿都会吸收新的决定。采用后，完整 Draft 回到普通输入框，等你审阅、修改并自行发送。需求明确之后，再用 Harness 原生 `/plan` 把它写成实施方案。
+模型、Provider、Agent Preset、权限、命令、工具、Settings、Skill、MCP 服务和插件来源均从正在运行的 Harness 动态读取，因此上游或第三方 Bundle 新增的能力不需要硬编码进 SeekTTY。
 
-[Clarify Host 插件](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 持有绑定 Session 的澄清进程、模型生成的问题、选项、预览稿和六方法 Remote。兼容的插件能力激活后，SeekTTY 会自动探测它，并加入本地 `/clarify` 命令与键盘优先的 TUI 界面。SeekTTY 把当前 Session 和草稿交给插件，再把用户采用的 Draft 写回输入框。
-
-Clarify 的模型调用由 [Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) 承接，用量写入独立的 `auxiliary_runtime` 账本。官方 Agent 循环继续使用 `tokenUsage`；快照合同健康时，SeekTTY `/status` 分别展示来源清楚的 Official、Auxiliary 和派生 Combined 总量。
-
-## DeepSeek 亮色与暗色界面
-
-### 亮色主题
-
-![SeekTTY DeepSeek 亮色首屏](assets/seektty-tui.png)
-
-### 暗色主题
-
-![SeekTTY DeepSeek 暗色首屏](assets/seektty-tui-dark.png)
-
-最新视图会铺满终端，并让输入框与状态栏始终沉在底部。未使用的行属于中间的对话视口，会随着输出增长逐行收缩；更长的对话继续进入终端原生滚动记录。
-
-## Clarify 与 Plan
-
-[Clarify](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 是可选的 DeepSeek Harness Host 插件，SeekTTY 是它的键盘优先终端消费者。插件提供的 Clarify 与 Harness 原生 Plan 位于同一条工作流的前后两段。
-
-Clarify 处理“要做什么还需要问清”的阶段。它根据当前 Session 和草稿一次提出一个聚焦问题，把已经确认的决定带入后续问题，并在每一答之后更新可审阅的 Draft。采用后，这份 Draft 回到输入框；你可以继续改字，在它准确表达真实意图时按 Enter 发送。
-
-Plan 处理“需求已经明确、需要决定怎么做”的阶段。Harness 原生 `/plan` 把已经提交的需求整理为实施方案，并进入正常的计划审查流程。
-
-### `/clarify` 来自哪里
-
-| 组件 | 职责 |
-| --- | --- |
-| **SeekTTY** | 探测 Clarify Remote，动态把 `/clarify` 加入本地命令目录，渲染终端交互，提供当前 Session 与输入草稿，并把采用后的 Draft 写回输入框。 |
-| **dsh-plugin-clarify** | 通过 `clarify.wire/1` 发布 `start`、`answer`、`accept`、`refine`、`cancel` 和 `fetchDraft`，持有临时澄清进程，生成问题、选项与持续演进的 Draft preview。 |
-| **dsh-plugin-auxiliary-runtime** | 为 Clarify 提供同进程模型执行、限额、取消和来源独立的辅助用量。 |
-
-SeekTTY 单独运行时展示核心命令目录；两个 Host 插件在同一 Profile 激活后，命令目录会扩展出完整的 `/clarify` 工作流。
-
-```text
-[当前 Session + 输入草稿]
-              |
-              v
-     +------------------+      clarify Remote      +------------------+
-     | SeekTTY 消费端   | -----------------------> | Clarify 插件     |
-     | /clarify 适配器  | <----------------------- | 进程 / 模型生成  |
-     +--------+---------+   live Draft preview     +--------+---------+
-              |                                            |
-              |                                            | 同进程 run
-              |                                            v
-              |                                   +-------------------+
-              |                                   | Auxiliary Runtime |
-              |                                   | 限额 / 取消       |
-              |                                   | 独立用量账本      |
-              |                                   +---------+---------+
-              |                                             |
-              |                                             v
-              |                                   [官方模型路由]
-              |                                   transcript 外、无工具
-              |
-              | 采用：Draft 回到输入框
-              v
-          [审阅与修改]
-              |
-              | 按 Enter
-              v
-       [正式 Session 消息]
-              |
-              | 需要实施方案时运行 /plan
-              v
-       [计划审查 -> Agent 执行]
-
-Auxiliary snapshot ---------------------> SeekTTY /status
-                                          Official | Auxiliary | Combined
-```
-
-### 主 Session 对话记录
-
-问题、选项、预览稿变化和 refine 反馈保留在 Host 内存中的临时澄清进程里，默认 15 分钟无交互后进入 `stale`，并返回 `staleReason=ttl-expired`。主 Session transcript 在你正式发送采用后的 Draft 时才写入这条用户消息。澄清状态与 input queue、pending、Plan、Goal、Profile 文件和 SeekTTY 本地文件相互分离。
-
-### 辅助模型用量
-
-每一次 Clarify 模型调用都由 Auxiliary Runtime 记入官方 `storageDomain` 下的 `auxiliary_runtime` 域。官方 `tokenUsage` 继续表示 Agent 循环调用。Combined 在读取时按四个互不重叠的 Token 桶相加。辅助账本保存调用标识、purpose、状态、Token 桶、规范化失败和时间戳；prompt、消息正文、模型输出、自定义回答、凭据和文件路径不会进入账本。
-
-### 从输入框启动插件提供的 Clarify
-
-`dsh-plugin-clarify` Host 插件暴露兼容的六方法 Remote 与 `clarify.wire/1` 后，SeekTTY 会把 `/clarify` 加入本地命令目录。最近一次联合验收 Release 仍安装 Clarify `0.2.1`；`0.2.0` 保留为已发布回滚工件。未发布三件套 SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` 已有 Lane A 无 key PTY 证据，以及 2026-08-22 在 `candidate4` 上的 Lane B live-provider 观察。这不是 Release，也不是完整联合验收。详见 [已验证范围](#已验证范围)。
-
-- 从命令面板执行：保留整个输入区作为 seed。
-- 输入 `/clarify some text`：以参数文本作为 seed。
-- 在现有草稿末尾单独加入 `/clarify` token 或一行：以前面的草稿作为 seed。
-
-每次回答都会刷新 live Draft preview。提问数量跟随当前 Session 中尚未确认的关键决定：Clarify 通常一次只追问一个聚焦问题，预览已经可发送时直接进入审阅。你可以继续回答、直接 refine 当前预览、采用或放弃。采用会把审阅后的 Draft 写入普通输入框，按 Enter 仍是明确的发送动作。
-
-## 界面与代码主题自定义，并可导入 VS Code 主题
-
-主题能力是 SeekTTY 的核心特色：界面背景与文字颜色可自定义，代码块的背景、文字、语法高亮及粗体／斜体可独立自定义，`/theme import` 可导入本地 VS Code JSON/JSONC 主题并保留可移植的 TextMate Token 配色；还可以输入 3–16 个颜色，自动生成一套可预览、可继续调整的亮色或暗色主题。
-
-### DeepSeek 亮色界面中的 TypeScript
-
-![SeekTTY 亮色 TypeScript 语法高亮](assets/seektty-code-light.png)
-
-### DeepSeek 暗色界面中的工具参数、文件读取与 Diff
-
-![SeekTTY 暗色工具调用与 Diff 语法高亮](assets/seektty-code-dark.png)
-
-Markdown 围栏会直接渲染成连续代码色块。助手代码、Shell 指令、结构化工具参数、文件读取、JSON 和 Diff 使用同一套代码主题，普通对话文字仍保持界面样式。每块代码背景都连续覆盖真实终端单元格，不会出现逐行断开的横纹。
-
-## 已经接入的 Harness 能力
-
-当前版本覆盖以下能力：
-
-| 能力 | 当前可用操作 |
-| --- | --- |
-| 对话与运行 | 流式回复、Markdown/GFM、不显示围栏的主题语法高亮代码色块、链接、表格、推理显示切换、工具卡片折叠/展开/隐藏、模型重试、上下文压缩、最大输出与错误状态、Ctrl+C 停止当前轮次 |
-| 会话 | 新建、恢复、列表、全文搜索、重命名、Fork、归档、复制最后一条回复、导出 ZIP，或 `/export md` 导出 Markdown |
-| 工作区 | 从当前目录启动，添加、选择、重命名、移除注册、调整工作区顺序和工作区内会话顺序；移除注册不会删除目录、文件或会话日志 |
-| Agent 模式 | 支持 Standard、Code/PTC、Minimal、Cordis/Create 四种基线模式，并动态显示插件注册的新 Agent Preset；活跃会话切换模式时在同一工作区创建新会话 |
-| 模型与 Provider | 动态读取 Provider、模型和模型支持的推理强度，显示当前实际路由，切换当前会话模型，并报告目录、凭证和路由错误 |
-| 权限与审批 | 查看和切换只读、工作区、完全访问等 Host 权限；Shift+Tab 快速循环；进入高风险权限前确认；工具调用支持仅本次允许、本会话不再询问或拒绝 |
-| 输入队列与 Steer | Agent 运行时继续排队消息，查看、编辑、删除队列项，将单条或整队消息转为当前轮次引导，并可直接发送 `/steer` |
-| 人机交互 | 处理单选、多选、自定义回答、跳过、取消和计划审查；提交后自动回到最新输出并展示原轮次续答，失败时可通过 `/pending` 重试 |
-| 图片附件 | 直接粘贴图片或图片路径，或用 `/attach` 加入 PNG、JPEG、GIF、WebP；macOS 用系统剪贴板（osascript，可选 pngpaste），Linux 用 wl-paste/xclip，Windows 用 PowerShell；待发送图片显示在输入框下方；按当前 Host 动态 `imageLimits` 目录检查数量、字节、像素和可选边长；终端支持时内联显示，否则显示文件名、尺寸、类型和大小。能否理解图片由同一份动态模型目录决定。官方 dsh `0.1.1-rc.2` 的 Vision-Exp 必须在 `/model` 里显式选择。Lane A 已观察到目录可见且可选择；Lane B 在 `candidate4` 上已观察 PNG 发送即清附件，以及经官方 Host 转 PNG variant 的 JFIF。详见 [已验证范围](#已验证范围) |
-| Plan、Goal、Todo 与压缩 | 使用 Harness 原生 `/plan`、`/goal`、`/compact` 命令，显示计划审查、目标状态、Todo 数量和上下文压缩记录 |
-| 工具与产出文件 | `◆ 操作 · 耗时` 标题、运行中同步计时及带连接符的调用代码、动态工具目录、工具参数与安全边界说明、带原文件行号的高亮读取、Shell／JSON／Diff 高亮、安全保留的终端 ANSI、通用降级卡片；按轮次查看本会话生成文件、在 TUI 内查看、复制绝对路径，并在确认后交给外部程序打开 |
-| 子 Agent | 查看直接子 Agent、运行状态、树结构、Token 和耗时；打开可继续会话或只读会话，并在运行时停止当前子 Agent 轮次 |
-| 后台任务与工作流 | 查看 Jobs 的类型、状态、开始/结束时间、耗时和详情；在 Transcript 中显示工作流阶段、成员、结果和失败状态 |
-| 统计与轨迹 | 每轮显示步骤数、LLM/工具耗时、首 Token、吞吐率、缓存命中和输入/输出 Token；检查模型请求、运行中工具与结构化 Trajectory |
-| Profile | 查看、创建、复制和切换 Profile，诊断终端兼容性；受控重启会恢复工作区、会话、未发送草稿和附件 |
-| 设置与凭证 | 没有可用 Provider 时提供首次 API Key 引导；枚举当前 Profile 注册的全部 Settings；专用处理默认模型、默认权限、默认 Agent 模式和插件来源，其余字段通过 Schema 通用控件编辑；Secret 只写不回显 |
-| 插件与市场 | `/plugin` 插件中心、已安装列表、搜索、详情、安装、删除、更新、Bundle 排序、来源管理和诊断；支持 npm、Git、tarball 与本地路径安装 |
-| Skills 与 MCP | 动态列出当前可调用 Skills 并插入原生命令；查看 MCP 工具、实例、设置、加载状态和独立进程/远端服务风险 |
-| 反馈 | 记录会话反馈；对 Assistant 回复提交好评、差评和可选说明，也可删除已有消息反馈 |
-| 状态与诊断 | 查看 Harness、Node、平台、Profile、工作区、会话、模式、模型、权限、pnpm、插件运行状态及诊断信息 |
-| 主题 | 界面主题与代码块主题独立；自动模式下代码颜色跟随 DeepSeek 暗色／亮色；支持命名自定义主题、手动配色、输入 3–16 个颜色自动生成，以及本地导入 VS Code JSON/JSONC 并保留 TextMate 颜色和可移植 Token 样式；实时预览、对比度警告、终端颜色降级和 `NO_COLOR` |
-| 界面语言 | 通过 `/language` 在中文和英文之间实时切换；显式偏好通过官方 `locale.preference` Settings 与 Harness Web 共用，`auto` 则跟随终端语言环境 |
-
-模型、Provider、Agent Preset、权限、Host 命令、工具、Settings、Skills、MCP 和插件来源都从当前 Harness 运行时读取。上游或第三方 Bundle 注册新能力后，SeekTTY 会将它加入动态目录；需要专用界面的能力也保留 Schema、结构化详情和错误诊断入口。
+需求还需要澄清时，可选的 [Clarify Host 插件](https://github.com/Hilbert-beinghappy/dsh-plugin-clarify) 会加入引导式 `/clarify` 工作流：逐一提出聚焦问题，每次回答后更新可审阅的 Draft，并把采用后的 Draft 写回输入框。随后可用 Harness 原生 `/plan` 把正式提交的需求整理成实施方案。
 
 ## 快速开始
 
-三个仓库与 GitHub Releases 均已公开。最近一次联合验收的 Clarify 工作流仍是官方 DeepSeek Harness `0.1.0-rc.8`，搭配 SeekTTY `1.2.0`、Auxiliary Runtime `0.1.0` 和 Clarify `0.2.1`。先通过原生 `dsh plugin` 安装这些已经发布的 tarball：
+最近一次联合验收的 Clarify 组合使用官方 DeepSeek Harness `0.1.0-rc.8`、SeekTTY `1.2.0`、[Auxiliary Runtime](https://github.com/Hilbert-beinghappy/dsh-plugin-auxiliary-runtime) `0.1.0` 和 Clarify `0.2.1`：
 
 ```sh
 pnpm add --global @deepseek-ai/dsh@0.1.0-rc.8
@@ -186,13 +54,11 @@ dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/dsh-plugin-cl
 dsh --profile tui
 ```
 
-这条路径直接使用打包产物，可以避开 Git 源的 `prepare` / `allowBuilds`。第一项安装 SeekTTY 终端壳，第二项提供 Auxiliary 模型执行，第三项提供 Clarify Host 服务与 Remote。两个 Host 插件在同一 Profile 激活后，SeekTTY 会发现 Remote，并把 `/clarify` 加入终端命令目录。
-
-SeekTTY `1.2.1` 当前已测官方 `0.1.1-rc.2`。未发布三件套 SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` 已有 Lane A 无 key PTY 证据，以及 2026-08-22 在 `candidate4` 上的 Lane B live-provider 观察。这不是 Release，也不是完整联合验收。详见 [已验证范围](#已验证范围)。现在还没有 `v1.2.1` Release 资产；请用本地 `pnpm pack` 的 tarball 安装这个候选，或等到 https://github.com/Hilbert-beinghappy/seektty/releases 列出未来 Release。不要编造下载 URL。
+这些命令通过原生 `dsh plugin` 协调机制安装预构建 tarball。SeekTTY 可以单独运行；两个 Host 插件负责加入 `/clarify` 及其独立计量的模型运行时。
 
 ### 裸 `deepseek` 启动器
 
-SeekTTY 支持 macOS、Linux 和 Windows。全局安装同一份 Release tarball；Windows 使用 `pnpm add --global` 后可以解析 PATHEXT 下的 `dsh.cmd` shim。
+安装 `dsh` 后，可全局安装同一个 SeekTTY Release，并把 Profile 协调固定到该 tarball：
 
 ```sh
 pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
@@ -200,7 +66,7 @@ export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/downl
 deepseek
 ```
 
-PowerShell 使用同一 URL：
+PowerShell 使用相同的包地址：
 
 ```powershell
 pnpm add --global 'https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz'
@@ -208,7 +74,7 @@ $env:SEEKTTY_SPEC='https://github.com/Hilbert-beinghappy/seektty/releases/downlo
 deepseek
 ```
 
-`deepseek` 需要 PATH 上的 `dsh`，也可以用 `DSH_BIN` 指向可执行文件。`SEEKTTY_SPEC` 会让 Profile 始终使用同一份预构建 tarball；没有这项覆盖时，本源码树的默认规格是 `github:Hilbert-beinghappy/seektty#v1.2.1`，该 Git tag 只在 Release 打出后才存在。在此之前请先 `pnpm pack` 得到 `seektty-1.2.1.tgz`，并把 `SEEKTTY_SPEC` 指到该文件。后续运行直接启动同一 Profile。它支持初始任务、工作区、会话恢复和自定义 Profile：
+`deepseek` 要求 `dsh` 位于 `PATH`，也可以用 `DSH_BIN` 指向其可执行文件。常用启动形式包括：
 
 ```sh
 deepseek "检查这个项目"
@@ -220,123 +86,114 @@ deepseek --version
 deepseek --update
 ```
 
-`deepseek --update` 会强制扫描，但每轮只安装一个许可组件。默认 `SEEKTTY_UPDATE=auto`：启动时拉取官方 dsh 的 npm `latest`（只用于发现，不跟 `next` 或 GitHub 预发布）和 SeekTTY 最新 GitHub Release。SeekTTY 自更新优先，本轮不再装 dsh。否则仅当 `latest` 落在 peer 对齐的自动范围（legacy rc.6–rc.8，或当前精确已测 Host）且新于**已安装**的 `dsh --version` 时才安装 dsh。future / gap Host（例如 `0.1.1-rc.1`）只提示、不安装。`DSH_BIN` 固定可执行文件时跳过 dsh。本地 `link:`/`file:` 安装和 `SEEKTTY_SPEC` 覆盖不会被改写。网络或安装失败不会挡住启动。设 `SEEKTTY_UPDATE=check` 可改回会话后提示，设 `SEEKTTY_UPDATE=0` 可关闭。
+`deepseek --update` 优先检查 SeekTTY，每轮最多安装一个兼容组件，绝不自动安装未测试的 gap 或未来 Host。`DSH_BIN`、本地安装和 `SEEKTTY_SPEC` 覆盖不会被改写，更新失败也不会阻止启动。设置 `SEEKTTY_UPDATE=check` 可改为会话后提示，设置 `SEEKTTY_UPDATE=0` 可关闭检查。
+
+SeekTTY `1.2.1` 目前是已在官方 Harness `0.1.1-rc.2` 上测试的源码候选版，尚未发布 `v1.2.1` tarball。请运行 `pnpm run build && pnpm pack`，把 `SEEKTTY_SPEC` 指向生成的 tarball，或使用 [Releases 页面](https://github.com/Hilbert-beinghappy/seektty/releases)中后续列出的工件。
+
+## 界面预览
+
+| DeepSeek 亮色 | DeepSeek 暗色 |
+| --- | --- |
+| ![SeekTTY DeepSeek 亮色首屏](assets/seektty-tui.png) | ![SeekTTY DeepSeek 暗色首屏](assets/seektty-tui-dark.png) |
+
+| 亮色界面中的 TypeScript | 暗色界面中的工具、文件读取与 Diff |
+| --- | --- |
+| ![SeekTTY 亮色 TypeScript 语法高亮](assets/seektty-code-light.png) | ![SeekTTY 暗色工具调用与 Diff 语法高亮](assets/seektty-code-dark.png) |
+
+最新视图会铺满终端，把输入框和状态栏固定在底部，并让更长的对话自然进入终端原生滚动记录。助手代码、Shell 指令、工具参数、文件读取、JSON 和 Diff 共用当前代码主题，普通对话文字仍使用界面主题。
+
+## Clarify 与 Plan
+
+Clarify 与 Plan 位于同一条工作流的前后两段：Clarify 帮助确认**要做什么**，Harness 原生 Plan 提议**如何实现**。
+
+| 组件 | 职责 |
+| --- | --- |
+| **SeekTTY** | 探测 Clarify Remote，加入 `/clarify`，渲染终端交互，提供当前 Session 与草稿，并把采用后的 Draft 写回输入框。 |
+| **dsh-plugin-clarify** | 持有临时澄清进程，通过 `clarify.wire/1` 发布 `start`、`answer`、`accept`、`refine`、`cancel` 和 `fetchDraft`。 |
+| **dsh-plugin-auxiliary-runtime** | 通过当前模型路由运行 Clarify 模型调用，并提供限额、取消与独立用量账本。 |
+
+可通过以下方式启动 Clarify：
+
+- 从命令面板选择 `/clarify`，以整个输入区作为 seed；
+- 输入 `/clarify some text`，以参数文本作为 seed；
+- 在现有草稿末尾单独加入 `/clarify` token 或一行，以前面的文字作为 seed。
+
+Clarify 一次提出一个聚焦问题，把已确认的决定带入后续问题，并在每次回答后刷新 Draft 预览。你可以回答、refine、采用或取消。采用只会把 Draft 写入普通输入框；按 Enter 仍是明确的发送动作。正式提交后，如需实施方案再运行 `/plan`。
+
+问题、选项、预览和 refine 反馈保留在 Host 内存中，默认 15 分钟无交互后失效。主 Session 只会收到你明确发送的 Draft。辅助用量写入官方 `storageDomain` 下的 `auxiliary_runtime`；prompt、回答、模型输出、凭据和文件路径不会进入账本。`/status` 会显示经过校验的 Official、Auxiliary 和派生 Combined 总量，同时保持官方 Agent `tokenUsage` 不变。
+
+已验收 Release 组合与当前候选边界见[兼容与验证](#兼容与验证)。
+
+## 功能
+
+| 范围 | 可用操作 |
+| --- | --- |
+| 对话 | 流式 Markdown/GFM、语法高亮代码、链接、表格、推理显示、工具卡片模式、重试、上下文压缩、取消与错误状态 |
+| Session 与工作区 | 新建、恢复、搜索、重命名、Fork、归档、排序、复制、导出和切换工作区，不删除项目文件或日志 |
+| Agent、模型与权限 | 动态 Agent Preset、Provider、模型、推理强度和权限预设，支持按 Session 切换与诊断 |
+| 队列与交互 | Agent 运行时继续排队或 steer；编辑队列项；处理单选、多选、自定义、跳过、取消和计划审查 |
+| 图片 | 粘贴或附加 PNG、JPEG、GIF、WebP；执行 Host 动态限制；恢复待发送附件；终端支持时内联显示 |
+| Plan、Goal、Todo 与压缩 | 原生 `/plan`、`/goal`、`/compact`，包含计划审查、目标状态、Todo 数量和 transcript 记录 |
+| 工具与文件 | 工具耗时、参数与结果高亮、带原文件行号的读取、Shell/JSON/Diff、产出文件浏览、路径复制与确认后外部打开 |
+| 子 Agent 与后台工作 | 查看或停止直接子 Agent；检查任务、工作流阶段、结果、失败、Token、耗时和结构化轨迹 |
+| Profile 与 Settings | 创建、复制、切换和诊断 Profile；通过 Schema 回退、revision 检查和只写 Secret 编辑全部设置命名空间 |
+| 插件、Skill 与 MCP | 插件中心、原生 Bundle 协调、动态 Skill 命令、MCP 实例、加载状态、设置与风险信息 |
+| 主题与语言 | 界面／代码主题独立切换、配色生成、VS Code 主题导入、对比度检查、`NO_COLOR` 和中英文实时切换 |
+| 诊断与反馈 | 运行状态、可执行的 `/doctor` 检查、Session 反馈、助手消息评分与反馈删除 |
+
+SeekTTY 从当前 Harness Profile 动态读取这些目录。暂不支持的可选能力会安全降级，专用终端界面则可以持续演进。
 
 ## 首次配置 API Key
 
-如果当前 Profile 没有任何可用模型 Provider，并且 DeepSeek 官方 Provider 暴露的凭证引用尚未配置且允许写入，SeekTTY 会在首个界面帧出现前打开居中的只写输入框。启动环境已有凭证、Harness 凭证存储已有值，或存在使用环境认证／无 Key 认证的其他活跃 Provider 时，都不会弹出引导。
+| 暗色 | 亮色 |
+| --- | --- |
+| ![SeekTTY 暗色首次 API Key 引导](assets/seektty-onboarding-dark.png) | ![SeekTTY 亮色首次 API Key 引导](assets/seektty-onboarding-light.png) |
 
-### 暗色首次引导
+当前 Profile 没有可用模型 Provider，且 DeepSeek 官方 Provider 暴露了可写但缺失的凭据时，SeekTTY 会打开居中的只写输入框。环境凭据、Harness 已存凭据，以及环境认证或无 Key Provider 都会跳过该引导。
 
-![SeekTTY 暗色首次 API Key 引导](assets/seektty-onboarding-dark.png)
+输入内容始终显示为掩码，并直接交给 Harness `credentials.set`。SeekTTY 不会读回密钥，也不会把它放入 Settings、日志、截图或 Session 数据。保存时不会发起可能计费的验证请求；认证错误由第一次真实请求通过正常 Provider 路径报告。
 
-### 亮色首次引导
-
-![SeekTTY 亮色首次 API Key 引导](assets/seektty-onboarding-light.png)
-
-这里只粘贴 API Key 本身。输入内容始终显示为掩码；按 Enter 后，规范化后的值会直接交给 Harness `credentials.set`。SeekTTY 不会读回密钥，也不会自行写凭证文件，更不会把它放进 Settings、日志、截图或 Session 数据。保存时不会主动发起可能计费的在线验证请求；Key 是否有效由第一次真实模型请求通过 Harness Provider 的原生错误路径报告。
-
-按 Esc 可以稍后配置，同时继续进入 `/settings`、`/plugin` 等本地界面。之后发送普通消息、Skill 命令或带附件消息时会再次打开同一引导。`deepseek "初始任务"`、已经提交的文字和草稿附件都不会丢失：保存成功后自动继续原请求，再次跳过则恢复到输入框。Provider 检查不可用、官方适配器缺席或凭证层只读时，SeekTTY 直接提示使用 `/settings` 与 `/doctor`，并保留 Harness 原有行为。
+按 Escape 可稍后配置，同时继续使用 `/settings`、`/plugin` 等本地界面。待发送文字和附件都会保留，保存成功后自动继续原请求。如果凭据无法检查或写入，SeekTTY 会提示使用 `/settings` 与 `/doctor`，而不是显示无法使用的表单。
 
 ## 斜杠命令
 
-在输入框键入 `/` 会打开可搜索的命令与 Skill 菜单。菜单会合并 SeekTTY 命令、当前 Agent 注册的 Host 命令和用户可调用的 Skills。
+在输入框键入 `/` 会打开可搜索菜单，合并 SeekTTY 命令、当前 Agent 的 Host 命令和用户可调用的 Skill。
 
 | 分类 | 命令 |
 | --- | --- |
-| 会话 | `/new`、`/resume`、`/sessions`、`/rename`、`/fork`、`/archive`、`/export`、`/export md`、`/copy` |
+| Session | `/new`、`/resume`、`/sessions`、`/rename`、`/fork`、`/archive`、`/export`、`/export md`、`/copy` |
 | 工作环境 | `/workspace`、`/profile` |
 | Agent | `/mode`、`/model`、`/permission`、`/plan`、`/goal`、`/compact` |
 | 运行交互 | `/queue`、`/steer`、`/attach`、`/attachments`、`/pending` |
 | 运行内容 | `/tools`、`/files`、`/jobs`、`/subagents`、`/trajectory` |
 | 扩展 | `/plugin`、`/plugins`、`/skills`、`/mcp` |
-| 插件工作流 | 当前 Profile 中的 `dsh-plugin-clarify` 及其 Auxiliary Runtime 依赖激活后出现 `/clarify` |
-| 配置与诊断 | `/settings`、`/language`、`/theme`、`/status`、`/doctor`、`/feedback`、`/restart`；当最近一次联合验收的 Auxiliary Runtime `0.1.0` 或当前 `0.1.1` 候选健康可用时，`/status` 分别显示标明来源的官方、辅助和组合（派生）会话总用量，且不修改官方 `tokenUsage` 投影 |
+| 插件工作流 | 兼容的 Clarify Remote 与 Auxiliary Runtime 激活后出现 `/clarify` |
+| 配置与诊断 | `/settings`、`/language`、`/theme`、`/status`、`/doctor`、`/feedback`、`/restart` |
 | 帮助与退出 | `/help`、`/quit`、`/exit` |
 
-`/plugin`、`/workspace` 和 `/profile` 既有完整的交互中心，也支持直接子命令。未知命令会给出相近候选，不会被当成普通消息发给模型。SeekTTY 探测 Clarify 插件兼容的六方法 Remote 与 `clarify.wire/1`，再把 `/clarify` 动态加入本地 `/` 目录。插件生成的问题、上下文选项和持续演进的预览稿会引导你得到一份进入普通输入框的 Draft；何时发送由你决定。完整旅程见 [Clarify 与 Plan](#clarify-与-plan)。
+`/plugin`、`/workspace` 和 `/profile` 同时提供交互中心与直接子命令。未知命令不会作为普通消息发送，而会留在命令界面并显示相近建议。
 
-## 常用交互
+## 常用操作
 
 | 输入 | 操作 |
 | --- | --- |
-| 鼠标左键拖动，再按终端复制快捷键 | 使用终端原生选区复制当前可见的任意 TUI 文字（macOS 使用 `Command+C`；Linux 和 Windows 终端通常使用 `Ctrl+Shift+C`） |
+| 鼠标左键拖动，再按终端复制快捷键 | 使用终端选择并复制可见 TUI 文字（macOS 使用 `Command+C`；Linux 和 Windows 通常使用 `Ctrl+Shift+C`） |
 | 鼠标滚轮 / 触控板 | 输入框保持激活时浏览终端原生滚动记录 |
 | `/` | 打开命令与 Skill 候选 |
 | Enter / Shift+Enter | 发送或确认 / 输入换行 |
-| Tab / Escape | 在输入区与 Transcript 间切换 / 返回输入区或关闭当前弹窗 |
-| PgUp / PgDn / Home / End | 浏览 Transcript 时翻页、跳到最早或回到最新内容 |
-| Shift+Tab | 循环当前权限，进入完全访问前确认 |
+| Tab / Escape | 在输入框与 transcript 间切换 / 返回或关闭当前弹窗 |
+| PgUp / PgDn / Home / End | 在 transcript 中翻页、跳到最早内容或回到最新 |
+| Shift+Tab | 循环权限预设，进入完全访问前确认 |
 | Shift+Left / Shift+Right | 跳到上一个或下一个用户轮次 |
-| F1 | 打开应用内帮助 |
-| Ctrl+P | 打开完整命令面板 |
-| Ctrl+M | 支持扩展键盘协议时打开模型选择器 |
-| Ctrl+S | 打开会话恢复选择器 |
-| Ctrl+O / Ctrl+T | 切换工具卡片显示 / 显示或隐藏推理内容 |
-| F2 / Ctrl+, / Cmd+, | 打开设置 |
+| F1 / Ctrl+P | 打开帮助 / 打开命令面板 |
+| Ctrl+M / Ctrl+S | 打开模型选择 / 打开 Session 恢复 |
+| Ctrl+O / Ctrl+T | 切换工具卡片显示 / 显示或隐藏推理 |
+| F2 / Ctrl+, / Cmd+, | 打开 Settings |
 | Ctrl+C | 停止当前轮次、清空草稿，或二次确认退出 |
 
-## 从 deepseek-tui 迁移
+## 主题与语言
 
-旧版全局包只需替换一次；新的 `deepseek` 启动器会通过原生 `dsh plugin` 命令把目标 Profile 中的旧 Bundle 标识替换为 `seektty`：
-
-```sh
-pnpm remove --global deepseek-tui
-pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-deepseek
-```
-
-自定义 Profile 在首次启动时分别迁移，例如 `deepseek --profile team-tui`。只使用 dsh 原生入口时，可显式执行：
-
-```sh
-dsh plugin --profile tui remove deepseek-tui
-dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-```
-
-## 直接插拔
-
-移除不会修改 dsh 本体，只会让 Bundle 离开目标 Profile：
-
-```sh
-dsh plugin --profile tui remove seektty
-```
-
-重新安装使用相同命令：
-
-```sh
-dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
-```
-
-安装结果直接写入目标 Harness Profile 的依赖、Bundle 顺序和 pnpm lockfile。TUI 的 `/plugin` 与原生 `dsh plugin` 操作同一份 Profile 状态。
-
-## 插件中心
-
-裸 `/plugin` 打开当前 Profile 的插件中心，`/plugins` 是同一入口。直接子命令包括 `list`、`search`、`info`、`install`、`remove`、`update`、`reorder`、`source` 和 `doctor`。
-
-- 默认从 npm Registry 搜索，可增加 JSON/HTTP Catalog，也能读取其他 Harness Bundle 注册的来源；
-- 安装输入支持 npm 包名、Git 地址、tarball、file URL 和本地目录；
-- 安装前检查 `dsh.bundle.patch`、包内文件、最终安装 spec、构建脚本和目标 Profile；
-- 安装、删除、更新和排序完成后可立即重启，重启会恢复当前工作区、会话、草稿和附件；
-- 插件详情会显示版本、来源、发布者、Bundle 状态、加载顺序和可执行诊断。
-
-## 模型、设置与主题
-
-`/model` 从 Harness 动态读取 Provider、模型和推理强度，选择完成后立即刷新输入框右下角的实际模型状态。`/mode` 管理 Agent Preset，`/permission` 管理当前会话权限；三者各自独立。
-
-`/settings` 会列出当前 Profile 注册的全部设置命名空间。默认模型、默认权限、默认 Agent 模式和插件来源使用专用选择器；布尔、枚举、数字、文本、JSON、Secret 和 Credential Ref 等其他字段由 Schema 通用界面处理。界面同时显示继承值、用户覆盖、重置操作以及立即生效或重启生效状态，写入时使用 revision 防止覆盖并发修改。Secret 只显示是否已配置，输入时不会回显。
-
-SeekTTY 的终端界面同时提供中文和英文。`/language` 会打开语言选择器，也可以直接输入以下命令快速切换：
-
-```text
-/language auto
-/language zh
-/language en
-```
-
-语言选择由官方 `@deepseek-ai/dsh-client-locale` Host 插件存储在 `locale.preference`，因此 TUI 与 Harness Web 共用同一个显式偏好。`auto` 会删除显式覆盖：SeekTTY 依次检查 `LC_ALL`、`LC_MESSAGES`、`LANGUAGE` 和 `LANG`，浏览器则继续使用自己的平台语言回退。切换会立即重建终端边框和对话呈现，不会改写模型、工具、用户、Provider 或插件提供的原始内容。
-
-SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 打开完整主题中心，内置主题和命名自定义主题也可以直接管理：
+SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 会打开主题中心，也可直接输入：
 
 ```text
 /theme dark
@@ -349,51 +206,85 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 打开完整主题中心�
 /theme delete <主题名>
 ```
 
-界面主题与代码块主题彼此独立。`/theme light`、`/theme dark` 和 `/theme use <主题名>` 会选择暗亮方向一致的完整界面／代码组合。使用 `/theme code auto` 时，代码背景、正文、语法颜色和暗亮方向都跟随当前界面主题，因此 DeepSeek 亮色界面使用亮色代码块；`/theme code dark`、`/theme code light` 或 `/theme code <主题名>` 只覆盖代码呈现，直到再次选择完整界面主题。`/theme edit` 编辑完整命名主题，`/theme palette` 接收 3–16 个 HEX/RGB 颜色并生成暗色与亮色候选方案。
+界面主题与代码主题彼此独立。输入 3–16 个 HEX/RGB 颜色即可生成亮色与暗色候选。`/theme import` 会读取本地 VS Code JSON/JSONC，解析相对 `include`，并保留可移植的 TextMate 颜色与样式。所有自定义路径都会先预览，并在保存前标出低对比度。定义保存在带 revision 保护的 `seektty-appearance` Harness Settings 命名空间中。
 
-`/theme import` 读取本地 VS Code JSON/JSONC，递归解析相对 `include`，映射编辑器颜色与语义 Token，并保留可移植的 TextMate 前景、背景、粗体、斜体、下划线和删除线规则。导入后只切换代码主题，不会覆盖当前界面主题。所有自定义路径保存前都会进入实时预览。低对比度颜色不会被静默修改；预览会标出问题角色并要求再次确认。
+使用 `/language` 或直接命令实时切换终端文案：
 
-自定义主题覆盖终端画布、面板、选中状态、正文、边框、品牌色、状态色、代码背景与正文，以及注释、关键字、字符串、数字、常量、函数、类型、变量、属性、参数、运算符、标点、标签、属性名和正则表达式等语法角色。助手 Markdown 代码、Shell 指令、结构化工具参数、文件读取、JSON 和 Diff 共用同一套代码主题。工具调用显示为紧凑的操作／耗时标题，下一行使用 `⎿` 连接调用代码；工具运行时从 Harness 调用时间开始同步计时，结束后停在最终耗时。折叠状态保留调用内容，展开状态再增加结果。常用语法随启动加载，其他支持的语法按需加载并原地重绘。切换主题会立即重新着色已有消息，不会改变当前滚动位置、展开状态或未发送草稿。
+```text
+/language auto
+/language zh
+/language en
+```
 
-界面选择、独立代码选择与命名定义都保存在 `seektty-appearance` Harness Settings 命名空间中，并使用 revision 保护写入，因此 `/settings` 也能通过 Schema 通用界面编辑同一份数据。主题名不区分大小写且不可重复；覆盖与删除都必须确认。删除正在使用的界面主题会切回 DeepSeek 暗色，删除正在使用的代码主题会恢复自动搭配。VS Code 的字体族和字号不会导入，因为字符网格字体由终端统一控制；导入的粗体、斜体等样式只作用于代码 Token，不会改变普通中文、英文、系统文字或工具标题。
+显式偏好由官方 locale 插件存入 `locale.preference`，并与 Harness Web 共享。`auto` 会删除覆盖并跟随终端语言环境。切换只改变 SeekTTY 界面和 transcript 呈现，不会改写模型、工具、用户、Provider 或插件生成的内容。
 
-## 已验证范围
+## 插件中心
 
-- 官方 stock `@deepseek-ai/dsh@0.1.0-rc.8` 隔离安装、配置装配和 PTY 启动；并对声明的最低版本 `@deepseek-ai/dsh@0.1.0-rc.6` 完成 add／boot／remove／re-add 插拔契约。
-- SeekTTY `1.2.1` 当前在壳、单测和 typecheck 层面对官方 `@deepseek-ai/dsh@0.1.1-rc.2`。Lane A（2026-08-21，未修改 stock `0.1.1-rc.2`、隔离 `DSH_HOME`、真实 PTY、未发布 SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`）：`/doctor` 0 error / 0 warning、99 plugins running；`/status` 健康；`/clarify` 路由到 Auxiliary 后无 key 返回 `MISSING_CREDENTIAL` 且保留 composer；Vision-Exp 可见且可选择；PNG 附件 `/restart` 成功恢复。丢失源文件恢复：单测保证失败文案只用 basename、覆盖两种通知顺序、绝对路径不进文案；真实 PTY hardcopy/可见区扫描只检出 ASCII basename `vision-logo.png`，未检出 `private/tmp`、`/tmp`、`Users`、`Volumes`。不能证明关闭无 key onboarding modal 后该 restore error 仍持续显示（Esc 也会清 notice）。Lane B（2026-08-22，未修改 stock `0.1.1-rc.2`、隔离 `DSH_HOME`、`candidate4`）：已显式选择 Vision-Exp；PNG image-only 发送成功、发送即清附件并识别 logo，但纯图无问题导致模型又调用 `read_image`；真实 JFIF JPEG 经 SeekTTY 入队、官方 Host 正常转 PNG variant 后，无工具 OCR 成功；Clarify 经 Auxiliary 完成 6 轮动态问答、41 行完整审阅、二次确认 accept 回 composer 且不自动发送；`/status` 显示官方／辅助／组合用量；895 文件扫描 secret literal 为 0。这不是 Release，也不是完整联合验收。未证明 Web UI、GIF/WebP、超限拒绝、JPEG 原字节直通、PNG 完全不靠工具、本轮中断恢复、成本／缓存 A/B。
-- 最近一次联合验收 Release 组合：Clarify `0.2.1`、SeekTTY `1.2.0`、Auxiliary Runtime `0.1.0` 与官方 dsh `0.1.0-rc.8`。Clarify `0.2.1` 保持 `0.2.0` 的六方法 Remote、`clarify.wire/1` 和精确 rc.8 兼容边界。
-- Clarify `0.2.0` live-provider 联合验收覆盖真实模型动态生成问题／选项／preview、多轮 preview 演进、审阅采用后只写回输入框并由用户自行发送、中断恢复、用量来源和隐私检查。
-- Clarify `0.2.1` 发布后无 Key 验收重新下载并核对三包 Release 资产，在 stock rc.8 Profile 完成 add／boot／remove／re-add，`/doctor` 为 0 错误／0 警告、99 个插件运行，随后进入 `running`、路由到 Auxiliary，并按隔离环境预期返回 `MISSING_CREDENTIAL`。`0.2.1` 尚未重跑 live-provider 动态多轮，也没有 cache／cost A/B。
-- 历史独立 Clarify lifecycle 证据覆盖官方 dsh rc.6／rc.7／rc.8；完整动态生产边界仍是精确 rc.8 与 Auxiliary Runtime `0.1.0`。
-- Auxiliary 调用的 usage／limits／cancel 持久化在 `auxiliary_runtime` 存储域。官方 Agent `tokenUsage` 保持原有归属；可选快照合同健康时，`/status` 展示经过校验的 Official、Auxiliary 和派生 Combined 桶。
-- 模型列表、Provider／模型／推理强度切换、请求提交和 Harness 错误透传。
-- 隔离 `DSH_HOME` 下的首次 Provider 就绪检查、API Key 掩码输入、跳过后的草稿恢复、Harness 凭证持久化，以及重启后不再提示。
-- 暗色、亮色及配色生成主题的真实 PTY 渲染，界面／代码主题独立即时切换，80／120／160 列布局，以及同一 Profile 重启后的主题恢复。
-- 中英文语言解析、带 revision 保护的共享偏好写入、终端实时切换，以及未知外部内容保持原样。
-- 原生 remove 后依赖、Bundle 和配置条目全部消失；re-add 后再次启动成功。
-- 全新打包后的全局安装在没有工作区开发依赖、也没有重复 `@deepseek-ai/*` 包的情况下，依然能暴露裸 `deepseek`，自动创建 `tui` Profile，并通过官方 dsh 模块回退完成启动。
-- 安装后已完成真实原生 `todo_write` 用户旅程；打包门禁还会拒绝 Profile 内出现官方身份型 Host 包的副本，并验证 Cordis、API proxy、Session 和工具运行时都解析到官方回退实例。
-- macOS、Linux 和 Windows 均支持安装、启动、键盘导航与终端交互。
+`/plugin` 打开当前 Profile 的插件中心，`/plugins` 是别名。直接子命令包括 `list`、`search`、`info`、`install`、`remove`、`update`、`reorder`、`source` 和 `doctor`。
 
-已在隔离 `DSH_HOME` 中把有效 DeepSeek 凭据粘贴进真实掩码引导并完成在线多轮验收：`v4-flash` 首轮返回 `REALCHECK_58597`，下一轮引用该结果后返回 `REALCHECK_58598`。同一 Profile 重启后没有再次弹出引导，Harness 凭证文件权限为 `0600`，凭据没有进入终端输出、截图或仓库；验收结束后已删除隔离凭证存储。
+- 默认搜索 npm，也可添加 JSON/HTTP Catalog，或使用其他 Bundle 注册的来源；
+- 支持 npm 包名、Git URL、tarball、file URL 和本地目录；
+- 安装前检查 `dsh.bundle.patch`、包内文件、安装 spec、构建脚本和目标 Profile；
+- 变更后可重启，并恢复工作区、Session、草稿和附件；
+- 可查看版本、来源、发布者、Bundle 顺序、加载状态和可执行诊断。
 
-可复用的 stock-dsh 插拔检查：
+TUI `/plugin` 与原生 `dsh plugin` 会协调同一份 Profile 依赖、Bundle 顺序和 pnpm lockfile。
+
+## 迁移与移除
+
+旧版 `deepseek-tui` 全局包只需替换一次：
 
 ```sh
+pnpm remove --global deepseek-tui
+pnpm add --global https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+deepseek
+```
+
+自定义 Profile 会在首次启动时分别迁移。只使用 dsh 原生入口时，可显式替换 Bundle：
+
+```sh
+dsh plugin --profile tui remove deepseek-tui
+dsh plugin --profile tui add https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.0/seektty-1.2.0.tgz
+```
+
+移除 SeekTTY 只影响目标 Profile，不会修改 dsh 本体：
+
+```sh
+dsh plugin --profile tui remove seektty
+```
+
+## 兼容与验证
+
+| 边界 | 版本 |
+| --- | --- |
+| Node.js | `^22.19.0 || >=24` |
+| 声明的最低 Harness Host | `0.1.0-rc.6` |
+| 当前已测 Harness Host | `0.1.1-rc.2` |
+| 最近一次联合验收的 Clarify Release 组合 | dsh `0.1.0-rc.8` + SeekTTY `1.2.0` + Auxiliary Runtime `0.1.0` + Clarify `0.2.1` |
+| 当前源码候选组合 | SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`；不是 Release，也不是完整联合验收 |
+
+低于声明最低版本的 Host 会被拒绝；高于已测版本的 Host 可以在提示后启动，但自动更新只会安装明确兼容的范围。发布 Bundle 不会把 Cordis 或身份型 `@deepseek-ai/dsh-*` 包安装进 Profile：optional peer 用来描述 Host 合同，运行时 import 统一从官方 Harness 安装解析。附件兼容适配器只处理精确测试过的旧版图片限制形状，遇到未知形状会直接拒绝适配。
+
+验证范围包括：
+
+- 隔离 stock dsh 下的 add、boot、remove、re-add 生命周期，包括声明的最低版本；
+- typecheck、单元测试、生产构建、打包内容检查和重复 Host 包拒绝；
+- 真实 PTY 的启动、导航、暗色／亮色／自定义主题、80／120／160 列布局、语言切换与重启恢复；安装和终端交互支持 macOS、Linux 与 Windows；
+- 首次凭据配置与真实 Provider 多轮对话，且凭据未进入输出、截图或仓库；
+- 在 stock `0.1.1-rc.2` 上对 Clarify、独立用量、PNG/JFIF 附件、Vision-Exp 选择和重启恢复的候选版观察。这些观察不代表 Web UI、GIF/WebP、超限、中断恢复或成本／缓存已经完整覆盖。
+
+可复用检查：
+
+```sh
+pnpm run check
+
 DSH_BIN=/path/to/dsh \
 SEEKTTY_SPEC=/path/to/seektty.tgz \
 pnpm test:stock
-```
 
-可复用的跨包 doctor 检查：
-
-```sh
 CLARIFY_SPEC=/path/to/dsh-plugin-clarify.tgz \
 pnpm test:clarify-doctor
 ```
 
-## 兼容和升级
-
-当前已测 Host 是官方 `0.1.1-rc.2`。壳声明的最低 Host 仍是官方 `0.1.0-rc.6`，legacy lifecycle 覆盖 rc.6／rc.7／rc.8。最近一次联合验收的 Clarify + Auxiliary 生产组合仍是精确 `0.1.0-rc.8`，搭配 SeekTTY `1.2.0`、Auxiliary Runtime `0.1.0` 和 Clarify `0.2.1`。未发布三件套 SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2` 已有 Lane A 无 key PTY 证据，以及 2026-08-22 在 `candidate4` 上的 Lane B live-provider 观察；这不是 Release，也不是完整联合验收（详见 [已验证范围](#已验证范围)）。新于 `tested` 的 dsh 仍可启动 SeekTTY 并给出提示；旧于 SeekTTY `minimum` 的 Host 会被拒绝。updater 以实际已装的 `dsh --version` 判断，SeekTTY 自更新优先，每轮只安装一个组件，future / gap Host 不装。发布的 Bundle 通过 optional peer 描述 Host 合同，运行时 import 统一从官方 `$DSH_HOME/profiles/node_modules` 回退解析，让原生工具调度器等身份型 Symbol 保持唯一。官方回退缺少的纯客户端辅助包会进入 Bundle。Host 插件 `seektty/attachment-compat` 紧挨在 `api-gateway` 之前，只适配精确的合法遗留 image-limit 能力形状；其他形状闭包失败。未来 Host 按能力匹配。定时工作流扫描官方 npm `latest` dist-tag，在 `pnpm run check`、隔离打包启动器和 stock-dsh 契约通过后，升级精确开发基线和 optional peer 范围并开 pull request；npm `next` 与 GitHub Harness 预发布留在发现轨道之外。
-
-源码仓库与 GitHub Releases 均公开。用户包通过对应 Release 附带的预构建 tarball 分发，当前没有 npm Registry 发布。
+用户包通过对应 GitHub Release 附带的预构建 tarball 分发，目前没有发布到 npm Registry。


### PR DESCRIPTION
## Summary

- reorganize the README around overview, quick start, interface, Clarify, features, and compatibility
- remove repeated candidate-version notes and compress internal acceptance logs while preserving release and Host boundaries
- keep the Chinese README structurally synchronized with the English source
- remove repository-visibility wording that does not belong in consumer-facing documentation

## Checks

- README heading and code-fence parity: passed
- local links and image targets: passed
- package-version badge consistency: passed
- git diff --check: passed
- pnpm run pack:check: packaging included both READMEs, then the existing Windows tar-list CRLF handling treated every entry as unexpected