### PR TITLE
docs: remove keyboard-first wording from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1>SeekTTY</h1>
 
-<p>A keyboard-first terminal workspace for DeepSeek Harness.</p>
+<p>A terminal workspace for DeepSeek Harness.</p>
 
 <p>
   <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.4-orange" alt="Version 1.2.4"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 <h1>SeekTTY</h1>
 
-<p>DeepSeek Harness 的键盘优先终端工作台。</p>
+<p>DeepSeek Harness 的终端工作台。</p>
 
 <p>
   <a href="https://github.com/Hilbert-beinghappy/seektty/releases"><img src="https://img.shields.io/badge/Version-1.2.4-orange" alt="Version 1.2.4"></a>


### PR DESCRIPTION
## Summary

- Remove "keyboard-first" from the English README tagline and "键盘优先" from the Chinese README tagline.
- Keep both descriptions neutral now that SeekTTY supports mouse interaction. No runtime behavior changes.

## Verification

- `git diff --check` passed.
- Repository-wide search found no remaining keyboard-first wording or equivalent Chinese descriptions.
- Exact-content assertions confirmed that only the two requested tagline replacements changed.
- Full build and runtime tests were not run locally because this change only edits documentation.
