### PR TITLE
fix(tui): stabilize viewport rendering and improve long-session performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>A keyboard-first terminal workspace for DeepSeek Harness.</p>
 
 <p>
-  <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.1-orange" alt="Version 1.2.1"></a>
+  <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.2-orange" alt="Version 1.2.2"></a>
   <img src="https://img.shields.io/badge/DeepSeek%20Harness-0.1.1--rc.2-5B5BD6" alt="DeepSeek Harness 0.1.1-rc.2">
   <img src="https://img.shields.io/badge/Node-%5E22.19.0%20%7C%7C%20%3E%3D24-339933?logo=nodedotjs&logoColor=white" alt="Node.js 22.19 or newer">
   <a href="https://github.com/Hilbert-beinghappy/seektty/actions"><img src="https://github.com/Hilbert-beinghappy/seektty/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -88,7 +88,7 @@ deepseek --update
 
 `deepseek --update` is self-first: it checks SeekTTY before dsh, installs at most one compatible component per run, and never installs an untested gap or future Host. `DSH_BIN`, local installs, and `SEEKTTY_SPEC` overrides are left unchanged. Update failures do not block startup. Set `SEEKTTY_UPDATE=check` for a post-session notice or `SEEKTTY_UPDATE=0` to disable checks.
 
-SeekTTY `1.2.1` is currently a source candidate tested with official Harness `0.1.1-rc.2`; no `v1.2.1` release tarball is published. Build it with `pnpm run build && pnpm pack` and point `SEEKTTY_SPEC` to the resulting tarball, or use a later asset listed on the [Releases page](https://github.com/Hilbert-beinghappy/seektty/releases).
+SeekTTY `1.2.2` is a maintenance update targeting official Harness `0.1.1-rc.2`, with fixes for long-session rendering performance, terminal viewport scrolling, and intermittent white blocks. Use the package listed on the [Releases page](https://github.com/Hilbert-beinghappy/seektty/releases), or build it with `pnpm run build && pnpm pack` and point `SEEKTTY_SPEC` to the resulting tarball.
 
 ## Interface
 
@@ -264,7 +264,7 @@ The current tested Host is official `0.1.1-rc.2`; the complete compatibility bou
 | Declared minimum Harness Host | `0.1.0-rc.6` |
 | Current tested Harness Host | `0.1.1-rc.2` |
 | Last jointly accepted Clarify release stack | dsh `0.1.0-rc.8` + SeekTTY `1.2.0` + Auxiliary Runtime `0.1.0` + Clarify `0.2.1` |
-| Current source candidate | SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`; not a Release or complete joint acceptance |
+| Current maintenance version | SeekTTY `1.2.2` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`; this patch does not establish new complete joint acceptance |
 
 Hosts older than the declared minimum are rejected. Newer-than-tested Hosts may boot with a notice, but automatic updates install only an explicitly compatible range. The published Bundle does not install Cordis or identity-bearing `@deepseek-ai/dsh-*` packages into a Profile: optional peers describe the Host contract, and runtime imports resolve through the official Harness installation. The attachment compatibility adapter handles only the exact tested legacy image-limit shape and fails closed for unknown shapes.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Clarify model calls run through [Auxiliary Runtime](https://github.com/Hilbert-b
 
 ![SeekTTY DeepSeek dark start screen](assets/seektty-tui-dark.png)
 
-The live view fills the terminal and keeps the composer and status at the bottom. Unused rows remain inside the conversation viewport and disappear as output grows; longer conversations continue into native terminal scrollback.
+The live view uses a fixed alternate-screen viewport and keeps the composer and status at the bottom. The mouse wheel and transcript navigation keys browse conversation history inside SeekTTY; exiting restores the previous main screen and its scrollback.
 
 ## Clarify and Plan
 
@@ -260,8 +260,8 @@ Typing `/` opens a searchable command and Skill menu. It merges SeekTTY commands
 
 | Input | Action |
 | --- | --- |
-| Left-button drag, then the terminal copy shortcut | Use the terminal's native selection and copy for any visible TUI text (`Command+C` on macOS; normally `Ctrl+Shift+C` on Linux and Windows terminals) |
-| Mouse wheel / trackpad | Browse the native terminal scrollback while the composer remains active |
+| Hold the terminal selection modifier while dragging, then copy | Use native selection for visible TUI text: hold `Fn` in Terminal.app or `Option` in iTerm2, drag, then press `Command+C`; use the outer terminal/tmux selection modifier elsewhere |
+| Mouse wheel / trackpad | Browse the internal transcript without moving composer focus, draft, selection, or cursor |
 | `/` | Open command and Skill candidates |
 | Enter / Shift+Enter | Submit or confirm / insert a newline |
 | Tab / Escape | Switch between composer and transcript / return or close the active overlay |

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,7 +52,7 @@ Clarify 的模型调用由 [Auxiliary Runtime](https://github.com/Hilbert-beingh
 
 ![SeekTTY DeepSeek 暗色首屏](assets/seektty-tui-dark.png)
 
-最新视图会铺满终端，并让输入框与状态栏始终沉在底部。未使用的行属于中间的对话视口，会随着输出增长逐行收缩；更长的对话继续进入终端原生滚动记录。
+最新视图使用固定高度的 alternate screen，并让输入框与状态栏始终沉在底部。鼠标滚轮和 Transcript 导航键只在 SeekTTY 内部浏览对话历史；退出后会恢复原主屏幕及其滚动记录。
 
 ## Clarify 与 Plan
 
@@ -260,8 +260,8 @@ deepseek --update
 
 | 输入 | 操作 |
 | --- | --- |
-| 鼠标左键拖动，再按终端复制快捷键 | 使用终端原生选区复制当前可见的任意 TUI 文字（macOS 使用 `Command+C`；Linux 和 Windows 终端通常使用 `Ctrl+Shift+C`） |
-| 鼠标滚轮 / 触控板 | 输入框保持激活时浏览终端原生滚动记录 |
+| 按住终端选择修饰键并拖动，再复制 | 使用原生选区复制当前可见文字：Terminal.app 按住 `Fn`、iTerm2 按住 `Option` 后拖选，再按 `Command+C`；其他终端或 tmux 使用外层终端的选择修饰键 |
+| 鼠标滚轮 / 触控板 | 在 SeekTTY 内部浏览 Transcript，不改变输入框焦点、草稿、选区或光标 |
 | `/` | 打开命令与 Skill 候选 |
 | Enter / Shift+Enter | 发送或确认 / 输入换行 |
 | Tab / Escape | 在输入区与 Transcript 间切换 / 返回输入区或关闭当前弹窗 |

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,7 +7,7 @@
 <p>DeepSeek Harness 的键盘优先终端工作台。</p>
 
 <p>
-  <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.1-orange" alt="Version 1.2.1"></a>
+  <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.2-orange" alt="Version 1.2.2"></a>
   <img src="https://img.shields.io/badge/DeepSeek%20Harness-0.1.1--rc.2-5B5BD6" alt="DeepSeek Harness 0.1.1-rc.2">
   <img src="https://img.shields.io/badge/Node-%5E22.19.0%20%7C%7C%20%3E%3D24-339933?logo=nodedotjs&logoColor=white" alt="Node.js 22.19 or newer">
   <a href="https://github.com/Hilbert-beinghappy/seektty/actions"><img src="https://github.com/Hilbert-beinghappy/seektty/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -88,7 +88,7 @@ deepseek --update
 
 `deepseek --update` 采用 SeekTTY 自更新优先策略：先检查 SeekTTY，再检查 dsh；每轮最多安装一个兼容组件，绝不自动安装未测试的 gap 或未来 Host。`DSH_BIN`、本地安装和 `SEEKTTY_SPEC` 覆盖不会被改写，更新失败也不会阻止启动。设置 `SEEKTTY_UPDATE=check` 可改为会话后提示，设置 `SEEKTTY_UPDATE=0` 可关闭检查。
 
-SeekTTY `1.2.1` 目前是已在官方 Harness `0.1.1-rc.2` 上测试的源码候选版，尚未发布 `v1.2.1` tarball。请运行 `pnpm run build && pnpm pack`，把 `SEEKTTY_SPEC` 指向生成的 tarball，或使用 [Releases 页面](https://github.com/Hilbert-beinghappy/seektty/releases)中后续列出的工件。
+SeekTTY `1.2.2` 是面向官方 Harness `0.1.1-rc.2` 的维护更新，修复长会话渲染性能、终端滚动越界和偶发白块问题。请使用 [Releases 页面](https://github.com/Hilbert-beinghappy/seektty/releases)列出的安装包，或运行 `pnpm run build && pnpm pack`，把 `SEEKTTY_SPEC` 指向生成的 tarball。
 
 ## 界面预览
 
@@ -264,7 +264,7 @@ dsh plugin --profile tui remove seektty
 | 声明的最低 Harness Host | `0.1.0-rc.6` |
 | 当前已测 Harness Host | `0.1.1-rc.2` |
 | 最近一次联合验收的 Clarify Release 组合 | dsh `0.1.0-rc.8` + SeekTTY `1.2.0` + Auxiliary Runtime `0.1.0` + Clarify `0.2.1` |
-| 当前源码候选组合 | SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`；不是 Release，也不是完整联合验收 |
+| 当前维护版本 | SeekTTY `1.2.2` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`；本次补丁不代表新增完整联合验收 |
 
 低于声明最低版本的 Host 会被拒绝；高于已测版本的 Host 可以在提示后启动，但自动更新只会安装明确兼容的范围。发布 Bundle 不会把 Cordis 或身份型 `@deepseek-ai/dsh-*` 包安装进 Profile：optional peer 用来描述 Host 合同，运行时 import 统一从官方 Harness 安装解析。附件兼容适配器只处理精确测试过的旧版图片限制形状，遇到未知形状会直接拒绝适配。
 

--- a/docs/maintenance-baseline-2026-08-26.md
+++ b/docs/maintenance-baseline-2026-08-26.md
@@ -1,0 +1,79 @@
+# Terminal maintenance baseline — 2026-08-26
+
+This report records the unmodified Task A/B baseline before implementation. It is intentionally committed first so later fixed-viewport and transcript-performance measurements have an auditable comparison point.
+
+## Fixed inputs
+
+- Repository commit: `6c03e80f0acb62f05dae9e80606ce54e80beb684`
+- SeekTTY: `1.2.1`
+- Official dsh dependency baseline: `0.1.1-rc.2`
+- `@mariozechner/pi-tui`: `0.73.1`
+- Package manager: pnpm `11.7.0`
+- Verification runtime: Node `24.19.0`
+- Host: macOS arm64, Asia/Shanghai
+
+The default shell runtime was Node `22.17.1`, below this repository's declared `^22.19.0 || >=24` engine. Its install result is not used as verification evidence. All checks and measurements below used the bundled Node `24.19.0` runtime.
+
+## Baseline behavior confirmed by source and tests
+
+- With the composer focused, `Surface` supplies `Number.POSITIVE_INFINITY` as the Transcript viewport.
+- `BottomAnchoredLayout.render()` may return more rows than the terminal height; the baseline test explicitly expects 11 logical rows for an 8-row viewport.
+- The baseline has no managed `CSI ?1049h/l` lifecycle and no `CSI ?1000h` / `CSI ?1006h` mouse reporting.
+- The pi-tui renderer can write tall roots with `CRLF`, and `TUI.stop()` moves to the logical content end and appends a final `CRLF`.
+- Synchronous fatal restore only forces cooked mode and shows the cursor.
+- `Transcript.render()` iterates every component, escapes every rendered line, and copies the complete line array into `lastFullLines` before selecting a finite viewport.
+
+These observations prove the structural paths described in the maintenance task. They do not substitute for Terminal.app, iTerm2, tmux, or long-duration acceptance.
+
+## Automated baseline verification
+
+Command:
+
+```sh
+PATH="<bundled-node-24-bin>:$PATH" pnpm run check
+```
+
+Observed pass:
+
+- TypeScript typecheck
+- Vitest: 87 files passed; 548 tests passed; 1 test skipped
+- Production build
+- Package-content check: 23 entries, no planning files, Profiles, credentials, caches, or AppleDouble entries
+
+The package checker removed 230 generated AppleDouble metadata files before inspecting the archive. They were untracked filesystem metadata, not repository content.
+
+## Structural performance baseline
+
+A temporary, uncommitted Vitest fixture constructed official-shape conversation snapshots with 100 lines per assistant node. For each size it measured:
+
+- initial `Transcript.update()`;
+- 25 cached `Transcript.render(80)` calls;
+- 10 iterations that replace only the final node, then call `update()` and `render(80)`.
+
+`NO_COLOR=1` was used to avoid animation noise. The fixture was removed immediately after the run.
+
+| Transcript lines | Nodes | Initial update (ms) | Cached render p50 / p95 / p99 (ms) | Tail update + render p50 / p95 / p99 (ms) | Observed heap delta (MiB) |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 10 | 0.749 | 0.638 / 1.466 / 3.616 | 0.652 / 7.002 / 7.002 | 1.368 |
+| 10,000 | 100 | 1.083 | 10.878 / 16.810 / 20.039 | 10.385 / 12.744 / 12.744 | 164.965 |
+| 50,000 | 500 | 3.684 | 66.892 / 106.284 / 110.617 | 59.162 / 72.291 / 72.291 | 343.160 |
+| 100,000 | 1,000 | 15.056 | 125.071 / 157.008 / 192.129 | 143.962 / 235.112 / 235.112 | 901.012 |
+
+The 100,000-line cached-render p99 exceeds the maintenance target of 25 ms by about 7.7×. This is direct evidence that a cache hit does not bound normal frame work to the viewport.
+
+### Measurement limits
+
+- These are in-process Transcript costs, not end-to-end keyboard-to-echo latency.
+- The benchmark did not force garbage collection; heap deltas include reclaimable temporary allocations and must not be called a retained-memory leak.
+- It did not measure terminal parser/paint latency, stdout backpressure, event-loop delay, CPU percentage, RSS slope, Terminal.app versus iTerm2 behavior, tmux, image rendering, or a 60-minute session.
+- End-to-end PTY and real-terminal measurements remain mandatory after Task B and again after Task A.
+
+## Required comparison points
+
+The same fixture and supported Node runtime must be used for:
+
+1. the fixed-viewport Task B commit before any Task A optimization;
+2. the final Task A implementation;
+3. release-candidate validation after packaging and isolated official-dsh lifecycle tests.
+
+Results must retain the distinction between structural microbenchmarks, PTY measurements, and manual terminal acceptance.

--- a/docs/maintenance-task-a-acceptance-2026-08-26.md
+++ b/docs/maintenance-task-a-acceptance-2026-08-26.md
@@ -1,0 +1,72 @@
+# Maintenance task A acceptance record — 2026-08-26
+
+Baseline: Task B `60cf8ca9bc640e8d059f6856bf312449b212544c`
+Branch: `codex/transcript-viewport-performance`
+Candidate: SeekTTY `1.2.1`, official unmodified `@deepseek-ai/dsh@0.1.1-rc.2`, `@mariozechner/pi-tui@0.73.1`
+Host: macOS arm64, tmux 3.7c, Node 24.19.0, 80×24 benchmark viewport
+
+## Delivered behavior
+
+- Finite Transcript frames render only the blocks needed by the viewport and retain a block-coordinate anchor while history is prepended, streamed, resized, or searched.
+- Width-specific block output is cached; pulse frames and completed image loads invalidate only their owning blocks.
+- Full rendered search indexes are cold-path state: they are built only while search is active, synchronously refreshed before search navigation, and preserve the historical block across tail growth, earlier-block growth, and width changes.
+- Image completions are fenced by Session generation and disposal. Pulse timers, listeners, subscriptions, and diagnostic hooks are cleaned up by lifecycle tests.
+- The opt-in `SEEKTTY_TUI_PERF=1` probe records content-free timing, write/backpressure, event-loop, resource, and lifecycle counters. The disabled path keeps the original terminal and I/O identities.
+- Snapshot reconciliation remains correctness-first. The official snapshot exposed no reliable revision token, so `update()` still fingerprints all visible nodes; no new persistence, history truncation, throttling, or dependency was introduced.
+
+## Automated verification
+
+| Check | Status | Observed result |
+| --- | --- | --- |
+| `pnpm run check` on bundled Node 24.19.0 | Pass | TypeScript; 91 test files; 594 passed / 1 skipped; production build; package check with 23 entries |
+| Viewport/search regression suite | Pass | 26 tests, including 1k–100k operation bounds, prepend/tail growth, search refresh, historical resize, earlier-block growth, pulse, image fencing, and 100 Transcript lifecycles |
+| Official dsh compatibility cycle | Pass | Isolated stock hosts for the supported rc.6–rc.8 line and rc.2 tested baseline completed add, boot boundary, remove, re-add, and boot boundary checks |
+| Final stock `0.1.1-rc.2` package cycle | Pass | Final tarball completed production launcher install, module-identity check, add, full boot boundary, remove, re-add, and full boot boundary in isolated homes |
+| Final tmux package smoke | Pass | Final tarball entered the TUI under `TERM=tmux-256color`; first-run dialog was deferred and double Ctrl+C exited the pane with status 0 |
+| Real-PTY Surface lifecycle | Pass | 100 complete first-run → defer → double-Ctrl+C cycles exited 0 under official rc.2 |
+
+One initial stock-cycle attempt referenced a package-check tarball that had already been removed and failed with `ENOENT` before installation. A retained tarball was then created and the complete cycle passed. One initial PTY driver sent Ctrl+C before the first-run modal was ready and timed out; the synchronized driver passed one smoke cycle and then 100 cycles.
+
+## Structural performance comparison
+
+The same opt-in harness ran each size in three independent processes with 100 logical lines per assistant node, 25 cached renders, and 10 tail update+render samples. Values below are medians of the three runs.
+
+| Lines | Task B cached p50 / p95 / p99 (ms) | Task A cached p50 / p95 / p99 (ms) | Task B tail p50 / p95 / p99 (ms) | Task A tail p50 / p95 / p99 (ms) |
+| ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 0.543 / 1.288 / 1.696 | 0.032 / 0.092 / 0.130 | 0.615 / 1.174 / 1.174 | 0.971 / 8.601 / 8.601 |
+| 10,000 | 9.768 / 13.023 / 13.855 | 0.042 / 0.093 / 0.099 | 9.729 / 12.362 / 12.362 | 1.791 / 10.576 / 10.576 |
+| 50,000 | 55.575 / 70.733 / 104.346 | 0.016 / 0.063 / 0.063 | 56.495 / 73.101 / 73.101 | 4.336 / 6.122 / 6.122 |
+| 100,000 | 118.722 / 186.710 / 225.310 | 0.024 / 0.082 / 0.215 | 119.734 / 225.158 / 225.158 | 9.529 / 40.304 / 40.304 |
+
+Every final cached sample visited at most one block, rendered zero components, escaped zero lines, and copied zero full-history lines. At 100k lines, cached-render p95 fell from 186.710 ms to 0.082 ms (about 99.96%). Tail update remains O(N) because correctness fingerprinting still scans the snapshot; its timings are allocator/GC-sensitive and are not represented as viewport-only work.
+
+These are structural in-process measurements, not terminal paint latency or keyboard-to-write latency. They do not by themselves prove the task's 1.5× end-to-end latency target.
+
+## Opt-in PTY probe
+
+A 42.3-second shared-PTY run used the packed candidate, deferred provider setup, entered and cleared input, consumed 100 alternating SGR wheel reports, and exited through double Ctrl+C.
+
+- 111 input events; 3 snapshots; 25 normal render requests.
+- Render p50/p95/p99: 0.612 / 16.593 / 16.593 ms.
+- Input-to-write p50/p95/p99: 1.880 / 5.671 / 5.671 ms.
+- 12 writes, 5,488 bytes, no stdout backpressure.
+- Event-loop delay p99: 21.266 ms; utilization: 0.013276.
+- Process listeners: 3 at start and end; subscriptions: 0.
+- Active resources were 8 at start and 10 at capture time. This live-process count is recorded without calling it a leak; the 100 full exit cycles provide the stronger lifecycle evidence.
+
+## Adversarial review
+
+Five Grok 4.6 Extra High review rounds were used across the implementation. Accepted findings were reproduced with focused tests before fixes. The final review candidate about search resizing was confirmed by a failing regression and fixed with block-coordinate anchoring; speculative findings that did not survive code-path analysis were not applied. A Fast invocation was stopped and excluded; after the user's instruction, no Fast model was used.
+
+The final review considered viewport anchoring, search index freshness, width changes, empty indexes, Session/disposal races, timer and listener cleanup, normal-frame complexity, output backpressure, official Host module identity, package contents, and rollback.
+
+## Remaining manual release gates
+
+- Terminal.app native `Fn` drag selection and iTerm2 native `Option` selection could not be controlled under the computer-use safety policy.
+- A user-operated 60-minute Terminal.app/iTerm2 session, including resize, search, scrolling, image/tool updates, and tmux, remains required. The shared PTY, tmux smoke, and 100 automated PTY cycles are not represented as equivalent to those native UI checks.
+
+No push, pull request, merge, tag, release, publication, credential write, Session migration, or persistence migration was performed.
+
+## Rollback
+
+Revert the Task A commits in reverse order, rebuild `lib/` with `pnpm run build`, and retain Task B `60cf8ca` as the fixed-viewport baseline. The change is presentation-cache and diagnostics state only; no Harness-owned Profile, plugin, Session, model, permission, credential, or persistence schema requires rollback.

--- a/docs/maintenance-task-a-post-b-baseline-2026-08-26.md
+++ b/docs/maintenance-task-a-post-b-baseline-2026-08-26.md
@@ -1,0 +1,65 @@
+# Task A post-Task-B performance baseline — 2026-08-26
+
+This report is the required comparison point after Task B's fixed viewport and before any Task A transcript optimization.
+
+## Fixed inputs
+
+- Repository commit: `60cf8ca9bc640e8d059f6856bf312449b212544c`
+- Branch: `codex/transcript-viewport-performance`
+- SeekTTY: `1.2.1`
+- Official dsh tested baseline: `0.1.1-rc.2`
+- `@mariozechner/pi-tui`: `0.73.1` with Task B patch hash `52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38`
+- Runtime: Node `24.19.0`, macOS arm64, Darwin kernel `25.5.0`
+- Fixture viewport: 80 columns × 24 transcript rows
+- Synthetic data: official-shape snapshots, 100 short Markdown lines per assistant node
+
+Command:
+
+```sh
+PATH="<bundled-node-24-bin>:$PATH" pnpm perf:tui
+```
+
+The committed harness runs each size/repeat in a separate Vitest process with `--expose-gc`. It measures only explicit `Transcript.update()` and `Transcript.render()` intervals; TypeScript transform, Vitest startup, and process startup are outside the samples. Each scenario warms the component line cache, takes 25 cached-render samples, then takes 10 samples that replace only the tail node before update+render.
+
+## Raw three-run results
+
+Times are milliseconds. Heap/RSS deltas are MiB after an explicit GC while the synthetic snapshot and Transcript caches are still live.
+
+| Run | Lines | Nodes | Initial update | Cached render p50 / p95 / p99 | Tail update + render p50 / p95 / p99 | Heap delta | RSS delta |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1,000 | 10 | 0.833 | 0.574 / 1.358 / 1.688 | 0.595 / 1.120 / 1.120 | 11.286 | 26.125 |
+| 1 | 10,000 | 100 | 3.201 | 9.710 / 14.138 / 14.219 | 9.985 / 12.383 / 12.383 | 165.231 | 260.422 |
+| 1 | 50,000 | 500 | 17.227 | 60.515 / 85.140 / 97.842 | 63.042 / 82.525 / 82.525 | 610.982 | 1,500.078 |
+| 1 | 100,000 | 1,000 | 23.036 | 118.722 / 171.473 / 177.275 | 115.535 / 225.158 / 225.158 | 1,823.111 | 2,115.484 |
+| 2 | 1,000 | 10 | 0.900 | 0.543 / 1.288 / 1.696 | 0.615 / 1.179 / 1.179 | 11.301 | 26.359 |
+| 2 | 10,000 | 100 | 3.052 | 9.933 / 12.930 / 13.855 | 9.532 / 11.707 / 11.707 | 164.862 | 260.359 |
+| 2 | 50,000 | 500 | 17.764 | 55.321 / 70.733 / 104.346 | 56.495 / 73.101 / 73.101 | 307.037 | 1,734.109 |
+| 2 | 100,000 | 1,000 | 24.722 | 116.383 / 215.647 / 225.310 | 119.734 / 167.394 / 167.394 | 1,417.581 | 2,127.047 |
+| 3 | 1,000 | 10 | 0.835 | 0.489 / 1.219 / 1.776 | 0.644 / 1.174 / 1.174 | 11.298 | 26.453 |
+| 3 | 10,000 | 100 | 2.701 | 9.768 / 13.023 / 13.294 | 9.729 / 12.362 / 12.362 | 164.731 | 260.047 |
+| 3 | 50,000 | 500 | 17.715 | 55.575 / 68.973 / 107.227 | 53.781 / 66.962 / 66.962 | 608.717 | 1,357.766 |
+| 3 | 100,000 | 1,000 | 28.129 | 127.064 / 186.710 / 250.010 | 144.060 / 483.351 / 483.351 | 815.578 | 1,443.266 |
+
+## Median of the three runs
+
+| Lines | Initial update | Cached render p50 / p95 / p99 | Tail update + render p50 / p95 / p99 | Heap delta | RSS delta |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 0.835 | 0.543 / 1.288 / 1.696 | 0.615 / 1.174 / 1.174 | 11.298 | 26.359 |
+| 10,000 | 3.052 | 9.768 / 13.023 / 13.855 | 9.729 / 12.362 / 12.362 | 164.862 | 260.359 |
+| 50,000 | 17.715 | 55.575 / 70.733 / 104.346 | 56.495 / 73.101 / 73.101 | 608.717 | 1,500.078 |
+| 100,000 | 24.722 | 118.722 / 186.710 / 225.310 | 119.734 / 225.158 / 225.158 | 1,417.581 | 2,115.484 |
+
+Every cached-render sample made zero component render calls. Despite that cache hit, the median p50 grew from 0.543 ms at 1k lines to 118.722 ms at 100k lines (about 219× for 100× history). The remaining cost is therefore outside component rebuilding: the current frame still walks every component, maps escaped lines, rebuilds anchors/search inputs, copies `lastFullLines`, and only then selects 24 visible rows.
+
+The 100k p50 is far above the maintenance target of making editor-only work viewport-bound. Task B correctly bounded the pi-tui root and terminal writes, but it did not remove Transcript's own O(N) frame work; Task A remains necessary.
+
+## Evidence limits
+
+- This is an in-process structural benchmark, not keyboard-to-terminal-write latency and not a Terminal.app/iTerm2 paint measurement.
+- Heap/RSS numbers describe a live synthetic 100k snapshot plus renderer caches. They are not retained-heap slopes and do not prove a leak. The 50k/100k spread also shows that allocator and GC behavior remains noisy even with per-scenario process isolation.
+- The pre-Task-B `6c03e80f` fixture was temporary and deleted after its recorded run. Its report used the same documented 100-lines-per-node shape but did not preserve machine-readable raw runs or per-scenario process isolation. Its 100k cached-render p50/p95/p99 of 125.071/157.008/192.129 ms is comparable in scale, but no precise percentage claim between the two baselines is made.
+- This fixture uses short Markdown text. Tool cards, code, images, partial streaming, concurrent 10/50 snapshot-per-second loads, event-loop delay, backpressure, lifecycle counts, and 60-minute terminal runs remain required after implementation.
+
+## Required final comparison
+
+The final Task A candidate must rerun this exact committed harness on the same host/runtime. In addition to latency improvement, deterministic operation-count tests must prove that editor-only frames visit only viewport blocks and do not perform full-history fingerprint, escape, or pi-tui diff work.

--- a/docs/maintenance-task-b-acceptance-2026-08-26.md
+++ b/docs/maintenance-task-b-acceptance-2026-08-26.md
@@ -1,0 +1,41 @@
+# Maintenance task B acceptance record — 2026-08-26
+
+Baseline: `main@6c03e80f0acb62f05dae9e80606ce54e80beb684`
+Branch: `codex/terminal-fixed-viewport`
+Candidate: SeekTTY `1.2.1`, official unmodified `@deepseek-ai/dsh@0.1.1-rc.2`, `@mariozechner/pi-tui@0.73.1`
+Host: macOS 26.5.2 (25F84), Terminal.app 2.15 (470.2), iTerm2 3.6.11, tmux 3.7c, Node 24.19.0
+
+## Automated verification
+
+| Check | Status | Observed result |
+| --- | --- | --- |
+| Focused terminal/viewport suite | Pass | 7 files, 82 tests passed |
+| `pnpm run check` | Pass | typecheck; 88 files, 563 passed / 1 skipped; build; pack-check 23 entries |
+| Packed official dsh lifecycle | Pass | isolated `DSH_HOME`: add, full boot boundary, remove, re-add, full boot; Profile kept official Host module identity |
+| Packaged launcher | Pass | isolated production install, `deepseek --version`, and non-TTY boot boundary from the tarball |
+| Normal PTY `/exit` | Pass | exit 0; pre/post `stty -g` equal; one `1049h/l`, `1000h/l`, and `1006h/l`; zero `3J`; no CRLF or cursor movement between `1049l` and shell output |
+| PTY double Ctrl+C + resize | Pass | 20 cycles between 24×80 and 60×100 with alternating wheel input; exit 0; one alternate-screen lifecycle; zero `3J`; mouse reports did not echo |
+| PTY SIGTERM + 100 wheel detents | Pass | exit 143; original termios observed restored before process exit; one alternate-screen lifecycle; zero `3J`; mouse reports did not echo |
+| PTY SIGHUP | Pass | exit 129; original termios observed restored before process exit; one alternate-screen lifecycle; zero `3J` |
+| PTY `TERM=dumb` | Pass | rejected before terminal construction with exit 1; zero alternate, mouse, paste, or cursor private sequences |
+
+The synchronous protocol restore emits bracketed-paste off once before `1049l`; the later pinned `ProcessTerminal.stop()` repeats only the idempotent paste-off sequence. It also detaches the input buffer, marks protocols restored, and quiesces pending TUI renders before leaving the alternate screen. Regression tests force a queued frame, a late Kitty reply, and the 150 ms modifyOtherKeys fallback; none can write after restore.
+
+Two invalid driver attempts were excluded from acceptance: a background shell child was not a foreground interactive TTY and correctly exited before private modes; a resize run sent `Esc` before `/exit`, changed input context, and submitted `exit` as an ordinary prompt. The same resize workload passed with the specified double-Ctrl+C path.
+
+## True-terminal matrix
+
+| Environment | Status | Evidence / blocker |
+| --- | --- | --- |
+| Codex shared PTY, direct | Pass | Final packed candidate booted visibly; 100 SGR wheel reports were consumed; double Ctrl+C returned to the shell; restore order was mouse → paste/keyboard → cursor → `1049l`; after a further 5 seconds there was no late `>7u`, `>4;2m`, or TUI frame |
+| Codex shared PTY + tmux 3.7c | Pass | Outer `TERM=xterm-256color`, inner `TERM=tmux-256color`; `mouse`, `alternate-screen`, and `extended-keys` all on; 100 wheel reports and double Ctrl+C returned to the tmux shell, then detach and exact test-server cleanup succeeded |
+| Terminal.app direct, mouse reporting and alternate-scroll variants | Blocked | Computer-use safety policy explicitly rejected control of `com.apple.Terminal`; no visual or selection result is claimed |
+| Terminal.app `Fn` drag + `Command+C` | Blocked | Same UI-control restriction; requires user-operated acceptance |
+| iTerm2 direct and Option selection variants | Blocked | iTerm2 3.6.11 was installed, but computer-use safety policy explicitly rejected control of `com.googlecode.iterm2`; modifier-drag selection remains user-operated |
+| Terminal.app/iTerm2 + tmux | Partial | tmux behavior passed in the shared PTY; Terminal.app/iTerm2 rendering and native selection remain blocked by UI-control policy |
+
+The blocked Terminal.app/iTerm2 rows remain release gates. Shared-terminal and automated PTY evidence proves protocol lifecycle, fixed-size resize handling, input consumption, tmux behavior, and termios restoration, but it is not represented as equivalent to native Terminal.app/iTerm2 selection behavior.
+
+## Rollback
+
+Revert the task-B implementation commit. The rollback removes the terminal session, restores the previous main-screen/native-scrollback behavior, restores the prior pi-tui patch hash, and regenerates `lib/` through `pnpm run build`. No Harness, Profile, plugin, Session, credential, or persistence schema is changed.

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_NAME, c as defaultPluginSpec, d as isVersionRequest, f as launcherCopy, i as HOST_DESCRIBE_VERSION_PLACEHOLDER, m as versionMessage, n as measureStartupSync, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as compareDshVersion } from "./startup-trace-BPC307Y6.js";
+import { a as PACKAGE_NAME, c as defaultPluginSpec, d as isVersionRequest, f as launcherCopy, i as HOST_DESCRIBE_VERSION_PLACEHOLDER, m as versionMessage, n as measureStartupSync, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as compareDshVersion } from "./startup-trace-BXdEIGJm.js";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-CVtK1ljQ.js";
-import { c as defaultPluginSpec, l as dshCompatibilityError, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, t as measureStartup, u as dshCompatibilityNotice } from "./startup-trace-BPC307Y6.js";
+import { c as defaultPluginSpec, l as dshCompatibilityError, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, t as measureStartup, u as dshCompatibilityNotice } from "./startup-trace-BXdEIGJm.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-vXC6VP5Q.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-CDUPNFEI.js";
 import { createRequire } from "node:module";

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ import * as os from "node:os";
 import { homedir as homedir$1, tmpdir } from "node:os";
 import * as path from "node:path";
 import { basename as basename$1, dirname as dirname$1, extname, isAbsolute, join as join$1, resolve } from "node:path";
-import { performance } from "node:perf_hooks";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { EventEmitter } from "events";
 import { Context, Service } from "@deepseek-ai/cordis";
 import commandsRemote from "@deepseek-ai/dsh-commands/remote";
@@ -25539,7 +25539,13 @@ const PULSE_FRAME_MS = 160;
 /** Replaceable counters used by incremental-render tests. */
 const internals$2 = {
 	markdownCreated: 0,
-	componentRenders: 0
+	componentRenders: 0,
+	blocksVisited: 0,
+	linesEscaped: 0,
+	lastFullLinesCopied: 0,
+	fingerprintsComputed: 0,
+	imageBlocksUpdated: 0,
+	activePulseTimers: 0
 };
 function thinkingRow() {
 	return {
@@ -26440,11 +26446,18 @@ function chatNodeRows(node, preferences) {
 		text: color.muted(ui(`扩展节点 ${node.kind} · /trajectory 查看详情`, `Extended node ${node.kind} · use /trajectory for details`))
 	}]);
 }
+function transcriptBlockMetadata(rows) {
+	return {
+		userTurnRows: rows.flatMap((row, index) => row.userTurn === true ? [index] : []),
+		toolKeys: [...new Set(rows.flatMap((row) => row.toolKey === void 0 ? [] : [row.toolKey]))],
+		dynamic: rows.some((row) => row.pulse !== void 0 || row.liveDurationSince !== void 0)
+	};
+}
 /** Mutable pi-tui component backed only by the official conversation snapshot. */
 var Transcript = class {
-	components = [new Text("", 0, 0)];
-	rows = [];
+	blocks = [];
 	imageComponents = /* @__PURE__ */ new Map();
+	imageBlockOwners = /* @__PURE__ */ new Map();
 	pendingImages = /* @__PURE__ */ new Set();
 	imageGeneration = 0;
 	imageLoader;
@@ -26459,12 +26472,20 @@ var Transcript = class {
 	hasMore = false;
 	loadingOlder = false;
 	scrollOffset = 0;
+	viewportAnchor = {
+		blockKey: "",
+		lineOffset: 0,
+		followLatest: true
+	};
+	viewportState;
 	renderedLineCount = 0;
 	turnAnchors = [];
 	turnCursor;
 	pulseFrame = 0;
 	pulseTimer;
 	lastFullLines = [];
+	blockGeneration = 0;
+	searchIndex;
 	search;
 	exampleCursor = 0;
 	toolCursor = 0;
@@ -26515,6 +26536,11 @@ var Transcript = class {
 	followLatest() {
 		this.turnCursor = void 0;
 		this.scrollOffset = 0;
+		this.viewportAnchor = {
+			blockKey: "",
+			lineOffset: 0,
+			followLatest: true
+		};
 		this.requestRender();
 	}
 	/**
@@ -26536,7 +26562,17 @@ var Transcript = class {
 		this.sessionId = void 0;
 		this.pendingImages.clear();
 		this.imageComponents.clear();
+		this.imageBlockOwners.clear();
 		this.nodeCache.clear();
+		this.search = void 0;
+		this.searchIndex = void 0;
+		this.lastFullLines = [];
+		this.viewportAnchor = {
+			blockKey: "",
+			lineOffset: 0,
+			followLatest: true
+		};
+		this.viewportState = void 0;
 		this.emptyState = true;
 		this.hasMore = false;
 		this.loadingOlder = false;
@@ -26560,13 +26596,26 @@ var Transcript = class {
 			this.imageGeneration += 1;
 			this.pendingImages.clear();
 			this.imageComponents.clear();
+			this.imageBlockOwners.clear();
 			this.sessionId = sessionId;
 			this.expandedTools.clear();
 			this.collapsedTools.clear();
 			this.toolCursor = 0;
 			this.nodeCache.clear();
+			this.viewportAnchor = {
+				blockKey: "",
+				lineOffset: 0,
+				followLatest: true
+			};
+			this.viewportState = void 0;
+			this.search = void 0;
+			this.searchIndex = void 0;
+			this.lastFullLines = [];
 		}
 		this.imageLoader = imageLoader;
+		this.blockGeneration += 1;
+		this.searchIndex = void 0;
+		if (this.search !== void 0) this.lastFullLines = [];
 		this.hasMore = snapshot.hasMore;
 		this.loadingOlder = snapshot.loadingOlder;
 		const preferences = {
@@ -26582,28 +26631,39 @@ var Transcript = class {
 			const node = snapshot.chat.nodes.get(key);
 			return node === void 0 || node.visibility !== "visible" ? [] : [node];
 		});
-		const rows = [];
-		const components = [];
+		const blocks = [];
 		const keep = /* @__PURE__ */ new Set();
+		let hasVisibleRows = false;
 		const take = (key, fingerprint, build) => {
 			keep.add(key);
 			const hit = this.nodeCache.get(key);
-			if (hit !== void 0 && hit.fingerprint === fingerprint) {
-				rows.push(...hit.rows);
-				components.push(...hit.components);
+			if (hit !== void 0 && hit.sourceToken === fingerprint) {
+				if (hit.rows.length > 0) {
+					hasVisibleRows = true;
+					blocks.push(hit);
+				}
 				return;
 			}
 			const built = build();
-			const created = built.map((row) => this.component(row));
-			this.nodeCache.set(key, {
-				fingerprint,
+			const block$1 = {
+				key,
+				sourceToken: fingerprint,
 				rows: built,
-				components: created
-			});
-			rows.push(...built);
-			components.push(...created);
+				components: built.map((row) => this.component(row)),
+				linesByWidth: /* @__PURE__ */ new Map(),
+				metadata: transcriptBlockMetadata(built),
+				dirty: false
+			};
+			this.nodeCache.set(key, block$1);
+			if (built.length > 0) {
+				hasVisibleRows = true;
+				blocks.push(block$1);
+			}
 		};
-		for (const node of visibleNodes) take(node.key, nodeFingerprint(node, preferences), () => chatNodeRows(node, preferences));
+		for (const node of visibleNodes) {
+			internals$2.fingerprintsComputed += 1;
+			take(node.key, nodeFingerprint(node, preferences), () => chatNodeRows(node, preferences));
+		}
 		if (snapshot.partial !== null && !visibleNodes.some((node) => node.kind === "assistant-step")) {
 			const partial = snapshot.partial;
 			take("__partial__", JSON.stringify({
@@ -26627,13 +26687,21 @@ var Transcript = class {
 			expanded: preferences.expandedTools.has(call.callId),
 			collapsed: preferences.collapsedTools.has(call.callId)
 		}), () => grouped(toolBlockRows(call, preferences, 0, call.callId)));
-		this.emptyState = rows.length === 0;
+		this.emptyState = !hasVisibleRows;
 		if (this.emptyState) take("__empty__", JSON.stringify({
 			cursor: this.exampleCursor,
 			session: this.sessionId
 		}), () => this.emptySessionRows());
 		for (const key of [...this.nodeCache.keys()]) if (!keep.has(key)) this.nodeCache.delete(key);
-		this.commit(rows, components);
+		this.commit(blocks);
+		this.imageBlockOwners.clear();
+		for (const block$1 of blocks) for (const row of block$1.rows) {
+			if (row.format !== "image") continue;
+			const cacheKey = `${this.sessionId ?? "none"}:${row.key}`;
+			const owners = this.imageBlockOwners.get(cacheKey) ?? /* @__PURE__ */ new Set();
+			owners.add(block$1.key);
+			this.imageBlockOwners.set(cacheKey, owners);
+		}
 		const keys = this.toolKeys();
 		if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1);
 	}
@@ -26693,6 +26761,7 @@ var Transcript = class {
 	refreshPresentation() {
 		const scrollOffset = this.scrollOffset;
 		const turnCursor = this.turnCursor;
+		const viewportAnchor = this.viewportAnchor;
 		const snapshot = this.snapshot;
 		this.nodeCache.clear();
 		if (snapshot === void 0) this.replace([{
@@ -26702,12 +26771,16 @@ var Transcript = class {
 		else this.update(snapshot, this.imageLoader);
 		this.scrollOffset = scrollOffset;
 		this.turnCursor = turnCursor;
+		this.viewportAnchor = viewportAnchor;
 		this.requestRender();
 	}
 	invalidate() {
-		for (const [index, component] of this.components.entries()) {
-			const row = this.rows[index];
-			if (row?.pulse !== void 0 || row?.liveDurationSince !== void 0) component.invalidate();
+		for (const block$1 of this.blocks) {
+			if (!block$1.metadata.dynamic) continue;
+			for (const [index, component] of block$1.components.entries()) {
+				const row = block$1.rows[index];
+				if (row?.pulse !== void 0 || row?.liveDurationSince !== void 0) component.invalidate();
+			}
 		}
 	}
 	/** Stop pending attachment presentation updates during terminal teardown. */
@@ -26717,6 +26790,238 @@ var Transcript = class {
 		this.imageLoader = void 0;
 		this.pendingImages.clear();
 		this.imageComponents.clear();
+		this.imageBlockOwners.clear();
+		this.search = void 0;
+		this.searchIndex = void 0;
+		this.lastFullLines = [];
+	}
+	renderBlock(blockIndex, contentWidth) {
+		const block$1 = this.blocks[blockIndex];
+		if (block$1 === void 0) return {
+			lines: [],
+			turnAnchors: []
+		};
+		internals$2.blocksVisited += 1;
+		const cacheKey = blockIndex === 0 ? -contentWidth : contentWidth;
+		if (block$1.dirty) {
+			block$1.linesByWidth.clear();
+			block$1.dirty = false;
+		}
+		const cachedBlock = block$1.metadata.dynamic ? void 0 : block$1.linesByWidth.get(cacheKey);
+		if (cachedBlock !== void 0) return cachedBlock;
+		const lines = [];
+		const turnAnchors = [];
+		for (const [index, component] of block$1.components.entries()) {
+			const row = block$1.rows[index];
+			if ((blockIndex > 0 || lines.length > 0) && row?.gapBefore === true) lines.push("");
+			if (row?.userTurn === true) turnAnchors.push(lines.length);
+			const pulsing = row?.pulse !== void 0 || row?.liveDurationSince !== void 0;
+			const cached = pulsing ? void 0 : this.lineCache.get(component);
+			const rendered = cached !== void 0 && cached.width === contentWidth ? cached.lines : (() => {
+				internals$2.componentRenders += 1;
+				const output = component.render(contentWidth);
+				if (!pulsing) this.lineCache.set(component, {
+					width: contentWidth,
+					lines: output
+				});
+				return output;
+			})();
+			if (row?.format === "image") lines.push(...rendered);
+			else for (const line of rendered) {
+				internals$2.linesEscaped += 1;
+				lines.push(escapeTerminalText(line));
+			}
+		}
+		const result = {
+			lines,
+			turnAnchors
+		};
+		if (!block$1.metadata.dynamic) {
+			block$1.linesByWidth.set(cacheKey, result);
+			while (block$1.linesByWidth.size > 4) {
+				const oldest = block$1.linesByWidth.keys().next().value;
+				if (oldest === void 0) break;
+				block$1.linesByWidth.delete(oldest);
+			}
+		}
+		return result;
+	}
+	finiteViewportLines(contentWidth, rows, olderMarker) {
+		if (this.blocks.length === 0) return Array.from({ length: rows }, () => "");
+		let startIndex;
+		let startOffset;
+		if (this.viewportAnchor.followLatest) {
+			const parts = [];
+			let remaining = rows;
+			startIndex = this.blocks.length - 1;
+			startOffset = 0;
+			for (let index$1 = this.blocks.length - 1; index$1 >= 0 && remaining > 0; index$1 -= 1) {
+				const rendered = this.renderBlock(index$1, contentWidth);
+				if (rendered.lines.length === 0) continue;
+				const offset$1 = Math.max(0, rendered.lines.length - remaining);
+				parts.unshift({
+					blockIndex: index$1,
+					offset: offset$1,
+					lines: [...rendered.lines.slice(offset$1)],
+					turnAnchors: rendered.turnAnchors
+				});
+				startIndex = index$1;
+				startOffset = offset$1;
+				remaining -= rendered.lines.length - offset$1;
+			}
+			let visible$1 = parts.flatMap((part) => part.lines);
+			const hasOlder$1 = startIndex > 0 || startOffset > 0 || this.hasMore;
+			if (hasOlder$1 && visible$1.length > 0) {
+				let lineBase = 0;
+				let latestTurn;
+				for (const part of parts) {
+					for (const anchor of part.turnAnchors) {
+						if (anchor < part.offset || anchor >= part.offset + part.lines.length) continue;
+						latestTurn = {
+							blockIndex: part.blockIndex,
+							lineOffset: anchor,
+							visibleOffset: lineBase + anchor - part.offset
+						};
+					}
+					lineBase += part.lines.length;
+				}
+				if (latestTurn !== void 0 && visible$1.length - latestTurn.visibleOffset <= rows - 1) {
+					visible$1 = [
+						...Array.from({ length: rows - (visible$1.length - latestTurn.visibleOffset) - 1 }, () => ""),
+						olderMarker(0),
+						...visible$1.slice(latestTurn.visibleOffset)
+					];
+					startIndex = latestTurn.blockIndex;
+					startOffset = latestTurn.lineOffset;
+				} else visible$1[0] = olderMarker(0);
+			}
+			const padding = Math.max(0, rows - visible$1.length);
+			const result = [...Array.from({ length: padding }, () => ""), ...visible$1];
+			const start$1 = {
+				blockKey: this.blocks[startIndex]?.key ?? "",
+				lineOffset: startOffset
+			};
+			this.viewportAnchor = {
+				...start$1,
+				followLatest: true
+			};
+			this.viewportState = {
+				contentWidth,
+				rows,
+				start: start$1,
+				hasOlder: hasOlder$1,
+				hasNewer: false
+			};
+			this.scrollOffset = 0;
+			return result;
+		}
+		startIndex = this.blocks.findIndex((block$1) => block$1.key === this.viewportAnchor.blockKey);
+		if (startIndex < 0) {
+			this.viewportAnchor = {
+				blockKey: "",
+				lineOffset: 0,
+				followLatest: true
+			};
+			return this.finiteViewportLines(contentWidth, rows, olderMarker);
+		}
+		const firstLines = this.renderBlock(startIndex, contentWidth).lines;
+		startOffset = Math.max(0, Math.min(this.viewportAnchor.lineOffset, Math.max(0, firstLines.length - 1)));
+		const visible = [];
+		let index = startIndex;
+		let offset = startOffset;
+		while (index < this.blocks.length && visible.length < rows) {
+			const blockLines = this.renderBlock(index, contentWidth).lines;
+			const available = blockLines.slice(offset, offset + rows - visible.length);
+			visible.push(...available);
+			if (offset + available.length < blockLines.length) {
+				offset += available.length;
+				break;
+			}
+			index += 1;
+			offset = 0;
+		}
+		const hasOlder = startIndex > 0 || startOffset > 0 || this.hasMore;
+		const hasNewer = index < this.blocks.length;
+		if (!hasNewer && visible.length < rows) {
+			this.viewportAnchor = {
+				blockKey: "",
+				lineOffset: 0,
+				followLatest: true
+			};
+			return this.finiteViewportLines(contentWidth, rows, olderMarker);
+		}
+		if (hasOlder && visible.length > 0) {
+			visible.unshift(olderMarker(0));
+			visible.splice(rows);
+		}
+		if (hasNewer && visible.length > 0) {
+			const hint = this.focused ? "PgDn/End" : ui("滚轮下翻", "Scroll down");
+			visible[visible.length - 1] = color.muted(ui(`↓ 有更新内容 · ${hint}`, `↓ Newer content · ${hint}`));
+		}
+		const start = {
+			blockKey: this.blocks[startIndex]?.key ?? "",
+			lineOffset: startOffset
+		};
+		this.viewportAnchor = {
+			...start,
+			followLatest: false
+		};
+		this.viewportState = {
+			contentWidth,
+			rows,
+			start,
+			hasOlder,
+			hasNewer
+		};
+		return visible;
+	}
+	ensureSearchIndex(contentWidth) {
+		const current = this.searchIndex;
+		if (current !== void 0 && current.width === contentWidth && current.generation === this.blockGeneration) return current;
+		const lines = [];
+		const spans = [];
+		for (const [blockIndex, block$1] of this.blocks.entries()) {
+			const start = lines.length;
+			lines.push(...this.renderBlock(blockIndex, contentWidth).lines);
+			spans.push({
+				blockKey: block$1.key,
+				start,
+				end: lines.length
+			});
+		}
+		const index = {
+			width: contentWidth,
+			generation: this.blockGeneration,
+			lines,
+			spans
+		};
+		this.searchIndex = index;
+		this.lastFullLines = lines;
+		return index;
+	}
+	searchViewportLines(contentWidth, totalRows, olderMarker) {
+		const index = this.ensureSearchIndex(contentWidth);
+		const rows = Math.max(1, totalRows - 1);
+		const maxOffset = Math.max(0, index.lines.length - rows);
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
+		const end = index.lines.length - this.scrollOffset;
+		const start = Math.max(0, end - rows);
+		const plan = planLineSearch(index.lines, this.search?.query ?? "");
+		if ((this.search?.matchIndex ?? 0) >= plan.matches.length && this.search !== void 0) this.search.matchIndex = 0;
+		const current = plan.matches[this.search?.matchIndex ?? 0];
+		const query = this.search?.query ?? "";
+		const visible = index.lines.slice(start, end).map((line, localIndex) => {
+			const lineIndex = start + localIndex;
+			if (query.trim() === "" || !plan.hit.has(lineIndex)) return line;
+			return highlightQuery(line, query, (matched) => lineIndex === current ? `\u001B[7m${matched}\u001B[0m` : color.accent(matched));
+		});
+		if (start > 0 && visible.length > 0) visible[0] = olderMarker(start);
+		else if (this.hasMore && visible.length > 0) visible[0] = olderMarker(0);
+		if (end < index.lines.length && visible.length > 0) {
+			const hint = this.focused ? "PgDn/End" : ui("滚轮下翻", "Scroll down");
+			visible[visible.length - 1] = color.muted(ui(`↓ ${String(index.lines.length - end)} 行更新内容 · ${hint}`, `↓ ${String(index.lines.length - end)} newer line(s) · ${hint}`));
+		}
+		return [...Array.from({ length: Math.max(0, rows - visible.length) }, () => ""), ...visible];
 	}
 	render(width) {
 		const inset = width >= 12 ? 2 : 0;
@@ -26734,25 +27039,14 @@ var Transcript = class {
 			const hint = this.focused ? "PgUp/Home" : ui("滚轮上翻", "Scroll up");
 			return color.muted(count === 0 ? ui(`↑ 还有更早内容 · ${hint}`, `↑ Older content available · ${hint}`) : ui(`↑ ${String(count)} 行更早内容 · ${hint}`, `↑ ${String(count)} older line(s) · ${hint}`));
 		};
+		if (Number.isFinite(totalRows) && this.search !== void 0) return withInset(this.searchViewportLines(contentWidth, totalRows, olderMarker));
+		if (Number.isFinite(totalRows) && this.search === void 0 && !this.emptyState) return withInset(this.finiteViewportLines(contentWidth, totalRows, olderMarker));
 		const lines = [];
 		const anchors = [];
-		for (const [index, component] of this.components.entries()) {
-			if (lines.length > 0 && this.rows[index]?.gapBefore === true) lines.push("");
-			if (this.rows[index]?.userTurn === true) anchors.push(lines.length);
-			const row = this.rows[index];
-			const pulsing = row?.pulse !== void 0 || row?.liveDurationSince !== void 0;
-			const cached = pulsing ? void 0 : this.lineCache.get(component);
-			const rendered = cached !== void 0 && cached.width === contentWidth ? cached.lines : (() => {
-				internals$2.componentRenders += 1;
-				const lines$1 = component.render(contentWidth);
-				if (!pulsing) this.lineCache.set(component, {
-					width: contentWidth,
-					lines: lines$1
-				});
-				return lines$1;
-			})();
-			const escaped = row?.format === "image" ? rendered : rendered.map(escapeTerminalText);
-			lines.push(...escaped);
+		for (const blockIndex of this.blocks.keys()) {
+			const rendered = this.renderBlock(blockIndex, contentWidth);
+			anchors.push(...rendered.turnAnchors.map((anchor) => lines.length + anchor));
+			lines.push(...rendered.lines);
 		}
 		if (this.emptyState) for (const [index, line] of lines.entries()) {
 			if (line === "") continue;
@@ -26760,7 +27054,10 @@ var Transcript = class {
 			lines[index] = `${" ".repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`;
 		}
 		const previousRenderedLineCount = this.renderedLineCount;
-		this.lastFullLines = [...lines];
+		if (this.search !== void 0) {
+			internals$2.lastFullLinesCopied += lines.length;
+			this.lastFullLines = [...lines];
+		}
 		if (this.scrollOffset > 0 && previousRenderedLineCount > 0) this.scrollOffset = Math.max(0, this.scrollOffset + lines.length - previousRenderedLineCount);
 		this.renderedLineCount = lines.length;
 		this.turnAnchors = anchors;
@@ -26838,12 +27135,7 @@ var Transcript = class {
 			return;
 		}
 		if (data === "/") {
-			this.search = {
-				query: "",
-				composing: true,
-				matchIndex: 0
-			};
-			this.requestRender();
+			this.beginSearch();
 			return;
 		}
 		if (this.emptyState && this.snapshot !== void 0) {
@@ -26871,13 +27163,12 @@ var Transcript = class {
 		}
 		this.turnCursor = void 0;
 		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		const maxOffset = Math.max(0, this.renderedLineCount - rows);
 		if (matchesKey(data, Key.up)) this.scrollBy(1);
 		else if (matchesKey(data, Key.down)) this.scrollBy(-1);
 		else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1));
 		else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
-		else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
-		else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset);
+		else if (matchesKey(data, Key.home)) this.scrollToStart();
+		else if (matchesKey(data, Key.end)) this.followLatest();
 	}
 	/**
 	* Leave incremental search and restore the ordinary transcript chrome.
@@ -26885,9 +27176,44 @@ var Transcript = class {
 	*/
 	cancelSearch() {
 		if (this.search === void 0) return false;
+		const index = this.searchIndex;
+		if (index !== void 0 && Number.isFinite(this.viewportRows())) {
+			const rows = Math.max(1, Math.floor(this.viewportRows()) - 1);
+			const top = Math.max(0, index.lines.length - this.scrollOffset - rows);
+			const span = index.spans.find((candidate) => candidate.start <= top && top < candidate.end);
+			if (span !== void 0) this.viewportAnchor = this.scrollOffset === 0 ? {
+				blockKey: "",
+				lineOffset: 0,
+				followLatest: true
+			} : {
+				blockKey: span.blockKey,
+				lineOffset: top - span.start,
+				followLatest: false
+			};
+		}
 		this.search = void 0;
+		this.searchIndex = void 0;
+		this.lastFullLines = [];
 		this.requestRender();
 		return true;
+	}
+	beginSearch() {
+		this.search = {
+			query: "",
+			composing: true,
+			matchIndex: 0
+		};
+		const viewport = this.viewportState;
+		if (viewport !== void 0) {
+			const index = this.ensureSearchIndex(viewport.contentWidth);
+			const span = index.spans.find((candidate) => candidate.blockKey === viewport.start.blockKey);
+			if (span !== void 0) {
+				const rows = Math.max(1, viewport.rows - 1);
+				const top = span.start + viewport.start.lineOffset;
+				this.scrollOffset = Math.max(0, Math.min(Math.max(0, index.lines.length - rows), index.lines.length - top - rows));
+			}
+		}
+		this.requestRender();
 	}
 	searchLabel() {
 		const query = this.search?.query ?? "";
@@ -26929,14 +27255,13 @@ var Transcript = class {
 		}
 		if (matchesKey(data, Key.up) || matchesKey(data, Key.down) || matchesKey(data, Key.pageUp) || matchesKey(data, Key.pageDown) || matchesKey(data, Key.home) || matchesKey(data, Key.end)) {
 			this.turnCursor = void 0;
-			const rows = Math.max(1, Math.floor(this.viewportRows()));
-			const maxOffset = Math.max(0, this.renderedLineCount - rows);
-			if (matchesKey(data, Key.up)) this.scrollBy(1);
-			else if (matchesKey(data, Key.down)) this.scrollBy(-1);
-			else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1));
-			else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1));
-			else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset);
-			else this.scrollBy(-this.scrollOffset);
+			const rows = Math.max(1, Math.floor(this.viewportRows()) - 1);
+			if (matchesKey(data, Key.up)) this.scrollSearchBy(1, rows);
+			else if (matchesKey(data, Key.down)) this.scrollSearchBy(-1, rows);
+			else if (matchesKey(data, Key.pageUp)) this.scrollSearchBy(Math.max(1, rows - 1), rows);
+			else if (matchesKey(data, Key.pageDown)) this.scrollSearchBy(-Math.max(1, rows - 1), rows);
+			else if (matchesKey(data, Key.home)) this.scrollSearchTo("start", rows);
+			else this.scrollSearchTo("end", rows);
 			return;
 		}
 		if (this.search?.composing === false) {
@@ -26983,7 +27308,92 @@ var Transcript = class {
 		if (this.search === void 0) return;
 		const lineIndex = findLineMatches(this.lastFullLines, this.search.query)[this.search.matchIndex];
 		if (lineIndex === void 0) return;
-		this.scrollOffset = scrollOffsetToReveal(this.lastFullLines.length, this.viewportRows(), lineIndex);
+		this.scrollOffset = scrollOffsetToReveal(this.lastFullLines.length, Math.max(1, this.viewportRows() - 1), lineIndex);
+	}
+	scrollSearchBy(lines, rows) {
+		const index = this.searchIndex;
+		if (index === void 0) return false;
+		const maxOffset = Math.max(0, index.lines.length - rows);
+		const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + Math.trunc(lines)));
+		if (nextOffset === this.scrollOffset) return false;
+		this.scrollOffset = nextOffset;
+		this.requestRender();
+		return true;
+	}
+	scrollSearchTo(edge, rows) {
+		const index = this.searchIndex;
+		if (index === void 0) return false;
+		const nextOffset = edge === "start" ? Math.max(0, index.lines.length - rows) : 0;
+		if (nextOffset === this.scrollOffset) return false;
+		this.scrollOffset = nextOffset;
+		this.requestRender();
+		return true;
+	}
+	moveViewportStart(start, lines, contentWidth) {
+		let blockIndex = this.blocks.findIndex((block$1) => block$1.key === start.blockKey);
+		if (blockIndex < 0) return {
+			coordinate: start,
+			moved: 0
+		};
+		let lineOffset = start.lineOffset;
+		let remaining = Math.abs(lines);
+		let moved = 0;
+		if (lines > 0) while (remaining > 0) {
+			if (lineOffset > 0) {
+				const step = Math.min(remaining, lineOffset);
+				lineOffset -= step;
+				remaining -= step;
+				moved += step;
+				continue;
+			}
+			if (blockIndex === 0) break;
+			blockIndex -= 1;
+			lineOffset = this.renderBlock(blockIndex, contentWidth).lines.length;
+		}
+		else while (remaining > 0) {
+			const blockLines = this.renderBlock(blockIndex, contentWidth).lines;
+			const available = Math.max(0, blockLines.length - lineOffset);
+			if (remaining < available) {
+				lineOffset += remaining;
+				moved += remaining;
+				remaining = 0;
+				continue;
+			}
+			if (blockIndex >= this.blocks.length - 1) {
+				const step = Math.max(0, available - 1);
+				lineOffset += step;
+				moved += step;
+				break;
+			}
+			remaining -= available;
+			moved += available;
+			blockIndex += 1;
+			lineOffset = 0;
+		}
+		return {
+			coordinate: {
+				blockKey: this.blocks[blockIndex]?.key ?? start.blockKey,
+				lineOffset
+			},
+			moved
+		};
+	}
+	scrollToStart() {
+		const first = this.blocks[0];
+		if (first === void 0) return false;
+		if (!this.viewportAnchor.followLatest && this.viewportAnchor.blockKey === first.key && this.viewportAnchor.lineOffset === 0) {
+			if (this.hasMore && !this.loadingOlder) this.requestOlder();
+			return false;
+		}
+		this.turnCursor = void 0;
+		this.viewportAnchor = {
+			blockKey: first.key,
+			lineOffset: 0,
+			followLatest: false
+		};
+		this.scrollOffset = Math.max(1, this.scrollOffset);
+		this.requestRender();
+		return true;
 	}
 	/**
 	* Move the conversation viewport while leaving the composer focus unchanged.
@@ -26994,6 +27404,27 @@ var Transcript = class {
 		this.turnCursor = void 0;
 		const delta = Math.trunc(lines);
 		if (!Number.isFinite(delta) || delta === 0) return false;
+		if (this.search === void 0 && !this.emptyState && this.viewportState !== void 0) {
+			if (delta < 0 && this.viewportAnchor.followLatest) return false;
+			const moved = this.moveViewportStart(this.viewportState.start, delta, this.viewportState.contentWidth);
+			if (moved.moved === 0) {
+				if (delta > 0 && this.hasMore && !this.loadingOlder) this.requestOlder();
+				return false;
+			}
+			const reachesLatest = delta < 0 && this.moveViewportStart(moved.coordinate, -this.viewportState.rows, this.viewportState.contentWidth).moved < this.viewportState.rows;
+			this.viewportAnchor = reachesLatest ? {
+				blockKey: "",
+				lineOffset: 0,
+				followLatest: true
+			} : {
+				...moved.coordinate,
+				followLatest: false
+			};
+			this.scrollOffset = Math.max(0, this.scrollOffset + delta);
+			if (reachesLatest) this.scrollOffset = 0;
+			this.requestRender();
+			return true;
+		}
 		const rows = Math.max(1, Math.floor(this.viewportRows()));
 		const maxOffset = Math.max(0, this.renderedLineCount - rows);
 		const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + delta));
@@ -27011,20 +27442,42 @@ var Transcript = class {
 	* @returns whether an adjacent turn exists and was selected.
 	*/
 	navigateTurn(offset) {
-		if (offset === 0 || this.turnAnchors.length === 0) return false;
-		const rows = Math.max(1, Math.floor(this.viewportRows()));
-		const viewportTop = Math.max(0, this.renderedLineCount - this.scrollOffset - rows);
-		const viewportEnd = Math.min(this.renderedLineCount, viewportTop + rows);
-		const index = this.turnCursor === void 0 ? offset < 0 ? this.turnAnchors.findLastIndex((candidate) => candidate < viewportEnd) : this.turnAnchors.findIndex((candidate) => candidate > viewportTop) : this.turnCursor + Math.sign(offset);
-		const anchor = this.turnAnchors[index];
+		const viewport = this.viewportState;
+		if (offset === 0 || viewport === void 0) return false;
+		const turns = [];
+		for (const [blockIndex, block$1] of this.blocks.entries()) {
+			if (block$1.metadata.userTurnRows.length === 0) continue;
+			const rendered = this.renderBlock(blockIndex, viewport.contentWidth);
+			for (const lineOffset of rendered.turnAnchors) turns.push({
+				blockIndex,
+				blockKey: block$1.key,
+				lineOffset
+			});
+		}
+		if (turns.length === 0) return false;
+		const topBlockIndex = this.blocks.findIndex((block$1) => block$1.key === viewport.start.blockKey);
+		const beforeTop = (turn) => turn.blockIndex < topBlockIndex || turn.blockIndex === topBlockIndex && turn.lineOffset < viewport.start.lineOffset;
+		const afterTop = (turn) => turn.blockIndex > topBlockIndex || turn.blockIndex === topBlockIndex && turn.lineOffset > viewport.start.lineOffset;
+		const cursorIndex = this.turnCursor === void 0 ? -1 : turns.findIndex((turn) => turn.blockKey === this.turnCursor?.blockKey && turn.lineOffset === this.turnCursor.lineOffset);
+		const anchor = turns[cursorIndex < 0 ? offset < 0 ? turns.findLastIndex(beforeTop) : turns.findIndex(afterTop) : cursorIndex + Math.sign(offset)];
 		if (anchor === void 0) return false;
-		this.turnCursor = index;
-		this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows));
+		this.turnCursor = {
+			blockKey: anchor.blockKey,
+			lineOffset: anchor.lineOffset
+		};
+		this.viewportAnchor = {
+			...this.moveViewportStart({
+				blockKey: anchor.blockKey,
+				lineOffset: anchor.lineOffset
+			}, 1, viewport.contentWidth).coordinate,
+			followLatest: false
+		};
+		this.scrollOffset = Math.max(1, this.scrollOffset);
 		this.requestRender();
 		return true;
 	}
 	toolKeys() {
-		return [...new Set(this.rows.flatMap((row) => row.toolKey === void 0 ? [] : [row.toolKey]))];
+		return [...new Set(this.blocks.flatMap((block$1) => block$1.metadata.toolKeys))];
 	}
 	toggleToolCard(key) {
 		if (toolCardExpanded({
@@ -27062,13 +27515,26 @@ var Transcript = class {
 		];
 	}
 	replace(rows) {
-		this.commit(rows, rows.map((row) => this.component(row)));
+		const components = rows.map((row) => this.component(row));
+		const block$1 = {
+			key: "__replacement__",
+			sourceToken: "",
+			rows: [...rows],
+			components,
+			linesByWidth: /* @__PURE__ */ new Map(),
+			metadata: transcriptBlockMetadata(rows),
+			dirty: false
+		};
+		this.commit(rows.length === 0 ? [] : [block$1]);
 	}
-	commit(rows, components) {
-		this.rows = rows;
-		this.turnCursor = void 0;
-		this.components = [...components];
-		this.syncPulseAnimation(rows.some((row) => row.liveDurationSince !== void 0 || row.pulse !== void 0 && terminalColorLevel() !== 0));
+	commit(blocks) {
+		this.blocks = blocks;
+		if (!this.viewportAnchor.followLatest && !blocks.some((block$1) => block$1.key === this.viewportAnchor.blockKey)) this.viewportAnchor = {
+			blockKey: "",
+			lineOffset: 0,
+			followLatest: true
+		};
+		this.syncPulseAnimation(blocks.some((block$1) => block$1.rows.some((row) => row.liveDurationSince !== void 0 || row.pulse !== void 0 && terminalColorLevel() !== 0)));
 	}
 	component(row) {
 		if (row.format === "markdown") {
@@ -27108,8 +27574,16 @@ var Transcript = class {
 				this.requestRender();
 				return;
 			}
-			this.components = this.rows.map((current, index) => current.format === "image" && `${this.sessionId ?? "none"}:${current.key}` === cacheKey ? image : this.components[index] ?? this.component(current));
-			for (const entry of this.nodeCache.values()) for (const [index, current] of entry.rows.entries()) if (current.format === "image" && `${this.sessionId ?? "none"}:${current.key}` === cacheKey) entry.components[index] = image;
+			for (const owner of this.imageBlockOwners.get(cacheKey) ?? []) {
+				const entry = this.nodeCache.get(owner);
+				if (entry === void 0) continue;
+				for (const [index, current] of entry.rows.entries()) if (current.format === "image" && `${this.sessionId ?? "none"}:${current.key}` === cacheKey) {
+					entry.components[index] = image;
+					entry.linesByWidth.clear();
+					entry.dirty = true;
+					internals$2.imageBlocksUpdated += 1;
+				}
+			}
 			this.requestRender();
 		});
 		return fallback;
@@ -27125,10 +27599,14 @@ var Transcript = class {
 			this.pulseFrame = this.pulseFrame === Number.MAX_SAFE_INTEGER ? 0 : this.pulseFrame + 1;
 			this.requestRender();
 		}, PULSE_FRAME_MS);
+		internals$2.activePulseTimers += 1;
 		this.pulseTimer.unref();
 	}
 	stopPulseAnimation() {
-		if (this.pulseTimer !== void 0) clearInterval(this.pulseTimer);
+		if (this.pulseTimer !== void 0) {
+			clearInterval(this.pulseTimer);
+			internals$2.activePulseTimers = Math.max(0, internals$2.activePulseTimers - 1);
+		}
 		this.pulseTimer = void 0;
 		this.pulseFrame = 0;
 	}
@@ -34027,6 +34505,178 @@ function attachFatalGuards(options$1) {
 }
 
 //#endregion
+//#region src/client/tui-performance.ts
+const PROCESS_EVENTS = [
+	"uncaughtException",
+	"unhandledRejection",
+	"SIGINT",
+	"SIGTERM",
+	"SIGHUP"
+];
+function percentile(values, fraction) {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((left, right) => left - right);
+	return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
+}
+function latencySummary(values) {
+	const rounded = (value) => Number(value.toFixed(3));
+	return {
+		p50: rounded(percentile(values, .5)),
+		p95: rounded(percentile(values, .95)),
+		p99: rounded(percentile(values, .99)),
+		max: rounded(Math.max(0, ...values))
+	};
+}
+function activeResources() {
+	return typeof process.getActiveResourcesInfo === "function" ? process.getActiveResourcesInfo().length : 0;
+}
+function processListeners() {
+	return PROCESS_EVENTS.reduce((sum, event) => sum + process.listenerCount(event), 0);
+}
+/** Keep the production terminal untouched unless performance collection is enabled. */
+function instrumentTerminalWrites(rawTerminal, probe, output) {
+	if (!probe.isEnabled) return {
+		terminal: rawTerminal,
+		release: () => void 0
+	};
+	let waitingForDrain = false;
+	const onDrain = () => {
+		waitingForDrain = false;
+		probe.markDrain();
+	};
+	const measuredWrite = (data) => {
+		rawTerminal.write(data);
+		const backpressured = output.writableNeedDrain;
+		probe.markWrite(data, backpressured);
+		if (backpressured && !waitingForDrain) {
+			waitingForDrain = true;
+			output.once("drain", onDrain);
+		}
+	};
+	return {
+		terminal: new Proxy(rawTerminal, { get(target, property) {
+			if (property === "write") return measuredWrite;
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		} }),
+		release: () => {
+			if (!waitingForDrain) return;
+			output.off("drain", onDrain);
+			waitingForDrain = false;
+		}
+	};
+}
+/** Default-off, content-free aggregate metrics for terminal performance acceptance. */
+var TuiPerformanceProbe = class {
+	enabled;
+	startedAt = performance.now();
+	eventLoop = monitorEventLoopDelay({ resolution: 20 });
+	eventLoopStart = performance.eventLoopUtilization();
+	activeResourcesStart = activeResources();
+	processListenersStart = processListeners();
+	renderRequests = /* @__PURE__ */ new Map();
+	renderDurations = [];
+	inputToWrite = [];
+	lastInputAt;
+	inputs = 0;
+	snapshotCount = 0;
+	headerCount = 0;
+	statusCount = 0;
+	writeCalls = 0;
+	writeBytes = 0;
+	backpressureSignals = 0;
+	drains = 0;
+	subscriptions = 0;
+	finished = false;
+	constructor(enabled = process.env.SEEKTTY_TUI_PERF === "1") {
+		this.enabled = enabled;
+		if (enabled) this.eventLoop.enable();
+	}
+	get isEnabled() {
+		return this.enabled;
+	}
+	markInput() {
+		if (!this.enabled) return;
+		this.inputs += 1;
+		this.lastInputAt = performance.now();
+	}
+	markSnapshot() {
+		if (this.enabled) this.snapshotCount += 1;
+	}
+	markHeader() {
+		if (this.enabled) this.headerCount += 1;
+	}
+	markStatus() {
+		if (this.enabled) this.statusCount += 1;
+	}
+	markRenderRequest(reason) {
+		if (!this.enabled) return;
+		this.renderRequests.set(reason, (this.renderRequests.get(reason) ?? 0) + 1);
+	}
+	measureRender(render) {
+		if (!this.enabled) return render();
+		const started = performance.now();
+		try {
+			return render();
+		} finally {
+			this.renderDurations.push(performance.now() - started);
+		}
+	}
+	markWrite(data, backpressured) {
+		if (!this.enabled) return;
+		this.writeCalls += 1;
+		this.writeBytes += Buffer.byteLength(data);
+		if (backpressured) this.backpressureSignals += 1;
+		if (this.lastInputAt !== void 0) {
+			this.inputToWrite.push(performance.now() - this.lastInputAt);
+			this.lastInputAt = void 0;
+		}
+	}
+	markDrain() {
+		if (this.enabled) this.drains += 1;
+	}
+	changeSubscriptions(delta) {
+		if (this.enabled) this.subscriptions = Math.max(0, this.subscriptions + delta);
+	}
+	finish() {
+		if (!this.enabled || this.finished) return void 0;
+		this.finished = true;
+		this.eventLoop.disable();
+		const utilization = performance.eventLoopUtilization(this.eventLoopStart).utilization;
+		return {
+			schema: 1,
+			durationMs: Number((performance.now() - this.startedAt).toFixed(3)),
+			inputEvents: this.inputs,
+			snapshots: this.snapshotCount,
+			refreshHeaderCalls: this.headerCount,
+			updateStatusCalls: this.statusCount,
+			renderRequests: Object.fromEntries(this.renderRequests),
+			renderDurationMs: latencySummary(this.renderDurations),
+			inputToWriteMs: latencySummary(this.inputToWrite),
+			terminalWrites: {
+				calls: this.writeCalls,
+				bytes: this.writeBytes,
+				backpressureSignals: this.backpressureSignals,
+				drains: this.drains
+			},
+			eventLoop: {
+				p99DelayMs: Number((this.eventLoop.percentile(99) / 1e6).toFixed(3)),
+				utilization: Number(utilization.toFixed(6))
+			},
+			memory: process.memoryUsage(),
+			resource: process.resourceUsage(),
+			lifecycle: {
+				activeResourcesStart: this.activeResourcesStart,
+				activeResourcesEnd: activeResources(),
+				processListenersStart: this.processListenersStart,
+				processListenersEnd: processListeners(),
+				subscriptions: this.subscriptions
+			}
+		};
+	}
+};
+
+//#endregion
 //#region src/client/surface.ts
 /** Replaceable terminal seams used by virtual-terminal tests. */
 const internals$1 = {
@@ -34034,6 +34684,9 @@ const internals$1 = {
 	isInteractive: () => process.stdin.isTTY && process.stdout.isTTY,
 	reportCleanupError: (error) => {
 		process.stderr.write(`${escapeTerminalText(ui(`deepseek: 终端清理失败：${error.message}`, `deepseek: terminal cleanup failed: ${error.message}`))}\n`);
+	},
+	reportPerformance: (snapshot) => {
+		process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(snapshot)}\n`);
 	},
 	startClient: startTuiClient
 };
@@ -34053,16 +34706,32 @@ function noticeText(message, tone) {
 */
 async function startTuiSurface(options$1) {
 	if (!supportsManagedTerminal(internals$1.isInteractive(), process.env.TERM)) throw new Error(ui("需要支持终端私有模式的交互式 TTY；非交互任务请使用 dsh --profile headless", "An interactive TTY with private-mode support is required; use dsh --profile headless for non-interactive tasks"));
-	const terminal = internals$1.createTerminal();
+	const performanceProbe = new TuiPerformanceProbe();
+	const terminalInstrumentation = instrumentTerminalWrites(internals$1.createTerminal(), performanceProbe, process.stdout);
+	const terminal = terminalInstrumentation.terminal;
+	const reportPerformance = () => {
+		terminalInstrumentation.release();
+		const snapshot = performanceProbe.finish();
+		if (snapshot !== void 0) internals$1.reportPerformance(snapshot);
+	};
 	let stopTuiRenderingSync = () => void 0;
 	const terminalSession = createTerminalSession(terminal, true, () => {
 		stopTuiRenderingSync();
 	});
-	const [settingsDocuments, client, initialProviderReadiness] = await measureStartup("settings+client", () => Promise.all([
-		options$1.management.settings.describe(),
-		internals$1.startClient(options$1),
-		inspectProviderReadiness(options$1.api)
-	]));
+	const [settingsDocuments, client, initialProviderReadiness] = await (async () => {
+		try {
+			return await measureStartup("settings+client", () => Promise.all([
+				options$1.management.settings.describe(),
+				internals$1.startClient(options$1),
+				inspectProviderReadiness(options$1.api)
+			]));
+		} catch (error) {
+			try {
+				reportPerformance();
+			} catch {}
+			throw error;
+		}
+	})();
 	setUiLocale(localeFromSettings(settingsDocuments));
 	let stopConstructedTui = () => void 0;
 	let disposeConstructedSyntax = () => void 0;
@@ -34075,6 +34744,11 @@ async function startTuiSurface(options$1) {
 		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
+		const requestTuiRender = tui.requestRender.bind(tui);
+		tui.requestRender = (force = false) => {
+			performanceProbe.markRenderRequest(force ? "forced" : "normal");
+			requestTuiRender(force);
+		};
 		stopTuiRenderingSync = () => {
 			tui.stopRenderingSync?.();
 		};
@@ -34154,6 +34828,8 @@ async function startTuiSurface(options$1) {
 		}).catch(() => {});
 		const status = new StatusBar();
 		const canvas = new Box(0, 0, background.canvas);
+		const renderCanvas = canvas.render.bind(canvas);
+		canvas.render = (width) => performanceProbe.measureRender(() => renderCanvas(width));
 		if (options$1.draft !== void 0) editor.setText(escapeTerminalText(options$1.draft));
 		canvas.addChild(new BottomAnchoredLayout(() => terminal.rows, contextBar, transcript, editor, status, () => transcript.isEmptyState()));
 		tui.addChild(canvas);
@@ -34178,6 +34854,7 @@ async function startTuiSurface(options$1) {
 			if (stopping === void 0) tui.requestRender();
 		};
 		const updateTranscript = (current) => {
+			performanceProbe.markSnapshot();
 			transcript.update(current.session.getSnapshot(), async (attachment) => {
 				const result = await current.session.readAttachment(attachment.attachmentId);
 				if (!result.ok) throw new Error(ui(`图片读取失败：${result.error.message}`, `Failed to load image: ${result.error.message}`));
@@ -34216,6 +34893,7 @@ async function startTuiSurface(options$1) {
 		let actions;
 		const updateStatus = () => {
 			if (stopping !== void 0) return;
+			performanceProbe.markStatus();
 			editor.setDraftAttachments(capabilities.draftAttachments());
 			const chrome = sessionChrome.of(latestSessionId);
 			const snapshot = active?.session.getSnapshot();
@@ -34288,6 +34966,7 @@ async function startTuiSurface(options$1) {
 			renderWhileOpen();
 		});
 		const refreshHeader = (forceModel = false) => {
+			performanceProbe.markHeader();
 			const generation = ++headerGeneration;
 			capabilities.headerFacts(forceModel).then((facts) => {
 				if (stopping !== void 0 || generation !== headerGeneration) return;
@@ -34357,6 +35036,8 @@ async function startTuiSurface(options$1) {
 					unsubscribeActive();
 				} catch (error) {
 					failures.push(error);
+				} finally {
+					performanceProbe.changeSubscriptions(-1);
 				}
 				try {
 					await withCleanupTimeout(() => terminal.drainInput(250, 30));
@@ -34373,6 +35054,9 @@ async function startTuiSurface(options$1) {
 				} catch (error) {
 					failures.push(error);
 				}
+				try {
+					reportPerformance();
+				} catch {}
 				resolveClosed(failures.length === 0 ? outcome : {
 					kind: "exit",
 					code: 1
@@ -34489,6 +35173,7 @@ async function startTuiSurface(options$1) {
 			updateStatus();
 			renderWhileOpen();
 		});
+		performanceProbe.changeSubscriptions(1);
 		editor.setAutocompleteProvider(new HarnessAutocompleteProvider(capabilities, (message) => {
 			setNotice(ui(`命令目录：${message}`, `Command catalog: ${message}`), "error");
 		}));
@@ -34604,6 +35289,7 @@ async function startTuiSurface(options$1) {
 			return { consume: true };
 		};
 		tui.addInputListener((data) => {
+			performanceProbe.markInput();
 			const wheelDelta = terminalMouseDelta(data);
 			if (wheelDelta !== void 0) {
 				if (wheelDelta !== null) transcript.scrollBy(wheelDelta);
@@ -34834,6 +35520,9 @@ async function startTuiSurface(options$1) {
 		} catch {}
 		try {
 			await withCleanupTimeout(() => client.ctx.fiber.dispose());
+		} catch {}
+		try {
+			reportPerformance();
 		} catch {}
 		throw error;
 	}

--- a/lib/index.js
+++ b/lib/index.js
@@ -26614,8 +26614,7 @@ var Transcript = class {
 		}
 		this.imageLoader = imageLoader;
 		this.blockGeneration += 1;
-		this.searchIndex = void 0;
-		if (this.search !== void 0) this.lastFullLines = [];
+		if (this.search === void 0) this.searchIndex = void 0;
 		this.hasMore = snapshot.hasMore;
 		this.loadingOlder = snapshot.loadingOlder;
 		const preferences = {
@@ -26978,6 +26977,16 @@ var Transcript = class {
 	ensureSearchIndex(contentWidth) {
 		const current = this.searchIndex;
 		if (current !== void 0 && current.width === contentWidth && current.generation === this.blockGeneration) return current;
+		const viewportRows = this.viewportRows();
+		const rows = Number.isFinite(viewportRows) ? Math.max(1, Math.floor(viewportRows) - 1) : void 0;
+		const previousTop = current !== void 0 && rows !== void 0 && this.scrollOffset > 0 ? (() => {
+			const top = Math.max(0, current.lines.length - this.scrollOffset - rows);
+			const span = current.spans.find((candidate) => candidate.start <= top && top < candidate.end);
+			return span === void 0 ? void 0 : {
+				blockKey: span.blockKey,
+				lineOffset: top - span.start
+			};
+		})() : void 0;
 		const lines = [];
 		const spans = [];
 		for (const [blockIndex, block$1] of this.blocks.entries()) {
@@ -26996,6 +27005,15 @@ var Transcript = class {
 			spans
 		};
 		this.searchIndex = index;
+		if (previousTop !== void 0 && rows !== void 0) {
+			const span = spans.find((candidate) => candidate.blockKey === previousTop.blockKey);
+			if (span !== void 0) {
+				const lineOffset = Math.min(previousTop.lineOffset, Math.max(0, span.end - span.start - 1));
+				const top = span.start + lineOffset;
+				const maxOffset = Math.max(0, lines.length - rows);
+				this.scrollOffset = Math.max(0, Math.min(maxOffset, lines.length - top - rows));
+			}
+		}
 		this.lastFullLines = lines;
 		return index;
 	}
@@ -27176,7 +27194,7 @@ var Transcript = class {
 	*/
 	cancelSearch() {
 		if (this.search === void 0) return false;
-		const index = this.searchIndex;
+		const index = this.activeSearchIndex();
 		if (index !== void 0 && Number.isFinite(this.viewportRows())) {
 			const rows = Math.max(1, Math.floor(this.viewportRows()) - 1);
 			const top = Math.max(0, index.lines.length - this.scrollOffset - rows);
@@ -27207,7 +27225,8 @@ var Transcript = class {
 		if (viewport !== void 0) {
 			const index = this.ensureSearchIndex(viewport.contentWidth);
 			const span = index.spans.find((candidate) => candidate.blockKey === viewport.start.blockKey);
-			if (span !== void 0) {
+			if (this.viewportAnchor.followLatest) this.scrollOffset = 0;
+			else if (span !== void 0) {
 				const rows = Math.max(1, viewport.rows - 1);
 				const top = span.start + viewport.start.lineOffset;
 				this.scrollOffset = Math.max(0, Math.min(Math.max(0, index.lines.length - rows), index.lines.length - top - rows));
@@ -27294,7 +27313,9 @@ var Transcript = class {
 	}
 	stepSearch(direction) {
 		if (this.search === void 0) return;
-		const matches$1 = findLineMatches(this.lastFullLines, this.search.query);
+		const index = this.activeSearchIndex();
+		if (index === void 0) return;
+		const matches$1 = findLineMatches(index.lines, this.search.query);
 		const next = nextMatchIndex(matches$1, matches$1[this.search.matchIndex] ?? -1, direction);
 		if (next < 0) return;
 		this.search = {
@@ -27306,12 +27327,19 @@ var Transcript = class {
 	}
 	revealCurrentMatch() {
 		if (this.search === void 0) return;
-		const lineIndex = findLineMatches(this.lastFullLines, this.search.query)[this.search.matchIndex];
+		const index = this.activeSearchIndex();
+		if (index === void 0) return;
+		const lineIndex = findLineMatches(index.lines, this.search.query)[this.search.matchIndex];
 		if (lineIndex === void 0) return;
-		this.scrollOffset = scrollOffsetToReveal(this.lastFullLines.length, Math.max(1, this.viewportRows() - 1), lineIndex);
+		this.scrollOffset = scrollOffsetToReveal(index.lines.length, Math.max(1, this.viewportRows() - 1), lineIndex);
+	}
+	activeSearchIndex() {
+		if (this.search === void 0) return void 0;
+		const contentWidth = this.viewportState?.contentWidth;
+		return contentWidth === void 0 ? void 0 : this.ensureSearchIndex(contentWidth);
 	}
 	scrollSearchBy(lines, rows) {
-		const index = this.searchIndex;
+		const index = this.activeSearchIndex();
 		if (index === void 0) return false;
 		const maxOffset = Math.max(0, index.lines.length - rows);
 		const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + Math.trunc(lines)));
@@ -27321,7 +27349,7 @@ var Transcript = class {
 		return true;
 	}
 	scrollSearchTo(edge, rows) {
-		const index = this.searchIndex;
+		const index = this.activeSearchIndex();
 		if (index === void 0) return false;
 		const nextOffset = edge === "start" ? Math.max(0, index.lines.length - rows) : 0;
 		if (nextOffset === this.scrollOffset) return false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -150,7 +150,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -1293,7 +1293,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2109,7 +2109,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2187,7 +2187,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2861,7 +2861,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3079,7 +3079,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3155,7 +3155,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3197,7 +3197,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3469,7 +3469,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -3706,12 +3706,8 @@ var TUI = class TUI extends Container {
 		this.terminal.write("\x1B[16t");
 	}
 	stop() {
-		this.stopped = true;
-		if (this.renderTimer) {
-			clearTimeout(this.renderTimer);
-			this.renderTimer = void 0;
-		}
-		if (this.previousLines.length > 0) {
+		this.stopRenderingSync();
+		if (!this.terminal.__seekttyManagedAlternateScreen && this.previousLines.length > 0) {
 			const lineDiff = this.previousLines.length - this.hardwareCursorRow;
 			if (lineDiff > 0) this.terminal.write(`\x1b[${lineDiff}B`);
 			else if (lineDiff < 0) this.terminal.write(`\x1b[${-lineDiff}A`);
@@ -3719,6 +3715,14 @@ var TUI = class TUI extends Container {
 		}
 		this.terminal.showCursor();
 		this.terminal.stop();
+	}
+	stopRenderingSync() {
+		this.stopped = true;
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = void 0;
+		}
+		this.renderRequested = false;
 	}
 	requestRender(force = false) {
 		if (force) {
@@ -4010,6 +4014,7 @@ var TUI = class TUI extends Container {
 		};
 		let newLines = this.render(width);
 		if (this.overlayStack.length > 0) newLines = this.compositeOverlays(newLines, width, height);
+		if (newLines.length > height) newLines = newLines.slice(-height);
 		const cursorPos = this.extractCursorPosition(newLines, height);
 		newLines = this.applyLineResets(newLines);
 		const fullRender = (clear) => {
@@ -4276,7 +4281,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4303,7 +4308,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4430,7 +4435,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5893,7 +5898,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5957,7 +5962,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -8120,7 +8125,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8617,7 +8622,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8851,7 +8856,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -8865,6 +8870,7 @@ var ProcessTerminal = class {
 	resizeHandler;
 	_kittyProtocolActive = false;
 	_modifyOtherKeysActive = false;
+	_protocolsRestored = false;
 	stdinBuffer;
 	stdinDataHandler;
 	progressInterval;
@@ -8885,6 +8891,7 @@ var ProcessTerminal = class {
 	}
 	start(onInput, onResize) {
 		this.inputHandler = onInput;
+		this._protocolsRestored = false;
 		this.resizeHandler = onResize;
 		this.wasRaw = process.stdin.isRaw || false;
 		if (process.stdin.setRawMode) process.stdin.setRawMode(true);
@@ -8908,7 +8915,7 @@ var ProcessTerminal = class {
 		this.stdinBuffer = new StdinBuffer({ timeout: 10 });
 		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
 		this.stdinBuffer.on("data", (sequence) => {
-			if (!this._kittyProtocolActive) {
+			if (!this._protocolsRestored && !this._kittyProtocolActive) {
 				if (sequence.match(kittyResponsePattern)) {
 					this._kittyProtocolActive = true;
 					setKittyProtocolActive(true);
@@ -8944,7 +8951,7 @@ var ProcessTerminal = class {
 		process.stdin.on("data", this.stdinDataHandler);
 		process.stdout.write("\x1B[?u");
 		setTimeout(() => {
-			if (this.inputHandler && !this._kittyProtocolActive && !this._modifyOtherKeysActive) {
+			if (!this._protocolsRestored && this.inputHandler && !this._kittyProtocolActive && !this._modifyOtherKeysActive) {
 				process.stdout.write("\x1B[>4;2m");
 				this._modifyOtherKeysActive = true;
 			}
@@ -8970,6 +8977,31 @@ var ProcessTerminal = class {
 			GetConsoleMode(handle, mode);
 			SetConsoleMode(handle, mode[0] | ENABLE_VIRTUAL_TERMINAL_INPUT);
 		} catch {}
+	}
+	restoreProtocolsSync() {
+		this._protocolsRestored = true;
+		this.inputHandler = void 0;
+		if (this.stdinBuffer) {
+			this.stdinBuffer.destroy();
+			this.stdinBuffer = void 0;
+		}
+		if (this.stdinDataHandler) {
+			process.stdin.removeListener("data", this.stdinDataHandler);
+			this.stdinDataHandler = void 0;
+		}
+		process.stdout.write("\x1B[?2004l");
+		if (this._kittyProtocolActive) {
+			process.stdout.write("\x1B[<u");
+			this._kittyProtocolActive = false;
+			setKittyProtocolActive(false);
+		}
+		if (this._modifyOtherKeysActive) {
+			process.stdout.write("\x1B[>4;0m");
+			this._modifyOtherKeysActive = false;
+		}
+	}
+	restoreRawModeSync() {
+		if (process.stdin.setRawMode) process.stdin.setRawMode(this.wasRaw);
 	}
 	async drainInput(maxMs = 1e3, idleMs = 50) {
 		if (this._kittyProtocolActive) {
@@ -24152,7 +24184,8 @@ function helpSectionText(id) {
 		"停止：Ctrl+C 停止当前轮次；再按一次退出。",
 		"会话：Ctrl+S 打开会话列表，新建或切换会话。",
 		"审批：弹窗里查看命令或 diff，再选仅本次允许或拒绝。",
-		"浏览对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。"
+		"浏览对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。",
+		"滚动与复制：滚轮浏览内部对话；Terminal.app 按住 Fn、iTerm2 按住 Option 后拖选，再按 Command+C。"
 	].join("\n"), [
 		"Input: type in the composer and press Enter to send.",
 		"Newline: Shift+Enter inserts a newline in the composer.",
@@ -24160,7 +24193,8 @@ function helpSectionText(id) {
 		"Stop: Ctrl+C stops the active turn; press again to exit.",
 		"Sessions: Ctrl+S opens the session list to create or switch sessions.",
 		"Approvals: inspect the command or diff in the overlay, then allow once or reject.",
-		"Browse the transcript: Tab into browse mode, press / to search, then n/N to jump."
+		"Browse the transcript: Tab into browse mode, press / to search, then n/N to jump.",
+		"Scroll and copy: the wheel browses the internal transcript; hold Fn in Terminal.app or Option in iTerm2 while dragging, then press Command+C."
 	].join("\n"));
 	return ui([
 		"输入 /doctor 检查 pnpm、Profile 插件和 Bundle 兼容性。",
@@ -26725,7 +26759,9 @@ var Transcript = class {
 			const content = line.trimEnd();
 			lines[index] = `${" ".repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`;
 		}
+		const previousRenderedLineCount = this.renderedLineCount;
 		this.lastFullLines = [...lines];
+		if (this.scrollOffset > 0 && previousRenderedLineCount > 0) this.scrollOffset = Math.max(0, this.scrollOffset + lines.length - previousRenderedLineCount);
 		this.renderedLineCount = lines.length;
 		this.turnAnchors = anchors;
 		if (this.search !== void 0) {
@@ -31984,7 +32020,7 @@ var BottomAnchoredLayout = class {
 	/**
 	* @param viewportRows - current terminal height in rows.
 	* @param context - one-row execution context.
-	* @param transcript - conversation content that grows into terminal scrollback.
+	* @param transcript - conversation content constrained to its internal viewport.
 	* @param composer - prompt editor and its autocomplete rows.
 	* @param status - one-row permission and runtime status.
 	* @param centerTranscript - whether spare conversation rows surround the transcript.
@@ -32013,22 +32049,27 @@ var BottomAnchoredLayout = class {
 		const transcriptRows = this.transcript.render(width);
 		const composerRows = this.composer.render(width);
 		const statusRows = this.status.render(width);
-		const naturalRows = contextRows.length + transcriptRows.length + composerRows.length + statusRows.length + 2;
 		const requestedRows = Math.floor(this.viewportRows());
-		const minimumRows = Number.isFinite(requestedRows) ? Math.max(1, requestedRows) : naturalRows;
-		const flexibleRows = Math.max(0, minimumRows - naturalRows);
+		const fixedRows = contextRows.length + composerRows.length + statusRows.length + 2;
+		const minimumRows = Number.isFinite(requestedRows) ? Math.max(1, requestedRows) : void 0;
+		const transcriptCapacity = minimumRows === void 0 ? transcriptRows.length : Math.max(0, minimumRows - fixedRows);
+		const visibleTranscript = transcriptCapacity === 0 ? [] : transcriptRows.slice(-transcriptCapacity);
+		const naturalRows = fixedRows + visibleTranscript.length;
+		const targetRows = minimumRows ?? naturalRows;
+		const flexibleRows = Math.max(0, targetRows - naturalRows);
 		const flexibleBefore = this.centerTranscript() ? Math.floor(flexibleRows / 2) : 0;
 		const flexibleAfter = flexibleRows - flexibleBefore;
-		return [
+		const rendered = [
 			...contextRows,
 			"",
 			...Array.from({ length: flexibleBefore }, () => ""),
-			...transcriptRows,
+			...visibleTranscript,
 			...Array.from({ length: flexibleAfter }, () => ""),
 			"",
 			...composerRows,
 			...statusRows
 		];
+		return minimumRows === void 0 || rendered.length <= minimumRows ? rendered : rendered.slice(-minimumRows);
 	}
 };
 /** One quiet context row containing only live execution state on the right. */
@@ -33799,6 +33840,64 @@ function sessionTerminalTitle(facts) {
 }
 
 //#endregion
+//#region src/client/terminal-session.ts
+const ENTER_ALTERNATE_SCREEN = "\x1B[?1049h\x1B[H";
+const ENABLE_MOUSE = "\x1B[?1002l\x1B[?1003l\x1B[?1007l\x1B[?1000h\x1B[?1006h";
+const DISABLE_MOUSE = "\x1B[?1000l\x1B[?1002l\x1B[?1003l\x1B[?1006l\x1B[?1007l";
+const SHOW_CURSOR_AND_LEAVE = "\x1B[?25h\x1B[?1049l";
+const SGR_MOUSE = /^\u001B\[<(\d+);(\d+);(\d+)[Mm]$/u;
+/** Whether an interactive Surface may safely use terminal private modes. */
+function supportsManagedTerminal(interactive, term) {
+	return interactive && term?.trim().toLowerCase() !== "dumb";
+}
+/**
+* Own the alternate-screen and mouse-reporting bytes around one Surface.
+* Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
+*/
+function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) {
+	let active = false;
+	return {
+		enter: () => {
+			if (!enabled || active) return;
+			active = true;
+			terminal.__seekttyManagedAlternateScreen = true;
+			terminal.write(ENTER_ALTERNATE_SCREEN + ENABLE_MOUSE);
+		},
+		restore: () => {
+			if (!active) return;
+			try {
+				beforeRestore();
+			} catch {}
+			try {
+				terminal.write(DISABLE_MOUSE);
+			} finally {
+				try {
+					terminal.restoreProtocolsSync?.();
+				} finally {
+					terminal.write(SHOW_CURSOR_AND_LEAVE);
+					active = false;
+				}
+			}
+		}
+	};
+}
+/**
+* Decode one SGR mouse report.
+* @returns positive/negative wheel lines, null for a consumed mouse sequence,
+* or undefined when the input is not mouse data.
+*/
+function terminalMouseDelta(data) {
+	const match = SGR_MOUSE.exec(data);
+	if (match !== null) {
+		const normalized = Number(match[1]) & -29;
+		if (normalized === 64) return 3;
+		if (normalized === 65) return -3;
+		return null;
+	}
+	if (data.startsWith("\x1B[<") || data.startsWith("\x1B[M")) return null;
+}
+
+//#endregion
 //#region src/client/pending-status.ts
 /**
 * Describe waiting approvals/questions. `/pending` is reserved for retry failures.
@@ -33826,7 +33925,14 @@ const CLEANUP_TIMEOUT_MS = 2e3;
 function restoreTerminalSync(stdin = process.stdin, write = (chunk) => {
 	process.stdout.write(chunk);
 }, terminal) {
+	let restoredOriginalRawMode = false;
 	try {
+		if (terminal?.restoreRawModeSync !== void 0) {
+			terminal.restoreRawModeSync();
+			restoredOriginalRawMode = true;
+		}
+	} catch {}
+	if (!restoredOriginalRawMode) try {
 		stdin.setRawMode?.(false);
 	} catch {}
 	try {
@@ -33835,6 +33941,16 @@ function restoreTerminalSync(stdin = process.stdin, write = (chunk) => {
 	try {
 		write(SHOW_CURSOR);
 	} catch {}
+}
+/** Restore managed private modes before raw/cursor state on every Surface exit path. */
+function restoreSurfaceTerminalSync(session, stdin = process.stdin, write = (chunk) => {
+	process.stdout.write(chunk);
+}, terminal) {
+	try {
+		session.restore();
+	} finally {
+		restoreTerminalSync(stdin, write, terminal);
+	}
 }
 /**
 * Bound a teardown step so a hung drain or dispose cannot trap the process.
@@ -33936,8 +34052,12 @@ function noticeText(message, tone) {
 * @returns idempotent lifecycle handle.
 */
 async function startTuiSurface(options$1) {
-	if (!internals$1.isInteractive()) throw new Error(ui("需要交互式 TTY；非交互任务请使用 dsh --profile headless", "An interactive TTY is required; use dsh --profile headless for non-interactive tasks"));
+	if (!supportsManagedTerminal(internals$1.isInteractive(), process.env.TERM)) throw new Error(ui("需要支持终端私有模式的交互式 TTY；非交互任务请使用 dsh --profile headless", "An interactive TTY with private-mode support is required; use dsh --profile headless for non-interactive tasks"));
 	const terminal = internals$1.createTerminal();
+	let stopTuiRenderingSync = () => void 0;
+	const terminalSession = createTerminalSession(terminal, true, () => {
+		stopTuiRenderingSync();
+	});
 	const [settingsDocuments, client, initialProviderReadiness] = await measureStartup("settings+client", () => Promise.all([
 		options$1.management.settings.describe(),
 		internals$1.startClient(options$1),
@@ -33955,6 +34075,9 @@ async function startTuiSurface(options$1) {
 		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		setTheme(initialTheme);
 		const tui = new TUI(terminal, true);
+		stopTuiRenderingSync = () => {
+			tui.stopRenderingSync?.();
+		};
 		stopConstructedTui = () => {
 			tui.stop();
 		};
@@ -33989,7 +34112,7 @@ async function startTuiSurface(options$1) {
 			}).catch(() => {});
 		};
 		let transcriptFocused = false;
-		const transcript = new Transcript(() => transcriptFocused ? transcriptViewportRows(terminal.rows, editor.render(terminal.columns).length) : Number.POSITIVE_INFINITY, () => {
+		const transcript = new Transcript(() => transcriptViewportRows(terminal.rows, editor.render(terminal.columns).length), () => {
 			if (stopping === void 0) tui.requestRender();
 		}, () => {
 			const current = active;
@@ -34003,6 +34126,7 @@ async function startTuiSurface(options$1) {
 			syntax?.dispose();
 		};
 		SyntaxHighlighter.create(initialTheme, () => {
+			if (stopping !== void 0) return;
 			transcript.refreshPresentation();
 			tui.invalidate();
 			tui.requestRender();
@@ -34211,7 +34335,7 @@ async function startTuiSurface(options$1) {
 			detachFatalGuards();
 			detachFatalGuards = () => void 0;
 			if (stopping !== void 0) return stopping;
-			restoreTerminalSync(process.stdin, (chunk) => {
+			restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 				process.stdout.write(chunk);
 			}, terminal);
 			stopping = (async () => {
@@ -34480,6 +34604,11 @@ async function startTuiSurface(options$1) {
 			return { consume: true };
 		};
 		tui.addInputListener((data) => {
+			const wheelDelta = terminalMouseDelta(data);
+			if (wheelDelta !== void 0) {
+				if (wheelDelta !== null) transcript.scrollBy(wheelDelta);
+				return { consume: true };
+			}
 			const interrupt = consumeRunningInterrupt(data, capabilities.active()?.session);
 			if (interrupt !== void 0) return interrupt;
 			if (overlays.hasActive()) return void 0;
@@ -34642,7 +34771,7 @@ async function startTuiSurface(options$1) {
 		applyTerminalTitle();
 		detachFatalGuards = attachFatalGuards({
 			restore: () => {
-				restoreTerminalSync(process.stdin, (chunk) => {
+				restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 					process.stdout.write(chunk);
 				}, terminal);
 			},
@@ -34662,6 +34791,7 @@ async function startTuiSurface(options$1) {
 				process.exit(code);
 			}
 		});
+		terminalSession.enter();
 		tui.start();
 		refreshHeader(true);
 		refresh();
@@ -34692,7 +34822,7 @@ async function startTuiSurface(options$1) {
 		};
 	} catch (error) {
 		detachFatalGuards();
-		restoreTerminalSync(process.stdin, (chunk) => {
+		restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 			process.stdout.write(chunk);
 		}, terminal);
 		setCodeHighlighter(void 0);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVI
 import { createRequire } from "node:module";
 import { InProcessApiClient, toFetchHandler } from "@deepseek-ai/dsh-host-apiproxy";
 import * as fs from "node:fs";
-import { chmodSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, chmodSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn } from "child_process";
 import { readdirSync as readdirSync$1, statSync as statSync$1 } from "fs";
 import { homedir } from "os";
@@ -60,7 +60,7 @@ var __export = (all) => {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/fuzzy.js
 /**
 * Fuzzy matching utilities.
 * Matches if all query characters appear in order (not necessarily consecutive).
@@ -150,7 +150,7 @@ function fuzzyFilter(items, query, getText) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/autocomplete.js
 const PATH_DELIMITERS = new Set([
 	" ",
 	"	",
@@ -1293,7 +1293,7 @@ function eastAsianWidth(codePoint, { ambiguousAsWide = false } = {}) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/utils.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/utils.js
 const segmenter$1 = new Intl.Segmenter(void 0, { granularity: "grapheme" });
 /**
 * Get the shared grapheme segmenter instance.
@@ -2109,7 +2109,7 @@ function extractSegments(line, beforeEnd, afterStart, afterLen, strictAfter = fa
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/box.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/box.js
 /**
 * Box component - a container that applies padding and background to all children
 */
@@ -2187,7 +2187,7 @@ var Box = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/keys.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/keys.js
 /**
 * Keyboard input handling for terminal applications.
 *
@@ -2861,7 +2861,7 @@ function decodePrintableKey(data) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/keybindings.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/keybindings.js
 const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": {
 		defaultKeys: "up",
@@ -3079,7 +3079,7 @@ function getKeybindings() {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/text.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/text.js
 /**
 * Text component - displays multi-line text with word wrapping
 */
@@ -3155,7 +3155,7 @@ var Text = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/kill-ring.js
 /**
 * Ring buffer for Emacs-style kill/yank operations.
 *
@@ -3197,7 +3197,7 @@ var KillRing = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/terminal-image.js
 let cachedCapabilities = null;
 let cellDimensions = {
 	widthPx: 9,
@@ -3469,7 +3469,7 @@ function imageFallback(mimeType, dimensions, filename) {
 }
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/tui.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/tui.js
 const KITTY_SEQUENCE_PREFIX = "\x1B_G";
 function extractKittyImageIds(line) {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -4019,19 +4019,29 @@ var TUI = class TUI extends Container {
 		newLines = this.applyLineResets(newLines);
 		const fullRender = (clear) => {
 			this.fullRedrawCount += 1;
-			const tall = newLines.length > height;
-			const paintStart = clear && tall ? Math.max(0, newLines.length - height) : 0;
 			let buffer$1 = "\x1B[?2026h";
 			if (clear) {
 				buffer$1 += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer$1 += "\x1B[H";
 			}
-			for (let i = paintStart; i < newLines.length; i++) {
-				if (i > paintStart) buffer$1 += "\r\n";
-				if (clear) buffer$1 += "\x1B[2K";
+			for (let i = 0; i < newLines.length; i++) {
+				if (i > 0) buffer$1 += "\r\n";
+				if (clear && visibleWidth(newLines[i]) < width) buffer$1 += "\x1B[2K";
 				buffer$1 += newLines[i];
 			}
-			if (clear) buffer$1 += "\x1B[0J";
+			if (clear && newLines.length < height) {
+				const extraLines = height - newLines.length;
+				if (newLines.length === 0) buffer$1 += "\x1B[0J";
+				else if (extraLines > 0) {
+					buffer$1 += "\r";
+					buffer$1 += "\x1B[1B";
+					for (let i = 0; i < extraLines; i++) {
+						buffer$1 += "\r\x1B[2K";
+						if (i < extraLines - 1) buffer$1 += "\x1B[1B";
+					}
+					buffer$1 += `\x1b[${extraLines}A`;
+				}
+			}
 			buffer$1 += "\x1B[?2026l";
 			this.terminal.write(buffer$1);
 			this.cursorRow = Math.max(0, newLines.length - 1);
@@ -4177,8 +4187,8 @@ var TUI = class TUI extends Container {
 		const renderEnd = Math.min(lastChanged, newLines.length - 1);
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
-			buffer += "\x1B[2K";
 			const line = newLines[i];
+			if (visibleWidth(line) < width) buffer += "\x1B[2K";
 			if (!isImageLine(line) && visibleWidth(line) > width) {
 				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
 				const crashData = [
@@ -4281,7 +4291,7 @@ var TUI = class TUI extends Container {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/undo-stack.js
 /**
 * Generic undo stack with clone-on-push semantics.
 *
@@ -4308,7 +4318,7 @@ var UndoStack = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/select-list.js
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
@@ -4435,7 +4445,7 @@ var SelectList = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/editor.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/editor.js
 const baseSegmenter = getSegmenter();
 /** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
 const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
@@ -5898,7 +5908,7 @@ var Editor = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/image.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/image.js
 var Image = class {
 	base64Data;
 	mimeType;
@@ -5962,7 +5972,7 @@ var Image = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/input.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/input.js
 const segmenter = getSegmenter();
 /**
 * Input component - single-line text input with horizontal scrolling
@@ -8125,7 +8135,7 @@ var parser = _Parser.parse;
 var lexer = _Lexer.lex;
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/components/markdown.js
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 var StrictStrikethroughTokenizer = class extends _Tokenizer {
 	del(src) {
@@ -8622,7 +8632,7 @@ var Markdown = class {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/stdin-buffer.js
 const ESC$1 = "\x1B";
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
@@ -8856,7 +8866,7 @@ var StdinBuffer = class extends EventEmitter {
 };
 
 //#endregion
-//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38/node_modules/@mariozechner/pi-tui/dist/terminal.js
+//#region node_modules/.pnpm/@mariozechner+pi-tui@0.73.1_patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35/node_modules/@mariozechner/pi-tui/dist/terminal.js
 const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1e3;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1B]9;4;3\x07";
@@ -27432,7 +27442,11 @@ var Transcript = class {
 		this.turnCursor = void 0;
 		const delta = Math.trunc(lines);
 		if (!Number.isFinite(delta) || delta === 0) return false;
-		if (this.search === void 0 && !this.emptyState && this.viewportState !== void 0) {
+		if (this.search !== void 0) {
+			const rows$1 = Math.max(1, Math.floor(this.viewportRows()) - 1);
+			return this.scrollSearchBy(delta, rows$1);
+		}
+		if (!this.emptyState && this.viewportState !== void 0) {
 			if (delta < 0 && this.viewportAnchor.followLatest) return false;
 			const moved = this.moveViewportStart(this.viewportState.start, delta, this.viewportState.contentWidth);
 			if (moved.moved === 0) {
@@ -34541,19 +34555,11 @@ const PROCESS_EVENTS = [
 	"SIGTERM",
 	"SIGHUP"
 ];
+const LATENCY_RETAINED_CAP = 4096;
 function percentile(values, fraction) {
 	if (values.length === 0) return 0;
 	const sorted = [...values].sort((left, right) => left - right);
 	return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
-}
-function latencySummary(values) {
-	const rounded = (value) => Number(value.toFixed(3));
-	return {
-		p50: rounded(percentile(values, .5)),
-		p95: rounded(percentile(values, .95)),
-		p99: rounded(percentile(values, .99)),
-		max: rounded(Math.max(0, ...values))
-	};
 }
 function activeResources() {
 	return typeof process.getActiveResourcesInfo === "function" ? process.getActiveResourcesInfo().length : 0;
@@ -34561,6 +34567,73 @@ function activeResources() {
 function processListeners() {
 	return PROCESS_EVENTS.reduce((sum, event) => sum + process.listenerCount(event), 0);
 }
+function mergeCounts(into, from) {
+	for (const [reason, count] of from) into.set(reason, (into.get(reason) ?? 0) + count);
+}
+function explicitBucketPath(raw) {
+	if (raw === void 0) return void 0;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : void 0;
+}
+function rankStandardError(retained) {
+	return {
+		p95: Number(Math.sqrt(.95 * .05 / retained).toFixed(6)),
+		p99: Number(Math.sqrt(.99 * .01 / retained).toFixed(6))
+	};
+}
+/** Parse `SEEKTTY_TUI_PERF_BUCKET_MS` as a positive integer milliseconds value. */
+function parsePerfBucketIntervalMs(raw) {
+	if (raw === void 0) return void 0;
+	const trimmed = raw.trim();
+	if (!/^[0-9]+$/u.test(trimmed)) return void 0;
+	const parsed = Number.parseInt(trimmed, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : void 0;
+}
+var BoundedLatencySeries = class {
+	samples = [];
+	random;
+	total = 0;
+	peak = 0;
+	constructor(random) {
+		this.random = random;
+	}
+	add(value) {
+		if (!Number.isFinite(value) || value < 0) return;
+		this.total += 1;
+		if (value > this.peak) this.peak = value;
+		if (this.samples.length < LATENCY_RETAINED_CAP) {
+			this.samples.push(value);
+			return;
+		}
+		const index = Math.floor(this.random() * this.total);
+		if (index < LATENCY_RETAINED_CAP) this.samples[index] = value;
+	}
+	reset() {
+		this.samples.length = 0;
+		this.total = 0;
+		this.peak = 0;
+	}
+	summarize() {
+		const retained = this.samples.length;
+		const approximate = this.total > LATENCY_RETAINED_CAP;
+		const rounded = (value) => Number(value.toFixed(3));
+		const summary = {
+			p50: rounded(percentile(this.samples, .5)),
+			p95: rounded(percentile(this.samples, .95)),
+			p99: rounded(percentile(this.samples, .99)),
+			max: rounded(this.peak),
+			count: this.total,
+			retained,
+			approximate
+		};
+		if (!approximate || retained === 0) return summary;
+		return {
+			...summary,
+			probabilistic: true,
+			rankStandardError: rankStandardError(retained)
+		};
+	}
+};
 /** Keep the production terminal untouched unless performance collection is enabled. */
 function instrumentTerminalWrites(rawTerminal, probe, output) {
 	if (!probe.isEnabled) return {
@@ -34597,28 +34670,64 @@ function instrumentTerminalWrites(rawTerminal, probe, output) {
 /** Default-off, content-free aggregate metrics for terminal performance acceptance. */
 var TuiPerformanceProbe = class {
 	enabled;
+	nowFn;
 	startedAt = performance.now();
 	eventLoop = monitorEventLoopDelay({ resolution: 20 });
 	eventLoopStart = performance.eventLoopUtilization();
 	activeResourcesStart = activeResources();
 	processListenersStart = processListeners();
-	renderRequests = /* @__PURE__ */ new Map();
-	renderDurations = [];
-	inputToWrite = [];
+	onBucket;
+	bucketPath;
+	allRenderDurations;
+	allInputToWrite;
+	windowRenderDurations;
+	windowInputToWrite;
+	bucketEventLoop;
+	bucketEventLoopStart = this.eventLoopStart;
+	bucketWindowStartedAt = this.startedAt;
+	bucketTimer;
+	fileSinkEnabled = true;
+	allRenderRequests = /* @__PURE__ */ new Map();
+	windowRenderRequests = /* @__PURE__ */ new Map();
 	lastInputAt;
 	inputs = 0;
+	windowInputs = 0;
 	snapshotCount = 0;
+	windowSnapshots = 0;
 	headerCount = 0;
+	windowHeaders = 0;
 	statusCount = 0;
+	windowStatus = 0;
 	writeCalls = 0;
+	windowWriteCalls = 0;
 	writeBytes = 0;
+	windowWriteBytes = 0;
 	backpressureSignals = 0;
+	windowBackpressure = 0;
 	drains = 0;
+	windowDrains = 0;
 	subscriptions = 0;
 	finished = false;
-	constructor(enabled = process.env.SEEKTTY_TUI_PERF === "1") {
+	constructor(enabled = process.env.SEEKTTY_TUI_PERF === "1", options$1 = {}) {
 		this.enabled = enabled;
+		this.nowFn = options$1.now ?? (() => performance.now());
+		const random = options$1.random ?? Math.random;
+		this.allRenderDurations = new BoundedLatencySeries(random);
+		this.allInputToWrite = new BoundedLatencySeries(random);
+		this.windowRenderDurations = new BoundedLatencySeries(random);
+		this.windowInputToWrite = new BoundedLatencySeries(random);
+		this.bucketPath = explicitBucketPath(process.env.SEEKTTY_TUI_PERF_BUCKET_PATH);
+		this.onBucket = options$1.onBucket;
 		if (enabled) this.eventLoop.enable();
+		const interval = options$1.bucketIntervalMs ?? parsePerfBucketIntervalMs(process.env.SEEKTTY_TUI_PERF_BUCKET_MS);
+		if (!enabled || interval === void 0) return;
+		this.bucketEventLoop = monitorEventLoopDelay({ resolution: 20 });
+		this.bucketEventLoop.enable();
+		this.bucketEventLoopStart = performance.eventLoopUtilization();
+		this.bucketTimer = setInterval(() => {
+			this.emitBucket();
+		}, interval);
+		this.bucketTimer.unref();
 	}
 	get isEnabled() {
 		return this.enabled;
@@ -34626,42 +34735,61 @@ var TuiPerformanceProbe = class {
 	markInput() {
 		if (!this.enabled) return;
 		this.inputs += 1;
-		this.lastInputAt = performance.now();
+		this.windowInputs += 1;
+		this.lastInputAt = this.nowFn();
 	}
 	markSnapshot() {
-		if (this.enabled) this.snapshotCount += 1;
+		if (!this.enabled) return;
+		this.snapshotCount += 1;
+		this.windowSnapshots += 1;
 	}
 	markHeader() {
-		if (this.enabled) this.headerCount += 1;
+		if (!this.enabled) return;
+		this.headerCount += 1;
+		this.windowHeaders += 1;
 	}
 	markStatus() {
-		if (this.enabled) this.statusCount += 1;
+		if (!this.enabled) return;
+		this.statusCount += 1;
+		this.windowStatus += 1;
 	}
 	markRenderRequest(reason) {
 		if (!this.enabled) return;
-		this.renderRequests.set(reason, (this.renderRequests.get(reason) ?? 0) + 1);
+		this.windowRenderRequests.set(reason, (this.windowRenderRequests.get(reason) ?? 0) + 1);
 	}
 	measureRender(render) {
 		if (!this.enabled) return render();
-		const started = performance.now();
+		const started = this.nowFn();
 		try {
 			return render();
 		} finally {
-			this.renderDurations.push(performance.now() - started);
+			const duration = this.nowFn() - started;
+			this.windowRenderDurations.add(duration);
+			this.allRenderDurations.add(duration);
 		}
 	}
 	markWrite(data, backpressured) {
 		if (!this.enabled) return;
+		const bytes = Buffer.byteLength(data);
 		this.writeCalls += 1;
-		this.writeBytes += Buffer.byteLength(data);
-		if (backpressured) this.backpressureSignals += 1;
+		this.windowWriteCalls += 1;
+		this.writeBytes += bytes;
+		this.windowWriteBytes += bytes;
+		if (backpressured) {
+			this.backpressureSignals += 1;
+			this.windowBackpressure += 1;
+		}
 		if (this.lastInputAt !== void 0) {
-			this.inputToWrite.push(performance.now() - this.lastInputAt);
+			const delta = this.nowFn() - this.lastInputAt;
+			this.windowInputToWrite.add(delta);
+			this.allInputToWrite.add(delta);
 			this.lastInputAt = void 0;
 		}
 	}
 	markDrain() {
-		if (this.enabled) this.drains += 1;
+		if (!this.enabled) return;
+		this.drains += 1;
+		this.windowDrains += 1;
 	}
 	changeSubscriptions(delta) {
 		if (this.enabled) this.subscriptions = Math.max(0, this.subscriptions + delta);
@@ -34669,26 +34797,128 @@ var TuiPerformanceProbe = class {
 	finish() {
 		if (!this.enabled || this.finished) return void 0;
 		this.finished = true;
+		this.stopBucketTimer();
 		this.eventLoop.disable();
-		const utilization = performance.eventLoopUtilization(this.eventLoopStart).utilization;
-		return {
-			schema: 1,
-			durationMs: Number((performance.now() - this.startedAt).toFixed(3)),
+		this.bucketEventLoop?.disable();
+		this.foldWindowIntoTotals();
+		return this.snapshot({
+			durationMs: performance.now() - this.startedAt,
 			inputEvents: this.inputs,
 			snapshots: this.snapshotCount,
-			refreshHeaderCalls: this.headerCount,
-			updateStatusCalls: this.statusCount,
-			renderRequests: Object.fromEntries(this.renderRequests),
-			renderDurationMs: latencySummary(this.renderDurations),
-			inputToWriteMs: latencySummary(this.inputToWrite),
+			headers: this.headerCount,
+			status: this.statusCount,
+			renderRequests: this.allRenderRequests,
+			renderDurations: this.allRenderDurations,
+			inputToWrite: this.allInputToWrite,
+			writes: this.writeCalls,
+			bytes: this.writeBytes,
+			backpressure: this.backpressureSignals,
+			drains: this.drains,
+			histogram: this.eventLoop,
+			utilizationSince: this.eventLoopStart
+		});
+	}
+	reportFinal(snapshot) {
+		if (!this.enabled) return;
+		this.writeDiagnosticSink({
+			...snapshot,
+			kind: "final",
+			t: (/* @__PURE__ */ new Date()).toISOString()
+		});
+	}
+	emitBucket() {
+		if (!this.enabled || this.finished || this.bucketEventLoop === void 0) return;
+		try {
+			const snapshot = {
+				...this.snapshot({
+					durationMs: performance.now() - this.bucketWindowStartedAt,
+					inputEvents: this.windowInputs,
+					snapshots: this.windowSnapshots,
+					headers: this.windowHeaders,
+					status: this.windowStatus,
+					renderRequests: this.windowRenderRequests,
+					renderDurations: this.windowRenderDurations,
+					inputToWrite: this.windowInputToWrite,
+					writes: this.windowWriteCalls,
+					bytes: this.windowWriteBytes,
+					backpressure: this.windowBackpressure,
+					drains: this.windowDrains,
+					histogram: this.bucketEventLoop,
+					utilizationSince: this.bucketEventLoopStart
+				}),
+				kind: "bucket",
+				t: (/* @__PURE__ */ new Date()).toISOString()
+			};
+			try {
+				if (this.onBucket !== void 0) this.onBucket(snapshot);
+				else this.writeDiagnosticSink(snapshot);
+			} catch {}
+		} finally {
+			if (!this.finished) {
+				this.foldWindowIntoTotals();
+				this.resetWindow();
+			}
+		}
+	}
+	writeDiagnosticSink(record) {
+		if (this.bucketPath !== void 0) {
+			if (!this.fileSinkEnabled) return;
+			try {
+				appendFileSync(this.bucketPath, `${JSON.stringify(record)}\n`);
+			} catch {
+				this.fileSinkEnabled = false;
+			}
+			return;
+		}
+		if (process.stderr.isTTY) return;
+		try {
+			process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(record)}\n`);
+		} catch {}
+	}
+	foldWindowIntoTotals() {
+		mergeCounts(this.allRenderRequests, this.windowRenderRequests);
+	}
+	resetWindow() {
+		this.windowRenderRequests = /* @__PURE__ */ new Map();
+		this.windowRenderDurations.reset();
+		this.windowInputToWrite.reset();
+		this.windowInputs = 0;
+		this.windowSnapshots = 0;
+		this.windowHeaders = 0;
+		this.windowStatus = 0;
+		this.windowWriteCalls = 0;
+		this.windowWriteBytes = 0;
+		this.windowBackpressure = 0;
+		this.windowDrains = 0;
+		this.bucketEventLoop?.reset();
+		this.bucketEventLoopStart = performance.eventLoopUtilization();
+		this.bucketWindowStartedAt = performance.now();
+	}
+	stopBucketTimer() {
+		if (this.bucketTimer === void 0) return;
+		clearInterval(this.bucketTimer);
+		this.bucketTimer = void 0;
+	}
+	snapshot(source) {
+		const utilization = performance.eventLoopUtilization(source.utilizationSince).utilization;
+		return {
+			schema: 1,
+			durationMs: Number((source.durationMs ?? 0).toFixed(3)),
+			inputEvents: source.inputEvents,
+			snapshots: source.snapshots,
+			refreshHeaderCalls: source.headers,
+			updateStatusCalls: source.status,
+			renderRequests: Object.fromEntries(source.renderRequests),
+			renderDurationMs: source.renderDurations.summarize(),
+			inputToWriteMs: source.inputToWrite.summarize(),
 			terminalWrites: {
-				calls: this.writeCalls,
-				bytes: this.writeBytes,
-				backpressureSignals: this.backpressureSignals,
-				drains: this.drains
+				calls: source.writes,
+				bytes: source.bytes,
+				backpressureSignals: source.backpressure,
+				drains: source.drains
 			},
 			eventLoop: {
-				p99DelayMs: Number((this.eventLoop.percentile(99) / 1e6).toFixed(3)),
+				p99DelayMs: Number((source.histogram.percentile(99) / 1e6).toFixed(3)),
 				utilization: Number(utilization.toFixed(6))
 			},
 			memory: process.memoryUsage(),
@@ -34713,9 +34943,7 @@ const internals$1 = {
 	reportCleanupError: (error) => {
 		process.stderr.write(`${escapeTerminalText(ui(`deepseek: 终端清理失败：${error.message}`, `deepseek: terminal cleanup failed: ${error.message}`))}\n`);
 	},
-	reportPerformance: (snapshot) => {
-		process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(snapshot)}\n`);
-	},
+	reportPerformance: () => void 0,
 	startClient: startTuiClient
 };
 function noticeText(message, tone) {
@@ -34740,7 +34968,9 @@ async function startTuiSurface(options$1) {
 	const reportPerformance = () => {
 		terminalInstrumentation.release();
 		const snapshot = performanceProbe.finish();
-		if (snapshot !== void 0) internals$1.reportPerformance(snapshot);
+		if (snapshot === void 0) return;
+		performanceProbe.reportFinal(snapshot);
+		internals$1.reportPerformance(snapshot);
 	};
 	let stopTuiRenderingSync = () => void 0;
 	const terminalSession = createTerminalSession(terminal, true, () => {

--- a/lib/startup-trace-BXdEIGJm.js
+++ b/lib/startup-trace-BXdEIGJm.js
@@ -1,6 +1,6 @@
 //#region src/dsh-compat.ts
 const PACKAGE_NAME = "seektty";
-const PACKAGE_VERSION = "1.2.1";
+const PACKAGE_VERSION = "1.2.2";
 const DSH_COMPATIBILITY = {
 	minimum: "0.1.0-rc.6",
 	tested: "0.1.1-rc.2"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "perf:tui": "node scripts/tui-perf-harness.mjs",
     "test:stock": "node scripts/stock-dsh-cycle.mjs",
     "test:clarify-doctor": "node scripts/clarify-doctor-acceptance.mjs",
     "pack:check": "node scripts/pack-check.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seektty",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "SeekTTY, a pluggable DeepSeek-colored terminal surface for DeepSeek Harness",
   "keywords": [

--- a/patches/@mariozechner__pi-tui@0.73.1.patch
+++ b/patches/@mariozechner__pi-tui@0.73.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 50f9225..579d818 100644
+index 50f92259fa88f4efe406a60b7db8e54a9eedace6..579d81846fc4284babe2f69cf0efc1b6e49e351a 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -1204,6 +1204,7 @@ export class Editor {
@@ -11,7 +11,7 @@ index 50f9225..579d818 100644
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol > 0) {
 diff --git a/dist/components/markdown.js b/dist/components/markdown.js
-index 7dc2747..fc274db 100644
+index 7dc27474f3e6e61be59d448f40c0a4e6b249e2b8..fc274db16b9779ecb525c0ebb921042ceeeb46ad 100644
 --- a/dist/components/markdown.js
 +++ b/dist/components/markdown.js
 @@ -231,28 +231,35 @@ export class Markdown {
@@ -134,7 +134,7 @@ index 7dc2747..fc274db 100644
              else {
                  // Other token types - try to render as inline
 diff --git a/dist/terminal.js b/dist/terminal.js
-index 3545b28..f9a5ddf 100644
+index 3545b284ce2da594cc728803feb607a34cea5ca0..8d1bb56398704c12b4e13e5d160a78768300f91d 100644
 --- a/dist/terminal.js
 +++ b/dist/terminal.js
 @@ -16,6 +16,7 @@ export class ProcessTerminal {
@@ -207,7 +207,7 @@ index 3545b28..f9a5ddf 100644
          if (this._kittyProtocolActive) {
              // Disable Kitty keyboard protocol first so any late key releases
 diff --git a/dist/tui.js b/dist/tui.js
-index b521ceb..c0bc7d4 100644
+index b521ceb326eb8a25fc9ebc3feee4d39708296065..4b6ff5b7b35e2d03d3614379596e4c2a4eccb0e3 100644
 --- a/dist/tui.js
 +++ b/dist/tui.js
 @@ -307,13 +307,9 @@ export class TUI extends Container {
@@ -243,7 +243,7 @@ index b521ceb..c0bc7d4 100644
      requestRender(force = false) {
          if (force) {
              this.previousLines = [];
-@@ -752,27 +758,39 @@ export class TUI extends Container {
+@@ -752,27 +758,54 @@ export class TUI extends Container {
          if (this.overlayStack.length > 0) {
              newLines = this.compositeOverlays(newLines, width, height);
          }
@@ -253,13 +253,11 @@ index b521ceb..c0bc7d4 100644
          // Extract cursor position before applying line resets (marker must be found first)
          const cursorPos = this.extractCursorPosition(newLines, height);
          newLines = this.applyLineResets(newLines);
-         // Helper to clear scrollback and viewport and render all new lines
+-        // Helper to clear scrollback and viewport and render all new lines
 +        // Helper to restore the visible window. Tall buffers must never be
 +        // dumped from line 0: that replays older turns through the viewport.
          const fullRender = (clear) => {
              this.fullRedrawCount += 1;
-+            const tall = newLines.length > height;
-+            const paintStart = clear && tall ? Math.max(0, newLines.length - height) : 0;
              let buffer = "\x1b[?2026h"; // Begin synchronized output
              if (clear) {
                  buffer += this.deleteKittyImages(this.previousKittyImageIds);
@@ -268,18 +266,34 @@ index b521ceb..c0bc7d4 100644
 +                // (destroy native scrollback and force a history replay).
 +                buffer += "\x1b[H";
              }
--            for (let i = 0; i < newLines.length; i++) {
--                if (i > 0)
-+            for (let i = paintStart; i < newLines.length; i++) {
-+                if (i > paintStart)
+             for (let i = 0; i < newLines.length; i++) {
+                 if (i > 0)
                      buffer += "\r\n";
-+                if (clear)
++                if (clear && visibleWidth(newLines[i]) < width)
 +                    buffer += "\x1b[2K";
                  buffer += newLines[i];
              }
 -            buffer += "\x1b[?2026l"; // End synchronized output
-+            if (clear)
-+                buffer += "\x1b[0J";
++            // newLines is already sliced to height above. Do not apply ED0
++            // (CSI 0J) to a wrap-pending last content cell: xenl keeps the
++            // cursor on that cell, so 0J erases it. Clear leftover rows with
++            // the same CR / CUD / 2K / CUU pattern used for deleted lines.
++            if (clear && newLines.length < height) {
++                const extraLines = height - newLines.length;
++                if (newLines.length === 0) {
++                    buffer += "\x1b[0J";
++                }
++                else if (extraLines > 0) {
++                    buffer += "\r";
++                    buffer += "\x1b[1B";
++                    for (let i = 0; i < extraLines; i++) {
++                        buffer += "\r\x1b[2K";
++                        if (i < extraLines - 1)
++                            buffer += "\x1b[1B";
++                    }
++                    buffer += `\x1b[${extraLines}A`;
++                }
++            }
 +            buffer += "\x1b[?2026l";
              this.terminal.write(buffer);
              this.cursorRow = Math.max(0, newLines.length - 1);
@@ -288,7 +302,7 @@ index b521ceb..c0bc7d4 100644
              if (clear) {
                  this.maxLinesRendered = newLines.length;
              }
-@@ -844,6 +862,37 @@ export class TUI extends Container {
+@@ -844,6 +877,37 @@ export class TUI extends Container {
              }
              lastChanged = newLines.length - 1;
          }
@@ -326,3 +340,11 @@ index b521ceb..c0bc7d4 100644
          if (firstChanged !== -1) {
              lastChanged = this.expandLastChangedForKittyImages(firstChanged, lastChanged);
          }
+@@ -945,5 +1009,6 @@ export class TUI extends Container {
+             if (i > firstChanged)
+                 buffer += "\r\n";
+-            buffer += "\x1b[2K"; // Clear current line
+             const line = newLines[i];
++            if (visibleWidth(line) < width)
++                buffer += "\x1b[2K";
+             const isImage = isImageLine(line);

--- a/patches/@mariozechner__pi-tui@0.73.1.patch
+++ b/patches/@mariozechner__pi-tui@0.73.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 50f92259fa88f4efe406a60b7db8e54a9eedace6..579d81846fc4284babe2f69cf0efc1b6e49e351a 100644
+index 50f9225..579d818 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -1204,6 +1204,7 @@ export class Editor {
@@ -11,7 +11,7 @@ index 50f92259fa88f4efe406a60b7db8e54a9eedace6..579d81846fc4284babe2f69cf0efc1b6
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol > 0) {
 diff --git a/dist/components/markdown.js b/dist/components/markdown.js
-index 7dc27474f3e6e61be59d448f40c0a4e6b249e2b8..fc274db16b9779ecb525c0ebb921042ceeeb46ad 100644
+index 7dc2747..fc274db 100644
 --- a/dist/components/markdown.js
 +++ b/dist/components/markdown.js
 @@ -231,28 +231,35 @@ export class Markdown {
@@ -134,23 +134,123 @@ index 7dc27474f3e6e61be59d448f40c0a4e6b249e2b8..fc274db16b9779ecb525c0ebb921042c
              else {
                  // Other token types - try to render as inline
 diff --git a/dist/terminal.js b/dist/terminal.js
-index 3545b284ce2da594cc728803feb607a34cea5ca0..9d56c55f99ecca559be9d12ced4ec38d4852ca73 100644
+index 3545b28..f9a5ddf 100644
 --- a/dist/terminal.js
 +++ b/dist/terminal.js
-@@ -130,7 +130,7 @@ export class ProcessTerminal {
+@@ -16,6 +16,7 @@ export class ProcessTerminal {
+     resizeHandler;
+     _kittyProtocolActive = false;
+     _modifyOtherKeysActive = false;
++    _protocolsRestored = false;
+     stdinBuffer;
+     stdinDataHandler;
+     progressInterval;
+@@ -40,6 +41,7 @@ export class ProcessTerminal {
+     }
+     start(onInput, onResize) {
+         this.inputHandler = onInput;
++        this._protocolsRestored = false;
+         this.resizeHandler = onResize;
+         // Save previous state and enable raw mode
+         this.wasRaw = process.stdin.isRaw || false;
+@@ -82,7 +84,7 @@ export class ProcessTerminal {
+         // Forward individual sequences to the input handler
+         this.stdinBuffer.on("data", (sequence) => {
+             // Check for Kitty protocol response (only if not already enabled)
+-            if (!this._kittyProtocolActive) {
++            if (!this._protocolsRestored && !this._kittyProtocolActive) {
+                 const match = sequence.match(kittyResponsePattern);
+                 if (match) {
+                     this._kittyProtocolActive = true;
+@@ -130,7 +132,7 @@ export class ProcessTerminal {
          process.stdin.on("data", this.stdinDataHandler);
          process.stdout.write("\x1b[?u");
          setTimeout(() => {
 -            if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {
-+            if (this.inputHandler && !this._kittyProtocolActive && !this._modifyOtherKeysActive) {
++            if (!this._protocolsRestored && this.inputHandler && !this._kittyProtocolActive && !this._modifyOtherKeysActive) {
                  process.stdout.write("\x1b[>4;2m");
                  this._modifyOtherKeysActive = true;
              }
+@@ -165,6 +167,34 @@ export class ProcessTerminal {
+             // koffi not available — Shift+Tab won't be distinguishable from Tab
+         }
+     }
++    // SeekTTY fatal guards need protocol bytes restored before any async cleanup.
++    // Keep this method private to the pinned runtime contract via duck typing.
++    restoreProtocolsSync() {
++        this._protocolsRestored = true;
++        this.inputHandler = undefined;
++        if (this.stdinBuffer) {
++            this.stdinBuffer.destroy();
++            this.stdinBuffer = undefined;
++        }
++        if (this.stdinDataHandler) {
++            process.stdin.removeListener("data", this.stdinDataHandler);
++            this.stdinDataHandler = undefined;
++        }
++        process.stdout.write("\x1b[?2004l");
++        if (this._kittyProtocolActive) {
++            process.stdout.write("\x1b[<u");
++            this._kittyProtocolActive = false;
++            setKittyProtocolActive(false);
++        }
++        if (this._modifyOtherKeysActive) {
++            process.stdout.write("\x1b[>4;0m");
++            this._modifyOtherKeysActive = false;
++        }
++    }
++    restoreRawModeSync() {
++        if (process.stdin.setRawMode)
++            process.stdin.setRawMode(this.wasRaw);
++    }
+     async drainInput(maxMs = 1000, idleMs = 50) {
+         if (this._kittyProtocolActive) {
+             // Disable Kitty keyboard protocol first so any late key releases
 diff --git a/dist/tui.js b/dist/tui.js
-index b521ceb326eb8a25fc9ebc3feee4d39708296065..6f6cb549140045b94c47987c164c3a6cf64a197a 100644
+index b521ceb..c0bc7d4 100644
 --- a/dist/tui.js
 +++ b/dist/tui.js
-@@ -756,23 +756,32 @@ export class TUI extends Container {
+@@ -307,13 +307,9 @@ export class TUI extends Container {
+         this.terminal.write("\x1b[16t");
+     }
+     stop() {
+-        this.stopped = true;
+-        if (this.renderTimer) {
+-            clearTimeout(this.renderTimer);
+-            this.renderTimer = undefined;
+-        }
++        this.stopRenderingSync();
+         // Move cursor to the end of the content to prevent overwriting/artifacts on exit
+-        if (this.previousLines.length > 0) {
++        if (!this.terminal.__seekttyManagedAlternateScreen && this.previousLines.length > 0) {
+             const targetRow = this.previousLines.length; // Line after the last content
+             const lineDiff = targetRow - this.hardwareCursorRow;
+             if (lineDiff > 0) {
+@@ -327,6 +323,16 @@ export class TUI extends Container {
+         this.terminal.showCursor();
+         this.terminal.stop();
+     }
++    // SeekTTY restores the main screen before asynchronous cleanup. Quiesce
++    // queued renders first so no frame can be painted after CSI ? 1049 l.
++    stopRenderingSync() {
++        this.stopped = true;
++        if (this.renderTimer) {
++            clearTimeout(this.renderTimer);
++            this.renderTimer = undefined;
++        }
++        this.renderRequested = false;
++    }
+     requestRender(force = false) {
+         if (force) {
+             this.previousLines = [];
+@@ -752,27 +758,39 @@ export class TUI extends Container {
+         if (this.overlayStack.length > 0) {
+             newLines = this.compositeOverlays(newLines, width, height);
+         }
++        if (newLines.length > height) {
++            newLines = newLines.slice(-height);
++        }
+         // Extract cursor position before applying line resets (marker must be found first)
          const cursorPos = this.extractCursorPosition(newLines, height);
          newLines = this.applyLineResets(newLines);
          // Helper to clear scrollback and viewport and render all new lines
@@ -188,7 +288,7 @@ index b521ceb326eb8a25fc9ebc3feee4d39708296065..6f6cb549140045b94c47987c164c3a6c
              if (clear) {
                  this.maxLinesRendered = newLines.length;
              }
-@@ -844,6 +853,37 @@ export class TUI extends Container {
+@@ -844,6 +862,37 @@ export class TUI extends Container {
              }
              lastChanged = newLines.length - 1;
          }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-tui@0.73.1': 52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38
+  '@mariozechner/pi-tui@0.73.1': d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35
 
 importers:
 
@@ -161,7 +161,7 @@ importers:
         version: 3.18.1
       '@mariozechner/pi-tui':
         specifier: 0.73.1
-        version: 0.73.1(patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38)
+        version: 0.73.1(patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35)
       '@types/cross-spawn':
         specifier: 6.0.6
         version: 6.0.6
@@ -3217,7 +3217,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mariozechner/pi-tui@0.73.1(patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38)':
+  '@mariozechner/pi-tui@0.73.1(patch_hash=d9e2b42d7e24cc0bb576be78ed0f40a51b9f35bf423d8924c5c056b3523abd35)':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-tui@0.73.1': 07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd
+  '@mariozechner/pi-tui@0.73.1': 52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38
 
 importers:
 
@@ -161,7 +161,7 @@ importers:
         version: 3.18.1
       '@mariozechner/pi-tui':
         specifier: 0.73.1
-        version: 0.73.1(patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd)
+        version: 0.73.1(patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38)
       '@types/cross-spawn':
         specifier: 6.0.6
         version: 6.0.6
@@ -3217,7 +3217,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mariozechner/pi-tui@0.73.1(patch_hash=07c9db07498f3f4d4e8f84d5304c490b1a004dcdd459dedd93cb248b3e1257cd)':
+  '@mariozechner/pi-tui@0.73.1(patch_hash=52c25621f3351d2eaef9354a1e8dbb55f052374587088aa7a529de33f72c5a38)':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/scripts/tui-perf-harness.mjs
+++ b/scripts/tui-perf-harness.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+const vitest = resolve(root, 'node_modules/vitest/vitest.mjs')
+const test = resolve(root, 'tests/tui-performance.test.ts')
+const commit = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).stdout.trim()
+const positiveIntegers = (value, fallback) => {
+  const parsed = (value ?? '').split(',').map(item => Number(item.trim()))
+    .filter(item => Number.isInteger(item) && item > 0)
+  return parsed.length === 0 ? fallback : parsed
+}
+const repeats = positiveIntegers(process.env.SEEKTTY_PERF_REPEATS, [3])[0] ?? 3
+const sizes = positiveIntegers(process.env.SEEKTTY_PERF_SIZES, [1_000, 10_000, 50_000, 100_000])
+const width = positiveIntegers(process.env.SEEKTTY_PERF_WIDTH, [80])[0] ?? 80
+const rows = positiveIntegers(process.env.SEEKTTY_PERF_ROWS, [24])[0] ?? 24
+const runs = []
+let runtime
+
+for (let repeat = 1; repeat <= repeats; repeat += 1) {
+  for (const size of sizes) {
+    const result = spawnSync(process.execPath, [
+      '--expose-gc',
+      vitest,
+      'run',
+      test,
+      '--reporter=dot',
+    ], {
+      cwd: root,
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        SEEKTTY_PERF_RUN: '1',
+        SEEKTTY_PERF_COMMIT: commit,
+        SEEKTTY_PERF_REPEAT_INDEX: String(repeat),
+        SEEKTTY_PERF_REPEATS: '1',
+        SEEKTTY_PERF_SIZES: String(size),
+        SEEKTTY_PERF_WIDTH: String(width),
+        SEEKTTY_PERF_ROWS: String(rows),
+      },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+    if (result.error !== undefined) throw result.error
+    if (result.status !== 0) {
+      process.stdout.write(result.stdout)
+      process.stderr.write(result.stderr)
+      process.exit(result.status ?? 1)
+    }
+    const match = result.stdout.match(/SEEKTTY_PERF_RESULT (\{[^\n]+\})/u)
+    if (match?.[1] === undefined) {
+      process.stderr.write(result.stdout)
+      process.stderr.write('tui performance result marker was not emitted\n')
+      process.exit(1)
+    }
+    const measured = JSON.parse(match[1])
+    runtime ??= measured.runtime
+    runs.push(...measured.runs)
+  }
+}
+
+process.stdout.write(`${JSON.stringify({
+  schema: 1,
+  commit,
+  runtime,
+  fixture: {
+    width,
+    rows,
+    linesPerNode: 100,
+    cachedRenderSamples: 25,
+    tailUpdateSamples: 10,
+    repeats,
+    sizes,
+    processIsolation: 'one size/repeat per Vitest process',
+  },
+  runs,
+}, null, 2)}\n`)

--- a/src/client/chrome.ts
+++ b/src/client/chrome.ts
@@ -143,7 +143,7 @@ export class BottomAnchoredLayout implements Component {
   /**
    * @param viewportRows - current terminal height in rows.
    * @param context - one-row execution context.
-   * @param transcript - conversation content that grows into terminal scrollback.
+   * @param transcript - conversation content constrained to its internal viewport.
    * @param composer - prompt editor and its autocomplete rows.
    * @param status - one-row permission and runtime status.
    * @param centerTranscript - whether spare conversation rows surround the transcript.
@@ -174,27 +174,35 @@ export class BottomAnchoredLayout implements Component {
     const transcriptRows = this.transcript.render(width)
     const composerRows = this.composer.render(width)
     const statusRows = this.status.render(width)
-    const naturalRows = contextRows.length + transcriptRows.length
-      + composerRows.length + statusRows.length + 2
     const requestedRows = Math.floor(this.viewportRows())
-    const minimumRows = Number.isFinite(requestedRows)
-      ? Math.max(1, requestedRows)
-      : naturalRows
-    const flexibleRows = Math.max(0, minimumRows - naturalRows)
+    const fixedRows = contextRows.length + composerRows.length + statusRows.length + 2
+    const minimumRows = Number.isFinite(requestedRows) ? Math.max(1, requestedRows) : undefined
+    const transcriptCapacity = minimumRows === undefined
+      ? transcriptRows.length
+      : Math.max(0, minimumRows - fixedRows)
+    const visibleTranscript = transcriptCapacity === 0
+      ? []
+      : transcriptRows.slice(-transcriptCapacity)
+    const naturalRows = fixedRows + visibleTranscript.length
+    const targetRows = minimumRows ?? naturalRows
+    const flexibleRows = Math.max(0, targetRows - naturalRows)
     const flexibleBefore = this.centerTranscript()
       ? Math.floor(flexibleRows / 2)
       : 0
     const flexibleAfter = flexibleRows - flexibleBefore
-    return [
+    const rendered = [
       ...contextRows,
       '',
       ...Array.from({ length: flexibleBefore }, () => ''),
-      ...transcriptRows,
+      ...visibleTranscript,
       ...Array.from({ length: flexibleAfter }, () => ''),
       '',
       ...composerRows,
       ...statusRows,
     ]
+    return minimumRows === undefined || rendered.length <= minimumRows
+      ? rendered
+      : rendered.slice(-minimumRows)
   }
 }
 

--- a/src/client/help.ts
+++ b/src/client/help.ts
@@ -26,6 +26,7 @@ export function helpSectionText(id: HelpSectionId): string {
         '会话：Ctrl+S 打开会话列表，新建或切换会话。',
         '审批：弹窗里查看命令或 diff，再选仅本次允许或拒绝。',
         '浏览对话：Tab 进入对话浏览，按 / 增量搜索，n/N 跳转。',
+        '滚动与复制：滚轮浏览内部对话；Terminal.app 按住 Fn、iTerm2 按住 Option 后拖选，再按 Command+C。',
       ].join('\n'),
       [
         'Input: type in the composer and press Enter to send.',
@@ -35,6 +36,7 @@ export function helpSectionText(id: HelpSectionId): string {
         'Sessions: Ctrl+S opens the session list to create or switch sessions.',
         'Approvals: inspect the command or diff in the overlay, then allow once or reject.',
         'Browse the transcript: Tab into browse mode, press / to search, then n/N to jump.',
+        'Scroll and copy: the wheel browses the internal transcript; hold Fn in Terminal.app or Option in iTerm2 while dragging, then press Command+C.',
       ].join('\n'),
     )
   }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -85,9 +85,16 @@ import { createSessionChromeStore, nextTitleWrite } from './session-chrome.ts'
 import { NoticeBoard, pickStatusLine } from './status-priority.ts'
 import { restartRequiredFact, restartRequiredNotice } from './restart-copy.ts'
 import { sessionTerminalTitle } from './terminal-title.ts'
+import {
+  createTerminalSession,
+  type ManagedTui,
+  supportsManagedTerminal,
+  terminalMouseDelta,
+  type ManagedTerminal,
+} from './terminal-session.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
 import { pendingInteractionStatus } from './pending-status.ts'
-import { attachFatalGuards, fatalLogHint, restoreTerminalSync, withCleanupTimeout } from '../process-guards.ts'
+import { attachFatalGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
@@ -126,13 +133,15 @@ function noticeText(message: string, tone: NoticeTone): string {
  * @returns idempotent lifecycle handle.
  */
 export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurfaceHandle> {
-  if (!internals.isInteractive()) {
+  if (!supportsManagedTerminal(internals.isInteractive(), process.env.TERM)) {
     throw new Error(ui(
-      '需要交互式 TTY；非交互任务请使用 dsh --profile headless',
-      'An interactive TTY is required; use dsh --profile headless for non-interactive tasks',
+      '需要支持终端私有模式的交互式 TTY；非交互任务请使用 dsh --profile headless',
+      'An interactive TTY with private-mode support is required; use dsh --profile headless for non-interactive tasks',
     ))
   }
-  const terminal = internals.createTerminal()
+  const terminal = internals.createTerminal() as Terminal & ManagedTerminal
+  let stopTuiRenderingSync = (): void => undefined
+  const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() })
   const [settingsDocuments, client, initialProviderReadiness] = await measureStartup('settings+client', () => Promise.all([
     options.management.settings.describe(),
     internals.startClient(options),
@@ -150,6 +159,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault)
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
+    stopTuiRenderingSync = () => {
+      (tui as TUI & ManagedTui).stopRenderingSync?.()
+    }
     stopConstructedTui = () => {
       tui.stop()
     }
@@ -191,11 +203,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
     let transcriptFocused = false
     const transcript = new Transcript(
-      // The default full transcript becomes normal terminal scrollback, which keeps
-      // native drag selection, Command+C, and wheel scrolling under terminal control.
-      () => transcriptFocused
-        ? transcriptViewportRows(terminal.rows, editor.render(terminal.columns).length)
-        : Number.POSITIVE_INFINITY,
+      () => transcriptViewportRows(terminal.rows, editor.render(terminal.columns).length),
       () => { if (stopping === undefined) tui.requestRender() },
       () => {
         const current = active
@@ -213,6 +221,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     let syntax: SyntaxHighlighter | undefined
     disposeConstructedSyntax = () => { syntax?.dispose() }
     void SyntaxHighlighter.create(initialTheme, () => {
+      if (stopping !== undefined) return
       // Non-forced render: a forced full redraw clears the screen and replays
       // the whole history, which flashes mid-session whenever a lazy grammar
       // finishes loading. The differential render repaints the visible rows.
@@ -465,7 +474,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       detachFatalGuards()
       detachFatalGuards = () => undefined
       if (stopping !== undefined) return stopping
-      restoreTerminalSync(process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
+      restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
       stopping = (async () => {
         const failures: unknown[] = []
         if (elapsedTimer !== undefined) {
@@ -748,6 +757,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     tui.addInputListener((data) => {
+      const wheelDelta = terminalMouseDelta(data)
+      if (wheelDelta !== undefined) {
+        if (wheelDelta !== null) transcript.scrollBy(wheelDelta)
+        return { consume: true }
+      }
       const interrupt = consumeRunningInterrupt(data, capabilities.active()?.session)
       if (interrupt !== undefined) return interrupt
       if (overlays.hasActive()) return undefined
@@ -927,7 +941,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const startupOnboarding = onboarding.ensure()
     applyTerminalTitle()
     detachFatalGuards = attachFatalGuards({
-      restore: () => { restoreTerminalSync(process.stdin, chunk => { process.stdout.write(chunk) }, terminal) },
+      restore: () => {
+        restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
+      },
       cleanup: () => close({ kind: 'exit', code: 1 }),
       writeError: (message) => { process.stderr.write(`${escapeTerminalText(message)}\n`) },
       formatError: (error) => {
@@ -940,6 +956,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       exit: (code) => { process.exit(code) },
     })
+    terminalSession.enter()
     tui.start()
     refreshHeader(true)
     refresh()
@@ -975,7 +992,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     return { closed, stop: () => close({ kind: 'exit', code: 0 }) }
   } catch (error) {
     detachFatalGuards()
-    restoreTerminalSync(process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
+    restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
     setCodeHighlighter(undefined)
     try { disposeConstructedSyntax() } catch { /* preserve the setup failure */ }
     try { stopConstructedTui() } catch { /* preserve the setup failure */ }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -96,12 +96,18 @@ import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } fro
 import { pendingInteractionStatus } from './pending-status.ts'
 import { attachFatalGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
+import {
+  instrumentTerminalWrites,
+  TuiPerformanceProbe,
+  type TuiPerformanceSnapshot,
+} from './tui-performance.ts'
 
 /** Replaceable terminal seams used by virtual-terminal tests. */
 export const internals: {
   createTerminal(): Terminal
   isInteractive(): boolean
   reportCleanupError(error: Error): void
+  reportPerformance(snapshot: TuiPerformanceSnapshot): void
   startClient(options: TuiStartOptions): Promise<TuiClient>
 } = {
   createTerminal: () => new ProcessTerminal(),
@@ -111,6 +117,9 @@ export const internals: {
       `deepseek: 终端清理失败：${error.message}`,
       `deepseek: terminal cleanup failed: ${error.message}`,
     ))}\n`)
+  },
+  reportPerformance: (snapshot) => {
+    process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(snapshot)}\n`)
   },
   startClient: startTuiClient,
 }
@@ -139,14 +148,30 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       'An interactive TTY with private-mode support is required; use dsh --profile headless for non-interactive tasks',
     ))
   }
-  const terminal = internals.createTerminal() as Terminal & ManagedTerminal
+  const performanceProbe = new TuiPerformanceProbe()
+  const rawTerminal = internals.createTerminal() as Terminal & ManagedTerminal
+  const terminalInstrumentation = instrumentTerminalWrites(rawTerminal, performanceProbe, process.stdout)
+  const terminal = terminalInstrumentation.terminal
+  const reportPerformance = (): void => {
+    terminalInstrumentation.release()
+    const snapshot = performanceProbe.finish()
+    if (snapshot !== undefined) internals.reportPerformance(snapshot)
+  }
   let stopTuiRenderingSync = (): void => undefined
   const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() })
-  const [settingsDocuments, client, initialProviderReadiness] = await measureStartup('settings+client', () => Promise.all([
-    options.management.settings.describe(),
-    internals.startClient(options),
-    inspectProviderReadiness(options.api),
-  ]))
+  const startup = await (async () => {
+    try {
+      return await measureStartup('settings+client', () => Promise.all([
+        options.management.settings.describe(),
+        internals.startClient(options),
+        inspectProviderReadiness(options.api),
+      ]))
+    } catch (error) {
+      try { reportPerformance() } catch { /* preserve the startup failure */ }
+      throw error
+    }
+  })()
+  const [settingsDocuments, client, initialProviderReadiness] = startup
   setUiLocale(localeFromSettings(settingsDocuments))
   let stopConstructedTui = (): void => undefined
   let disposeConstructedSyntax = (): void => undefined
@@ -159,6 +184,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault)
     setTheme(initialTheme)
     const tui = new TUI(terminal, true)
+    const requestTuiRender = tui.requestRender.bind(tui)
+    tui.requestRender = (force = false): void => {
+      performanceProbe.markRenderRequest(force ? 'forced' : 'normal')
+      requestTuiRender(force)
+    }
     stopTuiRenderingSync = () => {
       (tui as TUI & ManagedTui).stopRenderingSync?.()
     }
@@ -254,6 +284,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     })
     const status = new StatusBar()
     const canvas = new Box(0, 0, background.canvas)
+    const renderCanvas = canvas.render.bind(canvas)
+    canvas.render = (width: number): string[] => performanceProbe.measureRender(() => renderCanvas(width))
     if (options.draft !== undefined) editor.setText(escapeTerminalText(options.draft))
     canvas.addChild(new BottomAnchoredLayout(
       () => terminal.rows,
@@ -287,6 +319,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     const updateTranscript = (current: TuiActiveSession): void => {
+      performanceProbe.markSnapshot()
       transcript.update(current.session.getSnapshot(), async (attachment) => {
         const result = await current.session.readAttachment(attachment.attachmentId)
         if (!result.ok) throw new Error(ui(
@@ -337,6 +370,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
 
     const updateStatus = (): void => {
       if (stopping !== undefined) return
+      performanceProbe.markStatus()
       editor.setDraftAttachments(capabilities.draftAttachments())
       const chrome = sessionChrome.of(latestSessionId)
       const snapshot = active?.session.getSnapshot()
@@ -428,6 +462,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     })
 
     const refreshHeader = (forceModel = false): void => {
+      performanceProbe.markHeader()
       const generation = ++headerGeneration
       void capabilities.headerFacts(forceModel).then((facts) => {
         if (stopping !== undefined || generation !== headerGeneration) return
@@ -486,7 +521,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         transcript.dispose()
         setCodeHighlighter(undefined)
         try { syntax?.dispose() } catch (error) { failures.push(error) }
-        try { unsubscribeActive() } catch (error) { failures.push(error) }
+        try { unsubscribeActive() } catch (error) { failures.push(error) } finally {
+          performanceProbe.changeSubscriptions(-1)
+        }
         try {
           await withCleanupTimeout(() => terminal.drainInput(250, 30))
         } catch (error) {
@@ -502,6 +539,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         } catch (error) {
           failures.push(error)
         }
+        try { reportPerformance() } catch { /* optional diagnostics must not break cleanup */ }
         resolveClosed(failures.length === 0 ? outcome : { kind: 'exit', code: 1 })
         if (failures.length > 0) {
           const error = failures.length === 1 && failures[0] instanceof Error
@@ -621,6 +659,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       updateStatus()
       renderWhileOpen()
     })
+    performanceProbe.changeSubscriptions(1)
 
     editor.setAutocompleteProvider(new HarnessAutocompleteProvider(capabilities, (message) => {
       setNotice(ui(`命令目录：${message}`, `Command catalog: ${message}`), 'error')
@@ -757,6 +796,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     tui.addInputListener((data) => {
+      performanceProbe.markInput()
       const wheelDelta = terminalMouseDelta(data)
       if (wheelDelta !== undefined) {
         if (wheelDelta !== null) transcript.scrollBy(wheelDelta)
@@ -999,6 +1039,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     try {
       await withCleanupTimeout(() => client.ctx.fiber.dispose())
     } catch { /* preserve the setup failure */ }
+    try { reportPerformance() } catch { /* preserve the setup failure */ }
     throw error
   }
 }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -118,9 +118,7 @@ export const internals: {
       `deepseek: terminal cleanup failed: ${error.message}`,
     ))}\n`)
   },
-  reportPerformance: (snapshot) => {
-    process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(snapshot)}\n`)
-  },
+  reportPerformance: () => undefined,
   startClient: startTuiClient,
 }
 
@@ -155,7 +153,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   const reportPerformance = (): void => {
     terminalInstrumentation.release()
     const snapshot = performanceProbe.finish()
-    if (snapshot !== undefined) internals.reportPerformance(snapshot)
+    if (snapshot === undefined) return
+    performanceProbe.reportFinal(snapshot)
+    internals.reportPerformance(snapshot)
   }
   let stopTuiRenderingSync = (): void => undefined
   const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() })

--- a/src/client/terminal-session.ts
+++ b/src/client/terminal-session.ts
@@ -1,0 +1,81 @@
+import type { Terminal } from '@mariozechner/pi-tui'
+
+const ENTER_ALTERNATE_SCREEN = '\u001B[?1049h\u001B[H'
+const ENABLE_MOUSE = '\u001B[?1002l\u001B[?1003l\u001B[?1007l\u001B[?1000h\u001B[?1006h'
+const DISABLE_MOUSE = '\u001B[?1000l\u001B[?1002l\u001B[?1003l\u001B[?1006l\u001B[?1007l'
+const SHOW_CURSOR_AND_LEAVE = '\u001B[?25h\u001B[?1049l'
+const SGR_MOUSE = /^\u001B\[<(\d+);(\d+);(\d+)[Mm]$/u
+
+/** Private compatibility marker consumed only by the pinned pi-tui patch. */
+export interface ManagedTerminal {
+  __seekttyManagedAlternateScreen?: boolean
+  restoreProtocolsSync?(): void
+  restoreRawModeSync?(): void
+}
+
+/** Private compatibility hook supplied by the pinned pi-tui patch. */
+export interface ManagedTui {
+  stopRenderingSync?(): void
+}
+
+export interface TerminalSession {
+  enter(): void
+  restore(): void
+}
+
+/** Whether an interactive Surface may safely use terminal private modes. */
+export function supportsManagedTerminal(interactive: boolean, term: string | undefined): boolean {
+  return interactive && term?.trim().toLowerCase() !== 'dumb'
+}
+
+/**
+ * Own the alternate-screen and mouse-reporting bytes around one Surface.
+ * Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
+ */
+export function createTerminalSession(
+  terminal: Terminal & ManagedTerminal,
+  enabled: boolean,
+  beforeRestore: () => void = () => undefined,
+): TerminalSession {
+  let active = false
+  return {
+    enter: () => {
+      if (!enabled || active) return
+      active = true
+      terminal.__seekttyManagedAlternateScreen = true
+      terminal.write(ENTER_ALTERNATE_SCREEN + ENABLE_MOUSE)
+    },
+    restore: () => {
+      if (!active) return
+      try { beforeRestore() } catch { /* terminal restoration must still run */ }
+      try {
+        terminal.write(DISABLE_MOUSE)
+      } finally {
+        try {
+          terminal.restoreProtocolsSync?.()
+        } finally {
+          terminal.write(SHOW_CURSOR_AND_LEAVE)
+          active = false
+        }
+      }
+    },
+  }
+}
+
+/**
+ * Decode one SGR mouse report.
+ * @returns positive/negative wheel lines, null for a consumed mouse sequence,
+ * or undefined when the input is not mouse data.
+ */
+export function terminalMouseDelta(data: string): number | null | undefined {
+  const match = SGR_MOUSE.exec(data)
+  if (match !== null) {
+    const button = Number(match[1])
+    const normalized = button & ~28 // Ignore Shift/Alt/Ctrl modifier bits.
+    if (normalized === 64) return 3
+    if (normalized === 65) return -3
+    return null
+  }
+  if (data.startsWith('\u001B[<') || data.startsWith('\u001B[M')) return null
+  return undefined
+}

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -2250,7 +2250,11 @@ export class Transcript implements Component, Focusable {
     this.turnCursor = undefined
     const delta = Math.trunc(lines)
     if (!Number.isFinite(delta) || delta === 0) return false
-    if (this.search === undefined && !this.emptyState && this.viewportState !== undefined) {
+    if (this.search !== undefined) {
+      const rows = Math.max(1, Math.floor(this.viewportRows()) - 1)
+      return this.scrollSearchBy(delta, rows)
+    }
+    if (!this.emptyState && this.viewportState !== undefined) {
       if (delta < 0 && this.viewportAnchor.followLatest) return false
       const moved = this.moveViewportStart(
         this.viewportState.start,

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -1369,8 +1369,7 @@ export class Transcript implements Component, Focusable {
     }
     this.imageLoader = imageLoader
     this.blockGeneration += 1
-    this.searchIndex = undefined
-    if (this.search !== undefined) this.lastFullLines = []
+    if (this.search === undefined) this.searchIndex = undefined
     this.hasMore = snapshot.hasMore
     this.loadingOlder = snapshot.loadingOlder
     const preferences: TranscriptPreferences = {
@@ -1733,6 +1732,19 @@ export class Transcript implements Component, Focusable {
     if (current !== undefined
       && current.width === contentWidth
       && current.generation === this.blockGeneration) return current
+    const viewportRows = this.viewportRows()
+    const rows = Number.isFinite(viewportRows)
+      ? Math.max(1, Math.floor(viewportRows) - 1)
+      : undefined
+    const previousTop = current !== undefined && rows !== undefined && this.scrollOffset > 0
+      ? (() => {
+          const top = Math.max(0, current.lines.length - this.scrollOffset - rows)
+          const span = current.spans.find(candidate => candidate.start <= top && top < candidate.end)
+          return span === undefined
+            ? undefined
+            : { blockKey: span.blockKey, lineOffset: top - span.start }
+        })()
+      : undefined
     const lines: string[] = []
     const spans: Array<{ blockKey: string; start: number; end: number }> = []
     for (const [blockIndex, block] of this.blocks.entries()) {
@@ -1747,6 +1759,15 @@ export class Transcript implements Component, Focusable {
       spans,
     }
     this.searchIndex = index
+    if (previousTop !== undefined && rows !== undefined) {
+      const span = spans.find(candidate => candidate.blockKey === previousTop.blockKey)
+      if (span !== undefined) {
+        const lineOffset = Math.min(previousTop.lineOffset, Math.max(0, span.end - span.start - 1))
+        const top = span.start + lineOffset
+        const maxOffset = Math.max(0, lines.length - rows)
+        this.scrollOffset = Math.max(0, Math.min(maxOffset, lines.length - top - rows))
+      }
+    }
     this.lastFullLines = lines
     return index
   }
@@ -1977,7 +1998,7 @@ export class Transcript implements Component, Focusable {
    */
   cancelSearch(): boolean {
     if (this.search === undefined) return false
-    const index = this.searchIndex
+    const index = this.activeSearchIndex()
     if (index !== undefined && Number.isFinite(this.viewportRows())) {
       const rows = Math.max(1, Math.floor(this.viewportRows()) - 1)
       const top = Math.max(0, index.lines.length - this.scrollOffset - rows)
@@ -2001,7 +2022,9 @@ export class Transcript implements Component, Focusable {
     if (viewport !== undefined) {
       const index = this.ensureSearchIndex(viewport.contentWidth)
       const span = index.spans.find(candidate => candidate.blockKey === viewport.start.blockKey)
-      if (span !== undefined) {
+      if (this.viewportAnchor.followLatest) {
+        this.scrollOffset = 0
+      } else if (span !== undefined) {
         const rows = Math.max(1, viewport.rows - 1)
         const top = span.start + viewport.start.lineOffset
         this.scrollOffset = Math.max(0, Math.min(
@@ -2095,7 +2118,9 @@ export class Transcript implements Component, Focusable {
 
   private stepSearch(direction: 1 | -1): void {
     if (this.search === undefined) return
-    const matches = findLineMatches(this.lastFullLines, this.search.query)
+    const index = this.activeSearchIndex()
+    if (index === undefined) return
+    const matches = findLineMatches(index.lines, this.search.query)
     const current = matches[this.search.matchIndex] ?? -1
     const next = nextMatchIndex(matches, current, direction)
     if (next < 0) return
@@ -2106,18 +2131,26 @@ export class Transcript implements Component, Focusable {
 
   private revealCurrentMatch(): void {
     if (this.search === undefined) return
-    const matches = findLineMatches(this.lastFullLines, this.search.query)
+    const index = this.activeSearchIndex()
+    if (index === undefined) return
+    const matches = findLineMatches(index.lines, this.search.query)
     const lineIndex = matches[this.search.matchIndex]
     if (lineIndex === undefined) return
     this.scrollOffset = scrollOffsetToReveal(
-      this.lastFullLines.length,
+      index.lines.length,
       Math.max(1, this.viewportRows() - 1),
       lineIndex,
     )
   }
 
+  private activeSearchIndex(): TranscriptSearchIndex | undefined {
+    if (this.search === undefined) return undefined
+    const contentWidth = this.viewportState?.contentWidth
+    return contentWidth === undefined ? undefined : this.ensureSearchIndex(contentWidth)
+  }
+
   private scrollSearchBy(lines: number, rows: number): boolean {
-    const index = this.searchIndex
+    const index = this.activeSearchIndex()
     if (index === undefined) return false
     const maxOffset = Math.max(0, index.lines.length - rows)
     const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + Math.trunc(lines)))
@@ -2128,7 +2161,7 @@ export class Transcript implements Component, Focusable {
   }
 
   private scrollSearchTo(edge: 'start' | 'end', rows: number): boolean {
-    const index = this.searchIndex
+    const index = this.activeSearchIndex()
     if (index === undefined) return false
     const nextOffset = edge === 'start' ? Math.max(0, index.lines.length - rows) : 0
     if (nextOffset === this.scrollOffset) return false

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -1504,7 +1504,14 @@ export class Transcript implements Component, Focusable {
         lines[index] = `${' '.repeat(Math.max(0, Math.floor((contentWidth - visibleWidth(content)) / 2)))}${content}`
       }
     }
+    const previousRenderedLineCount = this.renderedLineCount
     this.lastFullLines = [...lines]
+    if (this.scrollOffset > 0 && previousRenderedLineCount > 0) {
+      this.scrollOffset = Math.max(
+        0,
+        this.scrollOffset + lines.length - previousRenderedLineCount,
+      )
+    }
     this.renderedLineCount = lines.length
     this.turnAnchors = anchors
     if (this.search !== undefined) {

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -64,6 +64,12 @@ const PULSE_FRAME_MS = 160
 export const internals = {
   markdownCreated: 0,
   componentRenders: 0,
+  blocksVisited: 0,
+  linesEscaped: 0,
+  lastFullLinesCopied: 0,
+  fingerprintsComputed: 0,
+  imageBlocksUpdated: 0,
+  activePulseTimers: 0,
 }
 
 /** User-visible tool-card posture; display only, never a model/runtime mutation. */
@@ -1148,11 +1154,66 @@ function chatNodeRows(node: ChatConversationViewNode, preferences: TranscriptPre
   }])
 }
 
+interface TranscriptBlockLines {
+  readonly lines: readonly string[]
+  readonly turnAnchors: readonly number[]
+}
+
+interface TranscriptBlock {
+  readonly key: string
+  readonly sourceToken: string
+  readonly rows: TranscriptRow[]
+  readonly components: Component[]
+  readonly linesByWidth: Map<number, TranscriptBlockLines>
+  readonly metadata: {
+    readonly userTurnRows: readonly number[]
+    readonly toolKeys: readonly string[]
+    readonly dynamic: boolean
+  }
+  dirty: boolean
+}
+
+function transcriptBlockMetadata(rows: readonly TranscriptRow[]): TranscriptBlock['metadata'] {
+  return {
+    userTurnRows: rows.flatMap((row, index) => row.userTurn === true ? [index] : []),
+    toolKeys: [...new Set(rows.flatMap(row => row.toolKey === undefined ? [] : [row.toolKey]))],
+    dynamic: rows.some(row => row.pulse !== undefined || row.liveDurationSince !== undefined),
+  }
+}
+
+interface TranscriptCoordinate {
+  readonly blockKey: string
+  readonly lineOffset: number
+}
+
+interface TranscriptViewportAnchor extends TranscriptCoordinate {
+  readonly followLatest: boolean
+}
+
+interface TranscriptViewportState {
+  readonly contentWidth: number
+  readonly rows: number
+  readonly start: TranscriptCoordinate
+  readonly hasOlder: boolean
+  readonly hasNewer: boolean
+}
+
+interface TranscriptSearchIndex {
+  readonly width: number
+  readonly generation: number
+  readonly lines: readonly string[]
+  readonly spans: readonly {
+    readonly blockKey: string
+    readonly start: number
+    readonly end: number
+  }[]
+}
+
 /** Mutable pi-tui component backed only by the official conversation snapshot. */
 export class Transcript implements Component, Focusable {
-  private components: Component[] = [new Text('', 0, 0)]
-  private rows: readonly TranscriptRow[] = []
+  private blocks: readonly TranscriptBlock[] = []
   private readonly imageComponents = new Map<string, Component>()
+  private readonly imageBlockOwners = new Map<string, Set<string>>()
   private readonly pendingImages = new Set<string>()
   private imageGeneration = 0
   private imageLoader: TranscriptImageLoader | undefined
@@ -1167,23 +1228,23 @@ export class Transcript implements Component, Focusable {
   private hasMore = false
   private loadingOlder = false
   private scrollOffset = 0
+  private viewportAnchor: TranscriptViewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+  private viewportState: TranscriptViewportState | undefined
   private renderedLineCount = 0
   private turnAnchors: readonly number[] = []
-  private turnCursor: number | undefined
+  private turnCursor: TranscriptCoordinate | undefined
   private pulseFrame = 0
   private pulseTimer: ReturnType<typeof setInterval> | undefined
   private lastFullLines: readonly string[] = []
+  private blockGeneration = 0
+  private searchIndex: TranscriptSearchIndex | undefined
   private search: { query: string; composing: boolean; matchIndex: number } | undefined
   private exampleCursor = 0
   private toolCursor = 0
   private toolFocus = false
   private readonly expandedTools = new Set<string>()
   private readonly collapsedTools = new Set<string>()
-  private readonly nodeCache = new Map<string, {
-    fingerprint: string
-    rows: TranscriptRow[]
-    components: Component[]
-  }>()
+  private readonly nodeCache = new Map<string, TranscriptBlock>()
   private readonly lineCache = new WeakMap<Component, { width: number; lines: readonly string[] }>()
   focused = false
 
@@ -1239,6 +1300,7 @@ export class Transcript implements Component, Focusable {
   followLatest(): void {
     this.turnCursor = undefined
     this.scrollOffset = 0
+    this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
     this.requestRender()
   }
 
@@ -1262,7 +1324,13 @@ export class Transcript implements Component, Focusable {
     this.sessionId = undefined
     this.pendingImages.clear()
     this.imageComponents.clear()
+    this.imageBlockOwners.clear()
     this.nodeCache.clear()
+    this.search = undefined
+    this.searchIndex = undefined
+    this.lastFullLines = []
+    this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+    this.viewportState = undefined
     this.emptyState = true
     this.hasMore = false
     this.loadingOlder = false
@@ -1287,13 +1355,22 @@ export class Transcript implements Component, Focusable {
       this.imageGeneration += 1
       this.pendingImages.clear()
       this.imageComponents.clear()
+      this.imageBlockOwners.clear()
       this.sessionId = sessionId
       this.expandedTools.clear()
       this.collapsedTools.clear()
       this.toolCursor = 0
       this.nodeCache.clear()
+      this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+      this.viewportState = undefined
+      this.search = undefined
+      this.searchIndex = undefined
+      this.lastFullLines = []
     }
     this.imageLoader = imageLoader
+    this.blockGeneration += 1
+    this.searchIndex = undefined
+    if (this.search !== undefined) this.lastFullLines = []
     this.hasMore = snapshot.hasMore
     this.loadingOlder = snapshot.loadingOlder
     const preferences: TranscriptPreferences = {
@@ -1309,24 +1386,38 @@ export class Transcript implements Component, Focusable {
       const node = snapshot.chat.nodes.get(key)
       return node === undefined || node.visibility !== 'visible' ? [] : [node]
     })
-    const rows: TranscriptRow[] = []
-    const components: Component[] = []
+    const blocks: TranscriptBlock[] = []
     const keep = new Set<string>()
+    let hasVisibleRows = false
     const take = (key: string, fingerprint: string, build: () => TranscriptRow[]): void => {
       keep.add(key)
       const hit = this.nodeCache.get(key)
-      if (hit !== undefined && hit.fingerprint === fingerprint) {
-        rows.push(...hit.rows)
-        components.push(...hit.components)
+      if (hit !== undefined && hit.sourceToken === fingerprint) {
+        if (hit.rows.length > 0) {
+          hasVisibleRows = true
+          blocks.push(hit)
+        }
         return
       }
       const built = build()
       const created = built.map(row => this.component(row))
-      this.nodeCache.set(key, { fingerprint, rows: built, components: created })
-      rows.push(...built)
-      components.push(...created)
+      const block: TranscriptBlock = {
+        key,
+        sourceToken: fingerprint,
+        rows: built,
+        components: created,
+        linesByWidth: new Map(),
+        metadata: transcriptBlockMetadata(built),
+        dirty: false,
+      }
+      this.nodeCache.set(key, block)
+      if (built.length > 0) {
+        hasVisibleRows = true
+        blocks.push(block)
+      }
     }
     for (const node of visibleNodes) {
+      internals.fingerprintsComputed += 1
       take(node.key, nodeFingerprint(node, preferences), () => chatNodeRows(node, preferences))
     }
     if (snapshot.partial !== null && !visibleNodes.some(node => node.kind === 'assistant-step')) {
@@ -1360,7 +1451,7 @@ export class Transcript implements Component, Focusable {
         }), () => grouped(toolBlockRows(call, preferences, 0, call.callId)))
       }
     }
-    this.emptyState = rows.length === 0
+    this.emptyState = !hasVisibleRows
     if (this.emptyState) {
       take('__empty__', JSON.stringify({
         cursor: this.exampleCursor,
@@ -1370,7 +1461,17 @@ export class Transcript implements Component, Focusable {
     for (const key of [...this.nodeCache.keys()]) {
       if (!keep.has(key)) this.nodeCache.delete(key)
     }
-    this.commit(rows, components)
+    this.commit(blocks)
+    this.imageBlockOwners.clear()
+    for (const block of blocks) {
+      for (const row of block.rows) {
+        if (row.format !== 'image') continue
+        const cacheKey = `${this.sessionId ?? 'none'}:${row.key}`
+        const owners = this.imageBlockOwners.get(cacheKey) ?? new Set<string>()
+        owners.add(block.key)
+        this.imageBlockOwners.set(cacheKey, owners)
+      }
+    }
     const keys = this.toolKeys()
     if (this.toolCursor >= keys.length) this.toolCursor = Math.max(0, keys.length - 1)
   }
@@ -1428,6 +1529,7 @@ export class Transcript implements Component, Focusable {
   refreshPresentation(): void {
     const scrollOffset = this.scrollOffset
     const turnCursor = this.turnCursor
+    const viewportAnchor = this.viewportAnchor
     const snapshot = this.snapshot
     this.nodeCache.clear()
     if (snapshot === undefined) {
@@ -1437,13 +1539,17 @@ export class Transcript implements Component, Focusable {
     }
     this.scrollOffset = scrollOffset
     this.turnCursor = turnCursor
+    this.viewportAnchor = viewportAnchor
     this.requestRender()
   }
 
   invalidate(): void {
-    for (const [index, component] of this.components.entries()) {
-      const row = this.rows[index]
-      if (row?.pulse !== undefined || row?.liveDurationSince !== undefined) component.invalidate()
+    for (const block of this.blocks) {
+      if (!block.metadata.dynamic) continue
+      for (const [index, component] of block.components.entries()) {
+        const row = block.rows[index]
+        if (row?.pulse !== undefined || row?.liveDurationSince !== undefined) component.invalidate()
+      }
     }
   }
 
@@ -1454,6 +1560,233 @@ export class Transcript implements Component, Focusable {
     this.imageLoader = undefined
     this.pendingImages.clear()
     this.imageComponents.clear()
+    this.imageBlockOwners.clear()
+    this.search = undefined
+    this.searchIndex = undefined
+    this.lastFullLines = []
+  }
+
+  private renderBlock(blockIndex: number, contentWidth: number): TranscriptBlockLines {
+    const block = this.blocks[blockIndex]
+    if (block === undefined) return { lines: [], turnAnchors: [] }
+    internals.blocksVisited += 1
+    const cacheKey = blockIndex === 0 ? -contentWidth : contentWidth
+    if (block.dirty) {
+      block.linesByWidth.clear()
+      block.dirty = false
+    }
+    const cachedBlock = block.metadata.dynamic ? undefined : block.linesByWidth.get(cacheKey)
+    if (cachedBlock !== undefined) return cachedBlock
+    const lines: string[] = []
+    const turnAnchors: number[] = []
+    for (const [index, component] of block.components.entries()) {
+      const row = block.rows[index]
+      if ((blockIndex > 0 || lines.length > 0) && row?.gapBefore === true) lines.push('')
+      if (row?.userTurn === true) turnAnchors.push(lines.length)
+      const pulsing = row?.pulse !== undefined || row?.liveDurationSince !== undefined
+      const cached = pulsing ? undefined : this.lineCache.get(component)
+      const rendered = cached !== undefined && cached.width === contentWidth
+        ? cached.lines
+        : (() => {
+          internals.componentRenders += 1
+          const output = component.render(contentWidth)
+          if (!pulsing) this.lineCache.set(component, { width: contentWidth, lines: output })
+          return output
+        })()
+      if (row?.format === 'image') {
+        lines.push(...rendered)
+      } else {
+        for (const line of rendered) {
+          internals.linesEscaped += 1
+          lines.push(escapeTerminalText(line))
+        }
+      }
+    }
+    const result = { lines, turnAnchors }
+    if (!block.metadata.dynamic) {
+      block.linesByWidth.set(cacheKey, result)
+      while (block.linesByWidth.size > 4) {
+        const oldest = block.linesByWidth.keys().next().value
+        if (oldest === undefined) break
+        block.linesByWidth.delete(oldest)
+      }
+    }
+    return result
+  }
+
+  private finiteViewportLines(
+    contentWidth: number,
+    rows: number,
+    olderMarker: (count: number) => string,
+  ): string[] {
+    if (this.blocks.length === 0) return Array.from({ length: rows }, () => '')
+    let startIndex: number
+    let startOffset: number
+    if (this.viewportAnchor.followLatest) {
+      const parts: Array<{
+        blockIndex: number
+        offset: number
+        lines: string[]
+        turnAnchors: readonly number[]
+      }> = []
+      let remaining = rows
+      startIndex = this.blocks.length - 1
+      startOffset = 0
+      for (let index = this.blocks.length - 1; index >= 0 && remaining > 0; index -= 1) {
+        const rendered = this.renderBlock(index, contentWidth)
+        if (rendered.lines.length === 0) continue
+        const offset = Math.max(0, rendered.lines.length - remaining)
+        parts.unshift({
+          blockIndex: index,
+          offset,
+          lines: [...rendered.lines.slice(offset)],
+          turnAnchors: rendered.turnAnchors,
+        })
+        startIndex = index
+        startOffset = offset
+        remaining -= rendered.lines.length - offset
+      }
+      let visible = parts.flatMap(part => part.lines)
+      const hasOlder = startIndex > 0 || startOffset > 0 || this.hasMore
+      if (hasOlder && visible.length > 0) {
+        let lineBase = 0
+        let latestTurn: { blockIndex: number; lineOffset: number; visibleOffset: number } | undefined
+        for (const part of parts) {
+          for (const anchor of part.turnAnchors) {
+            if (anchor < part.offset || anchor >= part.offset + part.lines.length) continue
+            latestTurn = {
+              blockIndex: part.blockIndex,
+              lineOffset: anchor,
+              visibleOffset: lineBase + anchor - part.offset,
+            }
+          }
+          lineBase += part.lines.length
+        }
+        if (latestTurn !== undefined && visible.length - latestTurn.visibleOffset <= rows - 1) {
+          visible = [
+            ...Array.from({ length: rows - (visible.length - latestTurn.visibleOffset) - 1 }, () => ''),
+            olderMarker(0),
+            ...visible.slice(latestTurn.visibleOffset),
+          ]
+          startIndex = latestTurn.blockIndex
+          startOffset = latestTurn.lineOffset
+        } else {
+          visible[0] = olderMarker(0)
+        }
+      }
+      const padding = Math.max(0, rows - visible.length)
+      const result = [...Array.from({ length: padding }, () => ''), ...visible]
+      const startBlock = this.blocks[startIndex]
+      const start = { blockKey: startBlock?.key ?? '', lineOffset: startOffset }
+      this.viewportAnchor = { ...start, followLatest: true }
+      this.viewportState = { contentWidth, rows, start, hasOlder, hasNewer: false }
+      this.scrollOffset = 0
+      return result
+    }
+
+    startIndex = this.blocks.findIndex(block => block.key === this.viewportAnchor.blockKey)
+    if (startIndex < 0) {
+      this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+      return this.finiteViewportLines(contentWidth, rows, olderMarker)
+    }
+    const firstLines = this.renderBlock(startIndex, contentWidth).lines
+    startOffset = Math.max(0, Math.min(this.viewportAnchor.lineOffset, Math.max(0, firstLines.length - 1)))
+    const visible: string[] = []
+    let index = startIndex
+    let offset = startOffset
+    while (index < this.blocks.length && visible.length < rows) {
+      const blockLines = this.renderBlock(index, contentWidth).lines
+      const available = blockLines.slice(offset, offset + rows - visible.length)
+      visible.push(...available)
+      if (offset + available.length < blockLines.length) {
+        offset += available.length
+        break
+      }
+      index += 1
+      offset = 0
+    }
+    const hasOlder = startIndex > 0 || startOffset > 0 || this.hasMore
+    const hasNewer = index < this.blocks.length
+    if (!hasNewer && visible.length < rows) {
+      this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+      return this.finiteViewportLines(contentWidth, rows, olderMarker)
+    }
+    if (hasOlder && visible.length > 0) {
+      visible.unshift(olderMarker(0))
+      visible.splice(rows)
+    }
+    if (hasNewer && visible.length > 0) {
+      const hint = this.focused ? 'PgDn/End' : ui('滚轮下翻', 'Scroll down')
+      visible[visible.length - 1] = color.muted(ui(
+        `↓ 有更新内容 · ${hint}`,
+        `↓ Newer content · ${hint}`,
+      ))
+    }
+    const start = { blockKey: this.blocks[startIndex]?.key ?? '', lineOffset: startOffset }
+    this.viewportAnchor = { ...start, followLatest: false }
+    this.viewportState = { contentWidth, rows, start, hasOlder, hasNewer }
+    return visible
+  }
+
+  private ensureSearchIndex(contentWidth: number): TranscriptSearchIndex {
+    const current = this.searchIndex
+    if (current !== undefined
+      && current.width === contentWidth
+      && current.generation === this.blockGeneration) return current
+    const lines: string[] = []
+    const spans: Array<{ blockKey: string; start: number; end: number }> = []
+    for (const [blockIndex, block] of this.blocks.entries()) {
+      const start = lines.length
+      lines.push(...this.renderBlock(blockIndex, contentWidth).lines)
+      spans.push({ blockKey: block.key, start, end: lines.length })
+    }
+    const index = {
+      width: contentWidth,
+      generation: this.blockGeneration,
+      lines,
+      spans,
+    }
+    this.searchIndex = index
+    this.lastFullLines = lines
+    return index
+  }
+
+  private searchViewportLines(
+    contentWidth: number,
+    totalRows: number,
+    olderMarker: (count: number) => string,
+  ): string[] {
+    const index = this.ensureSearchIndex(contentWidth)
+    const rows = Math.max(1, totalRows - 1)
+    const maxOffset = Math.max(0, index.lines.length - rows)
+    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset))
+    const end = index.lines.length - this.scrollOffset
+    const start = Math.max(0, end - rows)
+    const plan = planLineSearch(index.lines, this.search?.query ?? '')
+    if ((this.search?.matchIndex ?? 0) >= plan.matches.length && this.search !== undefined) {
+      this.search.matchIndex = 0
+    }
+    const current = plan.matches[this.search?.matchIndex ?? 0]
+    const query = this.search?.query ?? ''
+    const visible = index.lines.slice(start, end).map((line, localIndex) => {
+      const lineIndex = start + localIndex
+      if (query.trim() === '' || !plan.hit.has(lineIndex)) return line
+      return highlightQuery(line, query, matched =>
+        lineIndex === current ? `\u001B[7m${matched}\u001B[0m` : color.accent(matched))
+    })
+    if (start > 0 && visible.length > 0) visible[0] = olderMarker(start)
+    else if (this.hasMore && visible.length > 0) visible[0] = olderMarker(0)
+    if (end < index.lines.length && visible.length > 0) {
+      const hint = this.focused ? 'PgDn/End' : ui('滚轮下翻', 'Scroll down')
+      visible[visible.length - 1] = color.muted(ui(
+        `↓ ${String(index.lines.length - end)} 行更新内容 · ${hint}`,
+        `↓ ${String(index.lines.length - end)} newer line(s) · ${hint}`,
+      ))
+    }
+    return [
+      ...Array.from({ length: Math.max(0, rows - visible.length) }, () => ''),
+      ...visible,
+    ]
   }
 
   render(width: number): string[] {
@@ -1474,28 +1807,18 @@ export class Transcript implements Component, Focusable {
         ? ui(`↑ 还有更早内容 · ${hint}`, `↑ Older content available · ${hint}`)
         : ui(`↑ ${String(count)} 行更早内容 · ${hint}`, `↑ ${String(count)} older line(s) · ${hint}`))
     }
+    if (Number.isFinite(totalRows) && this.search !== undefined) {
+      return withInset(this.searchViewportLines(contentWidth, totalRows, olderMarker))
+    }
+    if (Number.isFinite(totalRows) && this.search === undefined && !this.emptyState) {
+      return withInset(this.finiteViewportLines(contentWidth, totalRows, olderMarker))
+    }
     const lines: string[] = []
     const anchors: number[] = []
-    for (const [index, component] of this.components.entries()) {
-      if (lines.length > 0 && this.rows[index]?.gapBefore === true) lines.push('')
-      if (this.rows[index]?.userTurn === true) {
-        anchors.push(lines.length)
-      }
-      const row = this.rows[index]
-      const pulsing = row?.pulse !== undefined || row?.liveDurationSince !== undefined
-      const cached = pulsing ? undefined : this.lineCache.get(component)
-      const rendered = cached !== undefined && cached.width === contentWidth
-        ? cached.lines
-        : (() => {
-          internals.componentRenders += 1
-          const lines = component.render(contentWidth)
-          if (!pulsing) this.lineCache.set(component, { width: contentWidth, lines })
-          return lines
-        })()
-      const escaped = row?.format === 'image'
-        ? rendered
-        : rendered.map(escapeTerminalText)
-      lines.push(...escaped)
+    for (const blockIndex of this.blocks.keys()) {
+      const rendered = this.renderBlock(blockIndex, contentWidth)
+      anchors.push(...rendered.turnAnchors.map(anchor => lines.length + anchor))
+      lines.push(...rendered.lines)
     }
     if (this.emptyState) {
       for (const [index, line] of lines.entries()) {
@@ -1505,7 +1828,10 @@ export class Transcript implements Component, Focusable {
       }
     }
     const previousRenderedLineCount = this.renderedLineCount
-    this.lastFullLines = [...lines]
+    if (this.search !== undefined) {
+      internals.lastFullLinesCopied += lines.length
+      this.lastFullLines = [...lines]
+    }
     if (this.scrollOffset > 0 && previousRenderedLineCount > 0) {
       this.scrollOffset = Math.max(
         0,
@@ -1609,8 +1935,7 @@ export class Transcript implements Component, Focusable {
       return
     }
     if (data === '/') {
-      this.search = { query: '', composing: true, matchIndex: 0 }
-      this.requestRender()
+      this.beginSearch()
       return
     }
     if (this.emptyState && this.snapshot !== undefined) {
@@ -1638,13 +1963,12 @@ export class Transcript implements Component, Focusable {
     }
     this.turnCursor = undefined
     const rows = Math.max(1, Math.floor(this.viewportRows()))
-    const maxOffset = Math.max(0, this.renderedLineCount - rows)
     if (matchesKey(data, Key.up)) this.scrollBy(1)
     else if (matchesKey(data, Key.down)) this.scrollBy(-1)
     else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1))
     else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1))
-    else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset)
-    else if (matchesKey(data, Key.end)) this.scrollBy(-this.scrollOffset)
+    else if (matchesKey(data, Key.home)) this.scrollToStart()
+    else if (matchesKey(data, Key.end)) this.followLatest()
   }
 
   /**
@@ -1653,9 +1977,40 @@ export class Transcript implements Component, Focusable {
    */
   cancelSearch(): boolean {
     if (this.search === undefined) return false
+    const index = this.searchIndex
+    if (index !== undefined && Number.isFinite(this.viewportRows())) {
+      const rows = Math.max(1, Math.floor(this.viewportRows()) - 1)
+      const top = Math.max(0, index.lines.length - this.scrollOffset - rows)
+      const span = index.spans.find(candidate => candidate.start <= top && top < candidate.end)
+      if (span !== undefined) {
+        this.viewportAnchor = this.scrollOffset === 0
+          ? { blockKey: '', lineOffset: 0, followLatest: true }
+          : { blockKey: span.blockKey, lineOffset: top - span.start, followLatest: false }
+      }
+    }
     this.search = undefined
+    this.searchIndex = undefined
+    this.lastFullLines = []
     this.requestRender()
     return true
+  }
+
+  private beginSearch(): void {
+    this.search = { query: '', composing: true, matchIndex: 0 }
+    const viewport = this.viewportState
+    if (viewport !== undefined) {
+      const index = this.ensureSearchIndex(viewport.contentWidth)
+      const span = index.spans.find(candidate => candidate.blockKey === viewport.start.blockKey)
+      if (span !== undefined) {
+        const rows = Math.max(1, viewport.rows - 1)
+        const top = span.start + viewport.start.lineOffset
+        this.scrollOffset = Math.max(0, Math.min(
+          Math.max(0, index.lines.length - rows),
+          index.lines.length - top - rows,
+        ))
+      }
+    }
+    this.requestRender()
   }
 
   private searchLabel(): string {
@@ -1704,14 +2059,13 @@ export class Transcript implements Component, Focusable {
       || matchesKey(data, Key.pageUp) || matchesKey(data, Key.pageDown)
       || matchesKey(data, Key.home) || matchesKey(data, Key.end)) {
       this.turnCursor = undefined
-      const rows = Math.max(1, Math.floor(this.viewportRows()))
-      const maxOffset = Math.max(0, this.renderedLineCount - rows)
-      if (matchesKey(data, Key.up)) this.scrollBy(1)
-      else if (matchesKey(data, Key.down)) this.scrollBy(-1)
-      else if (matchesKey(data, Key.pageUp)) this.scrollBy(Math.max(1, rows - 1))
-      else if (matchesKey(data, Key.pageDown)) this.scrollBy(-Math.max(1, rows - 1))
-      else if (matchesKey(data, Key.home)) this.scrollBy(maxOffset)
-      else this.scrollBy(-this.scrollOffset)
+      const rows = Math.max(1, Math.floor(this.viewportRows()) - 1)
+      if (matchesKey(data, Key.up)) this.scrollSearchBy(1, rows)
+      else if (matchesKey(data, Key.down)) this.scrollSearchBy(-1, rows)
+      else if (matchesKey(data, Key.pageUp)) this.scrollSearchBy(Math.max(1, rows - 1), rows)
+      else if (matchesKey(data, Key.pageDown)) this.scrollSearchBy(-Math.max(1, rows - 1), rows)
+      else if (matchesKey(data, Key.home)) this.scrollSearchTo('start', rows)
+      else this.scrollSearchTo('end', rows)
       return
     }
     if (this.search?.composing === false) {
@@ -1757,9 +2111,101 @@ export class Transcript implements Component, Focusable {
     if (lineIndex === undefined) return
     this.scrollOffset = scrollOffsetToReveal(
       this.lastFullLines.length,
-      this.viewportRows(),
+      Math.max(1, this.viewportRows() - 1),
       lineIndex,
     )
+  }
+
+  private scrollSearchBy(lines: number, rows: number): boolean {
+    const index = this.searchIndex
+    if (index === undefined) return false
+    const maxOffset = Math.max(0, index.lines.length - rows)
+    const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + Math.trunc(lines)))
+    if (nextOffset === this.scrollOffset) return false
+    this.scrollOffset = nextOffset
+    this.requestRender()
+    return true
+  }
+
+  private scrollSearchTo(edge: 'start' | 'end', rows: number): boolean {
+    const index = this.searchIndex
+    if (index === undefined) return false
+    const nextOffset = edge === 'start' ? Math.max(0, index.lines.length - rows) : 0
+    if (nextOffset === this.scrollOffset) return false
+    this.scrollOffset = nextOffset
+    this.requestRender()
+    return true
+  }
+
+  private moveViewportStart(
+    start: TranscriptCoordinate,
+    lines: number,
+    contentWidth: number,
+  ): { coordinate: TranscriptCoordinate; moved: number } {
+    let blockIndex = this.blocks.findIndex(block => block.key === start.blockKey)
+    if (blockIndex < 0) return { coordinate: start, moved: 0 }
+    let lineOffset = start.lineOffset
+    let remaining = Math.abs(lines)
+    let moved = 0
+    if (lines > 0) {
+      while (remaining > 0) {
+        if (lineOffset > 0) {
+          const step = Math.min(remaining, lineOffset)
+          lineOffset -= step
+          remaining -= step
+          moved += step
+          continue
+        }
+        if (blockIndex === 0) break
+        blockIndex -= 1
+        lineOffset = this.renderBlock(blockIndex, contentWidth).lines.length
+      }
+    } else {
+      while (remaining > 0) {
+        const blockLines = this.renderBlock(blockIndex, contentWidth).lines
+        const available = Math.max(0, blockLines.length - lineOffset)
+        if (remaining < available) {
+          lineOffset += remaining
+          moved += remaining
+          remaining = 0
+          continue
+        }
+        if (blockIndex >= this.blocks.length - 1) {
+          const step = Math.max(0, available - 1)
+          lineOffset += step
+          moved += step
+          break
+        }
+        remaining -= available
+        moved += available
+        blockIndex += 1
+        lineOffset = 0
+      }
+    }
+    return {
+      coordinate: {
+        blockKey: this.blocks[blockIndex]?.key ?? start.blockKey,
+        lineOffset,
+      },
+      moved,
+    }
+  }
+
+  private scrollToStart(): boolean {
+    const first = this.blocks[0]
+    if (first === undefined) return false
+    const alreadyAtStart = !this.viewportAnchor.followLatest
+      && this.viewportAnchor.blockKey === first.key
+      && this.viewportAnchor.lineOffset === 0
+    if (alreadyAtStart) {
+      if (this.hasMore && !this.loadingOlder) this.requestOlder()
+      return false
+    }
+    this.turnCursor = undefined
+    this.viewportAnchor = { blockKey: first.key, lineOffset: 0, followLatest: false }
+    this.scrollOffset = Math.max(1, this.scrollOffset)
+    this.requestRender()
+    return true
   }
 
   /**
@@ -1771,6 +2217,30 @@ export class Transcript implements Component, Focusable {
     this.turnCursor = undefined
     const delta = Math.trunc(lines)
     if (!Number.isFinite(delta) || delta === 0) return false
+    if (this.search === undefined && !this.emptyState && this.viewportState !== undefined) {
+      if (delta < 0 && this.viewportAnchor.followLatest) return false
+      const moved = this.moveViewportStart(
+        this.viewportState.start,
+        delta,
+        this.viewportState.contentWidth,
+      )
+      if (moved.moved === 0) {
+        if (delta > 0 && this.hasMore && !this.loadingOlder) this.requestOlder()
+        return false
+      }
+      const reachesLatest = delta < 0 && this.moveViewportStart(
+        moved.coordinate,
+        -this.viewportState.rows,
+        this.viewportState.contentWidth,
+      ).moved < this.viewportState.rows
+      this.viewportAnchor = reachesLatest
+        ? { blockKey: '', lineOffset: 0, followLatest: true }
+        : { ...moved.coordinate, followLatest: false }
+      this.scrollOffset = Math.max(0, this.scrollOffset + delta)
+      if (reachesLatest) this.scrollOffset = 0
+      this.requestRender()
+      return true
+    }
     const rows = Math.max(1, Math.floor(this.viewportRows()))
     const maxOffset = Math.max(0, this.renderedLineCount - rows)
     const nextOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset + delta))
@@ -1791,25 +2261,45 @@ export class Transcript implements Component, Focusable {
    * @returns whether an adjacent turn exists and was selected.
    */
   navigateTurn(offset: number): boolean {
-    if (offset === 0 || this.turnAnchors.length === 0) return false
-    const rows = Math.max(1, Math.floor(this.viewportRows()))
-    const viewportTop = Math.max(0, this.renderedLineCount - this.scrollOffset - rows)
-    const viewportEnd = Math.min(this.renderedLineCount, viewportTop + rows)
-    const index = this.turnCursor === undefined
-      ? offset < 0
-        ? this.turnAnchors.findLastIndex(candidate => candidate < viewportEnd)
-        : this.turnAnchors.findIndex(candidate => candidate > viewportTop)
-      : this.turnCursor + Math.sign(offset)
-    const anchor = this.turnAnchors[index]
+    const viewport = this.viewportState
+    if (offset === 0 || viewport === undefined) return false
+    const turns: Array<{ blockIndex: number; blockKey: string; lineOffset: number }> = []
+    for (const [blockIndex, block] of this.blocks.entries()) {
+      if (block.metadata.userTurnRows.length === 0) continue
+      const rendered = this.renderBlock(blockIndex, viewport.contentWidth)
+      for (const lineOffset of rendered.turnAnchors) {
+        turns.push({ blockIndex, blockKey: block.key, lineOffset })
+      }
+    }
+    if (turns.length === 0) return false
+    const topBlockIndex = this.blocks.findIndex(block => block.key === viewport.start.blockKey)
+    const beforeTop = (turn: (typeof turns)[number]): boolean => turn.blockIndex < topBlockIndex
+      || (turn.blockIndex === topBlockIndex && turn.lineOffset < viewport.start.lineOffset)
+    const afterTop = (turn: (typeof turns)[number]): boolean => turn.blockIndex > topBlockIndex
+      || (turn.blockIndex === topBlockIndex && turn.lineOffset > viewport.start.lineOffset)
+    const cursorIndex = this.turnCursor === undefined
+      ? -1
+      : turns.findIndex(turn => turn.blockKey === this.turnCursor?.blockKey
+        && turn.lineOffset === this.turnCursor.lineOffset)
+    const index = cursorIndex < 0
+      ? offset < 0 ? turns.findLastIndex(beforeTop) : turns.findIndex(afterTop)
+      : cursorIndex + Math.sign(offset)
+    const anchor = turns[index]
     if (anchor === undefined) return false
-    this.turnCursor = index
-    this.scrollOffset = Math.max(0, this.renderedLineCount - (anchor + rows))
+    this.turnCursor = { blockKey: anchor.blockKey, lineOffset: anchor.lineOffset }
+    const markerRoom = this.moveViewportStart(
+      { blockKey: anchor.blockKey, lineOffset: anchor.lineOffset },
+      1,
+      viewport.contentWidth,
+    ).coordinate
+    this.viewportAnchor = { ...markerRoom, followLatest: false }
+    this.scrollOffset = Math.max(1, this.scrollOffset)
     this.requestRender()
     return true
   }
 
   private toolKeys(): readonly string[] {
-    return [...new Set(this.rows.flatMap(row => row.toolKey === undefined ? [] : [row.toolKey]))]
+    return [...new Set(this.blocks.flatMap(block => block.metadata.toolKeys))]
   }
 
   private toggleToolCard(key: string): void {
@@ -1851,15 +2341,28 @@ export class Transcript implements Component, Focusable {
   }
 
   private replace(rows: readonly TranscriptRow[]): void {
-    this.commit(rows, rows.map(row => this.component(row)))
+    const components = rows.map(row => this.component(row))
+    const block: TranscriptBlock = {
+      key: '__replacement__',
+      sourceToken: '',
+      rows: [...rows],
+      components,
+      linesByWidth: new Map(),
+      metadata: transcriptBlockMetadata(rows),
+      dirty: false,
+    }
+    this.commit(rows.length === 0 ? [] : [block])
   }
 
-  private commit(rows: readonly TranscriptRow[], components: readonly Component[]): void {
-    this.rows = rows
-    this.turnCursor = undefined
-    this.components = [...components]
-    this.syncPulseAnimation(rows.some(row => row.liveDurationSince !== undefined
-      || (row.pulse !== undefined && terminalColorLevel() !== 0)))
+  private commit(blocks: readonly TranscriptBlock[]): void {
+    this.blocks = blocks
+    if (!this.viewportAnchor.followLatest
+      && !blocks.some(block => block.key === this.viewportAnchor.blockKey)) {
+      this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
+    }
+    this.syncPulseAnimation(blocks.some(block => block.rows.some(row =>
+      row.liveDurationSince !== undefined
+      || (row.pulse !== undefined && terminalColorLevel() !== 0))))
   }
 
   private component(row: TranscriptRow): Component {
@@ -1914,14 +2417,15 @@ export class Transcript implements Component, Focusable {
         this.requestRender()
         return
       }
-      this.components = this.rows.map((current, index) =>
-        current.format === 'image' && `${this.sessionId ?? 'none'}:${current.key}` === cacheKey
-          ? image
-          : this.components[index] ?? this.component(current))
-      for (const entry of this.nodeCache.values()) {
+      for (const owner of this.imageBlockOwners.get(cacheKey) ?? []) {
+        const entry = this.nodeCache.get(owner)
+        if (entry === undefined) continue
         for (const [index, current] of entry.rows.entries()) {
           if (current.format === 'image' && `${this.sessionId ?? 'none'}:${current.key}` === cacheKey) {
             entry.components[index] = image
+            entry.linesByWidth.clear()
+            entry.dirty = true
+            internals.imageBlocksUpdated += 1
           }
         }
       }
@@ -1941,11 +2445,15 @@ export class Transcript implements Component, Focusable {
       this.pulseFrame = this.pulseFrame === Number.MAX_SAFE_INTEGER ? 0 : this.pulseFrame + 1
       this.requestRender()
     }, PULSE_FRAME_MS)
+    internals.activePulseTimers += 1
     this.pulseTimer.unref()
   }
 
   private stopPulseAnimation(): void {
-    if (this.pulseTimer !== undefined) clearInterval(this.pulseTimer)
+    if (this.pulseTimer !== undefined) {
+      clearInterval(this.pulseTimer)
+      internals.activePulseTimers = Math.max(0, internals.activePulseTimers - 1)
+    }
     this.pulseTimer = undefined
     this.pulseFrame = 0
   }

--- a/src/client/tui-performance.ts
+++ b/src/client/tui-performance.ts
@@ -1,21 +1,13 @@
+import { appendFileSync } from 'node:fs'
 import { monitorEventLoopDelay, performance } from 'node:perf_hooks'
 
 const PROCESS_EVENTS = ['uncaughtException', 'unhandledRejection', 'SIGINT', 'SIGTERM', 'SIGHUP'] as const
+const LATENCY_RETAINED_CAP = 4096
 
 function percentile(values: readonly number[], fraction: number): number {
   if (values.length === 0) return 0
   const sorted = [...values].sort((left, right) => left - right)
   return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0
-}
-
-function latencySummary(values: readonly number[]): { p50: number; p95: number; p99: number; max: number } {
-  const rounded = (value: number): number => Number(value.toFixed(3))
-  return {
-    p50: rounded(percentile(values, 0.5)),
-    p95: rounded(percentile(values, 0.95)),
-    p99: rounded(percentile(values, 0.99)),
-    max: rounded(Math.max(0, ...values)),
-  }
 }
 
 function activeResources(): number {
@@ -26,6 +18,94 @@ function processListeners(): number {
   return PROCESS_EVENTS.reduce((sum, event) => sum + process.listenerCount(event), 0)
 }
 
+function mergeCounts(into: Map<string, number>, from: ReadonlyMap<string, number>): void {
+  for (const [reason, count] of from) into.set(reason, (into.get(reason) ?? 0) + count)
+}
+
+function explicitBucketPath(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function rankStandardError(retained: number): { p95: number; p99: number } {
+  return {
+    p95: Number(Math.sqrt(0.95 * 0.05 / retained).toFixed(6)),
+    p99: Number(Math.sqrt(0.99 * 0.01 / retained).toFixed(6)),
+  }
+}
+
+/** Parse `SEEKTTY_TUI_PERF_BUCKET_MS` as a positive integer milliseconds value. */
+export function parsePerfBucketIntervalMs(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const trimmed = raw.trim()
+  if (!/^[0-9]+$/u.test(trimmed)) return undefined
+  const parsed = Number.parseInt(trimmed, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export interface TuiLatencySummary {
+  readonly p50: number
+  readonly p95: number
+  readonly p99: number
+  readonly max: number
+  readonly count: number
+  readonly retained: number
+  readonly approximate: boolean
+  readonly probabilistic?: true
+  readonly rankStandardError?: { readonly p95: number; readonly p99: number }
+}
+
+class BoundedLatencySeries {
+  private readonly samples: number[] = []
+  private readonly random: () => number
+  private total = 0
+  private peak = 0
+
+  constructor(random: () => number) {
+    this.random = random
+  }
+
+  add(value: number): void {
+    if (!Number.isFinite(value) || value < 0) return
+    this.total += 1
+    if (value > this.peak) this.peak = value
+    if (this.samples.length < LATENCY_RETAINED_CAP) {
+      this.samples.push(value)
+      return
+    }
+    const index = Math.floor(this.random() * this.total)
+    if (index < LATENCY_RETAINED_CAP) this.samples[index] = value
+  }
+
+  reset(): void {
+    this.samples.length = 0
+    this.total = 0
+    this.peak = 0
+  }
+
+  summarize(): TuiLatencySummary {
+    const retained = this.samples.length
+    const approximate = this.total > LATENCY_RETAINED_CAP
+    const rounded = (value: number): number => Number(value.toFixed(3))
+    const summary: TuiLatencySummary = {
+      p50: rounded(percentile(this.samples, 0.5)),
+      p95: rounded(percentile(this.samples, 0.95)),
+      p99: rounded(percentile(this.samples, 0.99)),
+      max: rounded(this.peak),
+      count: this.total,
+      retained,
+      approximate,
+    }
+    if (!approximate || retained === 0) return summary
+    return {
+      ...summary,
+      probabilistic: true,
+      rankStandardError: rankStandardError(retained),
+    }
+  }
+}
+
 export interface TuiPerformanceSnapshot {
   readonly schema: 1
   readonly durationMs: number
@@ -34,8 +114,8 @@ export interface TuiPerformanceSnapshot {
   readonly refreshHeaderCalls: number
   readonly updateStatusCalls: number
   readonly renderRequests: Readonly<Record<string, number>>
-  readonly renderDurationMs: { p50: number; p95: number; p99: number; max: number }
-  readonly inputToWriteMs: { p50: number; p95: number; p99: number; max: number }
+  readonly renderDurationMs: TuiLatencySummary
+  readonly inputToWriteMs: TuiLatencySummary
   readonly terminalWrites: { calls: number; bytes: number; backpressureSignals: number; drains: number }
   readonly eventLoop: { p99DelayMs: number; utilization: number }
   readonly memory: NodeJS.MemoryUsage
@@ -47,6 +127,23 @@ export interface TuiPerformanceSnapshot {
     processListenersEnd: number
     subscriptions: number
   }
+}
+
+export interface TuiPerformanceBucketSnapshot extends TuiPerformanceSnapshot {
+  readonly kind: 'bucket'
+  readonly t: string
+}
+
+export interface TuiPerformanceFinalSnapshot extends TuiPerformanceSnapshot {
+  readonly kind: 'final'
+  readonly t: string
+}
+
+export interface TuiPerformanceProbeOptions {
+  readonly bucketIntervalMs?: number
+  readonly onBucket?: (snapshot: TuiPerformanceBucketSnapshot) => void
+  readonly now?: () => number
+  readonly random?: () => number
 }
 
 interface TerminalWriteTarget {
@@ -100,29 +197,67 @@ export function instrumentTerminalWrites<T extends TerminalWriteTarget>(
 /** Default-off, content-free aggregate metrics for terminal performance acceptance. */
 export class TuiPerformanceProbe {
   private readonly enabled: boolean
+  private readonly nowFn: () => number
   private readonly startedAt = performance.now()
   private readonly eventLoop = monitorEventLoopDelay({ resolution: 20 })
   private readonly eventLoopStart = performance.eventLoopUtilization()
   private readonly activeResourcesStart = activeResources()
   private readonly processListenersStart = processListeners()
-  private readonly renderRequests = new Map<string, number>()
-  private readonly renderDurations: number[] = []
-  private readonly inputToWrite: number[] = []
+  private readonly onBucket: ((snapshot: TuiPerformanceBucketSnapshot) => void) | undefined
+  private readonly bucketPath: string | undefined
+  private readonly allRenderDurations: BoundedLatencySeries
+  private readonly allInputToWrite: BoundedLatencySeries
+  private readonly windowRenderDurations: BoundedLatencySeries
+  private readonly windowInputToWrite: BoundedLatencySeries
+  private readonly bucketEventLoop: ReturnType<typeof monitorEventLoopDelay> | undefined
+  private bucketEventLoopStart = this.eventLoopStart
+  private bucketWindowStartedAt = this.startedAt
+  private bucketTimer: ReturnType<typeof setInterval> | undefined
+  private fileSinkEnabled = true
+  private readonly allRenderRequests = new Map<string, number>()
+  private windowRenderRequests = new Map<string, number>()
   private lastInputAt: number | undefined
   private inputs = 0
+  private windowInputs = 0
   private snapshotCount = 0
+  private windowSnapshots = 0
   private headerCount = 0
+  private windowHeaders = 0
   private statusCount = 0
+  private windowStatus = 0
   private writeCalls = 0
+  private windowWriteCalls = 0
   private writeBytes = 0
+  private windowWriteBytes = 0
   private backpressureSignals = 0
+  private windowBackpressure = 0
   private drains = 0
+  private windowDrains = 0
   private subscriptions = 0
   private finished = false
 
-  constructor(enabled = process.env.SEEKTTY_TUI_PERF === '1') {
+  constructor(
+    enabled = process.env.SEEKTTY_TUI_PERF === '1',
+    options: TuiPerformanceProbeOptions = {},
+  ) {
     this.enabled = enabled
+    this.nowFn = options.now ?? (() => performance.now())
+    const random = options.random ?? Math.random
+    this.allRenderDurations = new BoundedLatencySeries(random)
+    this.allInputToWrite = new BoundedLatencySeries(random)
+    this.windowRenderDurations = new BoundedLatencySeries(random)
+    this.windowInputToWrite = new BoundedLatencySeries(random)
+    this.bucketPath = explicitBucketPath(process.env.SEEKTTY_TUI_PERF_BUCKET_PATH)
+    this.onBucket = options.onBucket
     if (enabled) this.eventLoop.enable()
+    const interval = options.bucketIntervalMs
+      ?? parsePerfBucketIntervalMs(process.env.SEEKTTY_TUI_PERF_BUCKET_MS)
+    if (!enabled || interval === undefined) return
+    this.bucketEventLoop = monitorEventLoopDelay({ resolution: 20 })
+    this.bucketEventLoop.enable()
+    this.bucketEventLoopStart = performance.eventLoopUtilization()
+    this.bucketTimer = setInterval(() => { this.emitBucket() }, interval)
+    this.bucketTimer.unref()
   }
 
   get isEnabled(): boolean {
@@ -132,49 +267,68 @@ export class TuiPerformanceProbe {
   markInput(): void {
     if (!this.enabled) return
     this.inputs += 1
-    this.lastInputAt = performance.now()
+    this.windowInputs += 1
+    this.lastInputAt = this.nowFn()
   }
 
   markSnapshot(): void {
-    if (this.enabled) this.snapshotCount += 1
+    if (!this.enabled) return
+    this.snapshotCount += 1
+    this.windowSnapshots += 1
   }
 
   markHeader(): void {
-    if (this.enabled) this.headerCount += 1
+    if (!this.enabled) return
+    this.headerCount += 1
+    this.windowHeaders += 1
   }
 
   markStatus(): void {
-    if (this.enabled) this.statusCount += 1
+    if (!this.enabled) return
+    this.statusCount += 1
+    this.windowStatus += 1
   }
 
   markRenderRequest(reason: string): void {
     if (!this.enabled) return
-    this.renderRequests.set(reason, (this.renderRequests.get(reason) ?? 0) + 1)
+    this.windowRenderRequests.set(reason, (this.windowRenderRequests.get(reason) ?? 0) + 1)
   }
 
   measureRender<T>(render: () => T): T {
     if (!this.enabled) return render()
-    const started = performance.now()
+    const started = this.nowFn()
     try {
       return render()
     } finally {
-      this.renderDurations.push(performance.now() - started)
+      const duration = this.nowFn() - started
+      this.windowRenderDurations.add(duration)
+      this.allRenderDurations.add(duration)
     }
   }
 
   markWrite(data: string, backpressured: boolean): void {
     if (!this.enabled) return
+    const bytes = Buffer.byteLength(data)
     this.writeCalls += 1
-    this.writeBytes += Buffer.byteLength(data)
-    if (backpressured) this.backpressureSignals += 1
+    this.windowWriteCalls += 1
+    this.writeBytes += bytes
+    this.windowWriteBytes += bytes
+    if (backpressured) {
+      this.backpressureSignals += 1
+      this.windowBackpressure += 1
+    }
     if (this.lastInputAt !== undefined) {
-      this.inputToWrite.push(performance.now() - this.lastInputAt)
+      const delta = this.nowFn() - this.lastInputAt
+      this.windowInputToWrite.add(delta)
+      this.allInputToWrite.add(delta)
       this.lastInputAt = undefined
     }
   }
 
   markDrain(): void {
-    if (this.enabled) this.drains += 1
+    if (!this.enabled) return
+    this.drains += 1
+    this.windowDrains += 1
   }
 
   changeSubscriptions(delta: 1 | -1): void {
@@ -184,26 +338,154 @@ export class TuiPerformanceProbe {
   finish(): TuiPerformanceSnapshot | undefined {
     if (!this.enabled || this.finished) return undefined
     this.finished = true
+    this.stopBucketTimer()
     this.eventLoop.disable()
-    const utilization = performance.eventLoopUtilization(this.eventLoopStart).utilization
-    return {
-      schema: 1,
-      durationMs: Number((performance.now() - this.startedAt).toFixed(3)),
+    this.bucketEventLoop?.disable()
+    this.foldWindowIntoTotals()
+    return this.snapshot({
+      durationMs: performance.now() - this.startedAt,
       inputEvents: this.inputs,
       snapshots: this.snapshotCount,
-      refreshHeaderCalls: this.headerCount,
-      updateStatusCalls: this.statusCount,
-      renderRequests: Object.fromEntries(this.renderRequests),
-      renderDurationMs: latencySummary(this.renderDurations),
-      inputToWriteMs: latencySummary(this.inputToWrite),
+      headers: this.headerCount,
+      status: this.statusCount,
+      renderRequests: this.allRenderRequests,
+      renderDurations: this.allRenderDurations,
+      inputToWrite: this.allInputToWrite,
+      writes: this.writeCalls,
+      bytes: this.writeBytes,
+      backpressure: this.backpressureSignals,
+      drains: this.drains,
+      histogram: this.eventLoop,
+      utilizationSince: this.eventLoopStart,
+    })
+  }
+
+  reportFinal(snapshot: TuiPerformanceSnapshot): void {
+    if (!this.enabled) return
+    this.writeDiagnosticSink({
+      ...snapshot,
+      kind: 'final',
+      t: new Date().toISOString(),
+    })
+  }
+
+  private emitBucket(): void {
+    if (!this.enabled || this.finished || this.bucketEventLoop === undefined) return
+    try {
+      const snapshot: TuiPerformanceBucketSnapshot = {
+        ...this.snapshot({
+          durationMs: performance.now() - this.bucketWindowStartedAt,
+          inputEvents: this.windowInputs,
+          snapshots: this.windowSnapshots,
+          headers: this.windowHeaders,
+          status: this.windowStatus,
+          renderRequests: this.windowRenderRequests,
+          renderDurations: this.windowRenderDurations,
+          inputToWrite: this.windowInputToWrite,
+          writes: this.windowWriteCalls,
+          bytes: this.windowWriteBytes,
+          backpressure: this.windowBackpressure,
+          drains: this.windowDrains,
+          histogram: this.bucketEventLoop,
+          utilizationSince: this.bucketEventLoopStart,
+        }),
+        kind: 'bucket',
+        t: new Date().toISOString(),
+      }
+      try {
+        if (this.onBucket !== undefined) this.onBucket(snapshot)
+        else this.writeDiagnosticSink(snapshot)
+      } catch {
+        // User callbacks and sinks must not escape the timer.
+      }
+    } finally {
+      if (!this.finished) {
+        this.foldWindowIntoTotals()
+        this.resetWindow()
+      }
+    }
+  }
+
+  private writeDiagnosticSink(record: TuiPerformanceBucketSnapshot | TuiPerformanceFinalSnapshot): void {
+    if (this.bucketPath !== undefined) {
+      if (!this.fileSinkEnabled) return
+      try {
+        appendFileSync(this.bucketPath, `${JSON.stringify(record)}\n`)
+      } catch {
+        this.fileSinkEnabled = false
+      }
+      return
+    }
+    if (process.stderr.isTTY) return
+    try {
+      process.stderr.write(`SEEKTTY_TUI_PERF ${JSON.stringify(record)}\n`)
+    } catch {
+      // Diagnostics must never break callers.
+    }
+  }
+
+  private foldWindowIntoTotals(): void {
+    mergeCounts(this.allRenderRequests, this.windowRenderRequests)
+  }
+
+  private resetWindow(): void {
+    this.windowRenderRequests = new Map()
+    this.windowRenderDurations.reset()
+    this.windowInputToWrite.reset()
+    this.windowInputs = 0
+    this.windowSnapshots = 0
+    this.windowHeaders = 0
+    this.windowStatus = 0
+    this.windowWriteCalls = 0
+    this.windowWriteBytes = 0
+    this.windowBackpressure = 0
+    this.windowDrains = 0
+    this.bucketEventLoop?.reset()
+    this.bucketEventLoopStart = performance.eventLoopUtilization()
+    this.bucketWindowStartedAt = performance.now()
+  }
+
+  private stopBucketTimer(): void {
+    if (this.bucketTimer === undefined) return
+    clearInterval(this.bucketTimer)
+    this.bucketTimer = undefined
+  }
+
+  private snapshot(source: {
+    readonly durationMs?: number
+    readonly inputEvents: number
+    readonly snapshots: number
+    readonly headers: number
+    readonly status: number
+    readonly renderRequests: ReadonlyMap<string, number>
+    readonly renderDurations: BoundedLatencySeries
+    readonly inputToWrite: BoundedLatencySeries
+    readonly writes: number
+    readonly bytes: number
+    readonly backpressure: number
+    readonly drains: number
+    readonly histogram: ReturnType<typeof monitorEventLoopDelay>
+    readonly utilizationSince: ReturnType<typeof performance.eventLoopUtilization>
+  }): TuiPerformanceSnapshot {
+    const utilization = performance.eventLoopUtilization(source.utilizationSince).utilization
+    return {
+      schema: 1,
+      durationMs: Number((source.durationMs ?? 0).toFixed(3)),
+      inputEvents: source.inputEvents,
+      snapshots: source.snapshots,
+      refreshHeaderCalls: source.headers,
+      updateStatusCalls: source.status,
+      renderRequests: Object.fromEntries(source.renderRequests),
+      renderDurationMs: source.renderDurations.summarize(),
+      inputToWriteMs: source.inputToWrite.summarize(),
       terminalWrites: {
-        calls: this.writeCalls,
-        bytes: this.writeBytes,
-        backpressureSignals: this.backpressureSignals,
-        drains: this.drains,
+        calls: source.writes,
+        bytes: source.bytes,
+        backpressureSignals: source.backpressure,
+        drains: source.drains,
       },
       eventLoop: {
-        p99DelayMs: Number((this.eventLoop.percentile(99) / 1e6).toFixed(3)),
+        p99DelayMs: Number((source.histogram.percentile(99) / 1e6).toFixed(3)),
         utilization: Number(utilization.toFixed(6)),
       },
       memory: process.memoryUsage(),

--- a/src/client/tui-performance.ts
+++ b/src/client/tui-performance.ts
@@ -1,0 +1,220 @@
+import { monitorEventLoopDelay, performance } from 'node:perf_hooks'
+
+const PROCESS_EVENTS = ['uncaughtException', 'unhandledRejection', 'SIGINT', 'SIGTERM', 'SIGHUP'] as const
+
+function percentile(values: readonly number[], fraction: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((left, right) => left - right)
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0
+}
+
+function latencySummary(values: readonly number[]): { p50: number; p95: number; p99: number; max: number } {
+  const rounded = (value: number): number => Number(value.toFixed(3))
+  return {
+    p50: rounded(percentile(values, 0.5)),
+    p95: rounded(percentile(values, 0.95)),
+    p99: rounded(percentile(values, 0.99)),
+    max: rounded(Math.max(0, ...values)),
+  }
+}
+
+function activeResources(): number {
+  return typeof process.getActiveResourcesInfo === 'function' ? process.getActiveResourcesInfo().length : 0
+}
+
+function processListeners(): number {
+  return PROCESS_EVENTS.reduce((sum, event) => sum + process.listenerCount(event), 0)
+}
+
+export interface TuiPerformanceSnapshot {
+  readonly schema: 1
+  readonly durationMs: number
+  readonly inputEvents: number
+  readonly snapshots: number
+  readonly refreshHeaderCalls: number
+  readonly updateStatusCalls: number
+  readonly renderRequests: Readonly<Record<string, number>>
+  readonly renderDurationMs: { p50: number; p95: number; p99: number; max: number }
+  readonly inputToWriteMs: { p50: number; p95: number; p99: number; max: number }
+  readonly terminalWrites: { calls: number; bytes: number; backpressureSignals: number; drains: number }
+  readonly eventLoop: { p99DelayMs: number; utilization: number }
+  readonly memory: NodeJS.MemoryUsage
+  readonly resource: NodeJS.ResourceUsage
+  readonly lifecycle: {
+    activeResourcesStart: number
+    activeResourcesEnd: number
+    processListenersStart: number
+    processListenersEnd: number
+    subscriptions: number
+  }
+}
+
+interface TerminalWriteTarget {
+  write(data: string): void
+}
+
+interface BackpressureSource {
+  readonly writableNeedDrain: boolean
+  once(event: 'drain', listener: () => void): unknown
+  off(event: 'drain', listener: () => void): unknown
+}
+
+/** Keep the production terminal untouched unless performance collection is enabled. */
+export function instrumentTerminalWrites<T extends TerminalWriteTarget>(
+  rawTerminal: T,
+  probe: TuiPerformanceProbe,
+  output: BackpressureSource,
+): { readonly terminal: T; release(): void } {
+  if (!probe.isEnabled) return { terminal: rawTerminal, release: () => undefined }
+  let waitingForDrain = false
+  const onDrain = (): void => {
+    waitingForDrain = false
+    probe.markDrain()
+  }
+  const measuredWrite = (data: string): void => {
+    rawTerminal.write(data)
+    const backpressured = output.writableNeedDrain
+    probe.markWrite(data, backpressured)
+    if (backpressured && !waitingForDrain) {
+      waitingForDrain = true
+      output.once('drain', onDrain)
+    }
+  }
+  const terminal = new Proxy(rawTerminal, {
+    get(target, property) {
+      if (property === 'write') return measuredWrite
+      const value = Reflect.get(target, property, target) as unknown
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return {
+    terminal,
+    release: () => {
+      if (!waitingForDrain) return
+      output.off('drain', onDrain)
+      waitingForDrain = false
+    },
+  }
+}
+
+/** Default-off, content-free aggregate metrics for terminal performance acceptance. */
+export class TuiPerformanceProbe {
+  private readonly enabled: boolean
+  private readonly startedAt = performance.now()
+  private readonly eventLoop = monitorEventLoopDelay({ resolution: 20 })
+  private readonly eventLoopStart = performance.eventLoopUtilization()
+  private readonly activeResourcesStart = activeResources()
+  private readonly processListenersStart = processListeners()
+  private readonly renderRequests = new Map<string, number>()
+  private readonly renderDurations: number[] = []
+  private readonly inputToWrite: number[] = []
+  private lastInputAt: number | undefined
+  private inputs = 0
+  private snapshotCount = 0
+  private headerCount = 0
+  private statusCount = 0
+  private writeCalls = 0
+  private writeBytes = 0
+  private backpressureSignals = 0
+  private drains = 0
+  private subscriptions = 0
+  private finished = false
+
+  constructor(enabled = process.env.SEEKTTY_TUI_PERF === '1') {
+    this.enabled = enabled
+    if (enabled) this.eventLoop.enable()
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled
+  }
+
+  markInput(): void {
+    if (!this.enabled) return
+    this.inputs += 1
+    this.lastInputAt = performance.now()
+  }
+
+  markSnapshot(): void {
+    if (this.enabled) this.snapshotCount += 1
+  }
+
+  markHeader(): void {
+    if (this.enabled) this.headerCount += 1
+  }
+
+  markStatus(): void {
+    if (this.enabled) this.statusCount += 1
+  }
+
+  markRenderRequest(reason: string): void {
+    if (!this.enabled) return
+    this.renderRequests.set(reason, (this.renderRequests.get(reason) ?? 0) + 1)
+  }
+
+  measureRender<T>(render: () => T): T {
+    if (!this.enabled) return render()
+    const started = performance.now()
+    try {
+      return render()
+    } finally {
+      this.renderDurations.push(performance.now() - started)
+    }
+  }
+
+  markWrite(data: string, backpressured: boolean): void {
+    if (!this.enabled) return
+    this.writeCalls += 1
+    this.writeBytes += Buffer.byteLength(data)
+    if (backpressured) this.backpressureSignals += 1
+    if (this.lastInputAt !== undefined) {
+      this.inputToWrite.push(performance.now() - this.lastInputAt)
+      this.lastInputAt = undefined
+    }
+  }
+
+  markDrain(): void {
+    if (this.enabled) this.drains += 1
+  }
+
+  changeSubscriptions(delta: 1 | -1): void {
+    if (this.enabled) this.subscriptions = Math.max(0, this.subscriptions + delta)
+  }
+
+  finish(): TuiPerformanceSnapshot | undefined {
+    if (!this.enabled || this.finished) return undefined
+    this.finished = true
+    this.eventLoop.disable()
+    const utilization = performance.eventLoopUtilization(this.eventLoopStart).utilization
+    return {
+      schema: 1,
+      durationMs: Number((performance.now() - this.startedAt).toFixed(3)),
+      inputEvents: this.inputs,
+      snapshots: this.snapshotCount,
+      refreshHeaderCalls: this.headerCount,
+      updateStatusCalls: this.statusCount,
+      renderRequests: Object.fromEntries(this.renderRequests),
+      renderDurationMs: latencySummary(this.renderDurations),
+      inputToWriteMs: latencySummary(this.inputToWrite),
+      terminalWrites: {
+        calls: this.writeCalls,
+        bytes: this.writeBytes,
+        backpressureSignals: this.backpressureSignals,
+        drains: this.drains,
+      },
+      eventLoop: {
+        p99DelayMs: Number((this.eventLoop.percentile(99) / 1e6).toFixed(3)),
+        utilization: Number(utilization.toFixed(6)),
+      },
+      memory: process.memoryUsage(),
+      resource: process.resourceUsage(),
+      lifecycle: {
+        activeResourcesStart: this.activeResourcesStart,
+        activeResourcesEnd: activeResources(),
+        processListenersStart: this.processListenersStart,
+        processListenersEnd: processListeners(),
+        subscriptions: this.subscriptions,
+      },
+    }
+  }
+}

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -6,7 +6,7 @@ export interface DshCompatibility {
 }
 
 export const PACKAGE_NAME = 'seektty'
-export const PACKAGE_VERSION = '1.2.1'
+export const PACKAGE_VERSION = '1.2.2'
 export const DSH_COMPATIBILITY: DshCompatibility = {
   minimum: '0.1.0-rc.6',
   tested: '0.1.1-rc.2',

--- a/src/process-guards.ts
+++ b/src/process-guards.ts
@@ -9,6 +9,11 @@ export interface RestorableStdin {
 
 export interface RestorableTerminal {
   showCursor(): void
+  restoreRawModeSync?(): void
+}
+
+export interface RestorableTerminalSession {
+  restore(): void
 }
 
 /**
@@ -20,9 +25,28 @@ export function restoreTerminalSync(
   write: (chunk: string) => void = chunk => { process.stdout.write(chunk) },
   terminal?: RestorableTerminal,
 ): void {
-  try { stdin.setRawMode?.(false) } catch { /* cooked restore is best-effort */ }
+  let restoredOriginalRawMode = false
+  try {
+    if (terminal?.restoreRawModeSync !== undefined) {
+      terminal.restoreRawModeSync()
+      restoredOriginalRawMode = true
+    }
+  } catch { /* fall back to cooked mode below */ }
+  if (!restoredOriginalRawMode) {
+    try { stdin.setRawMode?.(false) } catch { /* cooked restore is best-effort */ }
+  }
   try { terminal?.showCursor() } catch { /* prefer the explicit cursor write below */ }
   try { write(SHOW_CURSOR) } catch { /* cursor restore is best-effort */ }
+}
+
+/** Restore managed private modes before raw/cursor state on every Surface exit path. */
+export function restoreSurfaceTerminalSync(
+  session: RestorableTerminalSession,
+  stdin: RestorableStdin = process.stdin,
+  write: (chunk: string) => void = chunk => { process.stdout.write(chunk) },
+  terminal?: RestorableTerminal,
+): void {
+  try { session.restore() } finally { restoreTerminalSync(stdin, write, terminal) }
 }
 
 /**

--- a/tests/chrome.test.ts
+++ b/tests/chrome.test.ts
@@ -82,7 +82,7 @@ describe('composer chrome', () => {
     ])
   })
 
-  it('keeps all long output and leaves the composer at the end', () => {
+  it('bounds long output to the viewport while keeping context and composer chrome', () => {
     let viewportRows = 8
     const layout = new BottomAnchoredLayout(
       () => viewportRows,
@@ -93,7 +93,10 @@ describe('composer chrome', () => {
     )
 
     const long = layout.render(80)
-    expect(long).toHaveLength(11)
+    expect(long).toHaveLength(8)
+    expect(long[0]).toBe('context')
+    expect(long).toContain('four')
+    expect(long).not.toContain('one')
     expect(long.slice(-4)).toEqual(['editor top', 'editor body', 'editor bottom', 'status'])
 
     viewportRows = 14

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -32,6 +32,8 @@ describe('in-app help keymap', () => {
     expect(flows.toLowerCase()).toMatch(/session/)
     expect(flows.toLowerCase()).toMatch(/approv/)
     expect(flows.toLowerCase()).toMatch(/brows/)
+    expect(flows).toContain('Terminal.app')
+    expect(flows).toContain('Option')
 
     const description = helpSectionChoices().find(choice => choice.id === 'flows')?.description ?? ''
     expect(description.toLowerCase()).not.toMatch(/export|shortcut/)

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -66,6 +66,7 @@ describe('launcher arguments', () => {
   })
 
   it('rejects an empty Profile name', () => {
+    stubChineseLocale()
     expect(() => launcherArgs(['--profile'])).toThrow('--profile 需要一个 Profile 名称')
     expect(() => launcherArgs(['--profile='])).toThrow('--profile 需要一个 Profile 名称')
   })

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -37,9 +37,9 @@ describe('out-of-tree Bundle contract', () => {
     }
   })
 
-  it('pins SeekTTY 1.2.1 to tested 0.1.1-rc.2 with a legacy union plus exact Host peer', () => {
-    expect(manifest.version).toBe('1.2.1')
-    expect(PACKAGE_VERSION).toBe('1.2.1')
+  it('pins SeekTTY 1.2.2 to tested 0.1.1-rc.2 with a legacy union plus exact Host peer', () => {
+    expect(manifest.version).toBe('1.2.2')
+    expect(PACKAGE_VERSION).toBe('1.2.2')
     expect(DSH_COMPATIBILITY).toEqual({ minimum: '0.1.0-rc.6', tested: '0.1.1-rc.2' })
     expect(AUTO_PERMITTED_DSH_MINIMUM).toBe(DSH_COMPATIBILITY.minimum)
     expect(AUTO_PERMITTED_DSH_EXACT).toBe(DSH_COMPATIBILITY.tested)
@@ -171,14 +171,14 @@ describe('out-of-tree Bundle contract', () => {
     expect(workflow).toContain("require('./package.json').dsh.compatibility.tested")
   })
 
-  it('states current 1.2.1 / rc.2 pins without inventing an unreleased download URL', () => {
+  it('states current 1.2.2 / rc.2 pins and links to available release assets', () => {
     for (const name of ['README.md', 'README.zh.md']) {
       const text = readFileSync(resolve(root, name), 'utf8')
-      expect(text).toContain('Version-1.2.1')
+      expect(text).toContain('Version-1.2.2')
       expect(text).toContain('DeepSeek%20Harness-0.1.1--rc.2')
       expect(text).toContain('https://github.com/Hilbert-beinghappy/seektty/releases')
-      expect(text).not.toContain('/releases/tag/v1.2.1')
-      expect(text).not.toContain('/releases/download/v1.2.1/')
+      expect(text).not.toContain('/releases/tag/v1.2.2')
+      expect(text).not.toContain('/releases/download/v1.2.2/')
       expect(text).toContain('/releases/download/v1.2.0/seektty-1.2.0.tgz')
       expect(text).toMatch(/Vision-Exp/)
       expect(text).toMatch(/self-first|SeekTTY 自更新优先|每轮只安装一个/u)
@@ -187,7 +187,7 @@ describe('out-of-tree Bundle contract', () => {
     const chinese = readFileSync(resolve(root, 'README.zh.md'), 'utf8')
     expect(english).toContain('The current tested Host is official `0.1.1-rc.2`')
     expect(chinese).toContain('当前已测 Host 是官方 `0.1.1-rc.2`')
-    expect(english).toContain('SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`')
-    expect(chinese).toContain('SeekTTY `1.2.1` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`')
+    expect(english).toContain('SeekTTY `1.2.2` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`')
+    expect(chinese).toContain('SeekTTY `1.2.2` + Auxiliary Runtime `0.1.1` + Clarify `0.2.2`')
   })
 })

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -111,11 +111,14 @@ describe('out-of-tree Bundle contract', () => {
     expect(management).not.toContain('@deepseek-ai/dsh-tui-app')
   })
 
-  it('leaves text selection, copying, and scrollback under terminal control', () => {
+  it('keeps transcript scrolling inside a managed fixed terminal viewport', () => {
     const surface = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
-    expect(surface).not.toContain("from './mouse.ts'")
-    expect(surface).not.toMatch(/\\u001B\[\?100[0-6]h/u)
-    expect(surface).toContain('Number.POSITIVE_INFINITY')
+    const session = readFileSync(resolve(root, 'src/client/terminal-session.ts'), 'utf8')
+    expect(surface).toContain('createTerminalSession')
+    expect(surface).toContain('terminalMouseDelta')
+    expect(surface).not.toContain('Number.POSITIVE_INFINITY')
+    expect(session).toContain('\\u001B[?1049h')
+    expect(session).toContain('\\u001B[?1000h\\u001B[?1006h')
   })
 
   it('gates pull requests on pnpm run check and a rebuilt lib/ tree', () => {

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -157,7 +157,7 @@ describe('out-of-tree Bundle contract', () => {
     expect(candidate.bundle).toBe(true)
     expect(candidate.patchValid).toBe(true)
     expect(candidate.diagnostics).toEqual([
-      '安装包声明脚本：build、typecheck、test、test:stock、test:clarify-doctor、pack:check、check',
+      '安装包声明脚本：build、typecheck、test、perf:tui、test:stock、test:clarify-doctor、pack:check、check',
     ])
   })
 

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -7,6 +7,7 @@ import {
   FATAL_SIGHUP_EXIT_CODE,
   FATAL_SIGTERM_EXIT_CODE,
   fatalLogHint,
+  restoreSurfaceTerminalSync,
   restoreTerminalSync,
   withCleanupTimeout,
 } from '../src/process-guards.ts'
@@ -23,6 +24,33 @@ describe('fatal terminal restore (review #14)', () => {
     expect(order).toContain('cursor')
   })
 
+  it('restores managed modes before the original raw state', () => {
+    const order: string[] = []
+    const session = { restore: () => { order.push('mouse,paste,keyboard,cursor,alt') } }
+    const stdin = { setRawMode: (mode: boolean) => { order.push(`fallback-raw:${String(mode)}`) } }
+    const terminal = {
+      restoreRawModeSync: () => { order.push('original-raw') },
+      showCursor: () => { order.push('cursor-fallback') },
+    }
+
+    restoreSurfaceTerminalSync(session, stdin, chunk => { order.push(`write:${chunk}`) }, terminal)
+
+    expect(order[0]).toBe('mouse,paste,keyboard,cursor,alt')
+    expect(order[1]).toBe('original-raw')
+    expect(order).not.toContain('fallback-raw:false')
+  })
+
+  it('still restores raw and cursor state when managed-mode restoration throws', () => {
+    const order: string[] = []
+    expect(() => restoreSurfaceTerminalSync(
+      { restore: () => { throw new Error('mode restore failed') } },
+      { setRawMode: mode => { order.push(`raw:${String(mode)}`) } },
+      chunk => { order.push(`write:${chunk}`) },
+      { showCursor: () => { order.push('cursor') } },
+    )).toThrow('mode restore failed')
+    expect(order).toEqual(['raw:false', 'cursor', 'write:\u001B[?25h'])
+  })
+
   it('bounds hanging async cleanup so restore is never waited on', async () => {
     const finished = await withCleanupTimeout(async () => {
       await new Promise(() => undefined)
@@ -33,7 +61,7 @@ describe('fatal terminal restore (review #14)', () => {
 
   it('restores the terminal in surface close before drainInput', () => {
     const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
-    const restoreAt = source.indexOf('restoreTerminalSync')
+    const restoreAt = source.indexOf('restoreSurfaceTerminalSync(terminalSession')
     const drainAt = source.indexOf('drainInput')
     expect(restoreAt).toBeGreaterThan(-1)
     expect(drainAt).toBeGreaterThan(restoreAt)

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   attachFatalGuards,
@@ -11,8 +9,6 @@ import {
   restoreTerminalSync,
   withCleanupTimeout,
 } from '../src/process-guards.ts'
-
-const root = resolve(import.meta.dirname, '..')
 
 describe('fatal terminal restore (review #14)', () => {
   it('restores cooked mode and the cursor synchronously before any cleanup', () => {
@@ -59,19 +55,6 @@ describe('fatal terminal restore (review #14)', () => {
     expect(finished).toBeUndefined()
   })
 
-  it('restores the terminal in surface close before drainInput', () => {
-    const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
-    const restoreAt = source.indexOf('restoreSurfaceTerminalSync(terminalSession')
-    const drainAt = source.indexOf('drainInput')
-    expect(restoreAt).toBeGreaterThan(-1)
-    expect(drainAt).toBeGreaterThan(restoreAt)
-  })
-
-  it('wires the shared fatal guards around the TUI lifetime', () => {
-    const source = readFileSync(resolve(root, 'src/client/surface.ts'), 'utf8')
-    expect(source).toContain('attachFatalGuards')
-    expect(source).toContain('detachFatalGuards')
-  })
 })
 
 describe('fatal process guards (review #14)', () => {

--- a/tests/terminal-session.test.ts
+++ b/tests/terminal-session.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ProcessTerminal, type Terminal } from '@mariozechner/pi-tui'
+import {
+  createTerminalSession,
+  supportsManagedTerminal,
+  terminalMouseDelta,
+  type ManagedTerminal,
+} from '../src/client/terminal-session.ts'
+
+class RecordingTerminal implements Terminal, ManagedTerminal {
+  writes: string[] = []
+  columns = 80
+  rows = 24
+  kittyProtocolActive = false
+  __seekttyManagedAlternateScreen?: boolean
+  restoreProtocolsSync(): void {
+    this.writes.push('\u001B[?2004l\u001B[<u\u001B[>4;0m')
+  }
+  restoreRawModeSync(): void {}
+  start(): void {}
+  stop(): void {}
+  drainInput(): Promise<void> { return Promise.resolve() }
+  write(data: string): void { this.writes.push(data) }
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+describe('managed terminal session', () => {
+  it('rejects non-interactive and TERM=dumb surfaces before private modes', () => {
+    expect(supportsManagedTerminal(false, 'xterm-256color')).toBe(false)
+    expect(supportsManagedTerminal(true, ' dumb ')).toBe(false)
+    expect(supportsManagedTerminal(true, 'xterm-256color')).toBe(true)
+    expect(supportsManagedTerminal(true, undefined)).toBe(true)
+  })
+
+  it('enters alternate screen and SGR wheel mode once, then restores once', () => {
+    const terminal = new RecordingTerminal()
+    const order: string[] = []
+    const session = createTerminalSession(terminal, true, () => { order.push('quiesce') })
+
+    session.enter()
+    session.enter()
+    expect(terminal.writes.join('')).toBe(
+      '\u001B[?1049h\u001B[H'
+      + '\u001B[?1002l\u001B[?1003l\u001B[?1007l'
+      + '\u001B[?1000h\u001B[?1006h',
+    )
+    expect(terminal.__seekttyManagedAlternateScreen).toBe(true)
+
+    terminal.writes = []
+    session.restore()
+    session.restore()
+    expect(order).toEqual(['quiesce'])
+    expect(terminal.writes.join('')).toBe(
+      '\u001B[?1000l\u001B[?1002l\u001B[?1003l\u001B[?1006l\u001B[?1007l'
+      + '\u001B[?2004l\u001B[<u\u001B[>4;0m'
+      + '\u001B[?25h\u001B[?1049l',
+    )
+  })
+
+  it('leaves alternate screen even when protocol restoration fails', () => {
+    const terminal = new RecordingTerminal()
+    terminal.restoreProtocolsSync = () => { throw new Error('protocol restore failed') }
+    const session = createTerminalSession(terminal, true)
+    session.enter()
+    terminal.writes = []
+
+    expect(() => { session.restore() }).toThrow('protocol restore failed')
+    expect(terminal.writes.join('')).toContain('\u001B[?25h\u001B[?1049l')
+
+    terminal.writes = []
+    session.restore()
+    expect(terminal.writes).toEqual([])
+  })
+
+  it('does nothing when private terminal modes are disabled', () => {
+    const terminal = new RecordingTerminal()
+    const session = createTerminalSession(terminal, false)
+    session.enter()
+    session.restore()
+    expect(terminal.writes).toEqual([])
+    expect(terminal.__seekttyManagedAlternateScreen).toBeUndefined()
+  })
+
+  it('restores pi-tui protocols synchronously and clears keyboard flags', () => {
+    const writes: string[] = []
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      writes.push(String(chunk))
+      return true
+    })
+    try {
+      const terminal = new ProcessTerminal() as unknown as {
+        _protocolsRestored: boolean
+        _kittyProtocolActive: boolean
+        _modifyOtherKeysActive: boolean
+        inputHandler: (() => void) | undefined
+        restoreProtocolsSync(): void
+      }
+      terminal.inputHandler = () => undefined
+      terminal._kittyProtocolActive = true
+      terminal._modifyOtherKeysActive = true
+
+      terminal.restoreProtocolsSync()
+      terminal.restoreProtocolsSync()
+
+      expect(writes.join('')).toBe(
+        '\u001B[?2004l\u001B[<u\u001B[>4;0m\u001B[?2004l',
+      )
+      expect(terminal._kittyProtocolActive).toBe(false)
+      expect(terminal._modifyOtherKeysActive).toBe(false)
+      expect(terminal._protocolsRestored).toBe(true)
+      expect(terminal.inputHandler).toBeUndefined()
+    } finally {
+      write.mockRestore()
+    }
+  })
+
+  it('blocks late Kitty replies and modifyOtherKeys fallback after restore', () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      writes.push(String(chunk))
+      return true
+    })
+    try {
+      const terminal = new ProcessTerminal() as unknown as {
+        inputHandler: (() => void) | undefined
+        stdinBuffer?: { listeners(event: string): ((sequence: string) => void)[] }
+        queryAndEnableKittyProtocol(): void
+        restoreProtocolsSync(): void
+      }
+      terminal.inputHandler = () => undefined
+      terminal.queryAndEnableKittyProtocol()
+      const lateKittyReply = terminal.stdinBuffer?.listeners('data')[0]
+      expect(lateKittyReply).toBeDefined()
+
+      terminal.restoreProtocolsSync()
+      const restoredAt = writes.length
+      lateKittyReply?.('\u001B[?1u')
+      vi.advanceTimersByTime(200)
+
+      expect(writes.slice(restoredAt).join('')).not.toContain('\u001B[>7u')
+      expect(writes.slice(restoredAt).join('')).not.toContain('\u001B[>4;2m')
+    } finally {
+      write.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('SGR mouse input', () => {
+  it('maps vertical wheel detents and consumes every other mouse report', () => {
+    expect(terminalMouseDelta('\u001B[<64;4;8M')).toBe(3)
+    expect(terminalMouseDelta('\u001B[<65;4;8M')).toBe(-3)
+    expect(terminalMouseDelta('\u001B[<68;4;8M')).toBe(3) // Shift+wheel up.
+    expect(terminalMouseDelta('\u001B[<66;4;8M')).toBeNull()
+    expect(terminalMouseDelta('\u001B[<0;4;8M')).toBeNull()
+    expect(terminalMouseDelta('\u001B[<0;4;8m')).toBeNull()
+  })
+
+  it('consumes incomplete mouse prefixes without stealing ordinary CSI keys', () => {
+    expect(terminalMouseDelta('\u001B[<64;4')).toBeNull()
+    expect(terminalMouseDelta('\u001B[M')).toBeNull()
+    expect(terminalMouseDelta('\u001B[A')).toBeUndefined()
+    expect(terminalMouseDelta('plain')).toBeUndefined()
+  })
+})

--- a/tests/transcript-viewport.test.ts
+++ b/tests/transcript-viewport.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@deepseek-ai/dsh-client-runtime/node-client'
 import { internals, Transcript } from '../src/client/transcript.ts'
 import type { TranscriptImagePayload } from '../src/client/transcript.ts'
+import { terminalMouseDelta } from '../src/client/terminal-session.ts'
 
 function assistant(key: string, text: string): ChatConversationViewNode {
   return {
@@ -321,6 +322,47 @@ describe('transcript block viewport', () => {
     expect(plain(transcript.render(80))).toContain('search-scroll-1')
     transcript.handleInput('\u001B[F')
     expect(plain(transcript.render(80))).toContain('search-scroll-29')
+    transcript.dispose()
+  })
+
+  it('keeps a searched Home viewport after one SGR wheel instead of jumping to the tail', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(Array.from({ length: 40 }, (_, index) =>
+      assistant(`k-${String(index)}`, `token-${String(index)}`))))
+    transcript.render(80)
+    transcript.handleInput('/')
+    transcript.render(80)
+    transcript.handleInput('\u001B[H')
+    const afterHome = plain(transcript.render(80))
+    expect(afterHome).toContain('token-0')
+    expect(afterHome).not.toContain('token-39')
+
+    const downDelta = terminalMouseDelta('\u001B[<65;10;5M')
+    const upDelta = terminalMouseDelta('\u001B[<64;10;5M')
+    expect(downDelta).toBe(-3)
+    expect(upDelta).toBe(3)
+    expect(transcript.scrollBy(downDelta!)).toBe(true)
+    const afterWheel = plain(transcript.render(80))
+    expect(afterWheel).not.toContain('token-39')
+    expect(afterWheel).toContain('token-2')
+    expect(afterWheel).toMatch(/↑ 3 行更早内容/u)
+
+    const keyboard = new Transcript(() => 8)
+    keyboard.update(snapshot(Array.from({ length: 40 }, (_, index) =>
+      assistant(`k-${String(index)}`, `token-${String(index)}`))))
+    keyboard.render(80)
+    keyboard.handleInput('/')
+    keyboard.render(80)
+    keyboard.handleInput('\u001B[H')
+    expect(plain(keyboard.render(80))).toContain('token-0')
+    keyboard.handleInput('\u001B[B')
+    const afterKey = plain(keyboard.render(80))
+    expect(afterKey).toContain('token-1')
+    expect(afterKey).not.toContain('token-39')
+    keyboard.handleInput('\u001B[F')
+    expect(plain(keyboard.render(80))).toContain('token-39')
+    keyboard.dispose()
     transcript.dispose()
   })
 

--- a/tests/transcript-viewport.test.ts
+++ b/tests/transcript-viewport.test.ts
@@ -1,0 +1,524 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ChatConversationViewNode,
+  ConversationSnapshot,
+} from '@deepseek-ai/dsh-client-runtime/node-client'
+import { internals, Transcript } from '../src/client/transcript.ts'
+import type { TranscriptImagePayload } from '../src/client/transcript.ts'
+
+function assistant(key: string, text: string): ChatConversationViewNode {
+  return {
+    key,
+    kind: 'fixture',
+    id: key,
+    target: 'chat',
+    anchorSeq: 1,
+    location: { kind: 'session' },
+    visibility: 'visible',
+    data: {
+      kind: 'assistant',
+      seq: 2,
+      time: 2,
+      turn: 1,
+      step: 1,
+      blocks: [{ kind: 'text', text }],
+    },
+  }
+}
+
+function user(key: string, text: string): ChatConversationViewNode {
+  return {
+    ...assistant(key, text),
+    data: {
+      kind: 'user',
+      seq: 1,
+      time: 1,
+      source: null,
+      content: [{ type: 'text', text }],
+    },
+  }
+}
+
+const imageAttachment = {
+  attachmentId: 'image-1',
+  mediaType: 'image/png',
+  bytes: 68,
+  width: 1,
+  height: 1,
+  name: 'pixel.png',
+} as const
+
+function imageNode(key: string): ChatConversationViewNode {
+  return {
+    ...assistant(key, ''),
+    data: {
+      kind: 'assistant',
+      seq: 2,
+      time: 2,
+      turn: 1,
+      step: 1,
+      blocks: [{ kind: 'image', attachment: imageAttachment }],
+    },
+  } as ChatConversationViewNode
+}
+
+function snapshot(
+  nodes: readonly ChatConversationViewNode[],
+  runningCalls: ConversationSnapshot['runningCalls'] = [],
+  options: {
+    readonly hasMore?: boolean
+    readonly loadingOlder?: boolean
+    readonly sessionId?: string
+  } = {},
+): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  return {
+    sessionId: options.sessionId ?? 'viewport-fixture',
+    views: { get: () => undefined },
+    chat: {
+      order: nodes.map(node => node.key),
+      nodes: { get: (key: string) => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls,
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: options.hasMore ?? false,
+    loadingOlder: options.loadingOlder ?? false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+function resetRenderCounters(): void {
+  internals.blocksVisited = 0
+  internals.linesEscaped = 0
+  internals.lastFullLinesCopied = 0
+}
+
+function plain(lines: readonly string[]): string {
+  return lines.join('\n').replace(/\u001B\[[0-9;:]*m/gu, '')
+}
+
+afterEach(() => {
+  resetRenderCounters()
+  internals.fingerprintsComputed = 0
+  internals.markdownCreated = 0
+  internals.componentRenders = 0
+  internals.imageBlocksUpdated = 0
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+})
+
+describe('transcript block viewport', () => {
+  it('bounds editor-only render work by the viewport instead of history size', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(Array.from({ length: 1_000 }, (_, index) =>
+      assistant(`node-${String(index)}`, `line-${String(index)}`))))
+    transcript.render(80)
+    resetRenderCounters()
+
+    const rendered = transcript.render(80)
+
+    expect(rendered).toHaveLength(8)
+    expect(internals.blocksVisited).toBeLessThanOrEqual(10)
+    expect(internals.linesEscaped).toBeLessThanOrEqual(10)
+    expect(internals.lastFullLinesCopied).toBe(0)
+  })
+
+  it('keeps the same historical block anchored when older nodes are prepended', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 5)
+    const history = Array.from({ length: 12 }, (_, index) =>
+      assistant(`node-${String(index)}`, `token-${String(index)}-a\ntoken-${String(index)}-b`))
+    transcript.update(snapshot(history))
+    transcript.render(60)
+    expect(transcript.scrollBy(9)).toBe(true)
+    const before = plain(transcript.render(60))
+    expect(before).toContain('token-7-a')
+
+    transcript.update(snapshot([
+      assistant('older-0', 'prepended-0-a\nprepended-0-b'),
+      assistant('older-1', 'prepended-1-a\nprepended-1-b'),
+      ...history,
+    ]))
+    const after = plain(transcript.render(60))
+
+    expect(after).toContain('token-7-a')
+    expect(after).not.toContain('prepended-')
+  })
+
+  it('resumes following tail growth after scrolling back to the latest page', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 5)
+    const history = Array.from({ length: 12 }, (_, index) =>
+      assistant(`follow-${String(index)}`, `follow-${String(index)}`))
+    transcript.update(snapshot(history))
+    transcript.render(60)
+
+    expect(transcript.scrollBy(4)).toBe(true)
+    transcript.render(60)
+    expect(transcript.scrollBy(-4)).toBe(true)
+    expect(plain(transcript.render(60))).toContain('follow-11')
+
+    transcript.update(snapshot([...history, assistant('follow-12', 'new-tail-token')]))
+    expect(plain(transcript.render(60))).toContain('new-tail-token')
+    transcript.dispose()
+  })
+
+  it('moves one logical line per wheel step across the latest marker', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 5)
+    transcript.update(snapshot([
+      assistant('wheel-lines', Array.from({ length: 10 }, (_, index) => `wheel-line-${String(index)}`).join('\n')),
+    ]))
+    const latest = plain(transcript.render(60))
+    expect(latest).toContain('wheel-line-9')
+    expect(latest).not.toContain('wheel-line-5')
+
+    expect(transcript.scrollBy(1)).toBe(true)
+    const oneStepOlder = plain(transcript.render(60))
+    expect(oneStepOlder).toContain('wheel-line-4')
+    expect(oneStepOlder).not.toContain('wheel-line-3')
+
+    expect(transcript.scrollBy(-1)).toBe(true)
+    expect(plain(transcript.render(60))).toContain('wheel-line-9')
+    transcript.dispose()
+  })
+
+  it('requests older history when Home is pressed again at the loaded boundary', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const requestOlder = vi.fn()
+    const transcript = new Transcript(() => 5, () => undefined, requestOlder)
+    transcript.update(snapshot(
+      Array.from({ length: 12 }, (_, index) => assistant(`home-${String(index)}`, `home-${String(index)}`)),
+      [],
+      { hasMore: true },
+    ))
+    transcript.render(60)
+
+    transcript.handleInput('\u001B[H')
+    const atStart = plain(transcript.render(60))
+    expect(atStart).toContain('home-0')
+    expect(atStart).not.toContain(String(Number.MAX_SAFE_INTEGER))
+    transcript.handleInput('\u001B[H')
+
+    expect(requestOlder).toHaveBeenCalledTimes(1)
+    transcript.dispose()
+  })
+
+  it('renders the latest tail without visiting old blocks', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    transcript.update(snapshot(Array.from({ length: 1_000 }, (_, index) =>
+      assistant(`node-${String(index)}`, `tail-${String(index)}`))))
+    resetRenderCounters()
+
+    const rendered = plain(transcript.render(80))
+
+    expect(rendered).toContain('tail-999')
+    expect(internals.blocksVisited).toBeLessThanOrEqual(8)
+  })
+
+  it.each([1_000, 10_000, 50_000, 100_000])(
+    'keeps first tail render viewport-bound for %d logical lines',
+    (lineCount) => {
+      vi.stubEnv('NO_COLOR', '1')
+      const nodeCount = lineCount / 100
+      const transcript = new Transcript(() => 12)
+      transcript.update(snapshot(Array.from({ length: nodeCount }, (_, index) =>
+        assistant(
+          `bulk-${String(index)}`,
+          Array.from({ length: 100 }, (_, line) => `bulk-${String(index)}-${String(line)}`).join('\n'),
+        ))))
+      resetRenderCounters()
+
+      const rendered = transcript.render(80)
+
+      expect(rendered).toHaveLength(12)
+      expect(rendered.join('\n')).toContain(`bulk-${String(nodeCount - 1)}-99`)
+      expect(internals.blocksVisited).toBeLessThanOrEqual(2)
+      expect(internals.linesEscaped).toBeLessThanOrEqual(102)
+      expect(internals.lastFullLinesCopied).toBe(0)
+      transcript.dispose()
+    },
+  )
+
+  it('rebuilds one changed middle block and searches its new text correctly', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const nodes = Array.from({ length: 40 }, (_, index) =>
+      assistant(`middle-${String(index)}`, `original-${String(index)}`))
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(nodes))
+    const created = internals.markdownCreated
+    transcript.update(snapshot([
+      ...nodes.slice(0, 20),
+      assistant('middle-20', 'updated-middle-token'),
+      ...nodes.slice(21),
+    ]))
+
+    expect(internals.markdownCreated - created).toBe(1)
+    transcript.handleInput('/')
+    transcript.handleInput('updated-middle-token')
+    transcript.handleInput('\r')
+    expect(plain(transcript.render(80))).toContain('updated-middle-token')
+    transcript.cancelSearch()
+    transcript.dispose()
+  })
+
+  it('builds the full rendered search index only while search is active', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(Array.from({ length: 200 }, (_, index) =>
+      assistant(`search-${String(index)}`, `searchable-${String(index)}`))))
+    transcript.render(80)
+    resetRenderCounters()
+
+    transcript.handleInput('/')
+    expect(internals.blocksVisited).toBeGreaterThanOrEqual(200)
+    resetRenderCounters()
+    transcript.render(80)
+    expect(internals.blocksVisited).toBe(0)
+    transcript.cancelSearch()
+    resetRenderCounters()
+    transcript.render(80)
+    expect(internals.blocksVisited).toBeLessThanOrEqual(10)
+    transcript.dispose()
+  })
+
+  it('scrolls search with its rendered index and honors Home and End', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    transcript.update(snapshot(Array.from({ length: 30 }, (_, index) =>
+      assistant(`search-scroll-${String(index)}`, `search-scroll-${String(index)}`))))
+    transcript.render(80)
+    transcript.handleInput('/')
+    transcript.render(80)
+
+    transcript.handleInput('\u001B[H')
+    expect(plain(transcript.render(80))).toContain('search-scroll-0')
+    transcript.handleInput('\u001B[B')
+    expect(plain(transcript.render(80))).toContain('search-scroll-1')
+    transcript.handleInput('\u001B[F')
+    expect(plain(transcript.render(80))).toContain('search-scroll-29')
+    transcript.dispose()
+  })
+
+  it('keeps resize work local to the latest viewport blocks', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 10)
+    transcript.update(snapshot(Array.from({ length: 500 }, (_, index) =>
+      assistant(`resize-${String(index)}`, `resize-${String(index)} ${'x'.repeat(100)}`))))
+    transcript.render(80)
+    resetRenderCounters()
+
+    const resized = plain(transcript.render(40))
+
+    expect(resized).toContain('resize-499')
+    expect(internals.blocksVisited).toBeLessThanOrEqual(6)
+    expect(internals.lastFullLinesCopied).toBe(0)
+    transcript.dispose()
+  })
+
+  it('keeps a historical block anchored while its width changes', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 7)
+    transcript.update(snapshot(Array.from({ length: 40 }, (_, index) => assistant(
+      `browse-resize-${String(index)}`,
+      `browse-resize-${String(index)} ${'wrapped '.repeat(12)}`,
+    ))))
+    transcript.render(80)
+    expect(transcript.scrollBy(12)).toBe(true)
+    const before = plain(transcript.render(80))
+    const anchor = before.match(/browse-resize-\d+/u)?.[0]
+
+    const resized = plain(transcript.render(40))
+
+    expect(anchor).toBeDefined()
+    expect(resized).toContain(anchor)
+    transcript.dispose()
+  })
+
+  it('navigates previous and next user turns with block coordinates', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    transcript.update(snapshot([
+      user('user-1', 'question-one'),
+      assistant('answer-1', 'answer-one-a\nanswer-one-b'),
+      user('user-2', 'question-two'),
+      assistant('answer-2', 'answer-two-a\nanswer-two-b'),
+      user('user-3', 'question-three'),
+      assistant('answer-3', 'answer-three'),
+    ]))
+    transcript.render(80)
+
+    expect(transcript.navigateTurn(-1)).toBe(true)
+    expect(plain(transcript.render(80))).toContain('question-two')
+    expect(transcript.navigateTurn(1)).toBe(true)
+    expect(plain(transcript.render(80))).toContain('question-three')
+    transcript.dispose()
+  })
+
+  it('keeps turn navigation stable when older user turns are prepended', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const current = [
+      user('turn-user-1', 'turn-question-one'),
+      assistant('turn-answer-1', 'turn-answer-one'),
+      user('turn-user-2', 'turn-question-two'),
+      assistant('turn-answer-2', 'turn-answer-two'),
+      user('turn-user-3', 'turn-question-three'),
+      assistant('turn-answer-3', 'turn-answer-three'),
+    ]
+    const transcript = new Transcript(() => 5)
+    transcript.update(snapshot(current))
+    transcript.render(80)
+    expect(transcript.navigateTurn(-1)).toBe(true)
+    expect(plain(transcript.render(80))).toContain('turn-question-two')
+
+    transcript.update(snapshot([
+      user('turn-user-0', 'prepended-turn-question'),
+      assistant('turn-answer-0', 'prepended-turn-answer'),
+      ...current,
+    ]))
+    transcript.render(80)
+    expect(transcript.navigateTurn(-1)).toBe(true)
+    expect(plain(transcript.render(80))).toContain('turn-question-one')
+    transcript.dispose()
+  })
+
+  it('redraws only the active running block on pulse frames', () => {
+    vi.useFakeTimers()
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(
+      Array.from({ length: 100 }, (_, index) => assistant(`pulse-${String(index)}`, `stable-${String(index)}`)),
+      [{
+        callId: 'running-tail',
+        name: 'read',
+        argsRaw: '{"file_path":"package.json"}',
+        turn: 1,
+        step: 1,
+        time: 1,
+        callView: { card: 'generic', title: 'Read package.json', kind: 'read' },
+        subCalls: [],
+      }],
+    ))
+    transcript.render(80)
+    internals.componentRenders = 0
+    resetRenderCounters()
+
+    vi.advanceTimersByTime(160)
+    transcript.invalidate()
+    transcript.render(80)
+
+    expect(internals.blocksVisited).toBeLessThanOrEqual(8)
+    expect(internals.componentRenders).toBeLessThanOrEqual(4)
+    transcript.dispose()
+  })
+
+  it('replaces only the block that owns a completed image load', async () => {
+    vi.stubEnv('NO_COLOR', '1')
+    let resolveImage: ((payload: TranscriptImagePayload) => void) | undefined
+    const loaded = new Promise<TranscriptImagePayload>((resolve) => {
+      resolveImage = resolve
+    })
+    const requestRender = vi.fn()
+    const transcript = new Transcript(() => 8, requestRender)
+    transcript.update(snapshot([
+      ...Array.from({ length: 200 }, (_, index) => assistant(`image-history-${String(index)}`, 'stable')),
+      imageNode('image-tail'),
+    ]), () => loaded)
+    transcript.render(80)
+    internals.imageBlocksUpdated = 0
+
+    resolveImage?.({
+      attachment: imageAttachment,
+      data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+    })
+    await loaded
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(internals.imageBlocksUpdated).toBe(1)
+    expect(requestRender).toHaveBeenCalledTimes(1)
+    resetRenderCounters()
+    transcript.render(80)
+    expect(internals.blocksVisited).toBeLessThanOrEqual(8)
+    transcript.dispose()
+  })
+
+  it('ignores an image completion after disposal or a Session switch', async () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const resolvers: Array<(payload: TranscriptImagePayload) => void> = []
+    const requestRender = vi.fn()
+    const transcript = new Transcript(() => 8, requestRender)
+    const loader = (): Promise<TranscriptImagePayload> => new Promise((resolve) => {
+      resolvers.push(resolve)
+    })
+    const payload: TranscriptImagePayload = {
+      attachment: imageAttachment,
+      data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+    }
+
+    transcript.update(snapshot([imageNode('image-old-session')], [], { sessionId: 'session-old' }), loader)
+    transcript.update(snapshot([assistant('new-session', 'new session')], [], { sessionId: 'session-new' }))
+    resolvers.shift()?.(payload)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(internals.imageBlocksUpdated).toBe(0)
+    expect(requestRender).not.toHaveBeenCalled()
+
+    transcript.update(snapshot([imageNode('image-disposed')], [], { sessionId: 'session-disposed' }), loader)
+    transcript.dispose()
+    resolvers.shift()?.(payload)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(internals.imageBlocksUpdated).toBe(0)
+    expect(requestRender).not.toHaveBeenCalled()
+  })
+
+  it('returns pulse timers to baseline after 100 transcript lifecycles', () => {
+    vi.useFakeTimers()
+    vi.stubEnv('NO_COLOR', undefined)
+    vi.stubEnv('TERM', 'xterm-256color')
+    vi.stubEnv('COLORTERM', 'truecolor')
+    const baseline = internals.activePulseTimers
+
+    for (let index = 0; index < 100; index += 1) {
+      const transcript = new Transcript(() => 8)
+      transcript.update(snapshot([], [{
+        callId: `lifecycle-${String(index)}`,
+        name: 'read',
+        argsRaw: '{}',
+        turn: 1,
+        step: 1,
+        time: 1,
+        callView: { card: 'generic', title: 'Read', kind: 'read' },
+        subCalls: [],
+      }]))
+      transcript.dispose()
+    }
+
+    expect(internals.activePulseTimers).toBe(baseline)
+  })
+})

--- a/tests/transcript-viewport.test.ts
+++ b/tests/transcript-viewport.test.ts
@@ -324,6 +324,114 @@ describe('transcript block viewport', () => {
     transcript.dispose()
   })
 
+  it('keeps the latest line visible when search opens and closes at the tail', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    transcript.update(snapshot(Array.from({ length: 30 }, (_, index) =>
+      assistant(`search-tail-${String(index)}`, `search-tail-${String(index)}`))))
+
+    expect(plain(transcript.render(80))).toContain('search-tail-29')
+    transcript.handleInput('/')
+    const searching = plain(transcript.render(80))
+    expect(searching).toContain('search-tail-29')
+    expect(searching).not.toContain('Newer content')
+
+    expect(transcript.cancelSearch()).toBe(true)
+    expect(plain(transcript.render(80))).toContain('search-tail-29')
+    transcript.dispose()
+  })
+
+  it('rebuilds search navigation immediately after a streaming snapshot update', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    const nodes = Array.from({ length: 20 }, (_, index) =>
+      assistant(`search-stream-${String(index)}`, `search-stream-${String(index)}`))
+    transcript.update(snapshot(nodes))
+    transcript.render(80)
+    transcript.handleInput('/')
+    for (const character of 'zzz-update-match') transcript.handleInput(character)
+
+    transcript.update(snapshot([
+      assistant('search-stream-0', 'zzz-update-match'),
+      ...nodes.slice(1),
+    ]))
+    transcript.handleInput('\r')
+
+    const rendered = plain(transcript.render(80))
+    expect(rendered.split('\n').filter(line => line.trim() === 'zzz-update-match')).toHaveLength(1)
+    transcript.dispose()
+  })
+
+  it('keeps a searched historical viewport anchored while the tail grows', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 6)
+    const nodes = Array.from({ length: 20 }, (_, index) =>
+      assistant(`search-anchor-${String(index)}`, `search-anchor-${String(index)}`))
+    transcript.update(snapshot(nodes))
+    transcript.render(80)
+    transcript.handleInput('/')
+    transcript.render(80)
+    transcript.handleInput('\u001B[H')
+    expect(plain(transcript.render(80))).toContain('search-anchor-0')
+
+    transcript.update(snapshot([
+      ...nodes,
+      assistant('search-anchor-new', 'search-anchor-new'),
+    ]))
+
+    expect(plain(transcript.render(80))).toContain('search-anchor-0')
+    transcript.dispose()
+  })
+
+  it('keeps a searched historical block anchored while its width changes', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 7)
+    transcript.update(snapshot(Array.from({ length: 40 }, (_, index) => assistant(
+      `search-resize-${String(index)}`,
+      `search-resize-${String(index)} ${'wrapped '.repeat(12)}`,
+    ))))
+    transcript.render(80)
+    transcript.handleInput('/')
+    transcript.render(80)
+    transcript.handleInput('\u001B[H')
+    transcript.handleInput('\u001B[6~')
+    transcript.handleInput('\u001B[6~')
+    const before = plain(transcript.render(80))
+    const anchor = before.match(/search-resize-\d+/u)?.[0]
+
+    const resized = plain(transcript.render(40))
+
+    expect(anchor).toBeDefined()
+    expect(resized).toContain(anchor)
+    transcript.dispose()
+  })
+
+  it('keeps a searched historical block anchored while an earlier block grows', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const nodes = Array.from({ length: 40 }, (_, index) =>
+      assistant(`search-shift-${String(index)}`, `search-shift-${String(index)}`))
+    const transcript = new Transcript(() => 7)
+    transcript.update(snapshot(nodes))
+    transcript.render(80)
+    transcript.handleInput('/')
+    transcript.render(80)
+    transcript.handleInput('\u001B[H')
+    transcript.handleInput('\u001B[6~')
+    transcript.handleInput('\u001B[6~')
+    const before = plain(transcript.render(80))
+    const anchor = before.match(/search-shift-\d+/u)?.[0]
+
+    transcript.update(snapshot([
+      assistant('search-shift-0', `search-shift-0\n${'expanded earlier line\n'.repeat(20)}`),
+      ...nodes.slice(1),
+    ]))
+    const updated = plain(transcript.render(80))
+
+    expect(anchor).toBeDefined()
+    expect(updated).toContain(anchor)
+    transcript.dispose()
+  })
+
   it('keeps resize work local to the latest viewport blocks', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 10)

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -740,6 +740,32 @@ describe('conversation viewport', () => {
     expect(requestRender).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps an explicitly scrolled viewport anchored while the tail grows', () => {
+    const transcript = new Transcript(() => 7)
+    const history = [
+      user('u1', '较早问题'),
+      assistant('a1', '锚点回答一\n锚点回答二\n锚点回答三'),
+      user('u2', '当前问题'),
+      assistant('a2', '当前回答一\n当前回答二\n当前回答三'),
+    ]
+    transcript.update(snapshot(history))
+    transcript.render(50)
+    expect(transcript.scrollBy(3)).toBe(true)
+    expect(stripAnsi(transcript.render(50).join('\n'))).toContain('锚点回答二')
+
+    transcript.update(snapshot([
+      ...history,
+      user('u3', '新增问题'),
+      assistant('a3', '新增回答一\n新增回答二'),
+    ]))
+    const anchored = stripAnsi(transcript.render(50).join('\n'))
+    expect(anchored).toContain('锚点回答二')
+    expect(anchored).not.toContain('新增回答二')
+
+    transcript.followLatest()
+    expect(stripAnsi(transcript.render(50).join('\n'))).toContain('新增回答二')
+  })
+
   it('searches rendered lines from focus mode and jumps with n/N', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 12)

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -375,7 +375,7 @@ describe('conversation viewport', () => {
     ]))
 
     const rendered = transcript.render(40).join('\n')
-    expect(rendered).toContain('行更早内容 · 滚轮上翻')
+    expect(rendered).toContain('更早内容 · 滚轮上翻')
     expect(rendered).not.toContain('思考完成')
     expect(rendered).toContain('最新回答')
   })
@@ -391,7 +391,7 @@ describe('conversation viewport', () => {
     ]))
 
     const rendered = transcript.render(40).join('\n')
-    expect(rendered).toContain('行更早内容 · 滚轮上翻')
+    expect(rendered).toContain('更早内容 · 滚轮上翻')
     expect(rendered).not.toContain('不应悬在顶部的尾行')
     expect(rendered).toContain('> 最新问题')
     expect(rendered).toContain('最新回答第二行')
@@ -419,7 +419,7 @@ describe('conversation viewport', () => {
     const previousPage = transcript.render(40).join('\n')
     expect(requestRender).toHaveBeenCalledTimes(1)
     expect(previousPage).not.toBe(latest)
-    expect(previousPage).toContain('行更新内容 · PgDn/End')
+    expect(previousPage).toContain('有更新内容 · PgDn/End')
 
     transcript.handleInput('\u001B[H')
     expect(transcript.render(40).join('\n')).toContain('第一个问题')
@@ -427,7 +427,7 @@ describe('conversation viewport', () => {
     transcript.handleInput('\u001B[F')
     const returned = transcript.render(40).join('\n')
     expect(returned).toContain('最新回答')
-    expect(returned).toContain('行更早内容 · PgUp/Home')
+    expect(returned).toContain('更早内容 · PgUp/Home')
     expect(requestRender).toHaveBeenCalledTimes(3)
   })
 

--- a/tests/tui-performance-probe.test.ts
+++ b/tests/tui-performance-probe.test.ts
@@ -1,7 +1,76 @@
-import { describe, expect, it, vi } from 'vitest'
-import { instrumentTerminalWrites, TuiPerformanceProbe } from '../src/client/tui-performance.ts'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  instrumentTerminalWrites,
+  parsePerfBucketIntervalMs,
+  TuiPerformanceProbe,
+  type TuiPerformanceBucketSnapshot,
+} from '../src/client/tui-performance.ts'
+
+const LATENCY_CAP = 4096
+const tempDirs: string[] = []
+const REAL_PROBE_SOURCE = fileURLToPath(new URL('../src/client/tui-performance.ts', import.meta.url))
+
+function probeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'seektty-tui-perf-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function spawnWhitespaceUnsetProbe(modulePath: string, tempRoot: string) {
+  const childCwd = join(tempRoot, 'child-cwd')
+  mkdirSync(childCwd, { recursive: true })
+  const scriptPath = join(tempRoot, 'whitespace-probe.mjs')
+  writeFileSync(scriptPath, `const { TuiPerformanceProbe } = await import(${JSON.stringify(pathToFileURL(modulePath).href)})
+const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 10 })
+probe.markInput()
+await new Promise((resolve) => { setTimeout(resolve, 50) })
+const snapshot = probe.finish()
+if (snapshot === undefined) throw new Error('expected snapshot')
+probe.reportFinal(snapshot)
+`)
+  const env: NodeJS.ProcessEnv = {
+    NODE_NO_WARNINGS: '1',
+    SEEKTTY_TUI_PERF_BUCKET_PATH: '   ',
+  }
+  return {
+    childCwd,
+    result: spawnSync(process.execPath, ['--experimental-strip-types', scriptPath], {
+      cwd: childCwd,
+      encoding: 'utf8',
+      env,
+      timeout: 10_000,
+    }),
+  }
+}
+
+/** One-standard-error estimate sqrt(q(1-q)/n). Not a guaranteed rank bound. */
+function rankStandardError(retained: number): { p95: number; p99: number } {
+  return {
+    p95: Number(Math.sqrt(0.95 * 0.05 / retained).toFixed(6)),
+    p99: Number(Math.sqrt(0.99 * 0.01 / retained).toFixed(6)),
+  }
+}
+
+function ceilRank(values: readonly number[], fraction: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((left, right) => left - right)
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0
+}
 
 describe('content-free TUI performance probe', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('stays inert unless explicitly enabled', () => {
     const probe = new TuiPerformanceProbe(false)
     probe.markInput()
@@ -21,6 +90,27 @@ describe('content-free TUI performance probe', () => {
     expect(terminal.write).toHaveBeenCalledWith('plain path')
     expect(output.once).not.toHaveBeenCalled()
     expect(output.off).not.toHaveBeenCalled()
+  })
+
+  it('does not start a bucket timer when diagnostics are off even with an interval', () => {
+    vi.useFakeTimers()
+    const onBucket = vi.fn()
+    const probe = new TuiPerformanceProbe(false, { bucketIntervalMs: 1_000, onBucket })
+    vi.advanceTimersByTime(5_000)
+    expect(onBucket).not.toHaveBeenCalled()
+    expect(probe.finish()).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('parses the bucket interval as a positive integer only', () => {
+    expect(parsePerfBucketIntervalMs(undefined)).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('')).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('abc')).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('0')).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('-5')).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('1.5')).toBeUndefined()
+    expect(parsePerfBucketIntervalMs('1000')).toBe(1_000)
+    expect(parsePerfBucketIntervalMs(' 2000 ')).toBe(2_000)
   })
 
   it('removes an enabled backpressure listener during cleanup', () => {
@@ -56,5 +146,535 @@ describe('content-free TUI performance probe', () => {
     expect(report?.renderRequests).toEqual({ input: 1 })
     expect(report?.lifecycle.subscriptions).toBe(0)
     expect(JSON.stringify(report)).not.toContain('sensitive')
+  })
+
+  it('emits timestamped buckets then resets window samples before the next interval', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-26T13:00:00.000Z'))
+    const onBucket = vi.fn()
+    const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000, onBucket })
+    probe.markInput()
+    vi.advanceTimersByTime(50)
+    probe.measureRender(() => undefined)
+    probe.markWrite('bucket-secret-text', false)
+    vi.advanceTimersByTime(950)
+    expect(onBucket).toHaveBeenCalledTimes(1)
+    const first = onBucket.mock.calls[0]?.[0]
+    expect(first?.kind).toBe('bucket')
+    expect(first?.t).toBe('2026-08-26T13:00:01.000Z')
+    expect(first?.inputToWriteMs.max).toBeGreaterThan(0)
+    expect(JSON.stringify(first)).not.toContain('bucket-secret-text')
+
+    vi.advanceTimersByTime(1_000)
+    expect(onBucket).toHaveBeenCalledTimes(2)
+    const second = onBucket.mock.calls[1]?.[0]
+    expect(second?.inputToWriteMs.max).toBe(0)
+    expect(second?.renderDurationMs.max).toBe(0)
+
+    const report = probe.finish()
+    expect(report).not.toHaveProperty('kind')
+    expect(report?.inputEvents).toBe(1)
+    expect(JSON.stringify(report)).not.toContain('bucket-secret-text')
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(5_000)
+    expect(onBucket).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts exactly one unrefed bucket timer and clears it on finish', () => {
+    vi.useFakeTimers()
+    const onBucket = vi.fn()
+    const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 5_000, onBucket })
+    expect(vi.getTimerCount()).toBe(1)
+    probe.finish()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(onBucket).not.toHaveBeenCalled()
+  })
+
+  it('keeps exact ceil-rank percentiles when a series has at most 4096 samples', () => {
+    let now = 0
+    const probe = new TuiPerformanceProbe(true, {
+      now: () => now,
+      random: () => 0,
+    })
+    const durations = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    for (const duration of durations) {
+      now = 0
+      probe.measureRender(() => {
+        now = duration
+      })
+    }
+    const report = probe.finish()
+    expect(report?.renderDurationMs).toMatchObject({
+      p50: ceilRank(durations, 0.5),
+      p95: ceilRank(durations, 0.95),
+      p99: ceilRank(durations, 0.99),
+      max: 10,
+      count: 10,
+      retained: 10,
+      approximate: false,
+    })
+    expect(report?.renderDurationMs).not.toHaveProperty('rankBound')
+    expect(report?.renderDurationMs).not.toHaveProperty('rankStandardError')
+    expect(report?.renderDurationMs).not.toHaveProperty('confidence')
+    expect(report?.renderDurationMs).not.toHaveProperty('confidenceLevel')
+  })
+
+  it('bounds retained latency storage at 4096 while keeping exact count and max', () => {
+    let now = 0
+    const probe = new TuiPerformanceProbe(true, {
+      now: () => now,
+      random: () => 0,
+    })
+    let report: ReturnType<TuiPerformanceProbe['finish']>
+    expect(() => {
+      for (let index = 0; index < 130_000; index += 1) {
+        now = 0
+        probe.measureRender(() => {
+          now = index + 1
+        })
+      }
+      report = probe.finish()
+    }).not.toThrow()
+    const standardError = rankStandardError(LATENCY_CAP)
+    expect(report?.renderDurationMs.count).toBe(130_000)
+    expect(report?.renderDurationMs.retained).toBe(LATENCY_CAP)
+    expect(report?.renderDurationMs.retained).toBeLessThanOrEqual(LATENCY_CAP)
+    expect(report?.renderDurationMs.max).toBe(130_000)
+    expect(report?.renderDurationMs.approximate).toBe(true)
+    expect(report?.renderDurationMs.probabilistic).toBe(true)
+    expect(report?.renderDurationMs.rankStandardError).toEqual(standardError)
+    expect(report?.renderDurationMs).not.toHaveProperty('rankBound')
+    expect(report?.renderDurationMs).not.toHaveProperty('confidence')
+    expect(report?.renderDurationMs).not.toHaveProperty('confidenceLevel')
+    expect(report?.inputToWriteMs.count).toBe(0)
+    expect(report?.inputToWriteMs.retained).toBe(0)
+  })
+
+  it('resets the bucket window when onBucket throws and does not let the error escape', () => {
+    vi.useFakeTimers()
+    const onBucket = vi.fn((_snapshot: TuiPerformanceBucketSnapshot) => {
+      throw new Error('bucket-callback-boom')
+    })
+    const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000, onBucket })
+    probe.markInput()
+    probe.markWrite('x', false)
+    expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+    expect(onBucket).toHaveBeenCalledTimes(1)
+    probe.measureRender(() => undefined)
+    expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+    expect(onBucket).toHaveBeenCalledTimes(2)
+    const second = onBucket.mock.calls[1]?.[0]
+    expect(second?.inputEvents).toBe(0)
+    expect(second?.renderDurationMs.count).toBe(1)
+    expect(probe.finish()?.inputEvents).toBe(1)
+  })
+
+  it('emits nothing to a TTY stderr when no explicit bucket path is set', () => {
+    vi.useFakeTimers()
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true })
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      vi.advanceTimersByTime(1_000)
+      probe.finish()
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('appends bucket JSONL only to an explicit path and never falls back to stdio', () => {
+    vi.useFakeTimers()
+    const bucketPath = join(probeTempDir(), 'buckets.jsonl')
+    vi.stubEnv('SEEKTTY_TUI_PERF_BUCKET_PATH', bucketPath)
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true })
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      vi.advanceTimersByTime(1_000)
+      probe.markHeader()
+      vi.advanceTimersByTime(1_000)
+      probe.finish()
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    const body = readFileSync(bucketPath, 'utf8')
+    const lines = body.trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines.every(line => !line.startsWith('SEEKTTY_TUI_PERF'))).toBe(true)
+    expect(JSON.parse(lines[0]!).kind).toBe('bucket')
+    expect(JSON.parse(lines[1]!).kind).toBe('bucket')
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('disables a failing explicit path sink without crashing the TUI or falling back to stdio', () => {
+    vi.useFakeTimers()
+    const failingDir = join(probeTempDir(), 'missing-bucket-parent')
+    const failingPath = join(failingDir, 'buckets.jsonl')
+    expect(existsSync(failingDir)).toBe(false)
+    vi.stubEnv('SEEKTTY_TUI_PERF_BUCKET_PATH', failingPath)
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+      probe.measureRender(() => undefined)
+      expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+      expect(probe.finish()?.inputEvents).toBe(1)
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+    }
+    expect(existsSync(failingDir)).toBe(false)
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('treats a whitespace-only bucket path as unset', () => {
+    const { childCwd, result } = spawnWhitespaceUnsetProbe(REAL_PROBE_SOURCE, probeTempDir())
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('')
+    const lines = result.stderr.split('\n').filter(line => line.length > 0)
+    expect(lines.every(line => line.startsWith('SEEKTTY_TUI_PERF '))).toBe(true)
+    const records = lines.map(line => JSON.parse(line.slice('SEEKTTY_TUI_PERF '.length)) as { kind: string })
+    expect(records.filter(record => record.kind === 'bucket').length).toBeGreaterThanOrEqual(1)
+    expect(records.filter(record => record.kind === 'final')).toHaveLength(1)
+    expect(existsSync(join(childCwd, '   '))).toBe(false)
+  })
+
+  it('writes one kind-final JSONL record only from reportFinal, never from finish', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-26T14:00:00.000Z'))
+    const bucketPath = join(probeTempDir(), 'final.jsonl')
+    vi.stubEnv('SEEKTTY_TUI_PERF_BUCKET_PATH', bucketPath)
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true })
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      vi.advanceTimersByTime(1_000)
+      const afterBucket = readFileSync(bucketPath, 'utf8').trim().split('\n')
+      expect(afterBucket).toHaveLength(1)
+      expect(JSON.parse(afterBucket[0]!).kind).toBe('bucket')
+      const snapshot = probe.finish()
+      expect(readFileSync(bucketPath, 'utf8').trim().split('\n')).toHaveLength(1)
+      probe.reportFinal(snapshot!)
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    const lines = readFileSync(bucketPath, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0]!).kind).toBe('bucket')
+    expect(JSON.parse(lines[1]!).kind).toBe('final')
+    expect(lines.every(line => !line.startsWith('SEEKTTY_TUI_PERF'))).toBe(true)
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('emits nothing from reportFinal to a TTY when no path is set', () => {
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true })
+    try {
+      const probe = new TuiPerformanceProbe(true)
+      probe.markInput()
+      probe.reportFinal(probe.finish()!)
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('keeps a failed bucket file sink disabled for reportFinal without stdio fallback', () => {
+    vi.useFakeTimers()
+    const failingDir = join(probeTempDir(), 'missing-bucket-parent')
+    const failingPath = join(failingDir, 'buckets.jsonl')
+    expect(existsSync(failingDir)).toBe(false)
+    vi.stubEnv('SEEKTTY_TUI_PERF_BUCKET_PATH', failingPath)
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+      const snapshot = probe.finish()
+      expect(() => probe.reportFinal(snapshot!)).not.toThrow()
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+    }
+    expect(existsSync(failingDir)).toBe(false)
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('prefixes a non-TTY stderr final record only when no path is set', () => {
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: false })
+    try {
+      const probe = new TuiPerformanceProbe(true)
+      probe.markInput()
+      probe.reportFinal(probe.finish()!)
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    const text = stderrChunks.join('')
+    expect(text.startsWith('SEEKTTY_TUI_PERF ')).toBe(true)
+    expect(JSON.parse(text.slice('SEEKTTY_TUI_PERF '.length)).kind).toBe('final')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('does not let reportFinal throw when non-TTY stderr.write fails', () => {
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = (() => {
+      throw new Error('stderr-boom')
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: false })
+    try {
+      const probe = new TuiPerformanceProbe(true)
+      probe.markInput()
+      const snapshot = probe.finish()
+      expect(snapshot).toBeDefined()
+      expect(() => probe.reportFinal(snapshot!)).not.toThrow()
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('trims leading and trailing whitespace on an explicit bucket path', () => {
+    vi.useFakeTimers()
+    const intended = join(probeTempDir(), 'trimmed-path.jsonl')
+    const padded = `  ${intended}  `
+    vi.stubEnv('SEEKTTY_TUI_PERF_BUCKET_PATH', padded)
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrIsTTY = process.stderr.isTTY
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true })
+    try {
+      const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000 })
+      probe.markInput()
+      vi.advanceTimersByTime(1_000)
+      probe.reportFinal(probe.finish()!)
+    } finally {
+      process.stderr.write = stderrWrite
+      process.stdout.write = stdoutWrite
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: stderrIsTTY })
+    }
+    expect(existsSync(intended)).toBe(true)
+    const lines = readFileSync(intended, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0]!).kind).toBe('bucket')
+    expect(JSON.parse(lines[1]!).kind).toBe('final')
+    expect(stderrChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+    expect(stdoutChunks.join('')).not.toContain('SEEKTTY_TUI_PERF')
+  })
+
+  it('counts renderRequests once when onBucket calls finish and does not emit a second bucket', () => {
+    vi.useFakeTimers()
+    let probe!: TuiPerformanceProbe
+    let fromCallback: ReturnType<TuiPerformanceProbe['finish']>
+    const onBucket = vi.fn(() => {
+      fromCallback = probe.finish()
+    })
+    probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000, onBucket })
+    probe.markRenderRequest('normal')
+    probe.markRenderRequest('normal')
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(1_000)
+    expect(onBucket).toHaveBeenCalledTimes(1)
+    expect(fromCallback?.renderRequests).toEqual({ normal: 2 })
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(5_000)
+    expect(onBucket).toHaveBeenCalledTimes(1)
+    expect(probe.finish()).toBeUndefined()
+  })
+
+  it('still folds the leftover tail window when finish runs outside a bucket callback', () => {
+    vi.useFakeTimers()
+    const onBucket = vi.fn()
+    const probe = new TuiPerformanceProbe(true, { bucketIntervalMs: 1_000, onBucket })
+    probe.markRenderRequest('input')
+    vi.advanceTimersByTime(1_000)
+    expect(onBucket.mock.calls[0]?.[0]?.renderRequests).toEqual({ input: 1 })
+    probe.markRenderRequest('resize')
+    const report = probe.finish()
+    expect(report?.renderRequests).toEqual({ input: 1, resize: 1 })
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(5_000)
+    expect(onBucket).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects NaN, Infinity, and negative durations on both latency series while keeping a valid zero', () => {
+    let now = 0
+    const probe = new TuiPerformanceProbe(true, { now: () => now })
+    now = 0
+    probe.measureRender(() => {
+      now = Number.NaN
+    })
+    now = 0
+    probe.measureRender(() => {
+      now = Number.POSITIVE_INFINITY
+    })
+    now = 10
+    probe.measureRender(() => {
+      now = 3
+    })
+    now = 4
+    probe.measureRender(() => {
+      now = 4
+    })
+    now = 1
+    probe.markInput()
+    now = Number.NaN
+    probe.markWrite('x', false)
+    now = 2
+    probe.markInput()
+    now = Number.POSITIVE_INFINITY
+    probe.markWrite('x', false)
+    now = 10
+    probe.markInput()
+    now = 4
+    probe.markWrite('x', false)
+    now = 8
+    probe.markInput()
+    now = 8
+    probe.markWrite('x', false)
+    const report = probe.finish()
+    expect(report?.renderDurationMs).toMatchObject({
+      count: 1,
+      retained: 1,
+      max: 0,
+      p50: 0,
+      p95: 0,
+      p99: 0,
+      approximate: false,
+    })
+    expect(report?.inputToWriteMs).toMatchObject({
+      count: 1,
+      retained: 1,
+      max: 0,
+      p50: 0,
+      p95: 0,
+      p99: 0,
+      approximate: false,
+    })
+    expect(report?.inputEvents).toBe(4)
+    expect(report?.terminalWrites.calls).toBe(4)
   })
 })

--- a/tests/tui-performance-probe.test.ts
+++ b/tests/tui-performance-probe.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { instrumentTerminalWrites, TuiPerformanceProbe } from '../src/client/tui-performance.ts'
+
+describe('content-free TUI performance probe', () => {
+  it('stays inert unless explicitly enabled', () => {
+    const probe = new TuiPerformanceProbe(false)
+    probe.markInput()
+    probe.markSnapshot()
+    probe.markWrite('secret user text', false)
+    expect(probe.finish()).toBeUndefined()
+  })
+
+  it('preserves terminal identity and listeners while disabled', () => {
+    const terminal = { write: vi.fn() }
+    const output = { writableNeedDrain: true, once: vi.fn(), off: vi.fn() }
+    const measured = instrumentTerminalWrites(terminal, new TuiPerformanceProbe(false), output)
+
+    expect(measured.terminal).toBe(terminal)
+    measured.terminal.write('plain path')
+    measured.release()
+    expect(terminal.write).toHaveBeenCalledWith('plain path')
+    expect(output.once).not.toHaveBeenCalled()
+    expect(output.off).not.toHaveBeenCalled()
+  })
+
+  it('removes an enabled backpressure listener during cleanup', () => {
+    const terminal = { write: vi.fn() }
+    const output = { writableNeedDrain: true, once: vi.fn(), off: vi.fn() }
+    const measured = instrumentTerminalWrites(terminal, new TuiPerformanceProbe(true), output)
+
+    expect(measured.terminal).not.toBe(terminal)
+    measured.terminal.write('measured path')
+    expect(output.once).toHaveBeenCalledTimes(1)
+    measured.release()
+    expect(output.off).toHaveBeenCalledWith('drain', output.once.mock.calls[0]?.[1])
+  })
+
+  it('reports only aggregate counts and timings', () => {
+    const probe = new TuiPerformanceProbe(true)
+    probe.markInput()
+    probe.markSnapshot()
+    probe.markHeader()
+    probe.markStatus()
+    probe.markRenderRequest('input')
+    probe.measureRender(() => undefined)
+    probe.markWrite('sensitive payload', true)
+    probe.markDrain()
+    probe.changeSubscriptions(1)
+    probe.changeSubscriptions(-1)
+
+    const report = probe.finish()
+
+    expect(report?.inputEvents).toBe(1)
+    expect(report?.snapshots).toBe(1)
+    expect(report?.terminalWrites).toMatchObject({ calls: 1, bytes: 17, backpressureSignals: 1, drains: 1 })
+    expect(report?.renderRequests).toEqual({ input: 1 })
+    expect(report?.lifecycle.subscriptions).toBe(0)
+    expect(JSON.stringify(report)).not.toContain('sensitive')
+  })
+})

--- a/tests/tui-performance.test.ts
+++ b/tests/tui-performance.test.ts
@@ -91,8 +91,24 @@ const enabled = process.env.SEEKTTY_PERF_RUN === '1'
 
 describe('TUI performance harness', () => {
   if (!enabled) {
-    it('stays opt-in during the ordinary test suite', () => {
-      expect(process.env.SEEKTTY_PERF_RUN).not.toBe('1')
+    it('proves editor-only render operations stay bounded at 100k lines', () => {
+      vi.stubEnv('NO_COLOR', '1')
+      const nodes = Array.from({ length: 1_000 }, (_, index) => assistant(
+        `operation-${String(index)}`,
+        Array.from({ length: 100 }, (_, line) => `operation-${String(index)}-${String(line)}`).join('\n'),
+      ))
+      const transcript = new Transcript(() => 24)
+      transcript.update(snapshot(nodes))
+      transcript.render(80)
+      internals.blocksVisited = 0
+      internals.linesEscaped = 0
+      internals.lastFullLinesCopied = 0
+
+      expect(transcript.render(80)).toHaveLength(24)
+      expect(internals.blocksVisited).toBeLessThanOrEqual(2)
+      expect(internals.linesEscaped).toBe(0)
+      expect(internals.lastFullLinesCopied).toBe(0)
+      transcript.dispose()
     })
     return
   }
@@ -124,12 +140,21 @@ describe('TUI performance harness', () => {
 
         const cachedRenderMs: number[] = []
         const cachedRenderComponents: number[] = []
+        const cachedBlocksVisited: number[] = []
+        const cachedLinesEscaped: number[] = []
+        const cachedFullLinesCopied: number[] = []
         for (let sample = 0; sample < 25; sample += 1) {
           const beforeComponents = internals.componentRenders
+          const beforeBlocks = internals.blocksVisited
+          const beforeEscaped = internals.linesEscaped
+          const beforeCopied = internals.lastFullLinesCopied
           const started = performance.now()
           const visible = transcript.render(width)
           cachedRenderMs.push(performance.now() - started)
           cachedRenderComponents.push(internals.componentRenders - beforeComponents)
+          cachedBlocksVisited.push(internals.blocksVisited - beforeBlocks)
+          cachedLinesEscaped.push(internals.linesEscaped - beforeEscaped)
+          cachedFullLinesCopied.push(internals.lastFullLinesCopied - beforeCopied)
           expect(visible.length).toBe(rows)
         }
 
@@ -161,6 +186,11 @@ describe('TUI performance harness', () => {
           cachedRenderComponentCalls: {
             max: Math.max(...cachedRenderComponents),
             total: cachedRenderComponents.reduce((sum, value) => sum + value, 0),
+          },
+          cachedRenderOperations: {
+            blocksVisitedMax: Math.max(...cachedBlocksVisited),
+            linesEscapedMax: Math.max(...cachedLinesEscaped),
+            fullLinesCopiedMax: Math.max(...cachedFullLinesCopied),
           },
           memoryMiB: {
             heapUsed: toMiB(memoryAfter.heapUsed),

--- a/tests/tui-performance.test.ts
+++ b/tests/tui-performance.test.ts
@@ -1,0 +1,196 @@
+import { arch, platform, release } from 'node:os'
+import { performance } from 'node:perf_hooks'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  ChatConversationViewNode,
+  ConversationSnapshot,
+} from '@deepseek-ai/dsh-client-runtime/node-client'
+import { internals, Transcript } from '../src/client/transcript.ts'
+
+function assistant(key: string, text: string): ChatConversationViewNode {
+  return {
+    key,
+    kind: 'fixture',
+    id: key,
+    target: 'chat',
+    anchorSeq: 1,
+    location: { kind: 'session' },
+    visibility: 'visible',
+    data: {
+      kind: 'assistant',
+      seq: 2,
+      time: 2,
+      turn: 1,
+      step: 1,
+      blocks: [{ kind: 'text', text }],
+    },
+  }
+}
+
+function snapshot(nodes: readonly ChatConversationViewNode[]): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  return {
+    sessionId: 'performance-fixture',
+    views: { get: () => undefined },
+    chat: {
+      order: nodes.map(node => node.key),
+      nodes: { get: (key: string) => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] },
+      timeline: { turnOrder: [], turns: new Map() },
+      legacy: {
+        nodes: [],
+        turnTimings: new Map(),
+        turnEnds: new Map(),
+        partial: null,
+        runningCalls: [],
+      },
+    },
+    nodes: [],
+    turnTimings: new Map(),
+    turnEnds: new Map(),
+    partial: null,
+    runningCalls: [],
+    pending: [],
+    queue: [],
+    running: false,
+    subagent: null,
+    composerPhase: 'active',
+    removed: false,
+    openState: 'open',
+    openError: null,
+    hasMore: false,
+    loadingOlder: false,
+    promptError: null,
+    blank: false,
+    lastAgentError: null,
+  } as unknown as ConversationSnapshot
+}
+
+function percentile(values: readonly number[], fraction: number): number {
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)
+  return sorted[Math.max(0, index)] ?? 0
+}
+
+function summary(values: readonly number[]): { p50: number, p95: number, p99: number } {
+  const round = (value: number): number => Number(value.toFixed(3))
+  return {
+    p50: round(percentile(values, 0.5)),
+    p95: round(percentile(values, 0.95)),
+    p99: round(percentile(values, 0.99)),
+  }
+}
+
+function positiveIntegers(value: string | undefined, fallback: readonly number[]): number[] {
+  const parsed = (value ?? '').split(',').map(item => Number(item.trim()))
+    .filter(item => Number.isInteger(item) && item > 0)
+  return parsed.length === 0 ? [...fallback] : parsed
+}
+
+const enabled = process.env.SEEKTTY_PERF_RUN === '1'
+
+describe('TUI performance harness', () => {
+  if (!enabled) {
+    it('stays opt-in during the ordinary test suite', () => {
+      expect(process.env.SEEKTTY_PERF_RUN).not.toBe('1')
+    })
+    return
+  }
+
+  it('records repeatable transcript update and render samples', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const sizes = positiveIntegers(process.env.SEEKTTY_PERF_SIZES, [1_000, 10_000, 50_000, 100_000])
+    const repeats = positiveIntegers(process.env.SEEKTTY_PERF_REPEATS, [3])[0] ?? 3
+    const repeatIndex = positiveIntegers(process.env.SEEKTTY_PERF_REPEAT_INDEX, [1])[0] ?? 1
+    const width = positiveIntegers(process.env.SEEKTTY_PERF_WIDTH, [80])[0] ?? 80
+    const rows = positiveIntegers(process.env.SEEKTTY_PERF_ROWS, [24])[0] ?? 24
+    const runs: unknown[] = []
+
+    for (let localRepeat = 0; localRepeat < repeats; localRepeat += 1) {
+      const repeat = repeatIndex + localRepeat
+      for (const requestedLines of sizes) {
+        globalThis.gc?.()
+        const memoryBefore = process.memoryUsage()
+        const nodeCount = Math.max(1, Math.ceil(requestedLines / 100))
+        let nodes = Array.from({ length: nodeCount }, (_, index) => assistant(
+          `assistant-${String(index)}`,
+          Array.from({ length: 100 }, (_, line) => `line-${String(index)}-${String(line)}`).join('\n'),
+        ))
+        const transcript = new Transcript(() => rows)
+        const initialStarted = performance.now()
+        transcript.update(snapshot(nodes))
+        const initialUpdateMs = performance.now() - initialStarted
+        transcript.render(width) // Populate component line caches before cached-render samples.
+
+        const cachedRenderMs: number[] = []
+        const cachedRenderComponents: number[] = []
+        for (let sample = 0; sample < 25; sample += 1) {
+          const beforeComponents = internals.componentRenders
+          const started = performance.now()
+          const visible = transcript.render(width)
+          cachedRenderMs.push(performance.now() - started)
+          cachedRenderComponents.push(internals.componentRenders - beforeComponents)
+          expect(visible.length).toBe(rows)
+        }
+
+        const tailUpdateRenderMs: number[] = []
+        for (let sample = 0; sample < 10; sample += 1) {
+          const previous = nodes.at(-1)
+          if (previous === undefined) throw new Error('performance fixture requires one node')
+          const previousText = (previous.data as { blocks: readonly { text: string }[] }).blocks[0]?.text ?? ''
+          nodes = [...nodes.slice(0, -1), assistant(previous.key, `${previousText}\nstream-${String(sample)}`)]
+          const next = snapshot(nodes)
+          const started = performance.now()
+          transcript.update(next)
+          const visible = transcript.render(width)
+          tailUpdateRenderMs.push(performance.now() - started)
+          expect(visible.length).toBe(rows)
+        }
+
+        globalThis.gc?.()
+        const memoryAfter = process.memoryUsage()
+        const toMiB = (bytes: number): number => Number((bytes / (1024 * 1024)).toFixed(3))
+        transcript.dispose()
+        runs.push({
+          repeat,
+          requestedLines,
+          nodeCount,
+          initialUpdateMs: Number(initialUpdateMs.toFixed(3)),
+          cachedRenderMs: summary(cachedRenderMs),
+          tailUpdateRenderMs: summary(tailUpdateRenderMs),
+          cachedRenderComponentCalls: {
+            max: Math.max(...cachedRenderComponents),
+            total: cachedRenderComponents.reduce((sum, value) => sum + value, 0),
+          },
+          memoryMiB: {
+            heapUsed: toMiB(memoryAfter.heapUsed),
+            heapDelta: toMiB(memoryAfter.heapUsed - memoryBefore.heapUsed),
+            rss: toMiB(memoryAfter.rss),
+            rssDelta: toMiB(memoryAfter.rss - memoryBefore.rss),
+          },
+        })
+      }
+    }
+
+    console.log(`SEEKTTY_PERF_RESULT ${JSON.stringify({
+      schema: 1,
+      commit: process.env.SEEKTTY_PERF_COMMIT,
+      runtime: {
+        node: process.version,
+        platform: platform(),
+        release: release(),
+        arch: arch(),
+      },
+      fixture: {
+        width,
+        rows,
+        linesPerNode: 100,
+        cachedRenderSamples: 25,
+        tailUpdateSamples: 10,
+        repeats,
+        sizes,
+      },
+      runs,
+    })}`)
+  }, 120_000)
+})

--- a/tests/tui-render-stability.test.ts
+++ b/tests/tui-render-stability.test.ts
@@ -21,6 +21,7 @@ class RecordingTerminal implements Terminal {
   columns = 40
   rows = 10
   kittyProtocolActive = false
+  __seekttyManagedAlternateScreen?: boolean
   start(): void {}
   stop(): void {}
   drainInput(): Promise<void> { return Promise.resolve() }
@@ -45,6 +46,7 @@ interface Harness {
   terminal: RecordingTerminal
   tui: TUI
   lines: string[]
+  initialOutput: string
 }
 
 /** Start a TUI whose single component renders 30 unique lines into a 10-row terminal. */
@@ -56,11 +58,21 @@ async function startedTui(): Promise<Harness> {
   tui.start()
   await nextFrame()
   expect(terminal.output()).toContain('row-29')
+  const initialOutput = terminal.output()
   terminal.reset()
-  return { terminal, tui, lines }
+  return { terminal, tui, lines, initialOutput }
 }
 
 describe('patched pi-tui render stability', () => {
+  it('clamps a tall first frame to the physical viewport', async () => {
+    const { terminal, tui, initialOutput: output } = await startedTui()
+    expect(output).not.toContain('row-00')
+    expect(output).toContain('row-20')
+    expect(output).toContain('row-29')
+    expect(output.match(/\r\n/gu)?.length ?? 0).toBeLessThan(terminal.rows)
+    tui.stop()
+  })
+
   it('repaints only visible rows when a scrollback row changes alongside a visible row', async () => {
     const { terminal, tui, lines } = await startedTui()
     // Rows 0-19 are scrollback (30 lines into a 10-row terminal); row 25 is visible.
@@ -126,7 +138,7 @@ describe('patched pi-tui render stability', () => {
     tui.stop()
   })
 
-  it('still fully redraws when content shrinks below one screen', async () => {
+  it('clears removed viewport rows without a full-screen redraw', async () => {
     const { terminal, tui, lines } = await startedTui()
     lines.length = 0
     lines.push('only-row')
@@ -134,7 +146,37 @@ describe('patched pi-tui render stability', () => {
     await nextFrame()
     const output = terminal.output()
     expect(output).toContain('only-row')
-    expect(tui.fullRedraws).toBe(2)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(tui.fullRedraws).toBe(1)
     tui.stop()
+  })
+
+  it('does not append a main-screen newline after a managed alternate-screen restore', async () => {
+    const { terminal, tui } = await startedTui()
+    terminal.__seekttyManagedAlternateScreen = true
+    terminal.reset()
+    tui.stop()
+    expect(terminal.output()).not.toContain('\r\n')
+    expect(terminal.output()).not.toMatch(/\u001B\[\d+[AB]/u)
+  })
+
+  it('discards queued frames before alternate-screen restoration', async () => {
+    const { terminal, tui, lines } = await startedTui()
+    const managed = tui as TUI & { stopRenderingSync(): void }
+    terminal.reset()
+    lines[29] = 'must-not-reach-main-screen'
+    tui.requestRender()
+    managed.stopRenderingSync()
+    await nextFrame()
+    expect(terminal.output()).not.toContain('must-not-reach-main-screen')
+    tui.stop()
+  })
+
+  it('preserves the upstream stop newline outside a managed alternate screen', async () => {
+    const { terminal, tui } = await startedTui()
+    terminal.reset()
+    tui.stop()
+    expect(terminal.output()).toContain('\r\n')
   })
 })

--- a/tests/tui-render-stability.test.ts
+++ b/tests/tui-render-stability.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { TUI, type Terminal } from '@mariozechner/pi-tui'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Box, TUI, visibleWidth, type Component, type Terminal } from '@mariozechner/pi-tui'
+import { BottomAnchoredLayout } from '../src/client/chrome.ts'
+import { background } from '../src/client/theme.ts'
 
 /**
  * Regression tests for the patched pi-tui renderer (patches/@mariozechner__pi-tui@0.73.1.patch).
@@ -15,6 +17,9 @@ import { TUI, type Terminal } from '@mariozechner/pi-tui'
 const CLEAR_SCREEN = '\u001B[2J'
 const CLEAR_SCROLLBACK = '\u001B[3J'
 const CLEAR_TO_END = '\u001B[0J'
+const ERASE_LINE = '\u001B[2K'
+const SYNC_BEGIN = '\u001B[?2026h'
+const SYNC_END = '\u001B[?2026l'
 
 class RecordingTerminal implements Terminal {
   writes: string[] = []
@@ -38,8 +43,39 @@ class RecordingTerminal implements Terminal {
   reset(): void { this.writes = [] }
 }
 
+const ASCII_PRINTABLE = /^[\x20-\x7e]+$/u
+
 const nextFrame = async (): Promise<void> => {
   await new Promise(resolve => setTimeout(resolve, 40))
+}
+
+const tuiCursor = (tui: TUI): { cursorRow: number; hardwareCursorRow: number } =>
+  tui as unknown as { cursorRow: number; hardwareCursorRow: number }
+
+const rowTokens = (text: string): string[] =>
+  [...text.matchAll(/row-\d+/gu)].map(match => match[0]!)
+
+const uniqueTokens = (tokens: readonly string[]): boolean =>
+  new Set(tokens).size === tokens.length
+
+const isAsciiCols = (line: string, cols: number): boolean =>
+  line.length === cols && ASCII_PRINTABLE.test(line)
+
+const csiCount = (output: string, token: string): number =>
+  token.length === 0 ? 0 : output.split(token).length - 1
+
+const stubRows = (...values: string[]): Component => ({
+  render: () => values,
+  invalidate: () => undefined,
+})
+
+/** Fill a row to exactly `cols` using `unit`, with ASCII `#` only for a leftover odd cell. */
+const exactWidthLine = (unit: string, cols: number): string => {
+  const unitWidth = visibleWidth(unit)
+  expect(unitWidth).toBeGreaterThan(0)
+  const count = Math.floor(cols / unitWidth)
+  const used = count * unitWidth
+  return `${unit.repeat(count)}${'#'.repeat(cols - used)}`
 }
 
 interface Harness {
@@ -116,7 +152,7 @@ describe('patched pi-tui render stability', () => {
     const output = terminal.output()
     expect(output).not.toContain(CLEAR_SCREEN)
     expect(output).not.toContain(CLEAR_SCROLLBACK)
-    expect(output).toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_TO_END)
     // Tall content: only the visible window is painted, so older turns stay
     // in native scrollback instead of replaying through the viewport.
     expect(output).not.toContain('row-05-restyled')
@@ -178,5 +214,496 @@ describe('patched pi-tui render stability', () => {
     terminal.reset()
     tui.stop()
     expect(terminal.output()).toContain('\r\n')
+  })
+
+  it('skips per-row 2K and trailing 0J when a forced redraw fills the viewport with full-width rows', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const lines = Array.from({ length: terminal.rows }, (_, index) =>
+      `full-${String(index).padStart(2, '0')}`.padEnd(terminal.columns, ' '))
+    expect(lines.every(line => isAsciiCols(line, terminal.columns))).toBe(true)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain(SYNC_BEGIN)
+    expect(output).toContain(SYNC_END)
+    expect(output).toContain('\u001B[H')
+    expect(output).not.toContain(ERASE_LINE)
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(output).toContain('full-00')
+    expect(output).toContain('full-09')
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(terminal.rows - 1)
+    expect(cursor.hardwareCursorRow).toBe(cursor.cursorRow)
+    tui.stop()
+  })
+
+  it('keeps per-row 2K and skips trailing 0J on a full-height forced redraw of short rows', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const lines = Array.from({ length: terminal.rows }, (_, index) => `short-${String(index)}`)
+    expect(lines.every(line => line.length < terminal.columns && ASCII_PRINTABLE.test(line))).toBe(true)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain(SYNC_BEGIN)
+    expect(output).toContain(SYNC_END)
+    expect(output).toContain(ERASE_LINE)
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(terminal.rows - 1)
+    expect(cursor.hardwareCursorRow).toBe(cursor.cursorRow)
+    tui.stop()
+  })
+
+  it('clears rows below a short-height full-width forced redraw without ED0 on a wrap-pending last cell', async () => {
+    const terminal = new RecordingTerminal()
+    const contentRows = 3
+    const lines = [
+      `${'a'.repeat(terminal.columns - 1)}A`,
+      `${'b'.repeat(terminal.columns - 1)}B`,
+      `${'c'.repeat(terminal.columns - 1)}#`,
+    ]
+    expect(lines).toHaveLength(contentRows)
+    expect(lines.every(line => isAsciiCols(line, terminal.columns))).toBe(true)
+    expect(lines[2]!.endsWith('#')).toBe(true)
+    const tui = new TUI(terminal, false)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain(SYNC_BEGIN)
+    expect(output).toContain(SYNC_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(`#${CLEAR_TO_END}`)
+    expect(output).toContain('#')
+    const extraLines = terminal.rows - contentRows
+    const leftover = `\r\u001B[1B${Array.from({ length: extraLines }, (_, index) =>
+      `\r${ERASE_LINE}${index < extraLines - 1 ? '\u001B[1B' : ''}`).join('')}\u001B[${extraLines}A`
+    expect(output).toContain(leftover)
+    expect(csiCount(output, ERASE_LINE)).toBe(extraLines)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(contentRows - 1)
+    expect(cursor.hardwareCursorRow).toBe(cursor.cursorRow)
+    tui.stop()
+  })
+
+  it('clears rows below a short-height short-row forced redraw without ED0', async () => {
+    const terminal = new RecordingTerminal()
+    const contentRows = 3
+    const lines = Array.from({ length: contentRows }, (_, index) => `short-${String(index)}`)
+    expect(lines.every(line => line.length < terminal.columns && ASCII_PRINTABLE.test(line))).toBe(true)
+    const tui = new TUI(terminal, false)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).toContain('short-0')
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(contentRows - 1)
+    expect(cursor.hardwareCursorRow).toBe(cursor.cursorRow)
+    tui.stop()
+  })
+
+  it('does not let trailing 0J erase a visible last-cell # on a full-height mixed forced redraw', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const lines = [
+      ...Array.from({ length: 8 }, () => 'x'.repeat(terminal.columns)),
+      'short',
+      `${'x'.repeat(terminal.columns - 1)}#`,
+    ]
+    expect(lines.slice(0, 8).every(line => isAsciiCols(line, terminal.columns))).toBe(true)
+    expect(lines[8]!.length < terminal.columns && ASCII_PRINTABLE.test(lines[8]!)).toBe(true)
+    expect(isAsciiCols(lines[9]!, terminal.columns)).toBe(true)
+    expect(lines[9]!.endsWith('#')).toBe(true)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain(SYNC_BEGIN)
+    expect(output).toContain(SYNC_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(output).toContain(ERASE_LINE)
+    expect(output).toContain('#')
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(`#${CLEAR_TO_END}`)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(terminal.rows - 1)
+    expect(cursor.hardwareCursorRow).toBe(cursor.cursorRow)
+    tui.stop()
+  })
+
+  it('allows 0J only from Home on an empty forced redraw and clears the viewport', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    tui.addChild({ render: () => [], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain('\u001B[H')
+    expect(output).toContain(CLEAR_TO_END)
+    expect(output.indexOf('\u001B[H')).toBeLessThan(output.indexOf(CLEAR_TO_END))
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+    expect(csiCount(output, CLEAR_TO_END)).toBe(1)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(0)
+    expect(cursor.hardwareCursorRow).toBe(0)
+    tui.stop()
+  })
+
+  it('preserves a one-row exact-width last cell and clears rows below without ED0', async () => {
+    const terminal = new RecordingTerminal()
+    const line = `${'x'.repeat(terminal.columns - 1)}#`
+    expect(isAsciiCols(line, terminal.columns)).toBe(true)
+    const tui = new TUI(terminal, false)
+    tui.addChild({ render: () => [line], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    tui.requestRender(true)
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+    expect(output).toContain('#')
+    expect(output).not.toContain(`#${CLEAR_TO_END}`)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(0)
+    expect(cursor.hardwareCursorRow).toBe(0)
+    tui.stop()
+  })
+
+  it('keeps last-cell and 2026 balance when height shrinks onto a full-width frame', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    tui.addChild({
+      render: () => Array.from({ length: terminal.rows }, (_, index) =>
+        `${'y'.repeat(terminal.columns - 1)}${index === terminal.rows - 1 ? '#' : 'Y'}`),
+      invalidate: () => undefined,
+    })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    terminal.rows = 6
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+    expect(output).toContain('#')
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(5)
+    expect(cursor.hardwareCursorRow).toBe(5)
+    tui.stop()
+  })
+
+  it('clears newly exposed rows when height grows under a three-row exact-width frame', async () => {
+    const terminal = new RecordingTerminal()
+    const lines = [
+      `${'a'.repeat(terminal.columns - 1)}A`,
+      `${'b'.repeat(terminal.columns - 1)}B`,
+      `${'c'.repeat(terminal.columns - 1)}#`,
+    ]
+    const tui = new TUI(terminal, false)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    terminal.rows = 14
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+    expect(output).toContain('#')
+    expect(output).toContain(ERASE_LINE)
+    const cursor = tuiCursor(tui)
+    expect(cursor.cursorRow).toBe(2)
+    expect(cursor.hardwareCursorRow).toBe(2)
+    tui.stop()
+  })
+
+  it('repaints an exact-width last cell after a width shrink without ED0, 2J, or 3J', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    tui.addChild({
+      render: () => [`${'z'.repeat(Math.max(1, terminal.columns - 1))}#`],
+      invalidate: () => undefined,
+    })
+    tui.start()
+    await nextFrame()
+    terminal.reset()
+    terminal.columns = 20
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_SCROLLBACK)
+    expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+    expect(output).toContain('#')
+    expect(output).not.toContain(`#${CLEAR_TO_END}`)
+    tui.stop()
+  })
+
+  it('follows the tail without duplicating or replaying the head when a short child grows past the viewport', async () => {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const lines = Array.from({ length: 5 }, (_, index) => `row-${String(index).padStart(2, '0')}`)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    expect(rowTokens(terminal.output())).toEqual(['row-00', 'row-01', 'row-02', 'row-03', 'row-04'])
+
+    terminal.reset()
+    lines.length = 0
+    lines.push(...Array.from({ length: 25 }, (_, index) => `row-${String(index).padStart(2, '0')}`))
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    const tokens = rowTokens(output)
+    expect(output).not.toContain('row-00')
+    expect(output).toContain('row-24')
+    expect(tokens.at(-1)).toBe('row-24')
+    expect(uniqueTokens(tokens)).toBe(true)
+    tui.stop()
+  })
+})
+
+describe('differential skip-2K on exact-width changed rows (TUI bytes, not a native oracle)', () => {
+  async function startedExact(line: string): Promise<Harness> {
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const lines = Array.from({ length: terminal.rows }, () => line)
+    tui.addChild({ render: () => [...lines], invalidate: () => undefined })
+    tui.start()
+    await nextFrame()
+    expect(visibleWidth(line)).toBe(terminal.columns)
+    expect(tui.fullRedraws).toBe(1)
+    terminal.reset()
+    return { terminal, tui, lines, initialOutput: '' }
+  }
+
+  it('does not emit 2K when one exact-width ASCII, CJK, emoji, or SGR row changes', async () => {
+    const cases = [
+      ['A'.repeat(40), 'B'.repeat(40), 'B'.repeat(40)],
+      [exactWidthLine('中', 40), exactWidthLine('文', 40), exactWidthLine('文', 40)],
+      [exactWidthLine('😀', 40), exactWidthLine('😄', 40), exactWidthLine('😄', 40)],
+      [`\u001B[44m${'C'.repeat(40)}\u001B[0m`, `\u001B[45m${'D'.repeat(40)}\u001B[0m`, 'D'.repeat(40)],
+    ] as const
+    for (const [before, after, token] of cases) {
+      const { terminal, tui, lines } = await startedExact(before)
+      lines[3] = after
+      tui.requestRender()
+      await nextFrame()
+      const output = terminal.output()
+      expect(csiCount(output, SYNC_BEGIN), token).toBe(csiCount(output, SYNC_END))
+      expect(output, token).toContain(token)
+      expect(output, token).not.toContain(ERASE_LINE)
+      expect(output, token).not.toContain(CLEAR_SCREEN)
+      expect(output, token).not.toContain(CLEAR_SCROLLBACK)
+      expect(output, token).not.toContain(CLEAR_TO_END)
+      expect(tui.fullRedraws, token).toBe(1)
+      tui.stop()
+    }
+  })
+
+  it('emits 2K when a full-width row shrinks so the tail must clear', async () => {
+    const { terminal, tui, lines } = await startedExact('A'.repeat(40))
+    lines[3] = 'hi'
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain(`${ERASE_LINE}hi`)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(output).not.toContain(CLEAR_TO_END)
+    expect(tui.fullRedraws).toBe(1)
+    tui.stop()
+  })
+})
+
+describe('unicode exact-width skip-2K (TUI bytes, not a terminal oracle)', () => {
+  it('skips 2K on forced exact-width CJK and emoji rows, and keeps 2K on a short SGR span', async () => {
+    for (const unit of ['中', '😀'] as const) {
+      const terminal = new RecordingTerminal()
+      const line = exactWidthLine(unit, terminal.columns)
+      expect(visibleWidth(line)).toBe(terminal.columns)
+      const tui = new TUI(terminal, false)
+      tui.addChild({
+        render: () => Array.from({ length: terminal.rows }, () => line),
+        invalidate: () => undefined,
+      })
+      tui.start()
+      await nextFrame()
+      terminal.reset()
+      tui.requestRender(true)
+      await nextFrame()
+      const output = terminal.output()
+      expect(csiCount(output, SYNC_BEGIN)).toBe(csiCount(output, SYNC_END))
+      expect(output).not.toContain(ERASE_LINE)
+      expect(output).not.toContain(CLEAR_TO_END)
+      expect(output).not.toContain(CLEAR_SCREEN)
+      tui.stop()
+    }
+
+    const shortTerm = new RecordingTerminal()
+    const shortBg = `\u001B[44mhi\u001B[0m`
+    expect(visibleWidth(shortBg)).toBeLessThan(shortTerm.columns)
+    const shortTui = new TUI(shortTerm, false)
+    shortTui.addChild({
+      render: () => Array.from({ length: shortTerm.rows }, () => shortBg),
+      invalidate: () => undefined,
+    })
+    shortTui.start()
+    await nextFrame()
+    shortTerm.reset()
+    shortTui.requestRender(true)
+    await nextFrame()
+    expect(shortTerm.output()).toContain(ERASE_LINE)
+    shortTui.stop()
+
+    const padded = new RecordingTerminal()
+    const bgLine = `\u001B[44m${' '.repeat(padded.columns)}\u001B[0m`
+    expect(visibleWidth(bgLine)).toBe(padded.columns)
+    const paddedTui = new TUI(padded, false)
+    paddedTui.addChild({
+      render: () => Array.from({ length: padded.rows }, () => bgLine),
+      invalidate: () => undefined,
+    })
+    paddedTui.start()
+    await nextFrame()
+    padded.reset()
+    paddedTui.requestRender(true)
+    await nextFrame()
+    expect(padded.output()).not.toContain(ERASE_LINE)
+    paddedTui.stop()
+  })
+})
+
+describe('SeekTTY Box + BottomAnchoredLayout first-frame bytes (not native pixels)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    Reflect.deleteProperty(process.env, 'NO_COLOR')
+  })
+
+  async function startedCanvas(columns: number, rows: number, color: boolean): Promise<{
+    terminal: RecordingTerminal
+    tui: TUI
+  }> {
+    vi.unstubAllEnvs()
+    if (color) {
+      Reflect.deleteProperty(process.env, 'NO_COLOR')
+      vi.stubEnv('COLORTERM', 'truecolor')
+      vi.stubEnv('TERM', 'xterm-256color')
+      vi.stubEnv('TERM_PROGRAM', 'iTerm.app')
+    }
+    else {
+      vi.stubEnv('NO_COLOR', '1')
+    }
+    const terminal = new RecordingTerminal()
+    terminal.columns = columns
+    terminal.rows = rows
+    const tui = new TUI(terminal, false)
+    const canvas = new Box(0, 0, background.canvas)
+    canvas.addChild(new BottomAnchoredLayout(
+      () => terminal.rows,
+      stubRows('context-bar'),
+      stubRows('hello', 'world'),
+      stubRows('editor-top', 'editor-body', 'editor-bot'),
+      stubRows('status-row'),
+    ))
+    tui.addChild(canvas)
+    tui.start()
+    await nextFrame()
+    return { terminal, tui }
+  }
+
+  it('does not emit 2K when a full-width canvas child changes without a forced redraw', async () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const terminal = new RecordingTerminal()
+    terminal.columns = 40
+    terminal.rows = 10
+    const tui = new TUI(terminal, false)
+    const mid = ['hello', 'world']
+    const canvas = new Box(0, 0, background.canvas)
+    canvas.addChild(new BottomAnchoredLayout(
+      () => terminal.rows,
+      stubRows('context-bar'),
+      { render: () => mid, invalidate: () => undefined },
+      stubRows('editor-top', 'editor-body', 'editor-bot'),
+      stubRows('status-row'),
+    ))
+    tui.addChild(canvas)
+    tui.start()
+    await nextFrame()
+    expect(tui.render(terminal.columns).every(line => visibleWidth(line) === terminal.columns)).toBe(true)
+    terminal.reset()
+    mid[0] = 'hello!'
+    tui.requestRender()
+    await nextFrame()
+    const output = terminal.output()
+    expect(output).toContain('hello!')
+    expect(output).not.toContain(ERASE_LINE)
+    expect(output).not.toContain(CLEAR_SCREEN)
+    expect(tui.fullRedraws).toBe(1)
+    tui.stop()
+  })
+
+  it('emits a full-height canvas without 2J/3J, and skips 2K on force', async () => {
+    for (const [columns, rows, color] of [[40, 10, false], [80, 24, true]] as const) {
+      const label = `${columns}x${rows} color=${color}`
+      const { terminal, tui } = await startedCanvas(columns, rows, color)
+      const first = terminal.output()
+      expect(first, label).not.toContain(CLEAR_SCREEN)
+      expect(first, label).not.toContain(CLEAR_SCROLLBACK)
+      const painted = tui.render(columns)
+      expect(painted.length, label).toBe(rows)
+      expect(painted.every(line => visibleWidth(line) === columns), label).toBe(true)
+      if (color) expect(first, label).toMatch(/\u001B\[48;/u)
+      terminal.reset()
+      tui.requestRender(true)
+      await nextFrame()
+      const forced = terminal.output()
+      expect(forced, `${label} force`).not.toContain(ERASE_LINE)
+      expect(forced, `${label} force`).not.toContain(CLEAR_TO_END)
+      tui.stop()
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Bring together the existing fixed-terminal-viewport and transcript-rendering performance work with the follow-up stability fixes.
- Keep conversation history inside the alternate-screen viewport, bound cached rendering to visible blocks, and preserve search position during wheel navigation.
- Avoid redundant full-row clears and wrap-pending end-of-display erases that can expose the terminal default background.
- Keep performance diagnostics default-off and content-free, bound retained latency samples, and avoid diagnostic writes to an interactive terminal.
- Make the existing empty-Profile launcher test explicitly select its expected language; its assertions and launcher behavior are unchanged.
- Integrate the latest `main` README simplification, retaining the fixed-viewport/control descriptions.

## Scope boundaries

- The unfinished direct mouse-drag selection/copy implementation is **excluded**. Existing wheel handling and alternate-screen lifecycle from the fixed-viewport baseline remain included.
- No API keys, local provider configuration, session data, raw test logs, or local Grok handoff/planning notes are included.
- Harness remains the owner of Agent, Session, model, permissions, Settings, Profile, plugins, and persistence. No state migration, release, or automatic merge is requested.

## Verification

- Cursor CLI Grok 4.6 Extra High **non-Fast** performed the scoped review and test execution.
- Fresh isolated dependencies installed from the unchanged lockfile with pnpm 11.7.0; runtime Node 24.19.0.
- `LANG=en_US.UTF-8 pnpm run check`: **629 passed, 1 skipped**; typecheck, production build, and package-content check passed (23 entries).
- `git diff --exit-code -- lib/`: passed; rebuilt runtime remains byte-for-byte identical to the locally tested candidate.
- The single skip is the optional Clarify doctor acceptance case without `CLARIFY_SPEC`.
- Initial attempts are not counted as passes: the dependency-link setup failed pnpm preflight, and the first English-locale suite exposed the existing locale-dependent assertion. Fresh isolated installation and the explicit test locale corrected these respectively.

## Remaining limits

- Native Terminal.app/iTerm2 pixel behavior, physical mouse selection, and a complete native 60-minute input-latency acceptance run are not established by unit tests or PTY evidence. Earlier acceptance records retain these distinctions.
- The user reports that the intermittent white block is no longer observed in their current manual testing; this is not an exhaustive native-platform guarantee.
- Provider token/chunk arrival throughput is separate from terminal rendering and is not claimed fixed here.
- Enabling the optional diagnostic file sink performs synchronous writes and may perturb measured latency; normal operation keeps diagnostics disabled.

## Rollback

This is presentation, terminal-lifecycle, and diagnostic state only. Revert the relevant fix commits and rebuild the bundle; no Harness-owned settings or session migration needs reversal.
