### PR TITLE
fix(tui): synchronize terminal background with the active theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Interface and code themes are independent. A palette of 3–16 HEX/RGB colors ca
 
 Hover styling is derived from the active interface theme, including existing custom themes, without adding required settings or altering saved colors. Indistinct or limited-color backgrounds use an underline cue; `NO_COLOR` remains respected.
 
+On supported truecolor terminals, SeekTTY queries the original terminal background and temporarily matches it to the interface theme, including live theme changes, so terminal padding does not show a different color. Exit restores the captured color. Unsupported or timed-out queries, `NO_COLOR`, limited-color terminals, and tmux/screen leave the terminal background untouched. Set `SEEKTTY_TERMINAL_BACKGROUND=off` to opt out. See [compatibility and verification](docs/terminal-background-compatibility.md); this does not change terminal settings, code highlighting, transparency, or window decorations.
+
 Use `/language` or a direct command to switch the terminal copy live:
 
 ```text

--- a/README.zh.md
+++ b/README.zh.md
@@ -274,6 +274,8 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 会打开主题中心，�
 
 悬停样式由当前界面主题统一推导，兼容已有自定义主题，不新增必填设置、不修改保存的配色。背景过于接近或终端色彩有限时使用下划线辅助区分；仍遵守 `NO_COLOR`。
 
+在支持的真彩色终端中，SeekTTY 会查询原终端背景色，并临时同步为界面主题背景，实时换主题时也会更新，避免终端边距露出异色；退出时恢复读取到的原色。不支持或查询超时、`NO_COLOR`、低色彩终端以及 tmux/screen 均保留原背景。设置 `SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭此功能。详见[兼容性与验证说明](docs/terminal-background-compatibility.md)；该功能不修改终端配置、代码高亮、透明度或窗口装饰。
+
 使用 `/language` 或直接命令实时切换终端文案：
 
 ```text

--- a/docs/terminal-background-compatibility.md
+++ b/docs/terminal-background-compatibility.md
@@ -1,0 +1,73 @@
+# Terminal background synchronization / 终端背景同步
+
+## Scope
+
+Terminal padding and leftover pixels outside the character grid use the terminal's own background. Painting more characters cannot reach them. SeekTTY now uses one platform-neutral OSC 11 controller to temporarily match that background to the **interface** theme's `colors.canvas`. Code-theme colors and highlighting are unchanged.
+
+- Start listening for input before issuing one asynchronous `OSC 11 ; ? ST` query. Startup never waits for a reply.
+- Require a valid `rgb:r/g/b` reply within 500 ms before changing the background. Each channel may contain 1–4 hex digits; retain the original precision for restoration.
+- Use the current theme if it changed while the query was pending. Deduplicate repeated colors; do not poll or write background commands on mouse movement or repaint.
+- Restore the captured color synchronously before normal/fatal teardown. Do **not** use OSC 111: resetting the configured profile color can lose a color previously selected by the shell or an enclosing application.
+- On POSIX `SIGTSTP`, restore terminal modes and background before suspending. On `SIGCONT`, re-enter, re-query, and redraw. Ctrl+Z remains input undo. Uncatchable termination (`SIGKILL`, forced termination, or a terminal crash) cannot guarantee cleanup.
+- Unsupported/expired queries never set or reset a color. Late, malformed, duplicate, and unsolicited OSC replies do not enter editors or overlays. Bracketed paste remains opaque.
+
+The pinned `@mariozechner/pi-tui@0.73.1` patch keeps OSC frames together across reads, supports BEL and ESC-backslash terminators, bounds incomplete buffers, and lets a new escape-prefixed event cancel a truncated frame. The ordinary lone-Escape key timeout is unchanged; after the OSC opener is recognized, the frame no longer expires into text.
+
+## Safe defaults
+
+Automatic synchronization requires the existing truecolor detection. It is disabled with:
+
+- `NO_COLOR`, `TERM=dumb`, or limited-color rendering;
+- `TMUX`, `STY`, or a `screen*` / `tmux*` terminal type;
+- `SEEKTTY_TERMINAL_BACKGROUND=off` (also accepts `0` or `false`).
+
+Direct SSH is not disabled merely because it is SSH: its terminal must still answer before the deadline. Multiplexers are deliberately excluded because a reply may be cached and changing the outer terminal may affect other panes. No passthrough is forced.
+
+This preserves Settings/Profile ownership, introduces no runtime dependencies, and never edits terminal configuration files or changes opacity/background images. Transparent or image-backed terminals may still look different from an opaque TUI; opt out when preserving that appearance is preferred. OS title bars, borders, and shadows are not part of this fix.
+
+## Verification
+
+Automated coverage is in `tests/terminal-background.test.ts`, `tests/terminal-input-framing.test.ts`, `tests/terminal-session.test.ts`, and `tests/process-guards.test.ts`. It covers capability policy, exact-color restoration, live changes, timeout/late replies, write failures, nested inputs, split replies, malformed/oversized frames, bracketed paste, fatal cleanup, and simulated POSIX suspend/resume signals. Synthetic terminal tests are **not** real GUI-terminal acceptance.
+
+Run the focused checks with:
+
+```sh
+pnpm exec vitest run tests/terminal-background.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
+```
+
+Use an isolated `DSH_HOME` and an unmodified official dsh `0.1.1-rc.2` for packaged installation/boot/removal/reinstallation checks. Compatibility adapters retain the existing declared Host range: `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2`.
+
+### Local automated results
+
+- Frozen pnpm `11.7.0` installation: passed; only the pinned pi-tui patch hash changed, not dependency versions.
+- `pnpm run check`: 110 test files; **929 passed / 1 conditional skip**, plus typecheck, build, and the 23-entry package allowlist.
+- Exact candidate on unmodified official dsh `0.1.1-rc.2`: isolated install, boot, remove, reinstall, second boot, and Host module-identity checks passed.
+- Windows ConPTY mouse/context-menu regression: one cycle, 9588 captured characters, exit code 0. This harness sets `NO_COLOR`, so it verifies the unchanged fallback and mouse path, **not** successful background synchronization in a GUI terminal.
+- Candidate SHA-256: `127fcdac44c1d39ebafda705f7161857dc62ae12d5ef84c2b456826e54647e0d`. This is a local development package still numbered `1.2.4`, not the published release asset; the public release was not replaced.
+
+The local Windows Terminal installation reports `1.24.11911.0`; its presence is not a manual background/exit acceptance result. Packaged compatibility checks used an isolated `DSH_HOME`; deploying a candidate into an everyday Profile is a separate, user-requested action and does not count as manual acceptance. The feature never edits terminal configuration files.
+
+### Manual matrix — not yet signed off
+
+| Environment | Expected policy | Manual result |
+| --- | --- | --- |
+| Windows Terminal, VS Code terminal | Probe when truecolor; synchronize only on a valid reply | Pending |
+| macOS iTerm2, Kitty, Ghostty | Same shared protocol and capability policy | Pending |
+| macOS Terminal.app | Existing limited-color detection leaves background unchanged | Pending fallback check |
+| Linux Kitty, Ghostty, GNOME Terminal / Konsole under Wayland or X11 | Probe when truecolor; synchronize only on a valid reply | Pending |
+| tmux / screen | No background query or mutation | Pending fallback check |
+| Direct SSH | Probe with the same bounded deadline | Pending latency/exit check |
+
+For each accepted terminal, record its version, OS, transparency, and color mode. Check a custom interface theme, light/dark changes, resizing to non-cell-aligned dimensions, nested overlay typing while starting, normal exit, SIGTERM, and (on POSIX) suspend/resume. The shell background after exit must match the color from before launch, including when it differs from the profile's configured default. Repeat with `SEEKTTY_TERMINAL_BACKGROUND=off` and `NO_COLOR`.
+
+Protocol references: [Kitty padding FAQ](https://sw.kovidgoyal.net/kitty/faq/#why-is-there-padding-between-the-text-area-and-the-window-border), [Ghostty OSC reference](https://ghostty.org/docs/vt/reference), [Windows Terminal dynamic-color query support](https://github.com/microsoft/terminal/discussions/17809).
+
+## 中文说明
+
+该修复统一处理字符网格外的终端背景色差，不扩大鼠标架构，也不改代码主题。启动后异步查询原色，500 ms 内收到有效回复才同步界面主题；换主题时更新，退出时恢复原始精度的颜色，而不是重置成终端默认配色。POSIX 暂停前恢复、继续后重新查询；Ctrl+Z 仍用于撤销。
+
+无回复、超时、`NO_COLOR`、低色彩模式和 tmux/screen 安全降级，不强制改色；`SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭。OSC 回复在输入分帧层完整接收，不进入普通输入框或多层搜索弹窗，粘贴内容不被当作回复解析。
+
+自动协议／虚拟终端测试、Windows ConPTY 与真实桌面终端验收分别记录。上表人工结果均未签收，不能宣称三端所有终端均已实测。透明背景、背景图片、操作系统窗口装饰及不可捕获的强制结束也不在“完全无色边、必定恢复”的保证范围内。
+
+本地全量检查为 929 项通过、1 项条件跳过，并通过类型检查、构建、23 项包白名单及官方 dsh 隔离插拔。Windows ConPTY 鼠标回归通过，但该脚本使用 `NO_COLOR`，不能算作背景同步实测。候选包仍使用开发中的 `1.2.4` 版本号，未覆盖已发布版本。打包兼容性检查均使用隔离的 `DSH_HOME`；按用户要求部署到日常 Profile 是另一步操作，不代表人工验收通过。该功能不会修改终端配置文件。

--- a/lib/index.js
+++ b/lib/index.js
@@ -8978,6 +8978,8 @@ var Markdown = class {
 const ESC$2 = "\x1B";
 const SGR_MOUSE_PREFIX = "\x1B[<";
 const MAX_MOUSE_SEQUENCE = 64;
+const OSC_PREFIX = "\x1B]";
+const MAX_OSC_SEQUENCE = 1024;
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
 /**
@@ -9067,6 +9069,33 @@ function extractCompleteSequences(buffer) {
 		if (remaining.startsWith(ESC$2 + ESC$2)) {
 			sequences.push(ESC$2);
 			pos++;
+			continue;
+		}
+		if (remaining.startsWith(OSC_PREFIX)) {
+			let end = -1;
+			let restart = -1;
+			for (let index = 2; index < remaining.length; index++) {
+				if (remaining[index] === "\x07") {
+					end = index + 1;
+					break;
+				}
+				if (remaining[index] === ESC$2) {
+					if (index + 1 === remaining.length) break;
+					if (remaining[index + 1] === "\\") end = index + 2;
+					else restart = index;
+					break;
+				}
+			}
+			if (restart !== -1) {
+				pos += restart;
+				continue;
+			}
+			if (end === -1) return {
+				sequences,
+				remainder: remaining
+			};
+			if (end <= MAX_OSC_SEQUENCE) sequences.push(remaining.slice(0, end));
+			pos += end;
 			continue;
 		}
 		if (remaining.startsWith(SGR_MOUSE_PREFIX)) {
@@ -9192,6 +9221,10 @@ var StdinBuffer = class extends EventEmitter {
 			return;
 		}
 		if (this.buffer.startsWith("\x1B[M")) return;
+		if (this.buffer.startsWith(OSC_PREFIX)) {
+			if (this.buffer.length > MAX_OSC_SEQUENCE) this.buffer = OSC_PREFIX + "!" + (this.buffer.endsWith(ESC$2) ? ESC$2 : "");
+			return;
+		}
 		if (this.buffer.length > 0) this.timeout = setTimeout(() => {
 			const flushed = this.flush();
 			for (const sequence of flushed) this.emitDataSequence(sequence);
@@ -9211,7 +9244,7 @@ var StdinBuffer = class extends EventEmitter {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
-		if (this.buffer.length === 0) return [];
+		if (this.buffer.length === 0 || this.buffer.startsWith(OSC_PREFIX)) return [];
 		const sequences = [this.buffer];
 		this.buffer = "";
 		this.pendingKittyPrintableCodepoint = void 0;
@@ -23489,8 +23522,8 @@ function editableTheme(theme, id, name$1) {
 const RESET = "\x1B[0m";
 const ESC$1 = 27;
 const CSI$2 = 155;
-const ST = 156;
-const OSC$1 = 157;
+const ST$1 = 156;
+const OSC$2 = 157;
 const CONTROL_STRING_INTRODUCERS = new Set([
 	80,
 	88,
@@ -23501,7 +23534,7 @@ const CONTROL_STRING_INTRODUCERS = new Set([
 const C1_CONTROL_STRING_INTRODUCERS = new Set([
 	144,
 	152,
-	OSC$1,
+	OSC$2,
 	158,
 	159
 ]);
@@ -23565,7 +23598,7 @@ let codeHighlighter;
 function controlStringEnd(text$1, start) {
 	for (let index = start; index < text$1.length; index += 1) {
 		const code = text$1.charCodeAt(index);
-		if (code === 7 || code === ST) return index + 1;
+		if (code === 7 || code === ST$1) return index + 1;
 		if (code === ESC$1 && text$1.charCodeAt(index + 1) === 92) return index + 2;
 	}
 	return text$1.length;
@@ -26253,7 +26286,7 @@ function offsetForTrackRow(model, row) {
 	return Math.round(clampedRow / maxTop * travel);
 }
 
-const OSC = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/gu;
+const OSC$1 = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/gu;
 const CSI$1 = /\u001B\[[0-9;:]*[ -/]*[@-~]/gu;
 const C1_OSC = /\u009D[\s\S]*?(?:\u0007|\u001B\\|\u009C)/gu;
 let graphemeSegmenter;
@@ -26268,7 +26301,7 @@ function wordsOf(text$1) {
 }
 /** Strip SGR, OSC (including OSC 8), and leftover CSI so copy matches visible text. */
 function stripCopyDecorations(value) {
-	return value.replace(OSC, "").replace(C1_OSC, "").replace(CSI$1, "");
+	return value.replace(OSC$1, "").replace(C1_OSC, "").replace(CSI$1, "");
 }
 function compareAnchors(left, right, order) {
 	if (left.surface !== right.surface) return left.surface === "transcript" ? -1 : 1;
@@ -37037,6 +37070,81 @@ function sessionTerminalTitle(facts) {
 	return session;
 }
 
+const BACKGROUND_QUERY = "\x1B]11;?\x1B\\";
+const BACKGROUND_QUERY_TIMEOUT_MS = 500;
+const OSC = "\x1B]";
+const ST = "\x1B\\";
+const RGB_REPLY = /^\u001B\]11;(rgb:[\da-f]{1,4}\/[\da-f]{1,4}\/[\da-f]{1,4})(?:\u0007|\u001B\\)$/iu;
+/** Only match truecolor canvases; do not recolor a multiplexer's shared outer window. */
+function supportsTerminalBackground(env = process.env) {
+	return terminalColorLevel(env) === 3 && !env.TMUX && !env.STY && !/^(?:screen|tmux)/iu.test(env.TERM ?? "") && !/^(?:0|off|false)$/iu.test(env.SEEKTTY_TERMINAL_BACKGROUND?.trim() ?? "");
+}
+/** One asynchronous probe per active lifetime; never guess a color to restore. */
+var TerminalBackground = class {
+	active = false;
+	original;
+	desired;
+	applied;
+	changed = false;
+	timer;
+	constructor(terminal, enabled) {
+		this.terminal = terminal;
+		this.enabled = enabled;
+	}
+	setColor(color$1) {
+		if (!/^#[\da-f]{6}$/iu.test(color$1)) return;
+		this.desired = `rgb:${color$1.slice(1, 3)}/${color$1.slice(3, 5)}/${color$1.slice(5, 7)}`.toLowerCase();
+		this.apply();
+	}
+	start() {
+		if (!this.enabled || this.active || this.desired === void 0) return;
+		this.active = true;
+		this.timer = setTimeout(() => {
+			this.timer = void 0;
+		}, BACKGROUND_QUERY_TIMEOUT_MS);
+		this.timer.unref?.();
+		try {
+			this.terminal.write(BACKGROUND_QUERY);
+		} catch {
+			this.restore();
+		}
+	}
+	/** Called after pi-tui framing and before any editor/overlay receives input. */
+	consumeInput(data) {
+		if (!data.startsWith(OSC)) return false;
+		const reply = RGB_REPLY.exec(data);
+		if (this.active && this.timer !== void 0 && reply?.[1] !== void 0) {
+			clearTimeout(this.timer);
+			this.timer = void 0;
+			this.original = reply[1].toLowerCase();
+			this.apply();
+		}
+		return true;
+	}
+	restore() {
+		if (this.timer !== void 0) clearTimeout(this.timer);
+		this.timer = void 0;
+		this.active = false;
+		const original = this.changed ? this.original : void 0;
+		this.original = void 0;
+		this.applied = void 0;
+		this.changed = false;
+		if (original !== void 0) try {
+			this.terminal.write(`${OSC}11;${original}${ST}`);
+		} catch {}
+	}
+	apply() {
+		if (!this.active || this.original === void 0 || this.desired === void 0 || this.applied === this.desired) return;
+		this.changed = true;
+		this.applied = this.desired;
+		try {
+			this.terminal.write(`${OSC}11;${this.desired}${ST}`);
+		} catch {
+			this.restore();
+		}
+	}
+};
+
 const ESC = "\x1B";
 const CSI = `${ESC}[`;
 const SGR_PREFIX = `${CSI}<`;
@@ -37196,7 +37304,8 @@ function supportsManagedTerminal(interactive, term) {
 * Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
 * Live mouse toggles write only mouse/focus private modes and never 1049h/1049l.
 */
-function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) {
+function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env) {
+	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env));
 	let active = false;
 	let mouseMode = "full";
 	let hoverFeedback = true;
@@ -37212,6 +37321,7 @@ function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) 
 			try {
 				beforeRestore();
 			} catch {}
+			background$1.restore();
 			try {
 				terminal.write(encodeDisableMouseReporting());
 			} finally {
@@ -37223,6 +37333,13 @@ function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) 
 				}
 			}
 		},
+		setBackgroundColor: (color$1) => {
+			background$1.setColor(color$1);
+		},
+		startBackgroundSync: () => {
+			if (active) background$1.start();
+		},
+		consumeInput: (data) => background$1.consumeInput(data),
 		setMouseReporting: (mode, nextHoverFeedback = hoverFeedback) => {
 			if (mouseMode === mode && hoverFeedback === nextHoverFeedback) return;
 			mouseMode = mode;
@@ -38250,6 +38367,35 @@ function attachFatalGuards(options$1) {
 		process.off("SIGHUP", onHup);
 	};
 }
+/** POSIX job control; Ctrl+Z remains input undo, not a new suspend shortcut. */
+function attachSuspendGuards(options$1, runtime = {
+	platform: process.platform,
+	on: (signal, handler) => process.on(signal, handler),
+	off: (signal, handler) => process.off(signal, handler),
+	suspendSelf: () => {
+		process.kill(process.pid, "SIGSTOP");
+	}
+}) {
+	if (runtime.platform === "win32") return () => void 0;
+	let suspended = false;
+	const onSuspend = () => {
+		if (suspended) return;
+		options$1.suspend();
+		suspended = true;
+		runtime.suspendSelf();
+	};
+	const onResume = () => {
+		if (!suspended) return;
+		suspended = false;
+		options$1.resume();
+	};
+	runtime.on("SIGTSTP", onSuspend);
+	runtime.on("SIGCONT", onResume);
+	return () => {
+		runtime.off("SIGTSTP", onSuspend);
+		runtime.off("SIGCONT", onResume);
+	};
+}
 
 const PROCESS_EVENTS = [
 	"uncaughtException",
@@ -38706,6 +38852,7 @@ async function startTuiSurface(options$1) {
 	let stopConstructedTui = () => void 0;
 	let disposeConstructedSyntax = () => void 0;
 	let detachFatalGuards = () => void 0;
+	let detachSuspendGuards = () => void 0;
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
 		let liveTheme = initialTheme;
@@ -38714,6 +38861,7 @@ async function startTuiSurface(options$1) {
 		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		terminalSession.setMouseReporting(liveBehavior.get().mouseMode, liveBehavior.get().hoverFeedback);
 		setTheme(initialTheme);
+		terminalSession.setBackgroundColor(initialTheme.colors.canvas);
 		const tui = new TUI(terminal, true);
 		const requestTuiRender = tui.requestRender.bind(tui);
 		tui.requestRender = (force = false) => {
@@ -39228,6 +39376,8 @@ async function startTuiSurface(options$1) {
 		const close = (outcome) => {
 			detachFatalGuards();
 			detachFatalGuards = () => void 0;
+			detachSuspendGuards();
+			detachSuspendGuards = () => void 0;
 			if (stopping !== void 0) return stopping;
 			restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 				process.stdout.write(chunk);
@@ -39298,6 +39448,7 @@ async function startTuiSurface(options$1) {
 			applyTheme: (theme) => {
 				liveTheme = theme;
 				setTheme(theme);
+				terminalSession.setBackgroundColor(theme.colors.canvas);
 				syntax?.setTheme(theme);
 				transcript.refreshPresentation();
 				tui.invalidate();
@@ -39842,6 +39993,7 @@ async function startTuiSurface(options$1) {
 			if (semantic.ended === true && liveBehavior.get().copyOnSelect) copyActiveSelection();
 		};
 		tui.addInputListener((data) => {
+			if (terminalSession.consumeInput(data)) return { consume: true };
 			performanceProbe.markInput();
 			const mouseEvent = decodeMouseSequence(data);
 			let pendingWheel = 0;
@@ -40093,8 +40245,29 @@ async function startTuiSurface(options$1) {
 				process.exit(code);
 			}
 		});
+		detachSuspendGuards = attachSuspendGuards({
+			suspend: () => {
+				contextMenu.close();
+				mouseController.endGesture();
+				clearTranscriptPointerGesture();
+				clearMouseArm(true);
+				clearHoverPresentation();
+				restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
+					process.stdout.write(chunk);
+				}, terminal);
+				tui.stop();
+			},
+			resume: () => {
+				if (stopping !== void 0) return;
+				terminalSession.enter();
+				tui.start();
+				terminalSession.startBackgroundSync();
+				tui.requestRender(true);
+			}
+		});
 		terminalSession.enter();
 		tui.start();
+		terminalSession.startBackgroundSync();
 		refreshHeader(true);
 		refresh();
 		if (options$1.startupNotice !== void 0) setNotice(options$1.startupNotice, "success");
@@ -40124,6 +40297,7 @@ async function startTuiSurface(options$1) {
 		};
 	} catch (error) {
 		detachFatalGuards();
+		detachSuspendGuards();
 		restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 			process.stdout.write(chunk);
 		}, terminal);

--- a/patches/@mariozechner__pi-tui@0.73.1.patch
+++ b/patches/@mariozechner__pi-tui@0.73.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index fb224b9da697aab89a31336eae65071dc07d736e..e45d408b34e2163f7f18b12e3391256ca50bf7ae 100644
+index fb224b9da697aab89a31336eae65071dc07d736e..49afe6c1c0769e856eb2a2ce10e49fd391c1d2af 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
 @@ -30,6 +30,20 @@ export interface EditorOptions {
@@ -83,7 +83,7 @@ index fb224b9da697aab89a31336eae65071dc07d736e..e45d408b34e2163f7f18b12e3391256c
      private handleBackspace;
      /**
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 50f92259fa88f4efe406a60b7db8e54a9eedace6..5117fc64d05296e15e7f3bf583c818828a3c667c 100644
+index 50f92259fa88f4efe406a60b7db8e54a9eedace6..e9749bd069e0fef9ebaa2e5ef2c893e53d4c2953 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -171,6 +171,7 @@ export class Editor {
@@ -608,7 +608,7 @@ index 50f92259fa88f4efe406a60b7db8e54a9eedace6..5117fc64d05296e15e7f3bf583c81882
      cancelAutocomplete() {
          this.cancelAutocompleteRequest();
 diff --git a/dist/components/input.d.ts b/dist/components/input.d.ts
-index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..73fe4b6fdad88ce068a96c00eae31d3e70b08afe 100644
+index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..1f51d1bd61fd0228bb0d65c2bdc3fa3a7d63edd9 100644
 --- a/dist/components/input.d.ts
 +++ b/dist/components/input.d.ts
 @@ -16,6 +16,12 @@ export declare class Input implements Component, Focusable {
@@ -625,7 +625,7 @@ index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..73fe4b6fdad88ce068a96c00eae31d3e
      private insertCharacter;
      private handleBackspace;
 diff --git a/dist/components/input.js b/dist/components/input.js
-index 5a8780c8b2e97f5d58a239c11a6c9aa6e1a26391..091f5615f8c0b1b6e0e149610999ebeca7235285 100644
+index 5a8780c8b2e97f5d58a239c11a6c9aa6e1a26391..73a9e73bd15bdb38478c2661ca1b463f41402e54 100644
 --- a/dist/components/input.js
 +++ b/dist/components/input.js
 @@ -1,5 +1,5 @@
@@ -960,7 +960,7 @@ index 7dc27474f3e6e61be59d448f40c0a4e6b249e2b8..ab0e6eec23ab76aacf8c71b5e58d0ea9
              else {
                  // Other token types - try to render as inline
 diff --git a/dist/components/select-list.d.ts b/dist/components/select-list.d.ts
-index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787b31fc6c4 100644
+index 9db54d907f801e43208a462bca925f2905787b7a..9c7d8757112767552afb732df006c2858610c101 100644
 --- a/dist/components/select-list.d.ts
 +++ b/dist/components/select-list.d.ts
 @@ -23,6 +23,15 @@ export interface SelectListLayoutOptions {
@@ -995,7 +995,7 @@ index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787
      render(width: number): string[];
      handleInput(keyData: string): void;
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7c5a32bd21f69bf1dc73f6d704e4e99334a03f1d 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..8c1ff1a67dd3718129f81bf93a46f7243d0692f9 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -10,6 +10,8 @@ export class SelectList {
@@ -1100,7 +1100,7 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7c5a32bd21f69bf1dc73f6d704e4e993
          }
          // Enter
 diff --git a/dist/keybindings.d.ts b/dist/keybindings.d.ts
-index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..cf0293a2f89698f8a0a02aea1dab6fae6bd8784b 100644
+index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..1001bb8463e8ca59c31390dfb3d583d57501ceeb 100644
 --- a/dist/keybindings.d.ts
 +++ b/dist/keybindings.d.ts
 @@ -125,7 +125,7 @@ export declare const TUI_KEYBINDINGS: {
@@ -1113,7 +1113,7 @@ index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..cf0293a2f89698f8a0a02aea1dab6fae
      };
      readonly "tui.input.newLine": {
 diff --git a/dist/keybindings.js b/dist/keybindings.js
-index 60d400872183f1f6b754b61d3ccbf6708219215d..89faba6dbf55eb7449db25ce23d28f48988fe504 100644
+index 60d400872183f1f6b754b61d3ccbf6708219215d..c0161b806238f2bd05995136dd7fcacf347a1ff5 100644
 --- a/dist/keybindings.js
 +++ b/dist/keybindings.js
 @@ -62,7 +62,7 @@ export const TUI_KEYBINDINGS = {
@@ -1126,19 +1126,21 @@ index 60d400872183f1f6b754b61d3ccbf6708219215d..89faba6dbf55eb7449db25ce23d28f48
      "tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
      "tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 diff --git a/dist/stdin-buffer.js b/dist/stdin-buffer.js
-index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352215456a8 100644
+index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..dd1dacc511b9ff5aec86b2354eacfc89e40624db 100644
 --- a/dist/stdin-buffer.js
 +++ b/dist/stdin-buffer.js
-@@ -18,6 +18,8 @@
+@@ -18,6 +18,10 @@
   */
  import { EventEmitter } from "events";
  const ESC = "\x1b";
 +const SGR_MOUSE_PREFIX = "\x1b[<";
 +const MAX_MOUSE_SEQUENCE = 64;
++const OSC_PREFIX = "\x1b]";
++const MAX_OSC_SEQUENCE = 1024;
  const BRACKETED_PASTE_START = "\x1b[200~";
  const BRACKETED_PASTE_END = "\x1b[201~";
  /**
-@@ -163,6 +165,28 @@ function extractCompleteSequences(buffer) {
+@@ -163,6 +167,54 @@ function extractCompleteSequences(buffer) {
      let pos = 0;
      while (pos < buffer.length) {
          const remaining = buffer.slice(pos);
@@ -1147,6 +1149,32 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
 +        if (remaining.startsWith(ESC + ESC)) {
 +            sequences.push(ESC);
 +            pos++;
++            continue;
++        }
++        if (remaining.startsWith(OSC_PREFIX)) {
++            // Color-query replies may span stdin chunks well beyond the key
++            // timeout. Frame them atomically, without quadratic prefix scans.
++            let end = -1;
++            let restart = -1;
++            for (let index = OSC_PREFIX.length; index < remaining.length; index++) {
++                if (remaining[index] === "\x07") {
++                    end = index + 1;
++                    break;
++                }
++                if (remaining[index] === ESC) {
++                    if (index + 1 === remaining.length) break;
++                    if (remaining[index + 1] === "\\") end = index + 2;
++                    else restart = index;
++                    break;
++                }
++            }
++            if (restart !== -1) {
++                pos += restart;
++                continue;
++            }
++            if (end === -1) return { sequences, remainder: remaining };
++            if (end <= MAX_OSC_SEQUENCE) sequences.push(remaining.slice(0, end));
++            pos += end;
 +            continue;
 +        }
 +        if (remaining.startsWith(SGR_MOUSE_PREFIX)) {
@@ -1167,7 +1195,7 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
          // Try to extract a sequence starting at this position
          if (remaining.startsWith(ESC)) {
              // Find the end of this escape sequence
-@@ -263,6 +287,9 @@ export class StdinBuffer extends EventEmitter {
+@@ -263,6 +315,9 @@ export class StdinBuffer extends EventEmitter {
                  for (const sequence of result.sequences) {
                      this.emitDataSequence(sequence);
                  }
@@ -1177,7 +1205,7 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
              }
              this.pendingKittyPrintableCodepoint = undefined;
              this.buffer = this.buffer.slice(startIndex + BRACKETED_PASTE_START.length);
-@@ -288,6 +315,15 @@ export class StdinBuffer extends EventEmitter {
+@@ -288,6 +343,22 @@ export class StdinBuffer extends EventEmitter {
          for (const sequence of result.sequences) {
              this.emitDataSequence(sequence);
          }
@@ -1190,9 +1218,25 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
 +            return;
 +        }
 +        if (this.buffer.startsWith("\x1b[M")) return;
++        if (this.buffer.startsWith(OSC_PREFIX)) {
++            // Preserve a split ST while bounding malformed/oversized reports.
++            if (this.buffer.length > MAX_OSC_SEQUENCE) {
++                this.buffer = OSC_PREFIX + "!" + (this.buffer.endsWith(ESC) ? ESC : "");
++            }
++            return;
++        }
          if (this.buffer.length > 0) {
              this.timeout = setTimeout(() => {
                  const flushed = this.flush();
+@@ -311,7 +382,7 @@ export class StdinBuffer extends EventEmitter {
+             clearTimeout(this.timeout);
+             this.timeout = null;
+         }
+-        if (this.buffer.length === 0) {
++        if (this.buffer.length === 0 || this.buffer.startsWith(OSC_PREFIX)) {
+             return [];
+         }
+         const sequences = [this.buffer];
 diff --git a/dist/terminal.js b/dist/terminal.js
 index 3545b284ce2da594cc728803feb607a34cea5ca0..79bb3e8769594c1b8f70ef71304ab9032ed4ecd3 100644
 --- a/dist/terminal.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-tui@0.73.1': f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb
+  '@mariozechner/pi-tui@0.73.1': 3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266
 
 importers:
 
@@ -161,7 +161,7 @@ importers:
         version: 3.18.1
       '@mariozechner/pi-tui':
         specifier: 0.73.1
-        version: 0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)
+        version: 0.73.1(patch_hash=3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266)
       '@types/cross-spawn':
         specifier: 6.0.6
         version: 6.0.6
@@ -3227,7 +3227,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mariozechner/pi-tui@0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)':
+  '@mariozechner/pi-tui@0.73.1(patch_hash=3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266)':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -111,7 +111,7 @@ import {
 } from './pi-tui-adapters.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
 import { pendingInteractionStatus } from './pending-status.ts'
-import { attachFatalGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
+import { attachFatalGuards, attachSuspendGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
 import {
   instrumentTerminalWrites,
@@ -210,6 +210,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let stopConstructedTui = (): void => undefined
   let disposeConstructedSyntax = (): void => undefined
   let detachFatalGuards = (): void => undefined
+  let detachSuspendGuards = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
     let liveTheme = initialTheme
@@ -221,6 +222,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       liveBehavior.get().hoverFeedback,
     )
     setTheme(initialTheme)
+    terminalSession.setBackgroundColor(initialTheme.colors.canvas)
     const tui = new TUI(terminal, true)
     const requestTuiRender = tui.requestRender.bind(tui)
     tui.requestRender = (force = false): void => {
@@ -785,6 +787,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const close = (outcome: TuiSurfaceOutcome): Promise<void> => {
       detachFatalGuards()
       detachFatalGuards = () => undefined
+      detachSuspendGuards()
+      detachSuspendGuards = () => undefined
       if (stopping !== undefined) return stopping
       restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
       stopping = (async () => {
@@ -839,6 +843,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       applyTheme: (theme) => {
         liveTheme = theme
         setTheme(theme)
+        terminalSession.setBackgroundColor(theme.colors.canvas)
         syntax?.setTheme(theme)
         transcript.refreshPresentation()
         tui.invalidate()
@@ -1492,6 +1497,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     tui.addInputListener((data) => {
+      if (terminalSession.consumeInput(data)) return { consume: true }
       performanceProbe.markInput()
       // ProcessTerminal's StdinBuffer owns framing and Escape timeouts. Rebuffering
       // a resolved Escape here would join it to the next mouse report again.
@@ -1763,8 +1769,27 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       exit: (code) => { process.exit(code) },
     })
+    detachSuspendGuards = attachSuspendGuards({
+      suspend: () => {
+        contextMenu.close()
+        mouseController.endGesture()
+        clearTranscriptPointerGesture()
+        clearMouseArm(true)
+        clearHoverPresentation()
+        restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
+        tui.stop()
+      },
+      resume: () => {
+        if (stopping !== undefined) return
+        terminalSession.enter()
+        tui.start()
+        terminalSession.startBackgroundSync()
+        tui.requestRender(true)
+      },
+    })
     terminalSession.enter()
     tui.start()
+    terminalSession.startBackgroundSync()
     refreshHeader(true)
     refresh()
     if (options.startupNotice !== undefined) setNotice(options.startupNotice, 'success')
@@ -1799,6 +1824,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     return { closed, stop: () => close({ kind: 'exit', code: 0 }) }
   } catch (error) {
     detachFatalGuards()
+    detachSuspendGuards()
     restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
     setCodeHighlighter(undefined)
     try { disposeConstructedSyntax() } catch { /* preserve the setup failure */ }

--- a/src/client/terminal-background.ts
+++ b/src/client/terminal-background.ts
@@ -1,0 +1,84 @@
+import { terminalColorLevel } from './theme.ts'
+
+export const BACKGROUND_QUERY = '\u001B]11;?\u001B\\'
+export const BACKGROUND_QUERY_TIMEOUT_MS = 500
+const OSC = '\u001B]'
+const ST = '\u001B\\'
+const RGB_REPLY = /^\u001B\]11;(rgb:[\da-f]{1,4}\/[\da-f]{1,4}\/[\da-f]{1,4})(?:\u0007|\u001B\\)$/iu
+
+/** Only match truecolor canvases; do not recolor a multiplexer's shared outer window. */
+export function supportsTerminalBackground(env: Readonly<NodeJS.ProcessEnv> = process.env): boolean {
+  return terminalColorLevel(env) === 3
+    && !env.TMUX && !env.STY && !/^(?:screen|tmux)/iu.test(env.TERM ?? '')
+    && !/^(?:0|off|false)$/iu.test(env.SEEKTTY_TERMINAL_BACKGROUND?.trim() ?? '')
+}
+
+/** One asynchronous probe per active lifetime; never guess a color to restore. */
+export class TerminalBackground {
+  private active = false
+  private original: string | undefined
+  private desired: string | undefined
+  private applied: string | undefined
+  private changed = false
+  private timer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(
+    private readonly terminal: { write(data: string): void },
+    private readonly enabled: boolean,
+  ) {}
+
+  setColor(color: string): void {
+    // Only validated theme RGB values may become terminal commands.
+    if (!/^#[\da-f]{6}$/iu.test(color)) return
+    this.desired = `rgb:${color.slice(1, 3)}/${color.slice(3, 5)}/${color.slice(5, 7)}`.toLowerCase()
+    this.apply()
+  }
+
+  start(): void {
+    if (!this.enabled || this.active || this.desired === undefined) return
+    this.active = true
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      // Late replies are still consumed, but cannot enable an expired probe.
+    }, BACKGROUND_QUERY_TIMEOUT_MS)
+    this.timer.unref?.()
+    try { this.terminal.write(BACKGROUND_QUERY) } catch { this.restore() }
+  }
+
+  /** Called after pi-tui framing and before any editor/overlay receives input. */
+  consumeInput(data: string): boolean {
+    // OSC reports are control messages, even if malformed or unsolicited.
+    // A bracketed paste starts with CSI, so literal pasted OSC remains opaque.
+    if (!data.startsWith(OSC)) return false
+    const reply = RGB_REPLY.exec(data)
+    if (this.active && this.timer !== undefined && reply?.[1] !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+      this.original = reply[1].toLowerCase()
+      this.apply()
+    }
+    return true
+  }
+
+  restore(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = undefined
+    this.active = false
+    const original = this.changed ? this.original : undefined
+    this.original = undefined
+    this.applied = undefined
+    this.changed = false
+    // Keep the original channel precision; OSC 111 would reset the profile,
+    // not necessarily the color set by the shell before SeekTTY started.
+    if (original !== undefined) {
+      try { this.terminal.write(`${OSC}11;${original}${ST}`) } catch { /* best-effort cleanup */ }
+    }
+  }
+
+  private apply(): void {
+    if (!this.active || this.original === undefined || this.desired === undefined || this.applied === this.desired) return
+    this.changed = true
+    this.applied = this.desired
+    try { this.terminal.write(`${OSC}11;${this.desired}${ST}`) } catch { this.restore() }
+  }
+}

--- a/src/client/terminal-session.ts
+++ b/src/client/terminal-session.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@mariozechner/pi-tui'
+import { supportsTerminalBackground, TerminalBackground } from './terminal-background.ts'
 import {
   encodeDisableMouseReporting,
   encodeMouseReporting,
@@ -41,6 +42,9 @@ export interface ManagedTui {
 export interface TerminalSession {
   enter(): void
   restore(): void
+  setBackgroundColor(color: string): void
+  startBackgroundSync(): void
+  consumeInput(data: string): boolean
   setMouseReporting(mode: MouseReportingMode, hoverFeedback?: boolean): void
   mouseReporting(): MouseReportingMode
 }
@@ -59,7 +63,9 @@ export function createTerminalSession(
   terminal: Terminal & ManagedTerminal,
   enabled: boolean,
   beforeRestore: () => void = () => undefined,
+  env: Readonly<NodeJS.ProcessEnv> = process.env,
 ): TerminalSession {
+  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env))
   let active = false
   let mouseMode: MouseReportingMode = 'full'
   let hoverFeedback = true
@@ -73,6 +79,7 @@ export function createTerminalSession(
     restore: () => {
       if (!active) return
       try { beforeRestore() } catch { /* terminal restoration must still run */ }
+      background.restore()
       try {
         terminal.write(encodeDisableMouseReporting())
       } finally {
@@ -84,6 +91,10 @@ export function createTerminalSession(
         }
       }
     },
+    setBackgroundColor: color => { background.setColor(color) },
+    // Must run after terminal.start() has installed its raw-mode input listener.
+    startBackgroundSync: () => { if (active) background.start() },
+    consumeInput: data => background.consumeInput(data),
     setMouseReporting: (mode, nextHoverFeedback = hoverFeedback) => {
       if (mouseMode === mode && hoverFeedback === nextHoverFeedback) return
       mouseMode = mode

--- a/src/process-guards.ts
+++ b/src/process-guards.ts
@@ -133,3 +133,41 @@ export function attachFatalGuards(options: FatalGuardOptions): () => void {
     process.off('SIGHUP', onHup)
   }
 }
+
+interface SuspendRuntime {
+  readonly platform: NodeJS.Platform
+  on(signal: 'SIGTSTP' | 'SIGCONT', handler: () => void): unknown
+  off(signal: 'SIGTSTP' | 'SIGCONT', handler: () => void): unknown
+  suspendSelf(): void
+}
+
+/** POSIX job control; Ctrl+Z remains input undo, not a new suspend shortcut. */
+export function attachSuspendGuards(
+  options: { suspend(): void; resume(): void },
+  runtime: SuspendRuntime = {
+    platform: process.platform,
+    on: (signal, handler) => process.on(signal, handler),
+    off: (signal, handler) => process.off(signal, handler),
+    suspendSelf: () => { process.kill(process.pid, 'SIGSTOP') },
+  },
+): () => void {
+  if (runtime.platform === 'win32') return () => undefined
+  let suspended = false
+  const onSuspend = (): void => {
+    if (suspended) return
+    options.suspend()
+    suspended = true
+    runtime.suspendSelf()
+  }
+  const onResume = (): void => {
+    if (!suspended) return
+    suspended = false
+    options.resume()
+  }
+  runtime.on('SIGTSTP', onSuspend)
+  runtime.on('SIGCONT', onResume)
+  return () => {
+    runtime.off('SIGTSTP', onSuspend)
+    runtime.off('SIGCONT', onResume)
+  }
+}

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
 import {
   attachFatalGuards,
+  attachSuspendGuards,
   createFatalHandler,
   FATAL_SIGHUP_EXIT_CODE,
   FATAL_SIGTERM_EXIT_CODE,
@@ -9,6 +11,45 @@ import {
   restoreTerminalSync,
   withCleanupTimeout,
 } from '../src/process-guards.ts'
+
+describe('POSIX suspend guards', () => {
+  it.each(['linux', 'darwin'] as const)('restores before stopping and resumes once on %s', platform => {
+    const events = new EventEmitter()
+    const order: string[] = []
+    const detach = attachSuspendGuards({
+      suspend: () => { order.push('restore+stop') },
+      resume: () => { order.push('start+query+redraw') },
+    }, {
+      platform,
+      on: (signal, handler) => events.on(signal, handler),
+      off: (signal, handler) => events.off(signal, handler),
+      suspendSelf: () => { order.push('SIGSTOP') },
+    })
+    events.emit('SIGCONT')
+    expect(order).toEqual([])
+    events.emit('SIGTSTP')
+    events.emit('SIGTSTP')
+    expect(order).toEqual(['restore+stop', 'SIGSTOP'])
+    events.emit('SIGCONT')
+    events.emit('SIGCONT')
+    expect(order).toEqual(['restore+stop', 'SIGSTOP', 'start+query+redraw'])
+    detach()
+    detach()
+    expect(events.listenerCount('SIGTSTP')).toBe(0)
+    expect(events.listenerCount('SIGCONT')).toBe(0)
+  })
+
+  it('does not install unsupported job-control signals on Windows', () => {
+    const on = vi.fn()
+    const off = vi.fn()
+    const suspendSelf = vi.fn()
+    const detach = attachSuspendGuards({ suspend: vi.fn(), resume: vi.fn() }, { platform: 'win32', on, off, suspendSelf })
+    detach()
+    expect(on).not.toHaveBeenCalled()
+    expect(off).not.toHaveBeenCalled()
+    expect(suspendSelf).not.toHaveBeenCalled()
+  })
+})
 
 describe('fatal terminal restore (review #14)', () => {
   it('restores cooked mode and the cursor synchronously before any cleanup', () => {

--- a/tests/terminal-background.test.ts
+++ b/tests/terminal-background.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Input, StdinBuffer, TUI, type Terminal } from '@mariozechner/pi-tui'
+import {
+  BACKGROUND_QUERY,
+  BACKGROUND_QUERY_TIMEOUT_MS,
+  supportsTerminalBackground,
+  TerminalBackground,
+} from '../src/client/terminal-background.ts'
+import { createTerminalSession, type ManagedTerminal } from '../src/client/terminal-session.ts'
+import { createFatalHandler } from '../src/process-guards.ts'
+
+const ESC = '\u001B'
+const ST = `${ESC}\\`
+const ORIGINAL = 'rgb:0c0c/1234/abcd'
+const reply = (color = ORIGINAL, end = ST): string => `${ESC}]11;${color}${end}`
+const desired = reply('rgb:28/2c/34')
+const truecolor = { COLORTERM: 'truecolor', TERM: 'xterm-256color' }
+const paste = (text: string): string => `${ESC}[200~${text}${ESC}[201~`
+
+function controller(enabled = true) {
+  const writes: string[] = []
+  const background = new TerminalBackground({ write: data => { writes.push(data) } }, enabled)
+  background.setColor('#282C34')
+  return { background, writes }
+}
+
+afterEach(() => { vi.useRealTimers() })
+
+describe('terminal background capability policy', () => {
+  it.each([
+    { WT_SESSION: 'test' },
+    { TERM_PROGRAM: 'iTerm.app' },
+    { TERM_PROGRAM: 'vscode' },
+    { TERM: 'xterm-kitty', COLORTERM: 'truecolor' },
+    { TERM: 'xterm-ghostty', COLORTERM: 'truecolor' },
+    { ...truecolor, SSH_CONNECTION: 'test' },
+  ])('allows a bounded probe without an OS-specific implementation: %j', env => {
+    expect(supportsTerminalBackground(env)).toBe(true)
+  })
+
+  it.each([
+    {}, { TERM: 'xterm-256color' }, { TERM_PROGRAM: 'Apple_Terminal' },
+    { ...truecolor, NO_COLOR: '' }, { ...truecolor, TERM: 'dumb' },
+    { ...truecolor, TMUX: 'test' }, { ...truecolor, STY: 'test' },
+    { ...truecolor, TERM: 'tmux-256color' }, { ...truecolor, TERM: 'screen-256color' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: 'off' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: '0' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: ' FALSE ' },
+  ])('leaves unsupported, opted-out and multiplexed terminals untouched: %j', env => {
+    expect(supportsTerminalBackground(env)).toBe(false)
+  })
+})
+
+describe('background ownership', () => {
+  it('waits for a valid reply, follows theme changes and restores exact original precision once', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    expect(writes).toEqual([])
+    background.start()
+    background.start()
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    expect(background.consumeInput(reply())).toBe(true)
+    expect(writes).toEqual([BACKGROUND_QUERY, desired])
+    background.setColor('#282c34')
+    background.setColor('#FFFFFF')
+    background.setColor('#FFFFFF')
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply('rgb:ff/ff/ff')])
+    background.restore()
+    background.restore()
+    expect(writes.at(-1)).toBe(reply())
+    expect(writes).toHaveLength(4)
+    expect(writes.join('')).not.toContain(`${ESC}]111`)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([ST, '\u0007'])('accepts the standard %j terminator and 1–4 digit RGB channels', end => {
+    const { background, writes } = controller()
+    background.start()
+    background.consumeInput(reply('rgb:F/Ab/123', end))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply('rgb:f/ab/123')])
+  })
+
+  it('uses the newest requested theme if it changes while the query is pending', () => {
+    const { background, writes } = controller()
+    background.start()
+    background.setColor('#123456')
+    background.consumeInput(reply())
+    expect(writes).toEqual([BACKGROUND_QUERY, reply('rgb:12/34/56')])
+    background.restore()
+  })
+
+  it('ignores malformed, duplicate and unsolicited reports without passing them to editors', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    expect(background.consumeInput(reply())).toBe(true)
+    expect(writes).toEqual([])
+    background.start()
+    for (const data of [reply('rgb:12345/0/0'), reply('red'), reply('rgb:gg/00/00'), `${ESC}]11;rgb:0/0/0`, `${ESC}]11;?${ST}`, `${ESC}]52;c;bad${ST}`]) {
+      expect(background.consumeInput(data)).toBe(true)
+    }
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.consumeInput(reply())
+    background.consumeInput(reply('rgb:ff/ff/ff'))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply()])
+  })
+
+  it('does not consume normal keys, plain text or an opaque bracketed paste', () => {
+    const { background } = controller()
+    for (const data of ['abc', '中文', ESC, `${ESC}[A`, ']11;rgb:ff/ff/ff', paste(reply())]) {
+      expect(background.consumeInput(data)).toBe(false)
+    }
+  })
+
+  it('never recolors on timeout or late replies and never polls on repaint/theme changes', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    background.start()
+    vi.advanceTimersByTime(BACKGROUND_QUERY_TIMEOUT_MS)
+    background.consumeInput(reply())
+    for (let index = 0; index < 100; index++) {
+      background.start()
+      background.setColor(index % 2 === 0 ? '#FFFFFF' : '#000000')
+    }
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels an early exit and re-queries a new original color on a later lifetime', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    background.start()
+    background.restore()
+    background.consumeInput(reply())
+    background.setColor('#FFFFFF')
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.start()
+    background.consumeInput(reply('rgb:1/2/3'))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, BACKGROUND_QUERY, reply('rgb:ff/ff/ff'), reply('rgb:1/2/3')])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does nothing when disabled, even with valid replies', () => {
+    const { background, writes } = controller(false)
+    background.start()
+    background.consumeInput(reply())
+    background.setColor('#FFFFFF')
+    background.restore()
+    expect(writes).toEqual([])
+  })
+
+  it('rejects theme command injection and fails safely when the write port throws', () => {
+    const writes: string[] = []
+    const background = new TerminalBackground({ write: data => {
+      writes.push(data)
+      if (data === desired) throw new Error('broken write')
+    } }, true)
+    background.setColor(`${ESC}]11;red${ST}`)
+    background.start()
+    expect(writes).toEqual([])
+    background.setColor('#282C34')
+    background.start()
+    expect(() => background.consumeInput(reply())).not.toThrow()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply()])
+    background.setColor('#FFFFFF')
+    background.restore()
+    expect(writes).toHaveLength(3)
+  })
+})
+
+/** Same StdinBuffer → TerminalSession → TUI boundary as the interactive Surface. */
+class VirtualTerminal implements Terminal, ManagedTerminal {
+  columns = 80
+  rows = 24
+  kittyProtocolActive = false
+  writes: string[] = []
+  readonly stdin = new StdinBuffer({ timeout: 10 })
+  start(onInput: (data: string) => void): void {
+    this.stdin.on('data', onInput)
+    this.stdin.on('paste', content => { onInput(paste(content)) })
+  }
+  stop(): void { this.stdin.destroy() }
+  drainInput(): Promise<void> { return Promise.resolve() }
+  restoreProtocolsSync(): void { this.stdin.clear() }
+  restoreRawModeSync(): void {}
+  write(data: string): void { this.writes.push(data) }
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+function inputHarness() {
+  const terminal = new VirtualTerminal()
+  const tui = new TUI(terminal, false)
+  const session = createTerminalSession(terminal, true, () => undefined, truecolor)
+  const keys: string[] = []
+  tui.addInputListener(data => {
+    if (session.consumeInput(data)) return { consume: true }
+    keys.push(data)
+    return undefined
+  })
+  const composer = new Input()
+  const search = new Input()
+  const nestedSearch = new Input()
+  tui.addChild(composer)
+  tui.setFocus(composer)
+  session.setBackgroundColor('#282C34')
+  session.enter()
+  // No query before input listeners/raw mode are ready.
+  expect(terminal.writes).not.toContain(BACKGROUND_QUERY)
+  tui.start()
+  tui.showOverlay(search)
+  tui.showOverlay(nestedSearch)
+  session.startBackgroundSync()
+  return { terminal, session, keys, composer, search, nestedSearch, close: () => { session.restore(); tui.stop() } }
+}
+
+describe('OSC framing and nested input isolation', () => {
+  it.each([ST, '\u0007'])('handles every split, including slow fragments after the OSC opener (%j)', end => {
+    vi.useFakeTimers()
+    const data = reply(ORIGINAL, end)
+    for (let split = 1; split < data.length; split++) {
+      const harness = inputHarness()
+      try {
+        harness.terminal.stdin.process(`a${ESC}${data.slice(0, split)}`)
+        vi.advanceTimersByTime(split === 1 ? 5 : 100)
+        harness.terminal.stdin.process(`${data.slice(split)}b`)
+        expect(harness.keys, `split ${split}`).toEqual(['a', ESC, 'b'])
+        expect(harness.nestedSearch.getValue()).toBe('ab')
+        expect(harness.search.getValue()).toBe('')
+        expect(harness.composer.getValue()).toBe('')
+        expect(harness.terminal.writes).toContain(desired)
+      } finally { harness.close() }
+    }
+  })
+
+  it('discards a delayed reply after timeout without dirtying a nested search or changing color', () => {
+    vi.useFakeTimers()
+    const harness = inputHarness()
+    try {
+      harness.terminal.stdin.process(`${ESC}]11;rgb:0c0c/`)
+      vi.advanceTimersByTime(1000)
+      expect(harness.terminal.stdin.flush()).toEqual([])
+      harness.terminal.stdin.process(`1234/abcd${ST}z`)
+      expect(harness.keys).toEqual(['z'])
+      expect(harness.nestedSearch.getValue()).toBe('z')
+      expect(harness.terminal.writes).not.toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('preserves opaque paste and normal keys while canceling truncated OSC on a fresh escape', () => {
+    const harness = inputHarness()
+    try {
+      const literal = paste(`中文 ${reply()} [<35;20;13M`)
+      harness.terminal.stdin.process(`${ESC}]11;rgb:bad${literal}${ESC}[A`)
+      expect(harness.keys).toEqual([literal, `${ESC}[A`])
+      expect(harness.terminal.writes).not.toContain(desired)
+      harness.terminal.stdin.process(`${ESC}]11;unfinished${ESC}[B`)
+      expect(harness.keys.at(-1)).toBe(`${ESC}[B`)
+      harness.terminal.stdin.process(reply())
+      expect(harness.terminal.writes).toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('bounds oversized OSC, preserves split ST, and does not turn the tail into text', () => {
+    const harness = inputHarness()
+    try {
+      harness.terminal.stdin.process(`${ESC}]11;${'f'.repeat(100_000)}${ESC}`)
+      expect(harness.terminal.stdin.getBuffer().length).toBeLessThanOrEqual(1024)
+      harness.terminal.stdin.process('\\z')
+      expect(harness.keys).toEqual(['z'])
+      expect(harness.terminal.writes).not.toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('restores background synchronously before fatal cleanup and private-mode teardown', async () => {
+    const harness = inputHarness()
+    harness.terminal.stdin.process(reply())
+    const exit = vi.fn()
+    const handle = createFatalHandler({
+      restore: () => { harness.session.restore() },
+      cleanup: async () => {
+        expect(harness.terminal.writes).toContain(reply())
+        harness.close()
+      },
+      writeError: () => undefined,
+      formatError: () => '',
+      exit,
+    })
+    handle(undefined, 143)
+    const restoredAt = harness.terminal.writes.indexOf(reply())
+    const leaveAt = harness.terminal.writes.findIndex(data => data.includes(`${ESC}[?1049l`))
+    expect(restoredAt).toBeGreaterThan(-1)
+    expect(restoredAt).toBeLessThan(leaveAt)
+    await vi.waitFor(() => { expect(exit).toHaveBeenCalledWith(143) })
+    expect(harness.terminal.writes.filter(data => data === reply())).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fix the differently colored terminal padding / leftover pixels around a themed SeekTTY canvas. Character-cell painting alone cannot reach this area.

- Query the original terminal background asynchronously with OSC 11 only after input handling is ready; apply the interface canvas color only after a valid reply within 500 ms.
- Follow live interface-theme changes, deduplicate writes, and restore the captured original RGB precision on normal/fatal cleanup and POSIX suspend; re-probe on resume.
- Frame OSC replies in the pinned pi-tui patch so fragmented, late, malformed, or oversized reports are not delivered as ordinary editor input after the OSC opener is recognized. Preserve bracketed paste and the existing lone-Escape timeout.
- Keep unsupported/timed-out terminals, low-color / NO_COLOR environments, and tmux/screen unchanged. Allow opt-out with `SEEKTTY_TERMINAL_BACKGROUND=off`.
- Update English and Chinese README documentation and record the compatibility/manual acceptance boundary.

No runtime dependencies or dependency versions were added/changed. The lockfile change is the existing pi-tui patch hash. The committed bundle was rebuilt.

## Scope

This does not add custom background modes, wallpaper, transparency, or blur; those are a separate proposal. It does not alter code-theme colors/highlighting, terminal configuration files, window decorations, the bundle manifest, or Harness ownership. No version bump or release asset replacement is included.

## Verification

Re-run immediately before this PR:

- [x] `pnpm run typecheck`
- [x] Background, input-framing, terminal-session, and process-guard tests: **66 passed**
- [x] `pnpm run build`; rebuilt `lib/index.js` matches the previously verified implementation
- [x] `pnpm run pack:check`: **23 allowlisted entries**
- [x] `git diff --check`

Previously completed on the same implementation; recorded in [the compatibility document](./docs/terminal-background-compatibility.md):

- [x] Frozen pnpm installation
- [x] `pnpm run check`: **929 passed / 1 conditional skip**, typecheck, build, and package checks
- [x] Unmodified official dsh **0.1.1-rc.2**, isolated `DSH_HOME`: install, boot, remove, reinstall, second boot, and Host module-identity checks
- [x] Windows ConPTY mouse/context-menu regression: exit 0; this harness uses `NO_COLOR` and validates fallback/mouse regression, **not successful background synchronization in a GUI terminal**
- [ ] Real-terminal background/theme-switch/resize/exit acceptance: Windows, macOS, and Linux matrix remains explicitly **pending**

The exact local candidate SHA-256 is documented. Existing dsh adapter range is unchanged: `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2`.

## 中文说明

修复主题背景与终端边距、字符网格外剩余像素颜色不一致的问题。启动后异步查询原背景，500 ms 内收到有效回复才同步界面画布；换主题时更新，退出或 POSIX 暂停前恢复原色，继续运行后重新查询。

OSC 回复在输入分帧层处理，避免被当成普通搜索框或输入框文本；保留粘贴和原有 Esc 超时语义。不支持、超时、低色彩、NO_COLOR 和 tmux/screen 安全降级，可通过 `SEEKTTY_TERMINAL_BACKGROUND=off` 关闭。

中英文 README 已同步，自动验证与真实终端人工验收分开记录。此 PR **不包含**刚讨论的独立自定义背景、壁纸或透明模式，不修改现有代码高亮、不升级版本、不替换已发布的 1.2.4。