### PR TITLE
docs(release): finalize v1.2.4 release notes and verification

### DIFF
--- a/docs/release-v1.2.4-verification.md
+++ b/docs/release-v1.2.4-verification.md
@@ -1,10 +1,11 @@
-# SeekTTY 1.2.4 — owner review and release checklist
+# SeekTTY 1.2.4 — release verification and checklist
 
-Status: prepared for review; **not merged, tagged, or published by this work**.
+Release record for `v1.2.4`. The [GitHub Release](https://github.com/Hilbert-beinghappy/seektty/releases/tag/v1.2.4) is the source of truth for publication time and downloadable artifacts.
 
-- Base: `v1.2.3` / `04f2837` on upstream `main`.
-- Implementation: `81a0b86` (`fix(tui): stabilize overlay input and context-menu gestures`).
-- Candidate: `seektty-1.2.4.tgz`, built from this PR with pnpm `11.7.0`.
+- Previous release: `v1.2.3` / `04f2837`.
+- Merged code baseline: upstream `main` at `a2e3950`, including mouse/input fixes in PR #154, user-message rules in PR #155, and the existing README update in PR #156.
+- Finalization changes only the release documents; package inputs and README files remain identical to that baseline.
+- Artifact: `seektty-1.2.4.tgz`, built with pnpm `11.7.0`; SHA-256 recorded below and in the release's `SHA256SUMS` asset.
 - Tested Host: unmodified official `@deepseek-ai/dsh@0.1.1-rc.2`.
 - Release notes: [English and Chinese in one document](release-v1.2.4.md).
 
@@ -14,6 +15,7 @@ No credentials, Profile/Session contents, raw terminal logs, personal theme file
 
 | Area | Primary code and regression coverage |
 | --- | --- |
+| User-message top and bottom rules | `src/client/horizontal-rule.ts`, `chrome.ts`, `transcript.ts`; transcript and viewport tests cover themes, wrapping, resize, selection, and search |
 | Stable list viewport, focus guard, nested hover | `patches/@mariozechner__pi-tui@0.73.1.patch`, `src/client/overlays.ts`, `mouse-activation.ts`, `mouse-controller.ts`, `theme*.ts`; autocomplete, overlay-pointer, and theme tests |
 | Escape/SGR framing and undo | The pinned pi-tui patch, `src/client/chrome.ts`, `transcript.ts`; `tests/terminal-input-framing.test.ts`, `tests/input-undo.test.ts` |
 | Overlay selection and footer buttons | `src/client/overlay-text.ts`, `overlay-footer.ts`, `overlays.ts`; overlay text-selection and footer tests |
@@ -24,28 +26,28 @@ Review the pi-tui patch together with its lockfile hash and generated bundle. It
 
 ## Candidate evidence
 
-The following entries must describe the final 1.2.4 tarball, not the earlier locally installed 1.2.3 test build.
+The following results were collected on 2026-08-28 for the final 1.2.4 package inputs, including the user-message rules. They do not describe the earlier PR #154 candidate or the locally installed 1.2.3 test build. Release documents are not packaged, so documentation-only finalization does not change this artifact.
 
 | Gate | Result |
 | --- | --- |
 | Frozen dependency installation | Pass — pnpm `11.7.0`, lockfile unchanged |
-| `pnpm run check` | Pass — 109 files; 885 passed / 1 conditional skip; typecheck, build and 23-entry pack allowlist passed |
-| Reproducible tracked `lib/` and launcher `--version` | Pass — second build byte-identical; `seektty 1.2.4`; generated renamed chunk included |
+| `pnpm run check` | Pass — 109 files; 892 passed / 1 conditional skip; typecheck, build and 23-entry pack allowlist passed |
+| Tracked `lib/` and launcher `--version` | Pass — rebuilt bundle matches the merged code; `seektty 1.2.4` |
 | `pnpm run perf:tui` | Pass — 12 runs: 1k / 10k / 50k / 100k lines, three repeats, 80 columns × 24 rows |
 | Official dsh isolated add / boot / remove / re-add | Pass — exact 1.2.4 tarball on unmodified official dsh `0.1.1-rc.2`, including second boot and package/Host identity checks |
 | Windows ConPTY menu gestures and clean exit | Pass — one cycle of the exact 1.2.4 candidate, `contextMenuGestures: true`, 9588 bytes, exit code 0; not GUI-equivalent |
-| Credential-pattern / forbidden-path / pack allowlist checks | Pass — no detected credential patterns or forbidden staged paths; 23 packaged entries; personal themes excluded |
-| GitHub CI | Consult the checks on the final PR head; local checks do not substitute for CI |
+| Package allowlist | Pass — 23 packaged entries; no Profile, Session, `.env`, package caches, or personal themes included |
+| GitHub CI | Consult checks for the release tag's commit and its documentation PR; local checks do not substitute for CI |
 
-Local reviewed candidate SHA-256 (`seektty-1.2.4.tgz`): `BC194710C15416188C8DA6D4310DA5489D8A993C09FBFE79DC9D33386E1D04A5`.
+Release artifact SHA-256 (`seektty-1.2.4.tgz`): `63a0a3d692a0380affe7701c8a37fc79bb0f749ba903df9dc5ecaf83abbc41ba`.
 
-Environment: Windows `10.0.22631`, x64, Node.js `v26.1.0`. The package targets Node `22.19`; GitHub CI checks Node `22.x`. These are local pre-publication results; the owner must record the final published artifact's checksum after rebuilding the reviewed merge commit.
+Environment: Windows `10.0.22631`, x64, Node.js `v26.1.0`. The package targets Node `22.19`; GitHub CI checks Node `22.x`. Compare a freshly downloaded release asset with `SHA256SUMS` before installation.
 
 The optional Clarify doctor test is conditional. A skipped optional test is not a passed joint-plugin acceptance run. No paid Provider request is needed for the automated mouse checks. Legacy Host versions, optional plugin workflows, real clipboard contents, and 100 repeated PTY lifecycles are not claimed as newly accepted here.
 
-## Test the PR before release
+## Test the release in isolation
 
-Prerequisites: Node.js `^22.19.0 || >=24`, pnpm `11.7.0`, and official `dsh --version` reporting `0.1.1-rc.2`. Check out this PR, then use a **new terminal** so the isolated environment does not replace your normal `DSH_HOME`.
+Prerequisites: Node.js `^22.19.0 || >=24`, pnpm `11.7.0`, and official `dsh --version` reporting `0.1.1-rc.2`. Check out `v1.2.4`, then use a **new terminal** so the isolated environment does not replace your normal `DSH_HOME`.
 
 ### Windows PowerShell
 
@@ -84,6 +86,7 @@ To rerun lifecycle and PTY checks, set `DSH_BIN` to the official dsh executable 
 
 These items are intentionally **unchecked**. Record terminal/OS versions and observed results in the PR; synthetic tests and ConPTY injection are not GUI acceptance.
 
+- [ ] **User-message framing:** verify one pair of thin top/bottom rules matching the composer around historical user messages, including multiline prompts and resized terminals; copying and searching in-app must use message text, not decorative rules.
 - [ ] **Startup and nested pages:** without minimizing first, open Settings; first click selects a row, a later click enters it. Confirm hover and Select/Back buttons through at least three page levels. Keep dangerous confirmations keyboard-only.
 - [ ] **List scrolling:** in slash candidates and long settings lists, wheel-scroll to the middle, click a visible item, and verify no recentering. Up/Down should scroll only at an edge; Enter and a second click target the visible candidate correctly.
 - [ ] **Escape framing:** repeatedly press Esc while moving the mouse over a search field; no protocol fragments appear. Check both hover enabled and disabled.
@@ -103,15 +106,15 @@ These items are intentionally **unchecked**. Record terminal/OS versions and obs
 
 The owner decides whether remaining platform gaps block publication or require explicitly scoped follow-up. Do not mark unchecked environments as passed.
 
-## Publish only after approval
+## Release procedure
 
-This PR does not add an automatic publishing workflow or change repository visibility. The existing workflow runs Linux checks/stock boot and Windows launcher checks. The following steps are for the owner **after approval**, not actions already performed:
+The release request authorizes publication. No automatic publishing workflow or repository visibility change is introduced. The existing workflow runs Linux checks/stock boot and Windows launcher checks. Use this sequence for the authorized release:
 
-1. Review the final PR head, require successful GitHub CI, and record manual sign-off or explicit acceptance of remaining gaps.
-2. Merge the PR. In a clean checkout of the reviewed merge commit, run frozen install, `pnpm run check`, the performance gate, and candidate pack/lifecycle checks again. Confirm `git diff --exit-code -- lib/` and `node lib/bin.js --version` reports `seektty 1.2.4`.
-3. Pack `seektty-1.2.4.tgz` into a directory outside the checkout. Record its SHA-256 and verify the archive allowlist. Do not upload local Profile, Session, `.env`, logs, caches, or personal theme files.
-4. Create the `v1.2.4` tag at that exact reviewed merge commit. Create a **draft** GitHub Release with the tarball, `SHA256SUMS`, and [this bilingual release document](release-v1.2.4.md) as the notes. Confirm tag, package version, asset name, and checksum match.
-5. Publish the draft only with the owner's release approval. Verify the README's versioned download URL and a fresh isolated install from the published asset. There is no npm Registry publication step.
+1. Finalize and merge the bilingual release documents without changing the reviewed code or READMEs. Check GitHub CI and keep untested manual environments explicitly listed above.
+2. Verify frozen dependencies, `pnpm run check`, the performance gate, and the exact packaged artifact's lifecycle/PTY checks. Confirm rebuilt `lib/` matches the reviewed code and `node lib/bin.js --version` reports `seektty 1.2.4`.
+3. Keep `seektty-1.2.4.tgz` and `SHA256SUMS` outside the checkout. Verify that the tag's package inputs match the verified artifact. Do not upload local Profile, Session, `.env`, logs, caches, or personal theme files.
+4. Create `v1.2.4` at the exact release commit and a **draft** GitHub Release with the tarball, `SHA256SUMS`, and [this bilingual release document](release-v1.2.4.md) as the notes. Confirm tag, package version, asset name, and checksum match.
+5. Publish the authorized draft. Download the published assets, compare their SHA-256 values, and verify isolated installation from the downloaded package. There is no npm Registry publication step.
 
 ## Rollback
 
@@ -125,8 +128,8 @@ Keep automatic updates off during rollback testing. If the global `deepseek` lau
 
 ## 中文审核说明
 
-本次仅准备 1.2.4 并提 PR，不代替 owner 合并、打 tag 或正式发布。实现提交为 `81a0b86`，版本、双语 README、同文件中英文 Release 说明及本清单在发布准备提交中整理。
+本记录对应正式 1.2.4 发布：包内容基于已合并的 `main@a2e3950`，包含 PR #154 的鼠标与输入修复和 PR #155 的历史用户消息上下细线。最后仅完善发布文档，不再修改 README。中英文 Release 说明仍保存在同一文件。
 
-上面的安装命令使用新终端和隔离 `DSH_HOME`，不会覆盖日常 Profile；退出首次 API Key 提示即可测试本地界面。证据表只记录最终 1.2.4 候选包，不把旧 1.2.3 本机测试包、模拟事件或 Windows ConPTY 当作三端 GUI 验收。人工清单仍需 owner 签收，未测环境不能标绿。
+最终包通过 892 项测试（1 项条件跳过）、类型检查、构建、23 项打包白名单、十万行性能检查、官方 dsh 隔离插拔，以及 Windows ConPTY 手势和退出检查。上面的安装命令使用新终端和隔离 `DSH_HOME`，不会覆盖日常 Profile；退出首次 API Key 提示即可测试本地界面。自动测试和 Windows ConPTY 不等于三端 GUI／真实剪贴板验收，未测环境仍明确保留，不标绿。
 
-审核重点为：启动即用、多层 hover 与底栏按钮、列表不居中、Esc 不混入鼠标协议、弹窗选区与撤销、独立右键菜单、滚轮／拖选交接、右键松手定位，以及危险确认和隐私边界。通过审核和 CI 后，owner 从已合并提交重新构建、验包、打 tag、创建带同一双语说明的草稿 Release，最后决定发布。回滚通过原生插件安装替换旧包，不删除配置或会话。
+发布时固定 tag 和包内容，上传安装包及 `SHA256SUMS`，使用同一份双语说明；发布后重新下载、核对校验和并验证隔离安装。发布时间与附件以 GitHub Release 页面为准。回滚通过原生插件安装替换旧包，不删除配置或会话。

--- a/docs/release-v1.2.4.md
+++ b/docs/release-v1.2.4.md
@@ -2,7 +2,12 @@
 
 ## English
 
-SeekTTY 1.2.4 improves the mouse navigation and input editing introduced in 1.2.3. It keeps the fixed transcript viewport and native terminal selection fallback, without changing Harness-owned runtime state.
+SeekTTY 1.2.4 improves conversation readability, mouse navigation, and input editing. It keeps the fixed transcript viewport and native terminal selection fallback, without changing Harness-owned runtime state.
+
+### Conversation readability
+
+- Historical user messages now have thin top and bottom rules matching the input composer, making conversation turns easier to distinguish as responses stream.
+- The rules follow the current theme and terminal width, including wrapped and multiline messages. These decorative lines are excluded from in-app copied text and transcript search.
 
 ### Mouse navigation
 
@@ -23,7 +28,6 @@ SeekTTY 1.2.4 improves the mouse navigation and input editing introduced in 1.2.
 - Escape immediately followed by an SGR mouse report no longer inserts fragments such as `[<35;20;13M` into search fields. Partial mouse reports remain separate from text and bracketed paste.
 - Ctrl+Z undoes edits in the focused input, including composer, search, single-line, multiline, and masked-secret fields; Ctrl+- remains available. Undo does not restore sent messages or reverse saved Settings.
 - The shortcut reference is grouped by editing, commands, transcript navigation, sessions, and selection, and reflects configured key overrides.
-- English and Chinese READMEs now use the current standalone SeekTTY installation instead of the historical Clarify plugin stack.
 
 ### Compatibility and verification
 
@@ -37,7 +41,12 @@ SeekTTY 1.2.4 improves the mouse navigation and input editing introduced in 1.2.
 
 ## 中文
 
-SeekTTY 1.2.4 改进了 1.2.3 引入的鼠标导航和输入编辑，保留固定 Transcript 视口与原生终端选择备用通道，不改变由 Harness 持有的运行状态。
+SeekTTY 1.2.4 改善对话的视觉观感、鼠标导航和输入编辑，保留固定 Transcript 视口与原生终端选择备用通道，不改变由 Harness 持有的运行状态。
+
+### 对话视觉优化
+
+- 历史用户消息新增与输入框一致的上下细线，让不同轮次的对话在回答持续输出时更易区分，改善阅读观感。
+- 细线适配当前主题和终端宽度，兼容自动换行及多行消息；这些装饰线不会混入应用内复制的文本，也不参与对话搜索。
 
 ### 鼠标导航
 
@@ -58,7 +67,6 @@ SeekTTY 1.2.4 改进了 1.2.3 引入的鼠标导航和输入编辑，保留固�
 - Esc 后紧接 SGR 鼠标报告不再把 `[<35;20;13M` 一类残片输入搜索框；不完整鼠标报告继续与文本、括号粘贴隔离。
 - Ctrl+Z 可撤销当前输入框内的编辑，覆盖主输入框、搜索、单行、多行及遮蔽密钥字段；保留 Ctrl+-。撤销不会找回已发送消息，也不会回滚已保存 Settings。
 - 键位速查按编辑、命令、对话浏览、会话和选择归类，并显示实际改绑后的快捷键。
-- 中英文 README 的安装示例改为当前独立 SeekTTY 版本，不再默认安装历史 Clarify 插件组合。
 
 ### 兼容与验证
 


### PR DESCRIPTION
## Summary

- Finalize the English and Chinese v1.2.4 release notes in one document, including the historical user-message top/bottom rules merged in #155.
- Update the verification record for the final package inputs at `a2e3950` (including #154, #155, and the existing README change in #156).
- Documentation only: no source, generated bundle, README, dependency, or personal-theme changes. Mathematical formula rendering is not part of this release.

## Verification

The already-verified package inputs are unchanged. Recorded local checks: 892 tests passed / 1 conditional skip, typecheck, build, the 23-entry package allowlist, the 100k-line performance gate, official dsh 0.1.1-rc.2 isolated add/boot/remove/re-add, and Windows ConPTY gesture/exit checks.

The final tarball was rechecked against the tracked package inputs and its SHA-256:

`63a0a3d692a0380affe7701c8a37fc79bb0f749ba903df9dc5ecaf83abbc41ba`

Manual cross-platform GUI/clipboard gaps remain explicitly listed; they are not marked as passed. PR CI must pass before merge.

## Release

Publication has been requested. After merge and successful CI, tag the exact release commit as `v1.2.4`, publish `seektty-1.2.4.tgz` and `SHA256SUMS` with the bilingual notes, then verify the downloaded assets and isolated installation. No npm Registry publication or repository visibility change.