### PR TITLE
feat(tui): inherit terminal background effects with configurable modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Interface and code themes are independent. A palette of 3–16 HEX/RGB colors ca
 
 Hover styling is derived from the active interface theme, including existing custom themes, without adding required settings or altering saved colors. Indistinct or limited-color backgrounds use an underline cue; `NO_COLOR` remains respected.
 
+On supported truecolor terminals, SeekTTY queries the original terminal background and temporarily matches it to the interface theme, including live theme changes, so terminal padding does not show a different color. Exit restores the captured color. Unsupported or timed-out queries, `NO_COLOR`, limited-color terminals, and tmux/screen leave the terminal background untouched. Set `SEEKTTY_TERMINAL_BACKGROUND=off` to opt out. See [compatibility and verification](docs/terminal-background-compatibility.md); this does not change terminal settings, code highlighting, transparency, or window decorations.
+
 Use `/language` or a direct command to switch the terminal copy live:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See [Compatibility and verification](#compatibility-and-verification) for the ac
 | Subagents and background work | Inspect or stop direct subagents; view jobs, workflow phases, results, failures, token use, duration, and structured trajectory data |
 | Profiles and Settings | Create, copy, switch, and diagnose Profiles; edit every registered Settings namespace with Schema fallbacks, revision checks, and write-only secrets |
 | Plugins, Skills, and MCP | Plugin center, native Bundle reconciliation, dynamic Skill commands, MCP instances, load state, settings, and risk information |
-| Themes and language | Independent interface/code themes, palette generation, VS Code theme import, contrast checks, `NO_COLOR`, and live Chinese/English switching |
+| Themes and language | Independent interface/code themes, terminal background effects, palette generation, VS Code theme import, contrast checks, `NO_COLOR`, and live Chinese/English switching |
 | Diagnostics and feedback | Runtime status, actionable `/doctor` checks, Session feedback, Assistant-message ratings, and feedback removal |
 
 SeekTTY reads these catalogs from the active Harness Profile. Unsupported optional capabilities degrade safely while dedicated terminal views continue to evolve.
@@ -274,7 +274,17 @@ Interface and code themes are independent. A palette of 3–16 HEX/RGB colors ca
 
 Hover styling is derived from the active interface theme, including existing custom themes, without adding required settings or altering saved colors. Indistinct or limited-color backgrounds use an underline cue; `NO_COLOR` remains respected.
 
-On supported truecolor terminals, SeekTTY queries the original terminal background and temporarily matches it to the interface theme, including live theme changes, so terminal padding does not show a different color. Exit restores the captured color. Unsupported or timed-out queries, `NO_COLOR`, limited-color terminals, and tmux/screen leave the terminal background untouched. Set `SEEKTTY_TERMINAL_BACKGROUND=off` to opt out. See [compatibility and verification](docs/terminal-background-compatibility.md); this does not change terminal settings, code highlighting, transparency, or window decorations.
+The main canvas now defaults to **theme colors + terminal effects**, instead of an explicit RGB fill. It uses the terminal's default background so the terminal can apply its configured transparency, blur, or background image. Choose **Background mode** in `/theme` or `/settings seektty-appearance`; both open the same editor and apply successful saves immediately.
+
+| `backgroundMode` | Main canvas | Terminal color |
+| --- | --- | --- |
+| `theme` (default, including older settings) | Terminal default background | Temporarily synchronize the interface theme with OSC 11 |
+| `terminal` | Terminal default background | Leave unchanged; restore the captured original if SeekTTY changed it |
+| `explicit` (compatibility) | Explicit theme fill, as before | Keep the previous OSC 11 synchronization behavior |
+
+Panels, code blocks, selections and hover keep their independent backgrounds and highlighting. Their transparency can differ from the canvas; even `explicit` is not guaranteed opaque. Background mode belongs to Harness `seektty-appearance` settings, not theme files: theme switching, previews, import and export do not overwrite it.
+
+Color synchronization requires a supported truecolor terminal and a valid reply to one 500 ms asynchronous query. Unsupported or timed-out queries, `NO_COLOR`, limited colors, and tmux/screen do not recolor the terminal. In `theme` mode, an unavailable sync leaves the default background in place with one non-blocking notice, not an automatic RGB fallback. `SEEKTTY_TERMINAL_BACKGROUND=off` disables recoloring only; it does not change the selected mode. Exit restores the captured color. SeekTTY does not read/set opacity, edit terminal configuration, or alter window decorations. See [compatibility](docs/terminal-background-compatibility.md) and [acceptance results](docs/background-inheritance-acceptance.md).
 
 Use `/language` or a direct command to switch the terminal copy live:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -274,6 +274,8 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 会打开主题中心，�
 
 悬停样式由当前界面主题统一推导，兼容已有自定义主题，不新增必填设置、不修改保存的配色。背景过于接近或终端色彩有限时使用下划线辅助区分；仍遵守 `NO_COLOR`。
 
+在支持的真彩色终端中，SeekTTY 会查询原终端背景色，并临时同步为界面主题背景，实时换主题时也会更新，避免终端边距露出异色；退出时恢复读取到的原色。不支持或查询超时、`NO_COLOR`、低色彩终端以及 tmux/screen 均保留原背景。设置 `SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭此功能。详见[兼容性与验证说明](docs/terminal-background-compatibility.md)；该功能不修改终端配置、代码高亮、透明度或窗口装饰。
+
 使用 `/language` 或直接命令实时切换终端文案：
 
 ```text

--- a/README.zh.md
+++ b/README.zh.md
@@ -147,7 +147,7 @@ Clarify 一次提出一个聚焦问题，把已确认的决定带入后续问题
 | 子 Agent 与后台工作 | 查看或停止直接子 Agent；检查任务、工作流阶段、结果、失败、Token、耗时和结构化轨迹 |
 | Profile 与 Settings | 创建、复制、切换和诊断 Profile；通过 Schema 回退、revision 检查和只写 Secret 编辑全部设置命名空间 |
 | 插件、Skill 与 MCP | 插件中心、原生 Bundle 协调、动态 Skill 命令、MCP 实例、加载状态、设置与风险信息 |
-| 主题与语言 | 界面／代码主题独立切换、配色生成、VS Code 主题导入、对比度检查、`NO_COLOR` 和中英文实时切换 |
+| 主题与语言 | 界面／代码主题独立切换、继承终端背景效果、配色生成、VS Code 主题导入、对比度检查、`NO_COLOR` 和中英文实时切换 |
 | 诊断与反馈 | 运行状态、可执行的 `/doctor` 检查、Session 反馈、助手消息评分与反馈删除 |
 
 SeekTTY 从当前 Harness Profile 动态读取这些目录。暂不支持的可选能力会安全降级，专用终端界面则可以持续演进。
@@ -274,7 +274,17 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 会打开主题中心，�
 
 悬停样式由当前界面主题统一推导，兼容已有自定义主题，不新增必填设置、不修改保存的配色。背景过于接近或终端色彩有限时使用下划线辅助区分；仍遵守 `NO_COLOR`。
 
-在支持的真彩色终端中，SeekTTY 会查询原终端背景色，并临时同步为界面主题背景，实时换主题时也会更新，避免终端边距露出异色；退出时恢复读取到的原色。不支持或查询超时、`NO_COLOR`、低色彩终端以及 tmux/screen 均保留原背景。设置 `SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭此功能。详见[兼容性与验证说明](docs/terminal-background-compatibility.md)；该功能不修改终端配置、代码高亮、透明度或窗口装饰。
+主画布现在默认采用**主题颜色＋终端效果**，不再显式铺满 RGB 底色，而是使用终端默认背景，让终端应用已有的透明、模糊或背景图片效果。在 `/theme` 或 `/settings seektty-appearance` 中选择**背景模式**，两处共用同一个编辑器，保存成功后立即生效。
+
+| `backgroundMode` | 主画布 | 终端颜色 |
+| --- | --- | --- |
+| `theme`（默认，兼容缺少该字段的旧设置） | 终端默认背景 | 通过 OSC 11 临时同步界面主题颜色 |
+| `terminal` | 终端默认背景 | 不改色；如果本次运行改过色，恢复捕获的原色 |
+| `explicit`（兼容） | 保留原有显式主题底色 | 保留原有 OSC 11 同步行为 |
+
+弹窗、代码块、选区和 hover 保留独立底色与高亮，透明效果可能与主画布不同；`explicit` 也不保证一定不透明。背景模式属于 Harness 的 `seektty-appearance` 设置，不属于主题文件，切换、预览、导入或导出主题均不会覆盖它。
+
+改色需要支持的真彩色终端，并在一次 500 ms 异步查询内收到有效回复。不支持、查询超时、`NO_COLOR`、低色彩及 tmux/screen 均不改色。`theme` 模式同步不可用时保留终端默认背景，给一次非阻塞提示，不自动回退成 RGB 铺底。`SEEKTTY_TERMINAL_BACKGROUND=off` 只禁止改色，不改变所选模式。退出时恢复捕获的原色。SeekTTY 不读取／设置透明度，不修改终端配置或窗口装饰。详见[兼容性说明](docs/terminal-background-compatibility.md)与[验收记录](docs/background-inheritance-acceptance.md)。
 
 使用 `/language` 或直接命令实时切换终端文案：
 

--- a/docs/background-inheritance-acceptance.md
+++ b/docs/background-inheritance-acceptance.md
@@ -1,0 +1,99 @@
+# Background inheritance acceptance / 背景继承验收
+
+Date: 2026-08-29 (Asia/Shanghai). Branch: `codex/background-inheritance`.
+
+Base: `662b753` (the OSC 11 implementation from PR #162). Implementation commits: `8f96856`, `e4273fd`. This is a local development candidate still numbered `1.2.4`; it does not replace the published release. No push, PR creation or release was performed for this feature.
+
+## Automated results
+
+| Layer | Result | What it proves / limitation |
+| --- | --- | --- |
+| `pnpm run check` | Passed: 113 test files, 962 passed / 1 conditional skip; typecheck and build passed | Includes existing renderer, mouse, clipboard, overlay and input regressions. The Clarify acceptance conditional skip is unrelated to backgrounds. |
+| `pack:check` and candidate pack | Passed: 23 allowlisted entries | No new dependency, `workspace:` consumer dependency, credential, personal theme or local Profile included. |
+| Official dsh `0.1.1-rc.2` | Passed | Fresh registry installation in a temporary directory; no Host package source changes. Candidate install, full boot to the non-interactive TUI boundary, removal, reinstall, second boot, packed launcher and Host module-identity checks passed in isolated `DSH_HOME` directories. |
+| Existing Windows ConPTY mouse harness | Passed: one cycle, 9,587 captured characters, exit 0 | Packaged interactive boot, mouse/context-menu gestures, resize and exit. This harness uses `NO_COLOR`, so it does not test transparency or successful OSC 11 synchronization. |
+| Additional local truecolor ConPTY probe | Passed: 61,592 captured characters, exit 0 | Packaged `theme → terminal → explicit → theme` saves, resize at 120×36 / 90×28, and the `/theme` background editor. Explicit RGB output observed. No OSC 11 query was visible to the harness; the application displayed its unavailable-sync notice. This verifies the fallback path, not a GUI compositor or successful query/restoration. |
+
+Environment: Windows, Node `26.1.0`, pnpm `11.7.0`, pinned pi-tui `0.73.1`, node-pty `1.1.0`. Candidate SHA-256:
+
+```text
+940866023a4aea18111654338d3c2b54aad87f1c6eb028108d53a125f7a162c0
+```
+
+The first local truecolor probe waited for a success toast, which was hidden by the higher-priority unavailable-sync warning. The saved namespace already showed `terminal`; the probe was corrected to assert the persisted field display instead. No product change was needed for that probe failure. The corrected run is the result above. Capture lengths are character counts, not encoded byte counts.
+
+### Coverage by invariant
+
+- `theme-config.test.ts`, `settings-schema-i18n.test.ts`, `appearance-background.test.ts`: legacy/default settings, invalid values, localized schema, revision-protected saves, failed/unexpected saves and theme-file independence.
+- `actions-background.test.ts`, `actions-theme.test.ts`: the same three-option editor via both Chinese/English entry points, immediate whole-appearance callback after save, no application on cancel/failure/no-op, theme preview/save/cancel and failed preview persistence.
+- `terminal-background.test.ts`, `terminal-session.test.ts`: deferred single query, all modes, pending switch to `terminal`, preserved original precision, duplicate replies, deduplicated writes, timeout/late reply behavior, one unavailable notice per lifetime, disabled synchronization, write failures, teardown and new lifetime.
+- `background-inheritance.test.ts`, `theme.test.ts`, `tui-render-stability.test.ts`: SGR 49 versus explicit fill, inner style resets, unchanged code/panel/hover/selection backgrounds, complete row filling, forced repaint, resize, shorter content, overlay removal and unchanged geometry.
+- `transcript-viewport.test.ts`: historical viewport, selection, copied text and hit maps survive mode changes, without full-history rendering.
+- `terminal-background.test.ts`, `terminal-input-framing.test.ts`: split/malformed/oversized/late OSC isolation from composer, nested search and a real secret-input overlay in all three modes; opaque bracketed paste.
+- `process-guards.test.ts`: normal/fatal cleanup and simulated POSIX suspend/resume. A simulated POSIX signal is not a macOS/Linux device test.
+
+## Real-terminal matrix — not signed off
+
+| Environment | Expected behavior | Actual GUI result |
+| --- | --- | --- |
+| Windows Terminal `1.24.11911.0`, current user transparency settings | Default canvas uses terminal effects; sync only after a valid reply | **Untested**. Installed version verified; desktop terminal automation is unavailable under the agent's UI-safety constraints. The user's opacity value/configuration was not read or changed. |
+| macOS iTerm2 or Ghostty | Same mode/state machine; verify effects and exit restoration in the actual emulator | **Untested: no device** |
+| Linux Kitty or Ghostty | Same mode/state machine; compositor may affect transparency/blur | **Untested: no device** |
+| Non-query-capable terminal | No recoloring; default canvas and one notice in `theme` | Unit tests + ConPTY unavailable-query fallback passed; **GUI untested** |
+| `SEEKTTY_TERMINAL_BACKGROUND=off`, low-color / `NO_COLOR` | No recoloring; selected mode unchanged | Unit policy and `NO_COLOR` ConPTY passed; **GUI untested** |
+| tmux / screen | No query, mutation or forced passthrough | Unit policy passed; **actual multiplexer untested** |
+
+No three-platform visual-compatibility claim is made. Manual acceptance remains required before treating this as visually verified on all supported platforms.
+
+### Manual checklist
+
+Use a temporary Profile, not the everyday Profile. Record terminal version, OS, color capability, and whether transparency/blur/images were already enabled. Do not change terminal settings during the comparison. No API key or model request is needed to open the settings/theme editors.
+
+1. Observe the shell background before launch. Start the candidate with old/default appearance settings; verify the canvas retains the terminal's effects in `theme`. On a query-capable terminal, check the theme color also reaches grid padding.
+2. Open `/settings seektty-appearance` → **Background mode**. Change to `terminal`; verify restoration of the pre-launch color, without a flash of explicit RGB or changed viewport dimensions.
+3. Choose `explicit`, then `theme`, several times. Check full repaint, no stale rows/characters, and no session restart. Confirm each choice remains selected when reopening the editor. Check `/theme` → **Background mode** reaches the same editor.
+4. Change interface and code themes; preview then cancel a custom theme. Confirm the background mode stays unchanged, and code, panels, hover and selection remain readable with their own colors.
+5. With a long test transcript, scroll into history and select text. Switch modes; verify copied selection and history anchor survive. Resize smaller/larger and close nested overlays; check empty areas, scrollbars and pointer targets.
+6. During startup and a mode change, type harmless text in chat/search and a disposable API-key field (do not save it). No `]11;rgb:…` or other control-frame fragment may appear. Cancel the field.
+7. Exit normally and check the shell color against step 1. Where available, also test a catchable termination and POSIX suspend/resume. Do not use forced termination to assess guaranteed restoration.
+8. Relaunch with `SEEKTTY_TERMINAL_BACKGROUND=off`; repeat all three modes. No terminal recoloring should occur. Repeat in a real tmux/screen session and a non-query-capable terminal. `theme` stays default-background and reports unavailable sync once; it must not silently become `explicit`.
+
+### Isolated manual launch
+
+Verify `dsh --version` reports `0.1.1-rc.2` first. From this checkout, build/pack and install the candidate into a temporary `DSH_HOME`. The following commands do not replace the everyday Profile or change terminal settings.
+
+PowerShell:
+
+```powershell
+pnpm run build
+$backgroundTestRoot = Join-Path $env:TEMP ('seektty-background-manual-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $backgroundTestRoot | Out-Null
+pnpm pack --pack-destination $backgroundTestRoot
+$backgroundPreviousDshHome = $env:DSH_HOME
+try {
+    $env:DSH_HOME = Join-Path $backgroundTestRoot 'home'
+    dsh plugin --profile tui add (Join-Path $backgroundTestRoot 'seektty-1.2.4.tgz')
+    if ($LASTEXITCODE -ne 0) { throw 'Candidate installation failed' }
+    dsh --profile tui
+} finally {
+    $env:DSH_HOME = $backgroundPreviousDshHome
+}
+```
+
+macOS/Linux shell:
+
+```sh
+pnpm run build
+background_test_dir="$(mktemp -d)"
+pnpm pack --pack-destination "$background_test_dir"
+DSH_HOME="$background_test_dir/home" dsh plugin --profile tui add "$background_test_dir/seektty-1.2.4.tgz" &&
+DSH_HOME="$background_test_dir/home" dsh --profile tui
+```
+
+## 中文验收结论
+
+已完成实现与自动化验收：962 项通过、1 项无关条件跳过，类型检查、构建、23 项包白名单，以及全新官方 dsh `0.1.1-rc.2` 下的隔离安装／启动／移除／重装均通过。背景模式使用完整外观应用回调；主题预览仍独立，取消或保存失败不改变背景模式。
+
+ConPTY 分别验证了现有鼠标路径，以及候选包三模式保存／切换、resize、主题入口和正常退出。后者走的是 OSC 11 不可用降级，不能冒充成功改色与透明度视觉验收。第一次补充探测误把成功 toast 当作唯一判据，实际上设置已保存；改为检查保存后的字段显示后通过。
+
+Windows Terminal 实机视觉验收受当前桌面终端自动化限制未执行；macOS/Linux 没有设备；真实 tmux 与其他终端仍待人工验证。上方清单与隔离启动命令用于后续逐项签收，不宣称“三端实测全过”。个人主题、#161 任务书、日常 Profile 和终端配置未修改；本次只做本地提交，不推送、不提 PR、不发布。

--- a/docs/terminal-background-compatibility.md
+++ b/docs/terminal-background-compatibility.md
@@ -1,73 +1,58 @@
-# Terminal background synchronization / 终端背景同步
+# Terminal background inheritance / 终端背景继承
 
-## Scope
+## Behavior and scope
 
-Terminal padding and leftover pixels outside the character grid use the terminal's own background. Painting more characters cannot reach them. SeekTTY now uses one platform-neutral OSC 11 controller to temporarily match that background to the **interface** theme's `colors.canvas`. Code-theme colors and highlighting are unchanged.
+The main canvas defaults to `theme`: interface colors with terminal-owned background effects. Older settings without `backgroundMode` use this default too. This changes the previous explicitly painted canvas; choose `explicit` to retain that rendering behavior.
 
-- Start listening for input before issuing one asynchronous `OSC 11 ; ? ST` query. Startup never waits for a reply.
-- Require a valid `rgb:r/g/b` reply within 500 ms before changing the background. Each channel may contain 1–4 hex digits; retain the original precision for restoration.
-- Use the current theme if it changed while the query was pending. Deduplicate repeated colors; do not poll or write background commands on mouse movement or repaint.
-- Restore the captured color synchronously before normal/fatal teardown. Do **not** use OSC 111: resetting the configured profile color can lose a color previously selected by the shell or an enclosing application.
-- On POSIX `SIGTSTP`, restore terminal modes and background before suspending. On `SIGCONT`, re-enter, re-query, and redraw. Ctrl+Z remains input undo. Uncatchable termination (`SIGKILL`, forced termination, or a terminal crash) cannot guarantee cleanup.
-- Unsupported/expired queries never set or reset a color. Late, malformed, duplicate, and unsolicited OSC replies do not enter editors or overlays. Bracketed paste remains opaque.
+| Harness `seektty-appearance.backgroundMode` | Canvas background | OSC 11 policy |
+| --- | --- | --- |
+| `theme` (default) | Default background (`SGR 49`) | Synchronize the interface theme's `colors.canvas` when safe |
+| `terminal` | Default background (`SGR 49`) | Do not recolor; restore an original captured earlier in this lifetime |
+| `explicit` (compatibility) | Explicit theme background, quantized to the terminal's color depth | Same synchronization policy as before |
 
-The pinned `@mariozechner/pi-tui@0.73.1` patch keeps OSC frames together across reads, supports BEL and ESC-backslash terminators, bounds incomplete buffers, and lets a new escape-prefixed event cancel a truncated frame. The ordinary lone-Escape key timeout is unchanged; after the OSC opener is recognized, the frame no longer expires into text.
+`/theme` → **Background mode** and `/settings seektty-appearance` → **Background mode** share one three-choice editor. Changes are persisted through revision-protected Harness Settings before applying; cancellation or failure leaves the current appearance unchanged. Successful changes redraw the full viewport without restarting, moving scroll anchors, clearing selection, or changing hit geometry. Theme previews retain the mode, and theme switching/import/export never writes it.
 
-## Safe defaults
+The canvas and its full-width/full-height blank filling remain in place. Foreground resets restore the selected background semantics. This is not a different layout or a full-history renderer. Panels, code blocks, selections and hover retain their existing independent backgrounds and syntax colors; those regions may have different transparency from the main canvas.
 
-Automatic synchronization requires the existing truecolor detection. It is disabled with:
+No dependencies, alpha-percentage probes, terminal-specific opacity APIs, or terminal configuration writes are added. Opacity, blur, background images, and OS window decorations remain terminal/compositor responsibilities. `explicit` describes escape sequences, not a promise of opacity. For example, [Kitty applies opacity to cells matching its default background](https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.background_opacity), while [Ghostty can optionally apply opacity to explicitly colored cells](https://ghostty.org/docs/config/reference#background-opacity-cells). [Windows Terminal owns its profile opacity, acrylic and background-image settings](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#transparency). SeekTTY does not change these options.
 
-- `NO_COLOR`, `TERM=dumb`, or limited-color rendering;
-- `TMUX`, `STY`, or a `screen*` / `tmux*` terminal type;
-- `SEEKTTY_TERMINAL_BACKGROUND=off` (also accepts `0` or `false`).
+## Color ownership and cleanup
 
-Direct SSH is not disabled merely because it is SSH: its terminal must still answer before the deadline. Multiplexers are deliberately excluded because a reply may be cached and changing the outer terminal may affect other panes. No passthrough is forced.
+- Start listening for input before the first needed `OSC 11 ; ? ST` query. A startup in `terminal` mode does not query; entering `theme` or `explicit` later may initiate the one query for that active lifetime.
+- The query is asynchronous and expires after 500 ms. Only a valid `rgb:r/g/b` reply with 1–4 hex digits per channel authorizes a color change. Preserve original channel precision.
+- Switching between synchronizing modes with the same color does not repeat a write. Repaints and mode switches never repeat the query.
+- Entering `terminal` restores the captured original immediately if this run changed it, but retains the snapshot for later switches. If a reply arrives while `terminal` is selected, capture it without recoloring. A later synchronizing mode uses the latest requested theme.
+- Missing, expired, or disabled synchronization in `theme` mode leaves the default canvas background in place with one non-blocking notice per active lifetime. Do not silently switch to explicit RGB. If foreground contrast is poor against an unrelated terminal background, select a matching interface theme or opt into `explicit`.
+- Restore the captured color synchronously before normal/fatal teardown. Do not use OSC 111: it resets the profile color, which may differ from a color previously chosen by the shell. Write failures are handled best-effort, without breaking cleanup.
+- POSIX suspend restores the background and protocols. Resume starts a new active lifetime, installs input first, then re-queries if needed. Ctrl+Z remains input undo. Uncatchable termination (`SIGKILL`, forced process termination, or terminal crash) cannot guarantee restoration.
 
-This preserves Settings/Profile ownership, introduces no runtime dependencies, and never edits terminal configuration files or changes opacity/background images. Transparent or image-backed terminals may still look different from an opaque TUI; opt out when preserving that appearance is preferred. OS title bars, borders, and shadows are not part of this fix.
+The existing pinned `@mariozechner/pi-tui@0.73.1` input framing is reused unchanged. Malformed, late, duplicate, unsolicited and oversized OSC frames are consumed before chat, search, or secret inputs; bracketed paste remains opaque. A new escape-prefixed event can cancel a truncated frame without changing the ordinary lone-Escape timeout.
+
+## Safe fallback
+
+Color synchronization still requires an interactive managed terminal and the existing truecolor detection. It is disabled by `NO_COLOR`, limited color depth, `TERM=dumb`, `TMUX`, `STY`, a `screen*`/`tmux*` terminal type, or `SEEKTTY_TERMINAL_BACKGROUND=off` (`0` and `false` also work). The environment switch disables recoloring only: `theme`/`terminal` still use the default background and `explicit` still uses a theme fill where colors are enabled. `NO_COLOR` retains unstyled output. Non-interactive and dumb terminals retain the existing headless guidance.
+
+Direct SSH uses the same bounded query; network latency may cause safe fallback. Multiplexers are excluded because cached replies or outer-window mutations could affect other panes. No passthrough is forced. A successful protocol test cannot prove compositor effects or pixel-perfect padding in every emulator.
 
 ## Verification
 
-Automated coverage is in `tests/terminal-background.test.ts`, `tests/terminal-input-framing.test.ts`, `tests/terminal-session.test.ts`, and `tests/process-guards.test.ts`. It covers capability policy, exact-color restoration, live changes, timeout/late replies, write failures, nested inputs, split replies, malformed/oversized frames, bracketed paste, fatal cleanup, and simulated POSIX suspend/resume signals. Synthetic terminal tests are **not** real GUI-terminal acceptance.
+See [dated acceptance results and manual checklist](background-inheritance-acceptance.md). Unit/synthetic frame tests, real PTY/ConPTY tests, official packaged lifecycle checks, and real GUI-terminal acceptance are recorded separately. Missing devices remain **untested**.
 
-Run the focused checks with:
+Focused checks:
 
 ```sh
-pnpm exec vitest run tests/terminal-background.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
+pnpm exec vitest run tests/appearance-background.test.ts tests/actions-background.test.ts tests/background-inheritance.test.ts tests/terminal-background.test.ts tests/theme-config.test.ts tests/actions-theme.test.ts tests/transcript-viewport.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
+pnpm run check
 ```
 
-Use an isolated `DSH_HOME` and an unmodified official dsh `0.1.1-rc.2` for packaged installation/boot/removal/reinstallation checks. Compatibility adapters retain the existing declared Host range: `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2`.
-
-### Local automated results
-
-- Frozen pnpm `11.7.0` installation: passed; only the pinned pi-tui patch hash changed, not dependency versions.
-- `pnpm run check`: 110 test files; **929 passed / 1 conditional skip**, plus typecheck, build, and the 23-entry package allowlist.
-- Exact candidate on unmodified official dsh `0.1.1-rc.2`: isolated install, boot, remove, reinstall, second boot, and Host module-identity checks passed.
-- Windows ConPTY mouse/context-menu regression: one cycle, 9588 captured characters, exit code 0. This harness sets `NO_COLOR`, so it verifies the unchanged fallback and mouse path, **not** successful background synchronization in a GUI terminal.
-- Candidate SHA-256: `127fcdac44c1d39ebafda705f7161857dc62ae12d5ef84c2b456826e54647e0d`. This is a local development package still numbered `1.2.4`, not the published release asset; the public release was not replaced.
-
-The local Windows Terminal installation reports `1.24.11911.0`; its presence is not a manual background/exit acceptance result. Packaged compatibility checks used an isolated `DSH_HOME`; deploying a candidate into an everyday Profile is a separate, user-requested action and does not count as manual acceptance. The feature never edits terminal configuration files.
-
-### Manual matrix — not yet signed off
-
-| Environment | Expected policy | Manual result |
-| --- | --- | --- |
-| Windows Terminal, VS Code terminal | Probe when truecolor; synchronize only on a valid reply | Pending |
-| macOS iTerm2, Kitty, Ghostty | Same shared protocol and capability policy | Pending |
-| macOS Terminal.app | Existing limited-color detection leaves background unchanged | Pending fallback check |
-| Linux Kitty, Ghostty, GNOME Terminal / Konsole under Wayland or X11 | Probe when truecolor; synchronize only on a valid reply | Pending |
-| tmux / screen | No background query or mutation | Pending fallback check |
-| Direct SSH | Probe with the same bounded deadline | Pending latency/exit check |
-
-For each accepted terminal, record its version, OS, transparency, and color mode. Check a custom interface theme, light/dark changes, resizing to non-cell-aligned dimensions, nested overlay typing while starting, normal exit, SIGTERM, and (on POSIX) suspend/resume. The shell background after exit must match the color from before launch, including when it differs from the profile's configured default. Repeat with `SEEKTTY_TERMINAL_BACKGROUND=off` and `NO_COLOR`.
-
-Protocol references: [Kitty padding FAQ](https://sw.kovidgoyal.net/kitty/faq/#why-is-there-padding-between-the-text-area-and-the-window-border), [Ghostty OSC reference](https://ghostty.org/docs/vt/reference), [Windows Terminal dynamic-color query support](https://github.com/microsoft/terminal/discussions/17809).
+Packaged checks require an isolated `DSH_HOME` and an unmodified official dsh `0.1.1-rc.2`. The declared compatibility-adapter range is unchanged: `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2`. Nothing in this feature changes Harness's ownership of settings, Profiles, Sessions or persistence, or native `dsh plugin` reconciliation.
 
 ## 中文说明
 
-该修复统一处理字符网格外的终端背景色差，不扩大鼠标架构，也不改代码主题。启动后异步查询原色，500 ms 内收到有效回复才同步界面主题；换主题时更新，退出时恢复原始精度的颜色，而不是重置成终端默认配色。POSIX 暂停前恢复、继续后重新查询；Ctrl+Z 仍用于撤销。
+默认从“显式 RGB 铺底”改为 `theme`：主画布使用终端默认背景（SGR 49），通过原有 OSC 11 同步界面主题颜色，让终端保留其背景效果。旧设置缺少字段时同样默认 `theme`。`terminal` 只跟随终端，不改色；`explicit` 保留旧铺底与原有改色行为，透明与否仍取决于终端。
 
-无回复、超时、`NO_COLOR`、低色彩模式和 tmux/screen 安全降级，不强制改色；`SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭。OSC 回复在输入分帧层完整接收，不进入普通输入框或多层搜索弹窗，粘贴内容不被当作回复解析。
+`/theme` 与 `/settings seektty-appearance` 的“背景模式”共用三选项编辑器，保存成功立即生效，失败／取消不改变状态。模式由 Harness 管理，主题切换、预览及取消、导入和导出均不覆盖它。只切模式不重建会话节点、不改变视口、选区、滚动锚点及鼠标命中；弹窗、代码块、选区与 hover 仍有独立底色。
 
-自动协议／虚拟终端测试、Windows ConPTY 与真实桌面终端验收分别记录。上表人工结果均未签收，不能宣称三端所有终端均已实测。透明背景、背景图片、操作系统窗口装饰及不可捕获的强制结束也不在“完全无色边、必定恢复”的保证范围内。
+每个活动终端生命周期最多一次 500 ms 异步查询；输入监听就绪、首次需要改色时才发起。切到 `terminal` 会恢复本次运行捕获的原色并保留快照，查询中的回复可记录但不可改色。超时、无效、迟到回复不进入输入框。同步不可用时 `theme` 保留默认背景并提示一次，不自动改成显式铺底。`SEEKTTY_TERMINAL_BACKGROUND=off` 只禁止改色；tmux/screen、低色彩和非交互环境沿用现有限制。
 
-本地全量检查为 929 项通过、1 项条件跳过，并通过类型检查、构建、23 项包白名单及官方 dsh 隔离插拔。Windows ConPTY 鼠标回归通过，但该脚本使用 `NO_COLOR`，不能算作背景同步实测。候选包仍使用开发中的 `1.2.4` 版本号，未覆盖已发布版本。打包兼容性检查均使用隔离的 `DSH_HOME`；按用户要求部署到日常 Profile 是另一步操作，不代表人工验收通过。该功能不会修改终端配置文件。
+该功能不读取或设置透明度，不调用终端专用透明 API，不修改终端配置，不新增依赖。实际效果由终端与桌面合成器决定；不保证所有彩色区域一样透明，也不保证强杀进程后恢复。实机、PTY、单元与插拔测试分别记录，未测设备不冒充通过。

--- a/docs/terminal-background-compatibility.md
+++ b/docs/terminal-background-compatibility.md
@@ -1,0 +1,73 @@
+# Terminal background synchronization / 终端背景同步
+
+## Scope
+
+Terminal padding and leftover pixels outside the character grid use the terminal's own background. Painting more characters cannot reach them. SeekTTY now uses one platform-neutral OSC 11 controller to temporarily match that background to the **interface** theme's `colors.canvas`. Code-theme colors and highlighting are unchanged.
+
+- Start listening for input before issuing one asynchronous `OSC 11 ; ? ST` query. Startup never waits for a reply.
+- Require a valid `rgb:r/g/b` reply within 500 ms before changing the background. Each channel may contain 1–4 hex digits; retain the original precision for restoration.
+- Use the current theme if it changed while the query was pending. Deduplicate repeated colors; do not poll or write background commands on mouse movement or repaint.
+- Restore the captured color synchronously before normal/fatal teardown. Do **not** use OSC 111: resetting the configured profile color can lose a color previously selected by the shell or an enclosing application.
+- On POSIX `SIGTSTP`, restore terminal modes and background before suspending. On `SIGCONT`, re-enter, re-query, and redraw. Ctrl+Z remains input undo. Uncatchable termination (`SIGKILL`, forced termination, or a terminal crash) cannot guarantee cleanup.
+- Unsupported/expired queries never set or reset a color. Late, malformed, duplicate, and unsolicited OSC replies do not enter editors or overlays. Bracketed paste remains opaque.
+
+The pinned `@mariozechner/pi-tui@0.73.1` patch keeps OSC frames together across reads, supports BEL and ESC-backslash terminators, bounds incomplete buffers, and lets a new escape-prefixed event cancel a truncated frame. The ordinary lone-Escape key timeout is unchanged; after the OSC opener is recognized, the frame no longer expires into text.
+
+## Safe defaults
+
+Automatic synchronization requires the existing truecolor detection. It is disabled with:
+
+- `NO_COLOR`, `TERM=dumb`, or limited-color rendering;
+- `TMUX`, `STY`, or a `screen*` / `tmux*` terminal type;
+- `SEEKTTY_TERMINAL_BACKGROUND=off` (also accepts `0` or `false`).
+
+Direct SSH is not disabled merely because it is SSH: its terminal must still answer before the deadline. Multiplexers are deliberately excluded because a reply may be cached and changing the outer terminal may affect other panes. No passthrough is forced.
+
+This preserves Settings/Profile ownership, introduces no runtime dependencies, and never edits terminal configuration files or changes opacity/background images. Transparent or image-backed terminals may still look different from an opaque TUI; opt out when preserving that appearance is preferred. OS title bars, borders, and shadows are not part of this fix.
+
+## Verification
+
+Automated coverage is in `tests/terminal-background.test.ts`, `tests/terminal-input-framing.test.ts`, `tests/terminal-session.test.ts`, and `tests/process-guards.test.ts`. It covers capability policy, exact-color restoration, live changes, timeout/late replies, write failures, nested inputs, split replies, malformed/oversized frames, bracketed paste, fatal cleanup, and simulated POSIX suspend/resume signals. Synthetic terminal tests are **not** real GUI-terminal acceptance.
+
+Run the focused checks with:
+
+```sh
+pnpm exec vitest run tests/terminal-background.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
+```
+
+Use an isolated `DSH_HOME` and an unmodified official dsh `0.1.1-rc.2` for packaged installation/boot/removal/reinstallation checks. Compatibility adapters retain the existing declared Host range: `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2`.
+
+### Local automated results
+
+- Frozen pnpm `11.7.0` installation: passed; only the pinned pi-tui patch hash changed, not dependency versions.
+- `pnpm run check`: 110 test files; **929 passed / 1 conditional skip**, plus typecheck, build, and the 23-entry package allowlist.
+- Exact candidate on unmodified official dsh `0.1.1-rc.2`: isolated install, boot, remove, reinstall, second boot, and Host module-identity checks passed.
+- Windows ConPTY mouse/context-menu regression: one cycle, 9588 captured characters, exit code 0. This harness sets `NO_COLOR`, so it verifies the unchanged fallback and mouse path, **not** successful background synchronization in a GUI terminal.
+- Candidate SHA-256: `127fcdac44c1d39ebafda705f7161857dc62ae12d5ef84c2b456826e54647e0d`. This is a local development package still numbered `1.2.4`, not the published release asset; the public release was not replaced.
+
+The local Windows Terminal installation reports `1.24.11911.0`; its presence is not a manual background/exit acceptance result. Packaged compatibility checks used an isolated `DSH_HOME`; deploying a candidate into an everyday Profile is a separate, user-requested action and does not count as manual acceptance. The feature never edits terminal configuration files.
+
+### Manual matrix — not yet signed off
+
+| Environment | Expected policy | Manual result |
+| --- | --- | --- |
+| Windows Terminal, VS Code terminal | Probe when truecolor; synchronize only on a valid reply | Pending |
+| macOS iTerm2, Kitty, Ghostty | Same shared protocol and capability policy | Pending |
+| macOS Terminal.app | Existing limited-color detection leaves background unchanged | Pending fallback check |
+| Linux Kitty, Ghostty, GNOME Terminal / Konsole under Wayland or X11 | Probe when truecolor; synchronize only on a valid reply | Pending |
+| tmux / screen | No background query or mutation | Pending fallback check |
+| Direct SSH | Probe with the same bounded deadline | Pending latency/exit check |
+
+For each accepted terminal, record its version, OS, transparency, and color mode. Check a custom interface theme, light/dark changes, resizing to non-cell-aligned dimensions, nested overlay typing while starting, normal exit, SIGTERM, and (on POSIX) suspend/resume. The shell background after exit must match the color from before launch, including when it differs from the profile's configured default. Repeat with `SEEKTTY_TERMINAL_BACKGROUND=off` and `NO_COLOR`.
+
+Protocol references: [Kitty padding FAQ](https://sw.kovidgoyal.net/kitty/faq/#why-is-there-padding-between-the-text-area-and-the-window-border), [Ghostty OSC reference](https://ghostty.org/docs/vt/reference), [Windows Terminal dynamic-color query support](https://github.com/microsoft/terminal/discussions/17809).
+
+## 中文说明
+
+该修复统一处理字符网格外的终端背景色差，不扩大鼠标架构，也不改代码主题。启动后异步查询原色，500 ms 内收到有效回复才同步界面主题；换主题时更新，退出时恢复原始精度的颜色，而不是重置成终端默认配色。POSIX 暂停前恢复、继续后重新查询；Ctrl+Z 仍用于撤销。
+
+无回复、超时、`NO_COLOR`、低色彩模式和 tmux/screen 安全降级，不强制改色；`SEEKTTY_TERMINAL_BACKGROUND=off` 可关闭。OSC 回复在输入分帧层完整接收，不进入普通输入框或多层搜索弹窗，粘贴内容不被当作回复解析。
+
+自动协议／虚拟终端测试、Windows ConPTY 与真实桌面终端验收分别记录。上表人工结果均未签收，不能宣称三端所有终端均已实测。透明背景、背景图片、操作系统窗口装饰及不可捕获的强制结束也不在“完全无色边、必定恢复”的保证范围内。
+
+本地全量检查为 929 项通过、1 项条件跳过，并通过类型检查、构建、23 项包白名单及官方 dsh 隔离插拔。Windows ConPTY 鼠标回归通过，但该脚本使用 `NO_COLOR`，不能算作背景同步实测。候选包仍使用开发中的 `1.2.4` 版本号，未覆盖已发布版本。打包兼容性检查均使用隔离的 `DSH_HOME`；按用户要求部署到日常 Profile 是另一步操作，不代表人工验收通过。该功能不会修改终端配置文件。

--- a/lib/index.js
+++ b/lib/index.js
@@ -9528,6 +9528,8 @@ var ProcessTerminal = class {
 
 /** Harness Settings namespace that persists SeekTTY-only visual preferences. */
 const TUI_APPEARANCE_SETTINGS_NAMESPACE = "seektty-appearance";
+/** Keep theme colors while inheriting the terminal's background effects. */
+const DEFAULT_TUI_BACKGROUND_MODE = "theme";
 /** First-run color scheme when no user override has been stored. */
 const DEFAULT_TUI_THEME = "dark";
 /** Default code pairing follows the active interface theme. */
@@ -23405,6 +23407,7 @@ function normalizeCustomTheme(value) {
 */
 function normalizeAppearance(value) {
 	const record = recordOf$2(value, "SeekTTY appearance");
+	const backgroundMode$1 = normalizeBackgroundMode(record.backgroundMode);
 	const rawTheme = stringOf(record, "theme", "SeekTTY appearance");
 	if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) throw new Error(ui(`SeekTTY 主题 ${JSON.stringify(rawTheme)} 不受支持`, `SeekTTY theme ${JSON.stringify(rawTheme)} is not supported`));
 	const rawThemes = record.customThemes ?? [];
@@ -23428,8 +23431,15 @@ function normalizeAppearance(value) {
 	return {
 		theme,
 		codeTheme,
+		backgroundMode: backgroundMode$1,
 		customThemes
 	};
+}
+/** Validate the independent canvas policy, including legacy settings without it. */
+function normalizeBackgroundMode(value) {
+	if (value === void 0) return DEFAULT_TUI_BACKGROUND_MODE;
+	if (value === "theme" || value === "terminal" || value === "explicit") return value;
+	throw new Error(ui(`SeekTTY 背景模式 ${JSON.stringify(value)} 不受支持`, `SeekTTY background mode ${JSON.stringify(value)} is not supported`));
 }
 /**
 * Resolve the active or requested theme definition.
@@ -23592,6 +23602,7 @@ function runtimePalette(theme) {
 	};
 }
 let selectedTheme = BUILT_IN_THEMES.dark;
+let backgroundMode = DEFAULT_TUI_BACKGROUND_MODE;
 let palette = runtimePalette(selectedTheme);
 const hoverUnderlineByLevel = /* @__PURE__ */ new Map();
 let codeHighlighter;
@@ -23769,7 +23780,7 @@ function paint(entry, text$1) {
 function layer(background$1, text$1, foreground = palette.text) {
 	const level = terminalColorLevel();
 	if (level === 0) return text$1;
-	const prefix = `${backgroundSequence(background$1, level)}${foregroundSequence(foreground, level)}`;
+	const prefix = `${background$1 === void 0 ? "\x1B[49m" : backgroundSequence(background$1, level)}${foregroundSequence(foreground, level)}`;
 	return `${prefix}${text$1.replace(/\u001B\[(?:0)?m/gu, `${RESET}${prefix}`)}${RESET}`;
 }
 function ansi(code, text$1) {
@@ -23819,6 +23830,10 @@ function setTheme(theme) {
 	palette = runtimePalette(theme);
 	hoverUnderlineByLevel.clear();
 }
+/** Independent of theme previews/imports; only the main canvas inherits terminal effects. */
+function setBackgroundMode(mode) {
+	backgroundMode = mode;
+}
 /**
 * Connect the asynchronously prepared syntax highlighter to Markdown rendering.
 * @param highlighter - synchronous cached renderer, or undefined during teardown.
@@ -23854,7 +23869,7 @@ const color = {
 };
 /** Background layers shared by the full frame, panels, and selected rows. */
 const background = {
-	canvas: (text$1) => layer(palette.canvas, text$1),
+	canvas: (text$1) => layer(backgroundMode === "explicit" ? palette.canvas : void 0, text$1),
 	surface: (text$1) => layer(palette.surface, text$1),
 	hover: hoverLayer,
 	selection: (text$1) => layer(palette.selection, text$1),
@@ -25070,6 +25085,10 @@ const FIELD_LABELS = {
 	[`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.codeTheme`]: {
 		zh: "代码块主题",
 		en: "Code theme"
+	},
+	[`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.backgroundMode`]: {
+		zh: "背景模式",
+		en: "Background mode"
 	},
 	[`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.toolCards`]: {
 		zh: "工具卡片默认形态",
@@ -29096,6 +29115,17 @@ async function saveCodeTheme(settings, document, codeTheme) {
 	if (stored.codeTheme !== codeTheme) throw new Error(ui(`Harness 保存了意外代码主题 ${JSON.stringify(stored.codeTheme)}`, `Harness saved an unexpected code theme ${JSON.stringify(stored.codeTheme)}`));
 	return updated;
 }
+/** Persist only the canvas policy; imported/exported themes do not own it. */
+async function saveBackgroundMode(settings, document, mode) {
+	const value = normalizeBackgroundMode(mode);
+	const updated = await settings.mutate(TUI_APPEARANCE_SETTINGS_NAMESPACE, [{
+		op: "set",
+		path: ["backgroundMode"],
+		value
+	}], document.revision);
+	if (appearanceFromSettings(updated).backgroundMode !== value) throw new Error(ui("Harness 未保存所选背景模式", "Harness did not save the selected background mode"));
+	return updated;
+}
 /**
 * Add or replace a named custom theme and activate it for the requested surfaces.
 * @param settings - same-process redacted Settings bridge.
@@ -31175,6 +31205,10 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		];
 		choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme));
 		choices.push({
+			id: "__background__",
+			label: ui("背景模式", "Background mode"),
+			description: ui("选择主画布背景；独立于主题文件", "Choose the canvas background independently of theme files")
+		}, {
 			id: "__code__",
 			label: ui("代码块主题", "Code-block theme"),
 			description: ui(`${appearance.codeTheme === "auto" ? "自动匹配" : "独立指定"} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === "auto" ? "Automatic" : "Explicit"} · current ${activeCodeTheme.name}`)
@@ -31216,6 +31250,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 				options: options$1
 			}, async (selected) => {
 				if (selected.id === "__code__") await this.themeCode("", navigation);
+				else if (selected.id === "__background__") await this.editBackgroundMode(navigation);
 				else if (selected.id === "__palette__") await this.themePalette("", navigation);
 				else if (selected.id === "__import__") await this.themeImport("", navigation);
 				else if (selected.id === "__export__") await this.themeExport("", navigation);
@@ -31236,6 +31271,47 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		}
 		const updated = await saveTheme(bridge, document, target);
 		await this.settingsChanged(updated, resolved.name);
+	}
+	/** Shared by /theme and the searchable Harness appearance field. No preview before saving. */
+	async editBackgroundMode(overlays) {
+		const bridge = this.capabilities.managementBridge().settings;
+		const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE));
+		const current = appearanceFromSettings(document).backgroundMode;
+		const selected = await overlays.select({
+			title: ui("背景模式", "Background mode"),
+			detail: ui("仅主画布继承终端效果，不设置透明度。弹窗、代码块和高亮保留独立底色；保存后立即生效。", "Only the canvas inherits terminal effects; opacity is not changed. Panels, code blocks and highlights keep their backgrounds. Saves apply immediately."),
+			searchable: false,
+			initialChoiceId: current,
+			choices: [
+				{
+					id: "theme",
+					label: ui("主题颜色＋终端效果（默认）", "Theme + terminal effects"),
+					description: ui("默认背景＋OSC 11 主题改色；保留终端透明、模糊和图片效果", "Default: OSC 11 theme color; retain terminal transparency, blur and images")
+				},
+				{
+					id: "terminal",
+					label: ui("跟随终端", "Follow terminal"),
+					description: ui("使用终端默认背景，不改色；恢复本次运行捕获的原色", "Use the terminal default background without recoloring; restore the captured original")
+				},
+				{
+					id: "explicit",
+					label: ui("显式主题底色（兼容）", "Explicit fill (compatibility)"),
+					description: ui("沿用 RGB 画布与主题改色；实际透明效果由终端决定", "Keep the RGB canvas and theme color sync; the terminal still decides opacity")
+				}
+			].map((choice) => ({
+				...choice,
+				active: choice.id === current
+			})),
+			options: {
+				width: 90,
+				maxHeight: "90%",
+				anchor: "center",
+				margin: 1
+			}
+		});
+		if (selected === void 0 || selected.id === current) return;
+		const updated = await saveBackgroundMode(bridge, document, selected.id);
+		await this.settingsChanged(updated, ui("背景模式", "Background mode"), overlays);
 	}
 	async themeUse(value) {
 		if (value === "") throw new Error(ui("用法：/theme use <主题名>", "Usage: /theme use <theme-name>"));
@@ -32183,6 +32259,10 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		await this.settingsChanged(updated, ui("新会话默认模式", "Default mode for new sessions"), overlays);
 	}
 	async editSetting(overlays, document, field) {
+		if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE && field.path.length === 1 && field.path[0] === "backgroundMode") {
+			await this.editBackgroundMode(overlays);
+			return;
+		}
 		const bridge = this.capabilities.managementBridge().settings;
 		const actions = [
 			{
@@ -32371,7 +32451,7 @@ Configured: ${field.overridden ? "User override" : `Use default ${formatSettings
 	}
 	async settingsChanged(document, label, overlays = this.host.overlays) {
 		if (document.applies === "live") {
-			if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) this.host.applyTheme(themeFromAppearance(document));
+			if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) this.host.applyAppearance(appearanceFromSettings(document));
 			if (document.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) this.host.applyBehavior?.(behaviorFromSettings(document));
 			if (document.namespace === LOCALE_SETTINGS_NAMESPACE) this.host.applyLocale(localeFromSettings([document]));
 			this.host.notice(ui(`${label} 已更新并立即生效`, `${label} was updated and is now active`), "success");
@@ -37082,31 +37162,58 @@ function supportsTerminalBackground(env = process.env) {
 /** One asynchronous probe per active lifetime; never guess a color to restore. */
 var TerminalBackground = class {
 	active = false;
+	queried = false;
+	mode = DEFAULT_TUI_BACKGROUND_MODE;
+	unavailable;
+	notified = false;
 	original;
 	desired;
 	applied;
 	changed = false;
 	timer;
-	constructor(terminal, enabled) {
+	constructor(terminal, enabled, onUnavailable = () => void 0) {
 		this.terminal = terminal;
 		this.enabled = enabled;
+		this.onUnavailable = onUnavailable;
 	}
-	setColor(color$1) {
+	/** Set color and policy atomically, without writing an intermediate theme. */
+	setColor(color$1, mode = this.mode) {
 		if (!/^#[\da-f]{6}$/iu.test(color$1)) return;
 		this.desired = `rgb:${color$1.slice(1, 3)}/${color$1.slice(3, 5)}/${color$1.slice(5, 7)}`.toLowerCase();
-		this.apply();
+		this.mode = mode;
+		if (mode === "terminal") this.restoreOriginal();
+		else this.sync();
 	}
 	start() {
-		if (!this.enabled || this.active || this.desired === void 0) return;
 		this.active = true;
+		this.sync();
+	}
+	sync() {
+		if (!this.active || this.mode === "terminal" || this.desired === void 0) return;
+		if (!this.enabled) this.unavailable = "unsupported";
+		if (this.unavailable !== void 0) {
+			this.notifyUnavailable();
+			return;
+		}
+		if (this.original !== void 0) {
+			this.apply();
+			return;
+		}
+		if (this.queried) return;
+		this.queried = true;
 		this.timer = setTimeout(() => {
 			this.timer = void 0;
+			this.unavailable = "timeout";
+			this.notifyUnavailable();
 		}, BACKGROUND_QUERY_TIMEOUT_MS);
 		this.timer.unref?.();
 		try {
 			this.terminal.write(BACKGROUND_QUERY);
 		} catch {
-			this.restore();
+			clearTimeout(this.timer);
+			this.timer = void 0;
+			this.unavailable = "write-failed";
+			this.notifyUnavailable();
 		}
 	}
 	/** Called after pi-tui framing and before any editor/overlay receives input. */
@@ -37117,7 +37224,7 @@ var TerminalBackground = class {
 			clearTimeout(this.timer);
 			this.timer = void 0;
 			this.original = reply[1].toLowerCase();
-			this.apply();
+			this.sync();
 		}
 		return true;
 	}
@@ -37125,13 +37232,24 @@ var TerminalBackground = class {
 		if (this.timer !== void 0) clearTimeout(this.timer);
 		this.timer = void 0;
 		this.active = false;
-		const original = this.changed ? this.original : void 0;
+		this.restoreOriginal();
+		this.queried = false;
+		this.unavailable = void 0;
+		this.notified = false;
 		this.original = void 0;
 		this.applied = void 0;
 		this.changed = false;
-		if (original !== void 0) try {
-			this.terminal.write(`${OSC}11;${original}${ST}`);
-		} catch {}
+	}
+	/** Switching to terminal-only restores color without losing the lifetime snapshot. */
+	restoreOriginal() {
+		if (!this.changed || this.original === void 0) return;
+		try {
+			this.terminal.write(`${OSC}11;${this.original}${ST}`);
+			this.changed = false;
+			this.applied = void 0;
+		} catch {
+			this.unavailable = "write-failed";
+		}
 	}
 	apply() {
 		if (!this.active || this.original === void 0 || this.desired === void 0 || this.applied === this.desired) return;
@@ -37140,8 +37258,17 @@ var TerminalBackground = class {
 		try {
 			this.terminal.write(`${OSC}11;${this.desired}${ST}`);
 		} catch {
-			this.restore();
+			this.unavailable = "write-failed";
+			this.restoreOriginal();
+			this.notifyUnavailable();
 		}
+	}
+	notifyUnavailable() {
+		if (!this.active || this.mode !== "theme" || this.unavailable === void 0 || this.notified) return;
+		this.notified = true;
+		try {
+			this.onUnavailable(this.unavailable);
+		} catch {}
 	}
 };
 
@@ -37304,8 +37431,8 @@ function supportsManagedTerminal(interactive, term) {
 * Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
 * Live mouse toggles write only mouse/focus private modes and never 1049h/1049l.
 */
-function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env) {
-	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env));
+function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env, onBackgroundUnavailable) {
+	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable);
 	let active = false;
 	let mouseMode = "full";
 	let hoverFeedback = true;
@@ -37333,8 +37460,8 @@ function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, 
 				}
 			}
 		},
-		setBackgroundColor: (color$1) => {
-			background$1.setColor(color$1);
+		setBackgroundColor: (color$1, mode) => {
+			background$1.setColor(color$1, mode);
 		},
 		startBackgroundSync: () => {
 			if (active) background$1.start();
@@ -38831,8 +38958,11 @@ async function startTuiSurface(options$1) {
 		internals$1.reportPerformance(snapshot);
 	};
 	let stopTuiRenderingSync = () => void 0;
+	let reportBackgroundUnavailable = () => void 0;
 	const terminalSession = createTerminalSession(terminal, true, () => {
 		stopTuiRenderingSync();
+	}, process.env, () => {
+		reportBackgroundUnavailable();
 	});
 	const [settingsDocuments, client, initialProviderReadiness] = await (async () => {
 		try {
@@ -38854,14 +38984,17 @@ async function startTuiSurface(options$1) {
 	let detachFatalGuards = () => void 0;
 	let detachSuspendGuards = () => void 0;
 	try {
-		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
+		const initialAppearance = appearanceFromSettings(appearanceSettings(settingsDocuments));
+		const initialTheme = resolveAppearanceTheme(initialAppearance);
 		let liveTheme = initialTheme;
+		let liveBackgroundMode = initialAppearance.backgroundMode;
 		const liveBehavior = createLiveBehavior(behaviorFromSettings(behaviorSettings(settingsDocuments)));
 		applyKeyBindingOverrides(liveBehavior.get().keyBindings);
 		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		terminalSession.setMouseReporting(liveBehavior.get().mouseMode, liveBehavior.get().hoverFeedback);
 		setTheme(initialTheme);
-		terminalSession.setBackgroundColor(initialTheme.colors.canvas);
+		setBackgroundMode(liveBackgroundMode);
+		terminalSession.setBackgroundColor(initialTheme.colors.canvas, liveBackgroundMode);
 		const tui = new TUI(terminal, true);
 		const requestTuiRender = tui.requestRender.bind(tui);
 		tui.requestRender = (force = false) => {
@@ -39232,6 +39365,9 @@ async function startTuiSurface(options$1) {
 			updateStatus();
 			renderWhileOpen();
 		};
+		reportBackgroundUnavailable = () => {
+			setNotice(ui("终端背景改色不可用，继续使用终端背景效果；可在 /theme 选择显式底色（兼容）。", "Terminal recoloring is unavailable; using terminal background effects. /theme offers an explicit-fill compatibility mode."), "warning");
+		};
 		const dismissNotice = () => {
 			notices.dismiss();
 		};
@@ -39437,6 +39573,20 @@ async function startTuiSurface(options$1) {
 			})();
 			return stopping;
 		};
+		const applyRenderedAppearance = (theme, mode) => {
+			const themeChanged = JSON.stringify(theme) !== JSON.stringify(liveTheme);
+			liveTheme = theme;
+			liveBackgroundMode = mode;
+			setTheme(theme);
+			setBackgroundMode(mode);
+			terminalSession.setBackgroundColor(theme.colors.canvas, mode);
+			if (themeChanged) {
+				syntax?.setTheme(theme);
+				transcript.refreshPresentation();
+			}
+			tui.invalidate();
+			tui.requestRender(true);
+		};
 		actions = new TuiActions(capabilities, {
 			overlays,
 			transcript,
@@ -39446,13 +39596,10 @@ async function startTuiSurface(options$1) {
 				refreshHeader(false);
 			},
 			applyTheme: (theme) => {
-				liveTheme = theme;
-				setTheme(theme);
-				terminalSession.setBackgroundColor(theme.colors.canvas);
-				syntax?.setTheme(theme);
-				transcript.refreshPresentation();
-				tui.invalidate();
-				tui.requestRender(true);
+				applyRenderedAppearance(theme, liveBackgroundMode);
+			},
+			applyAppearance: (appearance) => {
+				applyRenderedAppearance(resolveAppearanceTheme(appearance), appearance.backgroundMode);
 			},
 			applyLocale: (locale) => {
 				setUiLocale(locale);
@@ -40450,6 +40597,14 @@ const AppearanceSettingsSchema = z$1.object({
 	codeTheme: z$1.string().pattern(/^(?:auto|dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u).default(DEFAULT_TUI_CODE_THEME).description(localeDescription({
 		zh: "代码块独立主题；auto 跟随当前界面主题。",
 		en: "Independent code-block theme; auto follows the current interface theme."
+	})),
+	backgroundMode: z$1.union([
+		"theme",
+		"terminal",
+		"explicit"
+	]).default(DEFAULT_TUI_BACKGROUND_MODE).description(localeDescription({
+		zh: "主背景模式：主题颜色＋终端效果、完全跟随终端，或显式主题底色（兼容）。不改变终端透明度；弹窗和代码块保留底色。",
+		en: "Canvas background: theme colors with terminal effects, terminal background, or explicit theme fill (compatibility). Does not change terminal opacity; panels and code blocks keep their backgrounds."
 	})),
 	customThemes: z$1.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([]).description(localeDescription({
 		zh: "SeekTTY 命名自定义主题。",

--- a/lib/index.js
+++ b/lib/index.js
@@ -8978,6 +8978,8 @@ var Markdown = class {
 const ESC$2 = "\x1B";
 const SGR_MOUSE_PREFIX = "\x1B[<";
 const MAX_MOUSE_SEQUENCE = 64;
+const OSC_PREFIX = "\x1B]";
+const MAX_OSC_SEQUENCE = 1024;
 const BRACKETED_PASTE_START = "\x1B[200~";
 const BRACKETED_PASTE_END = "\x1B[201~";
 /**
@@ -9067,6 +9069,33 @@ function extractCompleteSequences(buffer) {
 		if (remaining.startsWith(ESC$2 + ESC$2)) {
 			sequences.push(ESC$2);
 			pos++;
+			continue;
+		}
+		if (remaining.startsWith(OSC_PREFIX)) {
+			let end = -1;
+			let restart = -1;
+			for (let index = 2; index < remaining.length; index++) {
+				if (remaining[index] === "\x07") {
+					end = index + 1;
+					break;
+				}
+				if (remaining[index] === ESC$2) {
+					if (index + 1 === remaining.length) break;
+					if (remaining[index + 1] === "\\") end = index + 2;
+					else restart = index;
+					break;
+				}
+			}
+			if (restart !== -1) {
+				pos += restart;
+				continue;
+			}
+			if (end === -1) return {
+				sequences,
+				remainder: remaining
+			};
+			if (end <= MAX_OSC_SEQUENCE) sequences.push(remaining.slice(0, end));
+			pos += end;
 			continue;
 		}
 		if (remaining.startsWith(SGR_MOUSE_PREFIX)) {
@@ -9192,6 +9221,10 @@ var StdinBuffer = class extends EventEmitter {
 			return;
 		}
 		if (this.buffer.startsWith("\x1B[M")) return;
+		if (this.buffer.startsWith(OSC_PREFIX)) {
+			if (this.buffer.length > MAX_OSC_SEQUENCE) this.buffer = OSC_PREFIX + "!" + (this.buffer.endsWith(ESC$2) ? ESC$2 : "");
+			return;
+		}
 		if (this.buffer.length > 0) this.timeout = setTimeout(() => {
 			const flushed = this.flush();
 			for (const sequence of flushed) this.emitDataSequence(sequence);
@@ -9211,7 +9244,7 @@ var StdinBuffer = class extends EventEmitter {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
-		if (this.buffer.length === 0) return [];
+		if (this.buffer.length === 0 || this.buffer.startsWith(OSC_PREFIX)) return [];
 		const sequences = [this.buffer];
 		this.buffer = "";
 		this.pendingKittyPrintableCodepoint = void 0;
@@ -23489,8 +23522,8 @@ function editableTheme(theme, id, name$1) {
 const RESET = "\x1B[0m";
 const ESC$1 = 27;
 const CSI$2 = 155;
-const ST = 156;
-const OSC$1 = 157;
+const ST$1 = 156;
+const OSC$2 = 157;
 const CONTROL_STRING_INTRODUCERS = new Set([
 	80,
 	88,
@@ -23501,7 +23534,7 @@ const CONTROL_STRING_INTRODUCERS = new Set([
 const C1_CONTROL_STRING_INTRODUCERS = new Set([
 	144,
 	152,
-	OSC$1,
+	OSC$2,
 	158,
 	159
 ]);
@@ -23565,7 +23598,7 @@ let codeHighlighter;
 function controlStringEnd(text$1, start) {
 	for (let index = start; index < text$1.length; index += 1) {
 		const code = text$1.charCodeAt(index);
-		if (code === 7 || code === ST) return index + 1;
+		if (code === 7 || code === ST$1) return index + 1;
 		if (code === ESC$1 && text$1.charCodeAt(index + 1) === 92) return index + 2;
 	}
 	return text$1.length;
@@ -26253,7 +26286,7 @@ function offsetForTrackRow(model, row) {
 	return Math.round(clampedRow / maxTop * travel);
 }
 
-const OSC = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/gu;
+const OSC$1 = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/gu;
 const CSI$1 = /\u001B\[[0-9;:]*[ -/]*[@-~]/gu;
 const C1_OSC = /\u009D[\s\S]*?(?:\u0007|\u001B\\|\u009C)/gu;
 let graphemeSegmenter;
@@ -26268,7 +26301,7 @@ function wordsOf(text$1) {
 }
 /** Strip SGR, OSC (including OSC 8), and leftover CSI so copy matches visible text. */
 function stripCopyDecorations(value) {
-	return value.replace(OSC, "").replace(C1_OSC, "").replace(CSI$1, "");
+	return value.replace(OSC$1, "").replace(C1_OSC, "").replace(CSI$1, "");
 }
 function compareAnchors(left, right, order) {
 	if (left.surface !== right.surface) return left.surface === "transcript" ? -1 : 1;
@@ -37037,6 +37070,81 @@ function sessionTerminalTitle(facts) {
 	return session;
 }
 
+const BACKGROUND_QUERY = "\x1B]11;?\x1B\\";
+const BACKGROUND_QUERY_TIMEOUT_MS = 500;
+const OSC = "\x1B]";
+const ST = "\x1B\\";
+const RGB_REPLY = /^\u001B\]11;(rgb:[\da-f]{1,4}\/[\da-f]{1,4}\/[\da-f]{1,4})(?:\u0007|\u001B\\)$/iu;
+/** Only match truecolor canvases; do not recolor a multiplexer's shared outer window. */
+function supportsTerminalBackground(env = process.env) {
+	return terminalColorLevel(env) === 3 && !env.TMUX && !env.STY && !/^(?:screen|tmux)/iu.test(env.TERM ?? "") && !/^(?:0|off|false)$/iu.test(env.SEEKTTY_TERMINAL_BACKGROUND?.trim() ?? "");
+}
+/** One asynchronous probe per active lifetime; never guess a color to restore. */
+var TerminalBackground = class {
+	active = false;
+	original;
+	desired;
+	applied;
+	changed = false;
+	timer;
+	constructor(terminal, enabled) {
+		this.terminal = terminal;
+		this.enabled = enabled;
+	}
+	setColor(color$1) {
+		if (!/^#[\da-f]{6}$/iu.test(color$1)) return;
+		this.desired = `rgb:${color$1.slice(1, 3)}/${color$1.slice(3, 5)}/${color$1.slice(5, 7)}`.toLowerCase();
+		this.apply();
+	}
+	start() {
+		if (!this.enabled || this.active || this.desired === void 0) return;
+		this.active = true;
+		this.timer = setTimeout(() => {
+			this.timer = void 0;
+		}, BACKGROUND_QUERY_TIMEOUT_MS);
+		this.timer.unref?.();
+		try {
+			this.terminal.write(BACKGROUND_QUERY);
+		} catch {
+			this.restore();
+		}
+	}
+	/** Called after pi-tui framing and before any editor/overlay receives input. */
+	consumeInput(data) {
+		if (!data.startsWith(OSC)) return false;
+		const reply = RGB_REPLY.exec(data);
+		if (this.active && this.timer !== void 0 && reply?.[1] !== void 0) {
+			clearTimeout(this.timer);
+			this.timer = void 0;
+			this.original = reply[1].toLowerCase();
+			this.apply();
+		}
+		return true;
+	}
+	restore() {
+		if (this.timer !== void 0) clearTimeout(this.timer);
+		this.timer = void 0;
+		this.active = false;
+		const original = this.changed ? this.original : void 0;
+		this.original = void 0;
+		this.applied = void 0;
+		this.changed = false;
+		if (original !== void 0) try {
+			this.terminal.write(`${OSC}11;${original}${ST}`);
+		} catch {}
+	}
+	apply() {
+		if (!this.active || this.original === void 0 || this.desired === void 0 || this.applied === this.desired) return;
+		this.changed = true;
+		this.applied = this.desired;
+		try {
+			this.terminal.write(`${OSC}11;${this.desired}${ST}`);
+		} catch {
+			this.restore();
+		}
+	}
+};
+
 const ESC = "\x1B";
 const CSI = `${ESC}[`;
 const SGR_PREFIX = `${CSI}<`;
@@ -37196,7 +37304,8 @@ function supportsManagedTerminal(interactive, term) {
 * Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
 * Live mouse toggles write only mouse/focus private modes and never 1049h/1049l.
 */
-function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) {
+function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env) {
+	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env));
 	let active = false;
 	let mouseMode = "full";
 	let hoverFeedback = true;
@@ -37212,6 +37321,7 @@ function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) 
 			try {
 				beforeRestore();
 			} catch {}
+			background$1.restore();
 			try {
 				terminal.write(encodeDisableMouseReporting());
 			} finally {
@@ -37223,6 +37333,13 @@ function createTerminalSession(terminal, enabled, beforeRestore = () => void 0) 
 				}
 			}
 		},
+		setBackgroundColor: (color$1) => {
+			background$1.setColor(color$1);
+		},
+		startBackgroundSync: () => {
+			if (active) background$1.start();
+		},
+		consumeInput: (data) => background$1.consumeInput(data),
 		setMouseReporting: (mode, nextHoverFeedback = hoverFeedback) => {
 			if (mouseMode === mode && hoverFeedback === nextHoverFeedback) return;
 			mouseMode = mode;
@@ -38250,6 +38367,35 @@ function attachFatalGuards(options$1) {
 		process.off("SIGHUP", onHup);
 	};
 }
+/** POSIX job control; Ctrl+Z remains input undo, not a new suspend shortcut. */
+function attachSuspendGuards(options$1, runtime = {
+	platform: process.platform,
+	on: (signal, handler) => process.on(signal, handler),
+	off: (signal, handler) => process.off(signal, handler),
+	suspendSelf: () => {
+		process.kill(process.pid, "SIGSTOP");
+	}
+}) {
+	if (runtime.platform === "win32") return () => void 0;
+	let suspended = false;
+	const onSuspend = () => {
+		if (suspended) return;
+		options$1.suspend();
+		suspended = true;
+		runtime.suspendSelf();
+	};
+	const onResume = () => {
+		if (!suspended) return;
+		suspended = false;
+		options$1.resume();
+	};
+	runtime.on("SIGTSTP", onSuspend);
+	runtime.on("SIGCONT", onResume);
+	return () => {
+		runtime.off("SIGTSTP", onSuspend);
+		runtime.off("SIGCONT", onResume);
+	};
+}
 
 const PROCESS_EVENTS = [
 	"uncaughtException",
@@ -38706,6 +38852,7 @@ async function startTuiSurface(options$1) {
 	let stopConstructedTui = () => void 0;
 	let disposeConstructedSyntax = () => void 0;
 	let detachFatalGuards = () => void 0;
+	let detachSuspendGuards = () => void 0;
 	try {
 		const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments));
 		let liveTheme = initialTheme;
@@ -38714,6 +38861,7 @@ async function startTuiSurface(options$1) {
 		setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault);
 		terminalSession.setMouseReporting(liveBehavior.get().mouseMode, liveBehavior.get().hoverFeedback);
 		setTheme(initialTheme);
+		terminalSession.setBackgroundColor(initialTheme.colors.canvas);
 		const tui = new TUI(terminal, true);
 		const requestTuiRender = tui.requestRender.bind(tui);
 		tui.requestRender = (force = false) => {
@@ -39228,6 +39376,8 @@ async function startTuiSurface(options$1) {
 		const close = (outcome) => {
 			detachFatalGuards();
 			detachFatalGuards = () => void 0;
+			detachSuspendGuards();
+			detachSuspendGuards = () => void 0;
 			if (stopping !== void 0) return stopping;
 			restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 				process.stdout.write(chunk);
@@ -39298,6 +39448,7 @@ async function startTuiSurface(options$1) {
 			applyTheme: (theme) => {
 				liveTheme = theme;
 				setTheme(theme);
+				terminalSession.setBackgroundColor(theme.colors.canvas);
 				syntax?.setTheme(theme);
 				transcript.refreshPresentation();
 				tui.invalidate();
@@ -39842,6 +39993,7 @@ async function startTuiSurface(options$1) {
 			if (semantic.ended === true && liveBehavior.get().copyOnSelect) copyActiveSelection();
 		};
 		tui.addInputListener((data) => {
+			if (terminalSession.consumeInput(data)) return { consume: true };
 			performanceProbe.markInput();
 			const mouseEvent = decodeMouseSequence(data);
 			let pendingWheel = 0;
@@ -40093,8 +40245,29 @@ async function startTuiSurface(options$1) {
 				process.exit(code);
 			}
 		});
+		detachSuspendGuards = attachSuspendGuards({
+			suspend: () => {
+				contextMenu.close();
+				mouseController.endGesture();
+				clearTranscriptPointerGesture();
+				clearMouseArm(true);
+				clearHoverPresentation();
+				restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
+					process.stdout.write(chunk);
+				}, terminal);
+				tui.stop();
+			},
+			resume: () => {
+				if (stopping !== void 0) return;
+				terminalSession.enter();
+				tui.start();
+				terminalSession.startBackgroundSync();
+				tui.requestRender(true);
+			}
+		});
 		terminalSession.enter();
 		tui.start();
+		terminalSession.startBackgroundSync();
 		refreshHeader(true);
 		refresh();
 		if (options$1.startupNotice !== void 0) setNotice(options$1.startupNotice, "success");
@@ -40124,6 +40297,7 @@ async function startTuiSurface(options$1) {
 		};
 	} catch (error) {
 		detachFatalGuards();
+		detachSuspendGuards();
 		restoreSurfaceTerminalSync(terminalSession, process.stdin, (chunk) => {
 			process.stdout.write(chunk);
 		}, terminal);

--- a/patches/@mariozechner__pi-tui@0.73.1.patch
+++ b/patches/@mariozechner__pi-tui@0.73.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index fb224b9da697aab89a31336eae65071dc07d736e..e45d408b34e2163f7f18b12e3391256ca50bf7ae 100644
+index fb224b9da697aab89a31336eae65071dc07d736e..49afe6c1c0769e856eb2a2ce10e49fd391c1d2af 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
 @@ -30,6 +30,20 @@ export interface EditorOptions {
@@ -83,7 +83,7 @@ index fb224b9da697aab89a31336eae65071dc07d736e..e45d408b34e2163f7f18b12e3391256c
      private handleBackspace;
      /**
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 50f92259fa88f4efe406a60b7db8e54a9eedace6..5117fc64d05296e15e7f3bf583c818828a3c667c 100644
+index 50f92259fa88f4efe406a60b7db8e54a9eedace6..e9749bd069e0fef9ebaa2e5ef2c893e53d4c2953 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -171,6 +171,7 @@ export class Editor {
@@ -608,7 +608,7 @@ index 50f92259fa88f4efe406a60b7db8e54a9eedace6..5117fc64d05296e15e7f3bf583c81882
      cancelAutocomplete() {
          this.cancelAutocompleteRequest();
 diff --git a/dist/components/input.d.ts b/dist/components/input.d.ts
-index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..73fe4b6fdad88ce068a96c00eae31d3e70b08afe 100644
+index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..1f51d1bd61fd0228bb0d65c2bdc3fa3a7d63edd9 100644
 --- a/dist/components/input.d.ts
 +++ b/dist/components/input.d.ts
 @@ -16,6 +16,12 @@ export declare class Input implements Component, Focusable {
@@ -625,7 +625,7 @@ index 32d03e6acdcf03a58c8a84f99b73ecd24bca29eb..73fe4b6fdad88ce068a96c00eae31d3e
      private insertCharacter;
      private handleBackspace;
 diff --git a/dist/components/input.js b/dist/components/input.js
-index 5a8780c8b2e97f5d58a239c11a6c9aa6e1a26391..091f5615f8c0b1b6e0e149610999ebeca7235285 100644
+index 5a8780c8b2e97f5d58a239c11a6c9aa6e1a26391..73a9e73bd15bdb38478c2661ca1b463f41402e54 100644
 --- a/dist/components/input.js
 +++ b/dist/components/input.js
 @@ -1,5 +1,5 @@
@@ -960,7 +960,7 @@ index 7dc27474f3e6e61be59d448f40c0a4e6b249e2b8..ab0e6eec23ab76aacf8c71b5e58d0ea9
              else {
                  // Other token types - try to render as inline
 diff --git a/dist/components/select-list.d.ts b/dist/components/select-list.d.ts
-index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787b31fc6c4 100644
+index 9db54d907f801e43208a462bca925f2905787b7a..9c7d8757112767552afb732df006c2858610c101 100644
 --- a/dist/components/select-list.d.ts
 +++ b/dist/components/select-list.d.ts
 @@ -23,6 +23,15 @@ export interface SelectListLayoutOptions {
@@ -995,7 +995,7 @@ index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787
      render(width: number): string[];
      handleInput(keyData: string): void;
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7c5a32bd21f69bf1dc73f6d704e4e99334a03f1d 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..8c1ff1a67dd3718129f81bf93a46f7243d0692f9 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -10,6 +10,8 @@ export class SelectList {
@@ -1100,7 +1100,7 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7c5a32bd21f69bf1dc73f6d704e4e993
          }
          // Enter
 diff --git a/dist/keybindings.d.ts b/dist/keybindings.d.ts
-index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..cf0293a2f89698f8a0a02aea1dab6fae6bd8784b 100644
+index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..1001bb8463e8ca59c31390dfb3d583d57501ceeb 100644
 --- a/dist/keybindings.d.ts
 +++ b/dist/keybindings.d.ts
 @@ -125,7 +125,7 @@ export declare const TUI_KEYBINDINGS: {
@@ -1113,7 +1113,7 @@ index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..cf0293a2f89698f8a0a02aea1dab6fae
      };
      readonly "tui.input.newLine": {
 diff --git a/dist/keybindings.js b/dist/keybindings.js
-index 60d400872183f1f6b754b61d3ccbf6708219215d..89faba6dbf55eb7449db25ce23d28f48988fe504 100644
+index 60d400872183f1f6b754b61d3ccbf6708219215d..c0161b806238f2bd05995136dd7fcacf347a1ff5 100644
 --- a/dist/keybindings.js
 +++ b/dist/keybindings.js
 @@ -62,7 +62,7 @@ export const TUI_KEYBINDINGS = {
@@ -1126,19 +1126,21 @@ index 60d400872183f1f6b754b61d3ccbf6708219215d..89faba6dbf55eb7449db25ce23d28f48
      "tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
      "tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 diff --git a/dist/stdin-buffer.js b/dist/stdin-buffer.js
-index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352215456a8 100644
+index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..dd1dacc511b9ff5aec86b2354eacfc89e40624db 100644
 --- a/dist/stdin-buffer.js
 +++ b/dist/stdin-buffer.js
-@@ -18,6 +18,8 @@
+@@ -18,6 +18,10 @@
   */
  import { EventEmitter } from "events";
  const ESC = "\x1b";
 +const SGR_MOUSE_PREFIX = "\x1b[<";
 +const MAX_MOUSE_SEQUENCE = 64;
++const OSC_PREFIX = "\x1b]";
++const MAX_OSC_SEQUENCE = 1024;
  const BRACKETED_PASTE_START = "\x1b[200~";
  const BRACKETED_PASTE_END = "\x1b[201~";
  /**
-@@ -163,6 +165,28 @@ function extractCompleteSequences(buffer) {
+@@ -163,6 +167,54 @@ function extractCompleteSequences(buffer) {
      let pos = 0;
      while (pos < buffer.length) {
          const remaining = buffer.slice(pos);
@@ -1147,6 +1149,32 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
 +        if (remaining.startsWith(ESC + ESC)) {
 +            sequences.push(ESC);
 +            pos++;
++            continue;
++        }
++        if (remaining.startsWith(OSC_PREFIX)) {
++            // Color-query replies may span stdin chunks well beyond the key
++            // timeout. Frame them atomically, without quadratic prefix scans.
++            let end = -1;
++            let restart = -1;
++            for (let index = OSC_PREFIX.length; index < remaining.length; index++) {
++                if (remaining[index] === "\x07") {
++                    end = index + 1;
++                    break;
++                }
++                if (remaining[index] === ESC) {
++                    if (index + 1 === remaining.length) break;
++                    if (remaining[index + 1] === "\\") end = index + 2;
++                    else restart = index;
++                    break;
++                }
++            }
++            if (restart !== -1) {
++                pos += restart;
++                continue;
++            }
++            if (end === -1) return { sequences, remainder: remaining };
++            if (end <= MAX_OSC_SEQUENCE) sequences.push(remaining.slice(0, end));
++            pos += end;
 +            continue;
 +        }
 +        if (remaining.startsWith(SGR_MOUSE_PREFIX)) {
@@ -1167,7 +1195,7 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
          // Try to extract a sequence starting at this position
          if (remaining.startsWith(ESC)) {
              // Find the end of this escape sequence
-@@ -263,6 +287,9 @@ export class StdinBuffer extends EventEmitter {
+@@ -263,6 +315,9 @@ export class StdinBuffer extends EventEmitter {
                  for (const sequence of result.sequences) {
                      this.emitDataSequence(sequence);
                  }
@@ -1177,7 +1205,7 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
              }
              this.pendingKittyPrintableCodepoint = undefined;
              this.buffer = this.buffer.slice(startIndex + BRACKETED_PASTE_START.length);
-@@ -288,6 +315,15 @@ export class StdinBuffer extends EventEmitter {
+@@ -288,6 +343,22 @@ export class StdinBuffer extends EventEmitter {
          for (const sequence of result.sequences) {
              this.emitDataSequence(sequence);
          }
@@ -1190,9 +1218,25 @@ index a3d15d66cf5f86b9d794e59c0646c0ba2ec73ce5..8c1e2368bdd2a39a63c6e9aa290de352
 +            return;
 +        }
 +        if (this.buffer.startsWith("\x1b[M")) return;
++        if (this.buffer.startsWith(OSC_PREFIX)) {
++            // Preserve a split ST while bounding malformed/oversized reports.
++            if (this.buffer.length > MAX_OSC_SEQUENCE) {
++                this.buffer = OSC_PREFIX + "!" + (this.buffer.endsWith(ESC) ? ESC : "");
++            }
++            return;
++        }
          if (this.buffer.length > 0) {
              this.timeout = setTimeout(() => {
                  const flushed = this.flush();
+@@ -311,7 +382,7 @@ export class StdinBuffer extends EventEmitter {
+             clearTimeout(this.timeout);
+             this.timeout = null;
+         }
+-        if (this.buffer.length === 0) {
++        if (this.buffer.length === 0 || this.buffer.startsWith(OSC_PREFIX)) {
+             return [];
+         }
+         const sequences = [this.buffer];
 diff --git a/dist/terminal.js b/dist/terminal.js
 index 3545b284ce2da594cc728803feb607a34cea5ca0..79bb3e8769594c1b8f70ef71304ab9032ed4ecd3 100644
 --- a/dist/terminal.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-tui@0.73.1': f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb
+  '@mariozechner/pi-tui@0.73.1': 3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266
 
 importers:
 
@@ -161,7 +161,7 @@ importers:
         version: 3.18.1
       '@mariozechner/pi-tui':
         specifier: 0.73.1
-        version: 0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)
+        version: 0.73.1(patch_hash=3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266)
       '@types/cross-spawn':
         specifier: 6.0.6
         version: 6.0.6
@@ -3227,7 +3227,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mariozechner/pi-tui@0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)':
+  '@mariozechner/pi-tui@0.73.1(patch_hash=3c9b9a42341d1ba1f9da1ba0a5dec4d415a6392c084f13fe6a58c30447a24266)':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -19,6 +19,7 @@ import {
   TUI_BEHAVIOR_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
   type TuiAppearanceSettings,
+  type TuiBackgroundMode,
   type TuiBehaviorSettings,
   type TuiCodeThemeId,
   type TuiCustomTheme,
@@ -81,6 +82,7 @@ import {
   appearanceFromSettings,
   appearanceSettings,
   deleteCustomTheme,
+  saveBackgroundMode,
   saveCodeTheme,
   saveCustomTheme,
   saveTheme,
@@ -131,6 +133,7 @@ export interface TuiActionHost {
   refresh(): void
   refreshHeader(): void
   applyTheme(theme: ResolvedTuiTheme): void
+  applyAppearance(appearance: TuiAppearanceSettings): void
   applyLocale(locale: LocaleId): void
   applyBehavior?(behavior: TuiBehaviorSettings): void
   setEditor(text: string): void
@@ -1282,6 +1285,11 @@ The directory, user files, and all session logs are kept; sessions become ungrou
     choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme))
     choices.push(
       {
+        id: '__background__',
+        label: ui('背景模式', 'Background mode'),
+        description: ui('选择主画布背景；独立于主题文件', 'Choose the canvas background independently of theme files'),
+      },
+      {
         id: '__code__',
         label: ui('代码块主题', "Code-block theme"),
         description: ui(`${appearance.codeTheme === 'auto' ? '自动匹配' : '独立指定'} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === 'auto' ? 'Automatic' : 'Explicit'} · current ${activeCodeTheme.name}`),
@@ -1304,6 +1312,7 @@ The directory, user files, and all session logs are kept; sessions become ungrou
         options,
       }, async (selected) => {
         if (selected.id === '__code__') await this.themeCode('', navigation)
+        else if (selected.id === '__background__') await this.editBackgroundMode(navigation)
         else if (selected.id === '__palette__') await this.themePalette('', navigation)
         else if (selected.id === '__import__') await this.themeImport('', navigation)
         else if (selected.id === '__export__') await this.themeExport('', navigation)
@@ -1325,6 +1334,40 @@ The directory, user files, and all session logs are kept; sessions become ungrou
     }
     const updated = await saveTheme(bridge, document, target)
     await this.settingsChanged(updated, resolved.name)
+  }
+
+  /** Shared by /theme and the searchable Harness appearance field. No preview before saving. */
+  private async editBackgroundMode(overlays: OverlayPrompts): Promise<void> {
+    const bridge = this.capabilities.managementBridge().settings
+    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
+    const current = appearanceFromSettings(document).backgroundMode
+    const selected = await overlays.select({
+      title: ui('背景模式', 'Background mode'),
+      detail: ui(
+        '仅主画布继承终端效果，不设置透明度。弹窗、代码块和高亮保留独立底色；保存后立即生效。',
+        'Only the canvas inherits terminal effects; opacity is not changed. Panels, code blocks and highlights keep their backgrounds. Saves apply immediately.',
+      ),
+      searchable: false,
+      initialChoiceId: current,
+      choices: [
+        {
+          id: 'theme', label: ui('主题颜色＋终端效果（默认）', 'Theme + terminal effects'),
+          description: ui('默认背景＋OSC 11 主题改色；保留终端透明、模糊和图片效果', 'Default: OSC 11 theme color; retain terminal transparency, blur and images'),
+        },
+        {
+          id: 'terminal', label: ui('跟随终端', 'Follow terminal'),
+          description: ui('使用终端默认背景，不改色；恢复本次运行捕获的原色', 'Use the terminal default background without recoloring; restore the captured original'),
+        },
+        {
+          id: 'explicit', label: ui('显式主题底色（兼容）', 'Explicit fill (compatibility)'),
+          description: ui('沿用 RGB 画布与主题改色；实际透明效果由终端决定', 'Keep the RGB canvas and theme color sync; the terminal still decides opacity'),
+        },
+      ].map(choice => ({ ...choice, active: choice.id === current })),
+      options: { width: 90, maxHeight: '90%', anchor: 'center', margin: 1 },
+    })
+    if (selected === undefined || selected.id === current) return
+    const updated = await saveBackgroundMode(bridge, document, selected.id as TuiBackgroundMode)
+    await this.settingsChanged(updated, ui('背景模式', 'Background mode'), overlays)
   }
 
   private async themeUse(value: string): Promise<void> {
@@ -2343,6 +2386,11 @@ The directory, user files, and all session logs are kept; sessions become ungrou
     document: TuiSettingsDocument,
     field: TuiSettingsField,
   ): Promise<void> {
+    if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE
+      && field.path.length === 1 && field.path[0] === 'backgroundMode') {
+      await this.editBackgroundMode(overlays)
+      return
+    }
     const bridge = this.capabilities.managementBridge().settings
     const actions: OverlayChoice[] = [
       { id: 'edit', label: field.control === 'secret' ? ui('写入新 Secret…', "Set new secret…") : ui('修改值…', "Edit value…"), description: ui(`控件：${field.control}`, `Control: ${field.control}`) },
@@ -2543,7 +2591,7 @@ Configured: ${field.overridden ? 'User override' : `Use default ${formatSettings
   ): Promise<void> {
     if (document.applies === 'live') {
       if (document.namespace === TUI_APPEARANCE_SETTINGS_NAMESPACE) {
-        this.host.applyTheme(themeFromAppearance(document))
+        this.host.applyAppearance(appearanceFromSettings(document))
       }
       if (document.namespace === TUI_BEHAVIOR_SETTINGS_NAMESPACE) {
         this.host.applyBehavior?.(behaviorFromSettings(document))

--- a/src/client/appearance.ts
+++ b/src/client/appearance.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TUI_THEME,
   TUI_APPEARANCE_SETTINGS_NAMESPACE,
   type TuiAppearanceSettings,
+  type TuiBackgroundMode,
   type TuiCodeThemeId,
   type TuiCustomTheme,
   type TuiManagementBridge,
@@ -13,6 +14,7 @@ import {
 import { ui } from './locale.ts'
 import {
   normalizeAppearance,
+  normalizeBackgroundMode,
   resolveAppearanceTheme,
   resolveTheme,
   type ResolvedTuiTheme,
@@ -112,6 +114,24 @@ export async function saveCodeTheme(
       `Harness 保存了意外代码主题 ${JSON.stringify(stored.codeTheme)}`,
       `Harness saved an unexpected code theme ${JSON.stringify(stored.codeTheme)}`,
     ))
+  }
+  return updated
+}
+
+/** Persist only the canvas policy; imported/exported themes do not own it. */
+export async function saveBackgroundMode(
+  settings: TuiManagementBridge['settings'],
+  document: TuiSettingsDocument,
+  mode: TuiBackgroundMode,
+): Promise<TuiSettingsDocument> {
+  const value = normalizeBackgroundMode(mode)
+  const updated = await settings.mutate(
+    TUI_APPEARANCE_SETTINGS_NAMESPACE,
+    [{ op: 'set', path: ['backgroundMode'], value }],
+    document.revision,
+  )
+  if (appearanceFromSettings(updated).backgroundMode !== value) {
+    throw new Error(ui('Harness 未保存所选背景模式', 'Harness did not save the selected background mode'))
   }
   return updated
 }

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -209,6 +209,7 @@ const FIELD_LABELS: Readonly<Record<string, { readonly zh: string; readonly en: 
   'permission.default': { zh: '默认权限', en: 'Default permission' },
   [`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.theme`]: { zh: '界面主题', en: 'Interface theme' },
   [`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.codeTheme`]: { zh: '代码块主题', en: 'Code theme' },
+  [`${TUI_APPEARANCE_SETTINGS_NAMESPACE}.backgroundMode`]: { zh: '背景模式', en: 'Background mode' },
   [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.toolCards`]: { zh: '工具卡片默认形态', en: 'Default tool-card shape' },
   [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.showReasoning`]: { zh: '推理默认显示', en: 'Show reasoning by default' },
   [`${TUI_BEHAVIOR_SETTINGS_NAMESPACE}.desktopNotifications`]: { zh: '完成/审批桌面通知', en: 'Desktop notifications' },

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -111,7 +111,7 @@ import {
 } from './pi-tui-adapters.ts'
 import { applyKeyBindingOverrides, consumeRunningInterrupt, matchesBinding } from './keymap.ts'
 import { pendingInteractionStatus } from './pending-status.ts'
-import { attachFatalGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
+import { attachFatalGuards, attachSuspendGuards, fatalLogHint, restoreSurfaceTerminalSync, withCleanupTimeout } from '../process-guards.ts'
 import { measureStartup } from '../startup-trace.ts'
 import {
   instrumentTerminalWrites,
@@ -210,6 +210,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let stopConstructedTui = (): void => undefined
   let disposeConstructedSyntax = (): void => undefined
   let detachFatalGuards = (): void => undefined
+  let detachSuspendGuards = (): void => undefined
   try {
     const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
     let liveTheme = initialTheme
@@ -221,6 +222,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       liveBehavior.get().hoverFeedback,
     )
     setTheme(initialTheme)
+    terminalSession.setBackgroundColor(initialTheme.colors.canvas)
     const tui = new TUI(terminal, true)
     const requestTuiRender = tui.requestRender.bind(tui)
     tui.requestRender = (force = false): void => {
@@ -785,6 +787,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     const close = (outcome: TuiSurfaceOutcome): Promise<void> => {
       detachFatalGuards()
       detachFatalGuards = () => undefined
+      detachSuspendGuards()
+      detachSuspendGuards = () => undefined
       if (stopping !== undefined) return stopping
       restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
       stopping = (async () => {
@@ -839,6 +843,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       applyTheme: (theme) => {
         liveTheme = theme
         setTheme(theme)
+        terminalSession.setBackgroundColor(theme.colors.canvas)
         syntax?.setTheme(theme)
         transcript.refreshPresentation()
         tui.invalidate()
@@ -1492,6 +1497,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
 
     tui.addInputListener((data) => {
+      if (terminalSession.consumeInput(data)) return { consume: true }
       performanceProbe.markInput()
       // ProcessTerminal's StdinBuffer owns framing and Escape timeouts. Rebuffering
       // a resolved Escape here would join it to the next mouse report again.
@@ -1763,8 +1769,27 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       },
       exit: (code) => { process.exit(code) },
     })
+    detachSuspendGuards = attachSuspendGuards({
+      suspend: () => {
+        contextMenu.close()
+        mouseController.endGesture()
+        clearTranscriptPointerGesture()
+        clearMouseArm(true)
+        clearHoverPresentation()
+        restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
+        tui.stop()
+      },
+      resume: () => {
+        if (stopping !== undefined) return
+        terminalSession.enter()
+        tui.start()
+        terminalSession.startBackgroundSync()
+        tui.requestRender(true)
+      },
+    })
     terminalSession.enter()
     tui.start()
+    terminalSession.startBackgroundSync()
     refreshHeader(true)
     refresh()
     if (options.startupNotice !== undefined) setNotice(options.startupNotice, 'success')
@@ -1799,6 +1824,7 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     return { closed, stop: () => close({ kind: 'exit', code: 0 }) }
   } catch (error) {
     detachFatalGuards()
+    detachSuspendGuards()
     restoreSurfaceTerminalSync(terminalSession, process.stdin, chunk => { process.stdout.write(chunk) }, terminal)
     setCodeHighlighter(undefined)
     try { disposeConstructedSyntax() } catch { /* preserve the setup failure */ }

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -13,6 +13,7 @@ import {
   MAX_WHEEL_SCROLL_LINES,
   TUI_COMPOSER_HISTORY_SETTINGS_NAMESPACE,
   TuiSettingsConflictError,
+  type TuiBackgroundMode,
 } from '@deepseek-ai/dsh-tui-protocol'
 import type { TuiStartOptions, TuiSurfaceHandle, TuiSurfaceOutcome } from './index.ts'
 import { startTuiClient, type TuiClient } from './client-runtime.ts'
@@ -43,7 +44,8 @@ import {
   StatusBar,
   transcriptViewportRows,
 } from './chrome.ts'
-import { appearanceSettings, themeFromAppearance } from './appearance.ts'
+import { appearanceFromSettings, appearanceSettings } from './appearance.ts'
+import { resolveAppearanceTheme, type ResolvedTuiTheme } from './theme-config.ts'
 import { behaviorFromSettings, behaviorSettings, createLiveBehavior } from './behavior.ts'
 import { clearIdleComposerDraft } from './composer-draft.ts'
 import {
@@ -64,7 +66,7 @@ import {
   type ProviderOnboardingResult,
 } from './provider-onboarding.ts'
 import { adoptSyntaxHighlighter, SyntaxHighlighter } from './syntax-highlighter.ts'
-import { background, color, escapeTerminalText, setCodeHighlighter, setTheme } from './theme.ts'
+import { background, color, escapeTerminalText, setBackgroundMode, setCodeHighlighter, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
 import { canReadClipboardText, readClipboardText, writeClipboard } from './clipboard.ts'
 import { graphemeRangeAt, type SelectionAnchor } from './text-selection.ts'
@@ -192,7 +194,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     internals.reportPerformance(snapshot)
   }
   let stopTuiRenderingSync = (): void => undefined
-  const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() })
+  let reportBackgroundUnavailable = (): void => undefined
+  const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() }, process.env,
+    () => { reportBackgroundUnavailable() })
   const startup = await (async () => {
     try {
       return await measureStartup('settings+client', () => Promise.all([
@@ -212,8 +216,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   let detachFatalGuards = (): void => undefined
   let detachSuspendGuards = (): void => undefined
   try {
-    const initialTheme = themeFromAppearance(appearanceSettings(settingsDocuments))
+    const initialAppearance = appearanceFromSettings(appearanceSettings(settingsDocuments))
+    const initialTheme = resolveAppearanceTheme(initialAppearance)
     let liveTheme = initialTheme
+    let liveBackgroundMode = initialAppearance.backgroundMode
     const liveBehavior = createLiveBehavior(behaviorFromSettings(behaviorSettings(settingsDocuments)))
     applyKeyBindingOverrides(liveBehavior.get().keyBindings)
     setDangerConfirmDefault(liveBehavior.get().dangerConfirmDefault)
@@ -222,7 +228,8 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       liveBehavior.get().hoverFeedback,
     )
     setTheme(initialTheme)
-    terminalSession.setBackgroundColor(initialTheme.colors.canvas)
+    setBackgroundMode(liveBackgroundMode)
+    terminalSession.setBackgroundColor(initialTheme.colors.canvas, liveBackgroundMode)
     const tui = new TUI(terminal, true)
     const requestTuiRender = tui.requestRender.bind(tui)
     tui.requestRender = (force = false): void => {
@@ -618,6 +625,13 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       renderWhileOpen()
     }
 
+    reportBackgroundUnavailable = () => {
+      setNotice(ui(
+        '终端背景改色不可用，继续使用终端背景效果；可在 /theme 选择显式底色（兼容）。',
+        'Terminal recoloring is unavailable; using terminal background effects. /theme offers an explicit-fill compatibility mode.',
+      ), 'warning')
+    }
+
     const dismissNotice = (): void => {
       notices.dismiss()
     }
@@ -834,6 +848,22 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       return stopping
     }
 
+    const applyRenderedAppearance = (theme: ResolvedTuiTheme, mode: TuiBackgroundMode): void => {
+      const themeChanged = JSON.stringify(theme) !== JSON.stringify(liveTheme)
+      liveTheme = theme
+      liveBackgroundMode = mode
+      setTheme(theme)
+      setBackgroundMode(mode)
+      terminalSession.setBackgroundColor(theme.colors.canvas, mode)
+      // Background-only changes must not rebuild transcript nodes or disturb selection/anchors.
+      if (themeChanged) {
+        syntax?.setTheme(theme)
+        transcript.refreshPresentation()
+      }
+      tui.invalidate()
+      tui.requestRender(true)
+    }
+
     actions = new TuiActions(capabilities, {
       overlays,
       transcript,
@@ -841,13 +871,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       refresh,
       refreshHeader: () => { refreshHeader(false) },
       applyTheme: (theme) => {
-        liveTheme = theme
-        setTheme(theme)
-        terminalSession.setBackgroundColor(theme.colors.canvas)
-        syntax?.setTheme(theme)
-        transcript.refreshPresentation()
-        tui.invalidate()
-        tui.requestRender(true)
+        applyRenderedAppearance(theme, liveBackgroundMode)
+      },
+      applyAppearance: (appearance) => {
+        applyRenderedAppearance(resolveAppearanceTheme(appearance), appearance.backgroundMode)
       },
       applyLocale: (locale) => {
         setUiLocale(locale)

--- a/src/client/terminal-background.ts
+++ b/src/client/terminal-background.ts
@@ -1,0 +1,84 @@
+import { terminalColorLevel } from './theme.ts'
+
+export const BACKGROUND_QUERY = '\u001B]11;?\u001B\\'
+export const BACKGROUND_QUERY_TIMEOUT_MS = 500
+const OSC = '\u001B]'
+const ST = '\u001B\\'
+const RGB_REPLY = /^\u001B\]11;(rgb:[\da-f]{1,4}\/[\da-f]{1,4}\/[\da-f]{1,4})(?:\u0007|\u001B\\)$/iu
+
+/** Only match truecolor canvases; do not recolor a multiplexer's shared outer window. */
+export function supportsTerminalBackground(env: Readonly<NodeJS.ProcessEnv> = process.env): boolean {
+  return terminalColorLevel(env) === 3
+    && !env.TMUX && !env.STY && !/^(?:screen|tmux)/iu.test(env.TERM ?? '')
+    && !/^(?:0|off|false)$/iu.test(env.SEEKTTY_TERMINAL_BACKGROUND?.trim() ?? '')
+}
+
+/** One asynchronous probe per active lifetime; never guess a color to restore. */
+export class TerminalBackground {
+  private active = false
+  private original: string | undefined
+  private desired: string | undefined
+  private applied: string | undefined
+  private changed = false
+  private timer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(
+    private readonly terminal: { write(data: string): void },
+    private readonly enabled: boolean,
+  ) {}
+
+  setColor(color: string): void {
+    // Only validated theme RGB values may become terminal commands.
+    if (!/^#[\da-f]{6}$/iu.test(color)) return
+    this.desired = `rgb:${color.slice(1, 3)}/${color.slice(3, 5)}/${color.slice(5, 7)}`.toLowerCase()
+    this.apply()
+  }
+
+  start(): void {
+    if (!this.enabled || this.active || this.desired === undefined) return
+    this.active = true
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      // Late replies are still consumed, but cannot enable an expired probe.
+    }, BACKGROUND_QUERY_TIMEOUT_MS)
+    this.timer.unref?.()
+    try { this.terminal.write(BACKGROUND_QUERY) } catch { this.restore() }
+  }
+
+  /** Called after pi-tui framing and before any editor/overlay receives input. */
+  consumeInput(data: string): boolean {
+    // OSC reports are control messages, even if malformed or unsolicited.
+    // A bracketed paste starts with CSI, so literal pasted OSC remains opaque.
+    if (!data.startsWith(OSC)) return false
+    const reply = RGB_REPLY.exec(data)
+    if (this.active && this.timer !== undefined && reply?.[1] !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+      this.original = reply[1].toLowerCase()
+      this.apply()
+    }
+    return true
+  }
+
+  restore(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = undefined
+    this.active = false
+    const original = this.changed ? this.original : undefined
+    this.original = undefined
+    this.applied = undefined
+    this.changed = false
+    // Keep the original channel precision; OSC 111 would reset the profile,
+    // not necessarily the color set by the shell before SeekTTY started.
+    if (original !== undefined) {
+      try { this.terminal.write(`${OSC}11;${original}${ST}`) } catch { /* best-effort cleanup */ }
+    }
+  }
+
+  private apply(): void {
+    if (!this.active || this.original === undefined || this.desired === undefined || this.applied === this.desired) return
+    this.changed = true
+    this.applied = this.desired
+    try { this.terminal.write(`${OSC}11;${this.desired}${ST}`) } catch { this.restore() }
+  }
+}

--- a/src/client/terminal-background.ts
+++ b/src/client/terminal-background.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TUI_BACKGROUND_MODE, type TuiBackgroundMode } from '@deepseek-ai/dsh-tui-protocol'
 import { terminalColorLevel } from './theme.ts'
 
 export const BACKGROUND_QUERY = '\u001B]11;?\u001B\\'
@@ -5,6 +6,8 @@ export const BACKGROUND_QUERY_TIMEOUT_MS = 500
 const OSC = '\u001B]'
 const ST = '\u001B\\'
 const RGB_REPLY = /^\u001B\]11;(rgb:[\da-f]{1,4}\/[\da-f]{1,4}\/[\da-f]{1,4})(?:\u0007|\u001B\\)$/iu
+
+export type BackgroundSyncUnavailable = 'unsupported' | 'timeout' | 'write-failed'
 
 /** Only match truecolor canvases; do not recolor a multiplexer's shared outer window. */
 export function supportsTerminalBackground(env: Readonly<NodeJS.ProcessEnv> = process.env): boolean {
@@ -16,6 +19,10 @@ export function supportsTerminalBackground(env: Readonly<NodeJS.ProcessEnv> = pr
 /** One asynchronous probe per active lifetime; never guess a color to restore. */
 export class TerminalBackground {
   private active = false
+  private queried = false
+  private mode: TuiBackgroundMode = DEFAULT_TUI_BACKGROUND_MODE
+  private unavailable: BackgroundSyncUnavailable | undefined
+  private notified = false
   private original: string | undefined
   private desired: string | undefined
   private applied: string | undefined
@@ -25,24 +32,52 @@ export class TerminalBackground {
   constructor(
     private readonly terminal: { write(data: string): void },
     private readonly enabled: boolean,
+    private readonly onUnavailable: (reason: BackgroundSyncUnavailable) => void = () => undefined,
   ) {}
 
-  setColor(color: string): void {
+  /** Set color and policy atomically, without writing an intermediate theme. */
+  setColor(color: string, mode: TuiBackgroundMode = this.mode): void {
     // Only validated theme RGB values may become terminal commands.
     if (!/^#[\da-f]{6}$/iu.test(color)) return
     this.desired = `rgb:${color.slice(1, 3)}/${color.slice(3, 5)}/${color.slice(5, 7)}`.toLowerCase()
-    this.apply()
+    this.mode = mode
+    if (mode === 'terminal') this.restoreOriginal()
+    else this.sync()
   }
 
   start(): void {
-    if (!this.enabled || this.active || this.desired === undefined) return
+    // The input listener is ready. A terminal-only start may defer its one probe
+    // until the first later switch to a mode that actually needs to change color.
     this.active = true
+    this.sync()
+  }
+
+  private sync(): void {
+    if (!this.active || this.mode === 'terminal' || this.desired === undefined) return
+    if (!this.enabled) this.unavailable = 'unsupported'
+    if (this.unavailable !== undefined) {
+      this.notifyUnavailable()
+      return
+    }
+    if (this.original !== undefined) {
+      this.apply()
+      return
+    }
+    if (this.queried) return
+    this.queried = true
     this.timer = setTimeout(() => {
       this.timer = undefined
       // Late replies are still consumed, but cannot enable an expired probe.
+      this.unavailable = 'timeout'
+      this.notifyUnavailable()
     }, BACKGROUND_QUERY_TIMEOUT_MS)
     this.timer.unref?.()
-    try { this.terminal.write(BACKGROUND_QUERY) } catch { this.restore() }
+    try { this.terminal.write(BACKGROUND_QUERY) } catch {
+      clearTimeout(this.timer)
+      this.timer = undefined
+      this.unavailable = 'write-failed'
+      this.notifyUnavailable()
+    }
   }
 
   /** Called after pi-tui framing and before any editor/overlay receives input. */
@@ -55,7 +90,7 @@ export class TerminalBackground {
       clearTimeout(this.timer)
       this.timer = undefined
       this.original = reply[1].toLowerCase()
-      this.apply()
+      this.sync()
     }
     return true
   }
@@ -64,14 +99,27 @@ export class TerminalBackground {
     if (this.timer !== undefined) clearTimeout(this.timer)
     this.timer = undefined
     this.active = false
-    const original = this.changed ? this.original : undefined
+    this.restoreOriginal()
+    this.queried = false
+    this.unavailable = undefined
+    this.notified = false
     this.original = undefined
     this.applied = undefined
     this.changed = false
+  }
+
+  /** Switching to terminal-only restores color without losing the lifetime snapshot. */
+  private restoreOriginal(): void {
+    if (!this.changed || this.original === undefined) return
     // Keep the original channel precision; OSC 111 would reset the profile,
     // not necessarily the color set by the shell before SeekTTY started.
-    if (original !== undefined) {
-      try { this.terminal.write(`${OSC}11;${original}${ST}`) } catch { /* best-effort cleanup */ }
+    try {
+      this.terminal.write(`${OSC}11;${this.original}${ST}`)
+      this.changed = false
+      this.applied = undefined
+    } catch {
+      // Retain ownership so exit can make one more best-effort restoration.
+      this.unavailable = 'write-failed'
     }
   }
 
@@ -79,6 +127,16 @@ export class TerminalBackground {
     if (!this.active || this.original === undefined || this.desired === undefined || this.applied === this.desired) return
     this.changed = true
     this.applied = this.desired
-    try { this.terminal.write(`${OSC}11;${this.desired}${ST}`) } catch { this.restore() }
+    try { this.terminal.write(`${OSC}11;${this.desired}${ST}`) } catch {
+      this.unavailable = 'write-failed'
+      this.restoreOriginal()
+      this.notifyUnavailable()
+    }
+  }
+
+  private notifyUnavailable(): void {
+    if (!this.active || this.mode !== 'theme' || this.unavailable === undefined || this.notified) return
+    this.notified = true
+    try { this.onUnavailable(this.unavailable) } catch { /* a notice cannot disrupt terminal cleanup */ }
   }
 }

--- a/src/client/terminal-session.ts
+++ b/src/client/terminal-session.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@mariozechner/pi-tui'
+import { supportsTerminalBackground, TerminalBackground } from './terminal-background.ts'
 import {
   encodeDisableMouseReporting,
   encodeMouseReporting,
@@ -41,6 +42,9 @@ export interface ManagedTui {
 export interface TerminalSession {
   enter(): void
   restore(): void
+  setBackgroundColor(color: string): void
+  startBackgroundSync(): void
+  consumeInput(data: string): boolean
   setMouseReporting(mode: MouseReportingMode, hoverFeedback?: boolean): void
   mouseReporting(): MouseReportingMode
 }
@@ -59,7 +63,9 @@ export function createTerminalSession(
   terminal: Terminal & ManagedTerminal,
   enabled: boolean,
   beforeRestore: () => void = () => undefined,
+  env: Readonly<NodeJS.ProcessEnv> = process.env,
 ): TerminalSession {
+  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env))
   let active = false
   let mouseMode: MouseReportingMode = 'full'
   let hoverFeedback = true
@@ -73,6 +79,7 @@ export function createTerminalSession(
     restore: () => {
       if (!active) return
       try { beforeRestore() } catch { /* terminal restoration must still run */ }
+      background.restore()
       try {
         terminal.write(encodeDisableMouseReporting())
       } finally {
@@ -84,6 +91,10 @@ export function createTerminalSession(
         }
       }
     },
+    setBackgroundColor: color => { background.setColor(color) },
+    // Must run after terminal.start() has installed its raw-mode input listener.
+    startBackgroundSync: () => { if (active) background.start() },
+    consumeInput: data => background.consumeInput(data),
     setMouseReporting: (mode, nextHoverFeedback = hoverFeedback) => {
       if (mouseMode === mode && hoverFeedback === nextHoverFeedback) return
       mouseMode = mode

--- a/src/client/terminal-session.ts
+++ b/src/client/terminal-session.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from '@mariozechner/pi-tui'
-import { supportsTerminalBackground, TerminalBackground } from './terminal-background.ts'
+import type { TuiBackgroundMode } from '@deepseek-ai/dsh-tui-protocol'
+import { supportsTerminalBackground, TerminalBackground, type BackgroundSyncUnavailable } from './terminal-background.ts'
 import {
   encodeDisableMouseReporting,
   encodeMouseReporting,
@@ -42,7 +43,7 @@ export interface ManagedTui {
 export interface TerminalSession {
   enter(): void
   restore(): void
-  setBackgroundColor(color: string): void
+  setBackgroundColor(color: string, mode?: TuiBackgroundMode): void
   startBackgroundSync(): void
   consumeInput(data: string): boolean
   setMouseReporting(mode: MouseReportingMode, hoverFeedback?: boolean): void
@@ -64,8 +65,9 @@ export function createTerminalSession(
   enabled: boolean,
   beforeRestore: () => void = () => undefined,
   env: Readonly<NodeJS.ProcessEnv> = process.env,
+  onBackgroundUnavailable?: (reason: BackgroundSyncUnavailable) => void,
 ): TerminalSession {
-  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env))
+  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable)
   let active = false
   let mouseMode: MouseReportingMode = 'full'
   let hoverFeedback = true
@@ -91,7 +93,7 @@ export function createTerminalSession(
         }
       }
     },
-    setBackgroundColor: color => { background.setColor(color) },
+    setBackgroundColor: (color, mode) => { background.setColor(color, mode) },
     // Must run after terminal.start() has installed its raw-mode input listener.
     startBackgroundSync: () => { if (active) background.start() },
     consumeInput: data => background.consumeInput(data),

--- a/src/client/theme-config.ts
+++ b/src/client/theme-config.ts
@@ -1,11 +1,13 @@
 /** Pure theme validation, color conversion, and palette generation. */
 
 import {
+  DEFAULT_TUI_BACKGROUND_MODE,
   DEFAULT_TUI_CODE_THEME,
   MAX_CUSTOM_THEMES,
   MAX_TEXTMATE_RULES,
   type TuiCodeThemeId,
   type TuiAppearanceSettings,
+  type TuiBackgroundMode,
   type TuiCustomTheme,
   type TuiSyntaxThemeColors,
   type TuiTextMateRule,
@@ -653,6 +655,7 @@ export function normalizeCustomTheme(value: unknown): TuiCustomTheme {
  */
 export function normalizeAppearance(value: unknown): TuiAppearanceSettings {
   const record = recordOf(value, 'SeekTTY appearance')
+  const backgroundMode = normalizeBackgroundMode(record.backgroundMode)
   const rawTheme = stringOf(record, 'theme', 'SeekTTY appearance')
   if (!/^(?:dark|light|custom:[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)$/u.test(rawTheme)) {
     throw new Error(ui(
@@ -710,7 +713,17 @@ export function normalizeAppearance(value: unknown): TuiAppearanceSettings {
       `The current custom code theme ${JSON.stringify(codeTheme)} does not exist`,
     ))
   }
-  return { theme, codeTheme, customThemes }
+  return { theme, codeTheme, backgroundMode, customThemes }
+}
+
+/** Validate the independent canvas policy, including legacy settings without it. */
+export function normalizeBackgroundMode(value: unknown): TuiBackgroundMode {
+  if (value === undefined) return DEFAULT_TUI_BACKGROUND_MODE
+  if (value === 'theme' || value === 'terminal' || value === 'explicit') return value
+  throw new Error(ui(
+    `SeekTTY 背景模式 ${JSON.stringify(value)} 不受支持`,
+    `SeekTTY background mode ${JSON.stringify(value)} is not supported`,
+  ))
 }
 
 /**

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -6,6 +6,7 @@ import {
   type MarkdownTheme,
 } from '@mariozechner/pi-tui'
 import { BUILT_IN_THEMES, resolveHoverStyle, type ResolvedTuiTheme } from './theme-config.ts'
+import { DEFAULT_TUI_BACKGROUND_MODE, type TuiBackgroundMode } from '@deepseek-ai/dsh-tui-protocol'
 import { ui } from './locale.ts'
 
 const RESET = '\u001B[0m'
@@ -99,6 +100,7 @@ function runtimePalette(theme: ResolvedTuiTheme): ThemePalette {
 }
 
 let selectedTheme: ResolvedTuiTheme = BUILT_IN_THEMES.dark
+let backgroundMode: TuiBackgroundMode = DEFAULT_TUI_BACKGROUND_MODE
 let palette = runtimePalette(selectedTheme)
 const hoverUnderlineByLevel = new Map<TerminalColorLevel, boolean>()
 let codeHighlighter: ((code: string, lang?: string) => string[]) | undefined
@@ -266,10 +268,10 @@ function paint(entry: SemanticColor, text: string): string {
   return `${foregroundSequence(entry, level)}${safeText}${RESET}`
 }
 
-function layer(background: SemanticColor, text: string, foreground = palette.text): string {
+function layer(background: SemanticColor | undefined, text: string, foreground = palette.text): string {
   const level = terminalColorLevel()
   if (level === 0) return text
-  const prefix = `${backgroundSequence(background, level)}${foregroundSequence(foreground, level)}`
+  const prefix = `${background === undefined ? '\u001B[49m' : backgroundSequence(background, level)}${foregroundSequence(foreground, level)}`
   const restored = text.replace(/\u001B\[(?:0)?m/gu, `${RESET}${prefix}`)
   return `${prefix}${restored}${RESET}`
 }
@@ -336,6 +338,9 @@ export function setTheme(theme: ResolvedTuiTheme): void {
 /** Return the complete theme currently used by renderers. */
 export function currentTheme(): ResolvedTuiTheme { return selectedTheme }
 
+/** Independent of theme previews/imports; only the main canvas inherits terminal effects. */
+export function setBackgroundMode(mode: TuiBackgroundMode): void { backgroundMode = mode }
+
 /**
  * Connect the asynchronously prepared syntax highlighter to Markdown rendering.
  * @param highlighter - synchronous cached renderer, or undefined during teardown.
@@ -376,7 +381,7 @@ export const color = {
 
 /** Background layers shared by the full frame, panels, and selected rows. */
 export const background = {
-  canvas: (text: string): string => layer(palette.canvas, text),
+  canvas: (text: string): string => layer(backgroundMode === 'explicit' ? palette.canvas : undefined, text),
   surface: (text: string): string => layer(palette.surface, text),
   hover: hoverLayer,
   selection: (text: string): string => layer(palette.selection, text),

--- a/src/host/management.ts
+++ b/src/host/management.ts
@@ -13,6 +13,7 @@ import type {
   TuiSettingsDocument,
 } from '@deepseek-ai/dsh-tui-protocol'
 import {
+  DEFAULT_TUI_BACKGROUND_MODE,
   DEFAULT_TUI_BEHAVIOR,
   DEFAULT_TUI_CODE_THEME,
   DEFAULT_TUI_THEME,
@@ -128,6 +129,12 @@ export const AppearanceSettingsSchema = z.object({
     .description(localeDescription({
       zh: '代码块独立主题；auto 跟随当前界面主题。',
       en: 'Independent code-block theme; auto follows the current interface theme.',
+    })),
+  backgroundMode: z.union(['theme', 'terminal', 'explicit'])
+    .default(DEFAULT_TUI_BACKGROUND_MODE)
+    .description(localeDescription({
+      zh: '主背景模式：主题颜色＋终端效果、完全跟随终端，或显式主题底色（兼容）。不改变终端透明度；弹窗和代码块保留底色。',
+      en: 'Canvas background: theme colors with terminal effects, terminal background, or explicit theme fill (compatibility). Does not change terminal opacity; panels and code blocks keep their backgrounds.',
     })),
   customThemes: z.array(CustomThemeSchema).max(MAX_CUSTOM_THEMES).default([])
     .description(localeDescription({

--- a/src/process-guards.ts
+++ b/src/process-guards.ts
@@ -133,3 +133,41 @@ export function attachFatalGuards(options: FatalGuardOptions): () => void {
     process.off('SIGHUP', onHup)
   }
 }
+
+interface SuspendRuntime {
+  readonly platform: NodeJS.Platform
+  on(signal: 'SIGTSTP' | 'SIGCONT', handler: () => void): unknown
+  off(signal: 'SIGTSTP' | 'SIGCONT', handler: () => void): unknown
+  suspendSelf(): void
+}
+
+/** POSIX job control; Ctrl+Z remains input undo, not a new suspend shortcut. */
+export function attachSuspendGuards(
+  options: { suspend(): void; resume(): void },
+  runtime: SuspendRuntime = {
+    platform: process.platform,
+    on: (signal, handler) => process.on(signal, handler),
+    off: (signal, handler) => process.off(signal, handler),
+    suspendSelf: () => { process.kill(process.pid, 'SIGSTOP') },
+  },
+): () => void {
+  if (runtime.platform === 'win32') return () => undefined
+  let suspended = false
+  const onSuspend = (): void => {
+    if (suspended) return
+    options.suspend()
+    suspended = true
+    runtime.suspendSelf()
+  }
+  const onResume = (): void => {
+    if (!suspended) return
+    suspended = false
+    options.resume()
+  }
+  runtime.on('SIGTSTP', onSuspend)
+  runtime.on('SIGCONT', onResume)
+  return () => {
+    runtime.off('SIGTSTP', onSuspend)
+    runtime.off('SIGCONT', onResume)
+  }
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -86,10 +86,17 @@ export interface TuiCustomTheme {
   readonly tokenColors: readonly TuiTextMateRule[]
 }
 
+/** How the main canvas uses the terminal's default background. */
+export type TuiBackgroundMode = 'theme' | 'terminal' | 'explicit'
+
+/** Keep theme colors while inheriting the terminal's background effects. */
+export const DEFAULT_TUI_BACKGROUND_MODE: TuiBackgroundMode = 'theme'
+
 /** Complete appearance value owned by the SeekTTY Settings namespace. */
 export interface TuiAppearanceSettings {
   readonly theme: TuiThemeId
   readonly codeTheme: TuiCodeThemeId
+  readonly backgroundMode: TuiBackgroundMode
   readonly customThemes: readonly TuiCustomTheme[]
 }
 

--- a/tests/actions-background.test.ts
+++ b/tests/actions-background.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
+import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
+import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
+import { OverlayQueue } from '../src/client/overlays.ts'
+import { setUiLocale } from '../src/client/locale.ts'
+import type { Transcript } from '../src/client/transcript.ts'
+import { AppearanceSettingsSchema } from '../src/host/management.ts'
+import { TUI_APPEARANCE_SETTINGS_NAMESPACE, type TuiSettingsDocument, type TuiManagementBridge, type TuiSettingsPathOp } from '../src/protocol.ts'
+
+function harness() {
+  let current: TuiSettingsDocument = {
+    namespace: TUI_APPEARANCE_SETTINGS_NAMESPACE, schema: AppearanceSettingsSchema.toJSON(),
+    value: { theme: 'dark', codeTheme: 'auto', customThemes: [] }, revision: 5, applies: 'live', secrets: [],
+  }
+  const mutate = vi.fn(async (_namespace: string, ops: readonly TuiSettingsPathOp[], revision: number) => {
+    expect(revision).toBe(current.revision)
+    const op = ops[0]
+    if (op?.op !== 'set') throw new Error('expected set')
+    current = { ...current, revision: revision + 1, value: { ...current.value as object, backgroundMode: op.value } }
+    return current
+  })
+  const management = { settings: { describe: async () => [current], mutate } } as unknown as TuiManagementBridge
+  const capabilities = { managementBridge: () => management, active: () => undefined } as unknown as HarnessTuiCapabilities
+  let mounted: Component | undefined
+  const overlays = new OverlayQueue({
+    showOverlay: (component: Component) => { mounted = component; return { hide: vi.fn() } as unknown as OverlayHandle },
+    requestRender: vi.fn(),
+  } as unknown as TUI)
+  const host: TuiActionHost = {
+    overlays, transcript: {} as Transcript,
+    notice: vi.fn(), refresh: vi.fn(), refreshHeader: vi.fn(), applyTheme: vi.fn(), applyAppearance: vi.fn(),
+    applyLocale: vi.fn(), setEditor: vi.fn(), copy: vi.fn(), close: vi.fn(), restart: vi.fn(), requireRestart: vi.fn(),
+  }
+  return {
+    actions: new TuiActions(capabilities, host), overlays, host, mutate, current: () => current,
+    text: () => mounted?.render(120).join('\n').replace(/\u001B\[[0-9;:]*m/gu, '') ?? '',
+    key: (data: string) => mounted?.handleInput?.(data),
+  }
+}
+
+afterEach(() => { setUiLocale('zh') })
+
+describe('shared background editor', () => {
+  it.each(['zh', 'en'] as const)('exposes the same three choices from /theme and /settings (%s)', async locale => {
+    setUiLocale(locale)
+    const panels: string[] = []
+    for (const entry of ['theme', 'settings']) {
+      const h = harness()
+      const pending = h.actions.execute(entry, entry === 'settings' ? TUI_APPEARANCE_SETTINGS_NAMESPACE : '')
+      try {
+        await vi.waitFor(() => { expect(h.text()).toContain(locale === 'zh' ? '背景模式' : 'Background mode') })
+        if (entry === 'settings') await vi.waitFor(() => { expect(h.text()).toContain(`${locale === 'zh' ? '设置' : 'Settings'} · seektty-appearance`) })
+        if (entry === 'theme') h.key(locale === 'zh' ? '背景模式' : 'Background mode')
+        h.key('\r')
+        await vi.waitFor(() => { expect(h.text()).toContain(locale === 'zh' ? '仅主画布继承终端效果' : 'Only the canvas inherits terminal effects') })
+        const panel = h.text()
+        panels.push(panel)
+        if (locale === 'en') expect(panel).not.toMatch(/\p{Script=Han}/u)
+        expect(panel).toContain(locale === 'zh' ? '跟随终端' : 'Follow terminal')
+        expect(panel).toContain(locale === 'zh' ? '显式主题底色' : 'Explicit fill')
+        h.key('\u001B[B')
+        h.key('\r')
+        await vi.waitFor(() => { expect(h.host.applyAppearance).toHaveBeenCalledExactlyOnceWith({
+          theme: 'dark', codeTheme: 'auto', customThemes: [], backgroundMode: 'terminal',
+        }) })
+        expect(h.mutate).toHaveBeenCalledExactlyOnceWith(TUI_APPEARANCE_SETTINGS_NAMESPACE,
+          [{ op: 'set', path: ['backgroundMode'], value: 'terminal' }], 5)
+        expect(h.host.applyTheme).not.toHaveBeenCalled()
+      } finally { h.overlays.dispose(); await pending }
+    }
+    expect(panels[0]).toBe(panels[1])
+  })
+
+  it.each(['cancel', 'same', 'failure'])('does not apply a background on %s', async outcome => {
+    const h = harness()
+    if (outcome === 'failure') h.mutate.mockRejectedValueOnce(new Error('save failed'))
+    const pending = h.actions.execute('settings', TUI_APPEARANCE_SETTINGS_NAMESPACE)
+    try {
+      await vi.waitFor(() => { expect(h.text()).toContain('设置 · seektty-appearance') })
+      h.key('\r')
+      await vi.waitFor(() => { expect(h.text()).toContain('仅主画布继承终端效果') })
+      if (outcome === 'failure') h.key('\u001B[B')
+      h.key(outcome === 'cancel' ? '\u001B' : '\r')
+      await vi.waitFor(() => {
+        if (outcome === 'failure') expect(h.host.notice).toHaveBeenCalledWith(expect.stringContaining('save failed'), 'error')
+        else expect(h.text()).toContain('设置 · seektty-appearance')
+      })
+      expect(h.host.applyAppearance).not.toHaveBeenCalled()
+      expect(h.host.applyTheme).not.toHaveBeenCalled()
+      expect(h.current().revision).toBe(5)
+      if (outcome !== 'failure') expect(h.mutate).not.toHaveBeenCalled()
+    } finally { h.overlays.dispose(); await pending }
+  })
+})

--- a/tests/actions-interaction.test.ts
+++ b/tests/actions-interaction.test.ts
@@ -61,6 +61,7 @@ function host(
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn(),
     copy: vi.fn(),

--- a/tests/actions-palette.test.ts
+++ b/tests/actions-palette.test.ts
@@ -29,6 +29,7 @@ function host(overlays: Partial<OverlayQueue>): TuiActionHost & {
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor,
     copy: vi.fn(),

--- a/tests/actions-settings-navigation.test.ts
+++ b/tests/actions-settings-navigation.test.ts
@@ -75,6 +75,7 @@ function actionHarness(): {
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn(),
     copy: vi.fn(),

--- a/tests/actions-theme.test.ts
+++ b/tests/actions-theme.test.ts
@@ -15,7 +15,10 @@ import {
   type TuiSettingsPathOp,
 } from '../src/protocol.ts'
 
-function document(value: TuiAppearanceSettings, revision = 0): TuiSettingsDocument {
+// Keep legacy persisted fixtures without the new field to exercise migration.
+type StoredAppearance = Omit<TuiAppearanceSettings, 'backgroundMode'> & Partial<Pick<TuiAppearanceSettings, 'backgroundMode'>>
+
+function document(value: StoredAppearance, revision = 0): TuiSettingsDocument {
   return {
     namespace: TUI_APPEARANCE_SETTINGS_NAMESPACE,
     schema: {},
@@ -26,7 +29,7 @@ function document(value: TuiAppearanceSettings, revision = 0): TuiSettingsDocume
   }
 }
 
-function settingsState(initial: TuiAppearanceSettings): {
+function settingsState(initial: StoredAppearance): {
   readonly settings: TuiManagementBridge['settings']
   readonly mutate: ReturnType<typeof vi.fn>
   current(): TuiSettingsDocument

--- a/tests/actions-theme.test.ts
+++ b/tests/actions-theme.test.ts
@@ -78,6 +78,7 @@ function actionHarness(
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn(),
     copy: vi.fn(),
@@ -104,10 +105,8 @@ describe('/theme commands', () => {
       ],
       0,
     )
-    expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({ id: 'light' }))
-    expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({
-      syntax: BUILT_IN_THEMES.light.syntax,
-    }))
+    expect(host.applyAppearance).toHaveBeenCalledWith(expect.objectContaining({ theme: 'light', codeTheme: 'auto', backgroundMode: 'theme' }))
+    expect(host.applyTheme).not.toHaveBeenCalled()
   })
 
   it('restores matching light code when the light interface is selected again', async () => {
@@ -117,9 +116,8 @@ describe('/theme commands', () => {
     await actions.execute('theme', 'light')
 
     expect(state.current().value).toEqual({ theme: 'light', codeTheme: 'auto', customThemes: [] })
-    expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({
-      id: 'light',
-      syntax: BUILT_IN_THEMES.light.syntax,
+    expect(host.applyAppearance).toHaveBeenCalledWith(expect.objectContaining({
+      theme: 'light', codeTheme: 'auto', backgroundMode: 'theme',
     }))
   })
 
@@ -135,9 +133,8 @@ describe('/theme commands', () => {
       [{ op: 'set', path: ['codeTheme'], value: 'dark' }],
       0,
     )
-    expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({
-      id: 'light',
-      syntax: BUILT_IN_THEMES.dark.syntax,
+    expect(host.applyAppearance).toHaveBeenCalledWith(expect.objectContaining({
+      theme: 'light', codeTheme: 'dark', backgroundMode: 'theme',
     }))
   })
 
@@ -165,11 +162,12 @@ describe('/theme commands', () => {
       ],
       0,
     )
-    expect(host.applyTheme).toHaveBeenCalledTimes(2)
+    expect(host.applyTheme).toHaveBeenCalledTimes(1)
+    expect(host.applyAppearance).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ theme: 'custom:ocean', backgroundMode: 'theme' }))
   })
 
   it('restores the original theme when a palette preview is cancelled', async () => {
-    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', backgroundMode: 'terminal', customThemes: [] })
     const input = vi.fn()
       .mockResolvedValueOnce('Ocean')
       .mockResolvedValueOnce('#071426 #F4F8FF #6682FF')
@@ -181,6 +179,21 @@ describe('/theme commands', () => {
     expect(state.mutate).not.toHaveBeenCalled()
     expect(host.applyTheme).toHaveBeenCalledTimes(2)
     expect(host.applyTheme).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'dark' }))
+    expect(host.applyAppearance).not.toHaveBeenCalled()
+    expect(state.current().value).toMatchObject({ backgroundMode: 'terminal' })
+  })
+
+  it('restores the preview on save failure without applying a different background mode', async () => {
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', backgroundMode: 'explicit', customThemes: [] })
+    state.mutate.mockRejectedValueOnce(new Error('save failed'))
+    const input = vi.fn().mockResolvedValueOnce('Ocean').mockResolvedValueOnce('#071426 #F4F8FF #6682FF')
+    const select = vi.fn().mockResolvedValue({ id: 'apply', label: '应用并保存' })
+    const { actions, host } = actionHarness(state.settings, { input, select })
+    await actions.execute('theme', 'palette')
+    expect(host.applyTheme).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'dark' }))
+    expect(host.applyAppearance).not.toHaveBeenCalled()
+    expect(state.current().value).toMatchObject({ theme: 'dark', backgroundMode: 'explicit' })
+    expect(host.notice).toHaveBeenCalledWith(expect.stringContaining('save failed'), 'error')
   })
 
   it('imports a local VS Code JSONC theme and saves it through Harness Settings', async () => {
@@ -211,7 +224,8 @@ describe('/theme commands', () => {
         source: 'vscode',
         tokenColors: [{ scope: ['keyword'], foreground: '#91A7FF', fontStyle: ['bold'] }],
       })
-      expect(host.applyTheme).toHaveBeenCalledTimes(2)
+      expect(host.applyTheme).toHaveBeenCalledTimes(1)
+      expect(host.applyAppearance).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ theme: 'light', codeTheme: 'custom:ocean-imported', backgroundMode: 'theme' }))
       expect(host.applyTheme).toHaveBeenLastCalledWith(expect.objectContaining({
         id: 'light',
         syntaxTone: 'dark',
@@ -249,6 +263,6 @@ describe('/theme commands', () => {
 
     expect(confirm).toHaveBeenCalledTimes(1)
     expect(state.current().value).toEqual({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
-    expect(host.applyTheme).toHaveBeenCalledWith(expect.objectContaining({ id: 'dark' }))
+    expect(host.applyAppearance).toHaveBeenCalledWith(expect.objectContaining({ theme: 'dark', backgroundMode: 'theme' }))
   })
 })

--- a/tests/appearance-background.test.ts
+++ b/tests/appearance-background.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appearanceFromSettings, saveBackgroundMode, saveCustomTheme, saveTheme } from '../src/client/appearance.ts'
+import { BUILT_IN_THEMES, editableTheme } from '../src/client/theme-config.ts'
+import { serializeThemeExport, themeForExport } from '../src/client/theme-export.ts'
+import { TUI_APPEARANCE_SETTINGS_NAMESPACE, type TuiManagementBridge, type TuiSettingsDocument, type TuiSettingsPathOp } from '../src/protocol.ts'
+
+function state() {
+  let current: TuiSettingsDocument = {
+    namespace: TUI_APPEARANCE_SETTINGS_NAMESPACE, schema: {}, revision: 7, applies: 'live', secrets: [],
+    value: { theme: 'dark', codeTheme: 'auto', backgroundMode: 'terminal', customThemes: [] },
+  }
+  const mutate = vi.fn(async (_namespace: string, ops: readonly TuiSettingsPathOp[], revision: number) => {
+    expect(revision).toBe(current.revision)
+    const value = { ...current.value as Record<string, unknown> }
+    for (const op of ops) {
+      expect(op.op).toBe('set')
+      if (op.op === 'set') value[String(op.path[0])] = op.value
+    }
+    current = { ...current, revision: revision + 1, value }
+    return current
+  })
+  return { current: () => current, mutate, settings: { mutate } as unknown as TuiManagementBridge['settings'] }
+}
+
+describe('Harness-owned background mode', () => {
+  it('persists just the background field using the current revision', async () => {
+    const harness = state()
+    const updated = await saveBackgroundMode(harness.settings, harness.current(), 'explicit')
+    expect(harness.mutate).toHaveBeenCalledWith(TUI_APPEARANCE_SETTINGS_NAMESPACE,
+      [{ op: 'set', path: ['backgroundMode'], value: 'explicit' }], 7)
+    expect(appearanceFromSettings(updated)).toEqual({
+      theme: 'dark', codeTheme: 'auto', backgroundMode: 'explicit', customThemes: [],
+    })
+  })
+
+  it('does not alter the source document when persistence fails or returns an unexpected value', async () => {
+    const harness = state()
+    const before = harness.current()
+    harness.mutate.mockRejectedValueOnce(new Error('revision conflict'))
+    await expect(saveBackgroundMode(harness.settings, before, 'explicit')).rejects.toThrow('revision conflict')
+    expect(harness.current()).toBe(before)
+    harness.mutate.mockResolvedValueOnce(before)
+    await expect(saveBackgroundMode(harness.settings, before, 'explicit')).rejects.toThrow()
+    expect(appearanceFromSettings(before).backgroundMode).toBe('terminal')
+  })
+
+  it('keeps mode outside theme selection, custom theme import/save and portable exports', async () => {
+    const harness = state()
+    await saveTheme(harness.settings, harness.current(), 'light')
+    const custom = editableTheme(BUILT_IN_THEMES.dark, 'imported', 'Imported')
+    const updated = await saveCustomTheme(harness.settings, harness.current(), custom)
+    expect(appearanceFromSettings(updated).backgroundMode).toBe('terminal')
+    expect(serializeThemeExport(themeForExport(BUILT_IN_THEMES.dark))).not.toContain('backgroundMode')
+    expect(harness.mutate.mock.calls.flatMap(call => call[1]).some(op => op.path[0] === 'backgroundMode')).toBe(false)
+  })
+})

--- a/tests/background-inheritance.test.ts
+++ b/tests/background-inheritance.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Box, TUI, visibleWidth, type Terminal } from '@mariozechner/pi-tui'
+import { BottomAnchoredLayout } from '../src/client/chrome.ts'
+import { background, color, setBackgroundMode, setTheme } from '../src/client/theme.ts'
+import { BUILT_IN_THEMES } from '../src/client/theme-config.ts'
+import { tuiFrameApi } from '../src/client/pi-tui-adapters.ts'
+import type { TuiBackgroundMode } from '../src/protocol.ts'
+
+const DEFAULT_BG = '\u001B[49m'
+const RGB_BG = '\u001B[48;2;9;14;27m'
+const plain = (text: string) => text.replace(/\u001B\[[0-9;:]*m/gu, '')
+
+function truecolor() {
+  vi.stubEnv('NO_COLOR', undefined)
+  vi.stubEnv('TERM', 'xterm-256color')
+  vi.stubEnv('COLORTERM', 'truecolor')
+  setTheme(BUILT_IN_THEMES.dark)
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+  setBackgroundMode('theme')
+  setTheme(BUILT_IN_THEMES.dark)
+})
+
+describe('main canvas background semantics', () => {
+  it.each(['theme', 'terminal', 'explicit'] as const)('restores %s semantics after nested text resets and theme preview cancellation', mode => {
+    truecolor()
+    setBackgroundMode(mode)
+    const prefix = mode === 'explicit' ? RGB_BG : DEFAULT_BG
+    const row = background.canvas(`before ${color.brand('中文')} after\u001B[m end`)
+    expect(row.split(prefix)).toHaveLength(4)
+    if (mode !== 'explicit') expect(row).not.toContain('\u001B[48;')
+    setTheme(BUILT_IN_THEMES.light)
+    setTheme(BUILT_IN_THEMES.dark)
+    expect(background.canvas(`before ${color.brand('中文')} after\u001B[m end`)).toBe(row)
+  })
+
+  it('leaves panel, code, hover and selection colors and text widths unchanged', () => {
+    truecolor()
+    const layers = () => [background.surface('panel'), background.code('const 中文 = 1'), background.hover('hover'), background.selection('selected')]
+    setBackgroundMode('explicit')
+    const original = layers()
+    for (const mode of ['theme', 'terminal', 'explicit'] as const) {
+      setBackgroundMode(mode)
+      expect(layers()).toEqual(original)
+      const composed = background.canvas(`${original.join(' ')} tail`)
+      expect(plain(composed)).toBe('panel const 中文 = 1 hover selected tail')
+      expect(visibleWidth(composed)).toBe(visibleWidth(plain(composed)))
+      for (const line of original) expect(composed).toContain(line.slice(0, line.indexOf('m') + 1))
+    }
+  })
+})
+
+class RecordingTerminal implements Terminal {
+  writes: string[] = []
+  columns = 80
+  rows = 24
+  kittyProtocolActive = false
+  start(): void {}
+  stop(): void {}
+  drainInput(): Promise<void> { return Promise.resolve() }
+  write(data: string): void { this.writes.push(data) }
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+describe('canvas / layout / overlay frame integration (synthetic terminal)', () => {
+  it('repaints all modes, resize, scrolling and overlay removal without changing geometry or leaving unfilled cells', async () => {
+    vi.useFakeTimers()
+    truecolor()
+    const terminal = new RecordingTerminal()
+    const tui = new TUI(terminal, false)
+    const canvas = new Box(0, 0, background.canvas)
+    let rows = ['old-long-row', 'second-row']
+    const fixed = (text: string) => ({ render: () => [text], invalidate: () => undefined })
+    canvas.addChild(new BottomAnchoredLayout(() => terminal.rows, fixed('header'),
+      { render: () => rows, invalidate: () => undefined }, fixed('composer'), fixed('status')))
+    tui.addChild(canvas)
+    const frame = async () => { await vi.advanceTimersByTimeAsync(40) }
+    const redraw = async (mode: TuiBackgroundMode) => {
+      terminal.writes = []
+      setBackgroundMode(mode)
+      tui.invalidate()
+      tui.requestRender(true)
+      await frame()
+      const painted = tui.render(terminal.columns)
+      expect(painted).toHaveLength(terminal.rows)
+      expect(painted.every(row => visibleWidth(row) === terminal.columns)).toBe(true)
+      for (const row of painted) {
+        expect(row).toContain(mode === 'explicit' ? RGB_BG : DEFAULT_BG)
+        if (mode !== 'explicit') expect(row).not.toContain(RGB_BG)
+      }
+      expect(terminal.writes.join('')).not.toMatch(/\u001B\[[23]J/u)
+      return painted.map(plain)
+    }
+    tui.start()
+    try {
+      await frame()
+      const original = await redraw('explicit')
+      const geometry = tuiFrameApi(tui).getLastFrameGeometry?.()
+      for (const mode of ['theme', 'terminal', 'explicit', 'theme'] as const) {
+        expect(await redraw(mode)).toEqual(original)
+        expect(tuiFrameApi(tui).getLastFrameGeometry?.()).toEqual(geometry)
+      }
+      const overlay = tui.showOverlay({ render: () => [background.surface('overlay')], invalidate: () => undefined }, { width: 20 })
+      await frame()
+      overlay.hide()
+      rows = ['new'] // a shorter/scrolling transcript still fills/cleans the entire canvas
+      await redraw('terminal')
+      expect(terminal.writes.join('')).not.toContain('overlay')
+      expect(terminal.writes.join('')).not.toContain('old-long-row')
+      for (const [columns, height] of [[40, 12], [100, 30]] as const) {
+        terminal.columns = columns
+        terminal.rows = height
+        await redraw('theme')
+        expect(tuiFrameApi(tui).getLastFrameGeometry?.().terminalWidth).toBe(columns)
+      }
+    } finally { tui.stop() }
+  })
+})

--- a/tests/clarify-composer-boundary.test.ts
+++ b/tests/clarify-composer-boundary.test.ts
@@ -207,6 +207,7 @@ function actionHost(overlays: OverlayQueueType, composer: { getText(): string; s
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: (text) => { composer.setText(text) },
     composerText: () => composer.getText(),

--- a/tests/clarify-shell.test.ts
+++ b/tests/clarify-shell.test.ts
@@ -249,6 +249,7 @@ function host(overlayQueue: OverlayQueue, composer = ''): TuiActionHost & {
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn<(text: string) => void>(),
     composerText: vi.fn(() => composer),

--- a/tests/keymap.test.ts
+++ b/tests/keymap.test.ts
@@ -67,6 +67,7 @@ function actionHarness(initial: TuiBehaviorSettings = DEFAULT_TUI_BEHAVIOR): {
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     applyBehavior: vi.fn((behavior: TuiBehaviorSettings) => {
       applyKeyBindingOverrides(behavior.keyBindings)

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -142,6 +142,7 @@ describe('terminal locale preference', () => {
       refresh: vi.fn(),
       refreshHeader: vi.fn(),
       applyTheme: vi.fn(),
+      applyAppearance: vi.fn(),
       applyLocale,
       setEditor: vi.fn(),
       copy: vi.fn(),

--- a/tests/overlay-backstack.test.ts
+++ b/tests/overlay-backstack.test.ts
@@ -129,6 +129,7 @@ function actionHarness(capabilities: Partial<HarnessTuiCapabilities> = {}): {
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn(),
     copy: vi.fn(),

--- a/tests/process-guards.test.ts
+++ b/tests/process-guards.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
 import {
   attachFatalGuards,
+  attachSuspendGuards,
   createFatalHandler,
   FATAL_SIGHUP_EXIT_CODE,
   FATAL_SIGTERM_EXIT_CODE,
@@ -9,6 +11,45 @@ import {
   restoreTerminalSync,
   withCleanupTimeout,
 } from '../src/process-guards.ts'
+
+describe('POSIX suspend guards', () => {
+  it.each(['linux', 'darwin'] as const)('restores before stopping and resumes once on %s', platform => {
+    const events = new EventEmitter()
+    const order: string[] = []
+    const detach = attachSuspendGuards({
+      suspend: () => { order.push('restore+stop') },
+      resume: () => { order.push('start+query+redraw') },
+    }, {
+      platform,
+      on: (signal, handler) => events.on(signal, handler),
+      off: (signal, handler) => events.off(signal, handler),
+      suspendSelf: () => { order.push('SIGSTOP') },
+    })
+    events.emit('SIGCONT')
+    expect(order).toEqual([])
+    events.emit('SIGTSTP')
+    events.emit('SIGTSTP')
+    expect(order).toEqual(['restore+stop', 'SIGSTOP'])
+    events.emit('SIGCONT')
+    events.emit('SIGCONT')
+    expect(order).toEqual(['restore+stop', 'SIGSTOP', 'start+query+redraw'])
+    detach()
+    detach()
+    expect(events.listenerCount('SIGTSTP')).toBe(0)
+    expect(events.listenerCount('SIGCONT')).toBe(0)
+  })
+
+  it('does not install unsupported job-control signals on Windows', () => {
+    const on = vi.fn()
+    const off = vi.fn()
+    const suspendSelf = vi.fn()
+    const detach = attachSuspendGuards({ suspend: vi.fn(), resume: vi.fn() }, { platform: 'win32', on, off, suspendSelf })
+    detach()
+    expect(on).not.toHaveBeenCalled()
+    expect(off).not.toHaveBeenCalled()
+    expect(suspendSelf).not.toHaveBeenCalled()
+  })
+})
 
 describe('fatal terminal restore (review #14)', () => {
   it('restores cooked mode and the cursor synchronously before any cleanup', () => {

--- a/tests/queue-order.test.ts
+++ b/tests/queue-order.test.ts
@@ -74,6 +74,7 @@ describe('queue reorder', () => {
       refresh: vi.fn(),
       refreshHeader: vi.fn(),
       applyTheme: vi.fn(),
+      applyAppearance: vi.fn(),
       applyLocale: vi.fn(),
       setEditor: vi.fn(),
       copy: vi.fn(),

--- a/tests/session-allowlist.test.ts
+++ b/tests/session-allowlist.test.ts
@@ -26,6 +26,7 @@ function host(
     refresh: vi.fn(),
     refreshHeader: vi.fn(),
     applyTheme: vi.fn(),
+    applyAppearance: vi.fn(),
     applyLocale: vi.fn(),
     setEditor: vi.fn(),
     copy: vi.fn(),

--- a/tests/settings-schema-i18n.test.ts
+++ b/tests/settings-schema-i18n.test.ts
@@ -35,6 +35,9 @@ describe('settings schema locale metadata (review #57)', () => {
     const theme = settingsFields(appearance).find(field => field.path[0] === 'theme')
     expect(theme?.description).toContain('interface theme')
     expect(theme?.description).not.toMatch(HAN)
+    const background = settingsFields(appearance).find(field => field.path[0] === 'backgroundMode')
+    expect(background?.description).toContain('terminal effects')
+    expect(background?.description).not.toMatch(HAN)
     const elapsed = settingsFields(behavior).find(field => field.path[0] === 'statusElapsed')
     expect(elapsed?.description).toContain('elapsed')
     expect(elapsed?.description).not.toMatch(HAN)
@@ -44,6 +47,17 @@ describe('settings schema locale metadata (review #57)', () => {
 
     setUiLocale('zh')
     expect(settingsFields(appearance).find(field => field.path[0] === 'theme')?.description).toContain('界面主题')
+    expect(settingsFields(appearance).find(field => field.path[0] === 'backgroundMode')?.description).toContain('终端效果')
+  })
+
+  it('defaults the Harness schema for old profiles and rejects unknown background modes', () => {
+    expect(AppearanceSettingsSchema({}).backgroundMode).toBe('theme')
+    expect(AppearanceSettingsSchema({ theme: 'light' }).backgroundMode).toBe('theme')
+    for (const backgroundMode of ['theme', 'terminal', 'explicit'] as const) {
+      expect(AppearanceSettingsSchema({ backgroundMode }).backgroundMode).toBe(backgroundMode)
+    }
+    // @ts-expect-error external persisted settings can contain invalid values
+    expect(() => AppearanceSettingsSchema({ backgroundMode: 'unknown' })).toThrow()
   })
 
   it('keeps the pnpm PATH warning as a stable machine string', () => {

--- a/tests/terminal-background.test.ts
+++ b/tests/terminal-background.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Input, StdinBuffer, TUI, type Terminal } from '@mariozechner/pi-tui'
+import {
+  BACKGROUND_QUERY,
+  BACKGROUND_QUERY_TIMEOUT_MS,
+  supportsTerminalBackground,
+  TerminalBackground,
+} from '../src/client/terminal-background.ts'
+import { createTerminalSession, type ManagedTerminal } from '../src/client/terminal-session.ts'
+import { createFatalHandler } from '../src/process-guards.ts'
+
+const ESC = '\u001B'
+const ST = `${ESC}\\`
+const ORIGINAL = 'rgb:0c0c/1234/abcd'
+const reply = (color = ORIGINAL, end = ST): string => `${ESC}]11;${color}${end}`
+const desired = reply('rgb:28/2c/34')
+const truecolor = { COLORTERM: 'truecolor', TERM: 'xterm-256color' }
+const paste = (text: string): string => `${ESC}[200~${text}${ESC}[201~`
+
+function controller(enabled = true) {
+  const writes: string[] = []
+  const background = new TerminalBackground({ write: data => { writes.push(data) } }, enabled)
+  background.setColor('#282C34')
+  return { background, writes }
+}
+
+afterEach(() => { vi.useRealTimers() })
+
+describe('terminal background capability policy', () => {
+  it.each([
+    { WT_SESSION: 'test' },
+    { TERM_PROGRAM: 'iTerm.app' },
+    { TERM_PROGRAM: 'vscode' },
+    { TERM: 'xterm-kitty', COLORTERM: 'truecolor' },
+    { TERM: 'xterm-ghostty', COLORTERM: 'truecolor' },
+    { ...truecolor, SSH_CONNECTION: 'test' },
+  ])('allows a bounded probe without an OS-specific implementation: %j', env => {
+    expect(supportsTerminalBackground(env)).toBe(true)
+  })
+
+  it.each([
+    {}, { TERM: 'xterm-256color' }, { TERM_PROGRAM: 'Apple_Terminal' },
+    { ...truecolor, NO_COLOR: '' }, { ...truecolor, TERM: 'dumb' },
+    { ...truecolor, TMUX: 'test' }, { ...truecolor, STY: 'test' },
+    { ...truecolor, TERM: 'tmux-256color' }, { ...truecolor, TERM: 'screen-256color' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: 'off' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: '0' },
+    { ...truecolor, SEEKTTY_TERMINAL_BACKGROUND: ' FALSE ' },
+  ])('leaves unsupported, opted-out and multiplexed terminals untouched: %j', env => {
+    expect(supportsTerminalBackground(env)).toBe(false)
+  })
+})
+
+describe('background ownership', () => {
+  it('waits for a valid reply, follows theme changes and restores exact original precision once', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    expect(writes).toEqual([])
+    background.start()
+    background.start()
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    expect(background.consumeInput(reply())).toBe(true)
+    expect(writes).toEqual([BACKGROUND_QUERY, desired])
+    background.setColor('#282c34')
+    background.setColor('#FFFFFF')
+    background.setColor('#FFFFFF')
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply('rgb:ff/ff/ff')])
+    background.restore()
+    background.restore()
+    expect(writes.at(-1)).toBe(reply())
+    expect(writes).toHaveLength(4)
+    expect(writes.join('')).not.toContain(`${ESC}]111`)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([ST, '\u0007'])('accepts the standard %j terminator and 1–4 digit RGB channels', end => {
+    const { background, writes } = controller()
+    background.start()
+    background.consumeInput(reply('rgb:F/Ab/123', end))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply('rgb:f/ab/123')])
+  })
+
+  it('uses the newest requested theme if it changes while the query is pending', () => {
+    const { background, writes } = controller()
+    background.start()
+    background.setColor('#123456')
+    background.consumeInput(reply())
+    expect(writes).toEqual([BACKGROUND_QUERY, reply('rgb:12/34/56')])
+    background.restore()
+  })
+
+  it('ignores malformed, duplicate and unsolicited reports without passing them to editors', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    expect(background.consumeInput(reply())).toBe(true)
+    expect(writes).toEqual([])
+    background.start()
+    for (const data of [reply('rgb:12345/0/0'), reply('red'), reply('rgb:gg/00/00'), `${ESC}]11;rgb:0/0/0`, `${ESC}]11;?${ST}`, `${ESC}]52;c;bad${ST}`]) {
+      expect(background.consumeInput(data)).toBe(true)
+    }
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.consumeInput(reply())
+    background.consumeInput(reply('rgb:ff/ff/ff'))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply()])
+  })
+
+  it('does not consume normal keys, plain text or an opaque bracketed paste', () => {
+    const { background } = controller()
+    for (const data of ['abc', '中文', ESC, `${ESC}[A`, ']11;rgb:ff/ff/ff', paste(reply())]) {
+      expect(background.consumeInput(data)).toBe(false)
+    }
+  })
+
+  it('never recolors on timeout or late replies and never polls on repaint/theme changes', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    background.start()
+    vi.advanceTimersByTime(BACKGROUND_QUERY_TIMEOUT_MS)
+    background.consumeInput(reply())
+    for (let index = 0; index < 100; index++) {
+      background.start()
+      background.setColor(index % 2 === 0 ? '#FFFFFF' : '#000000')
+    }
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels an early exit and re-queries a new original color on a later lifetime', () => {
+    vi.useFakeTimers()
+    const { background, writes } = controller()
+    background.start()
+    background.restore()
+    background.consumeInput(reply())
+    background.setColor('#FFFFFF')
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.start()
+    background.consumeInput(reply('rgb:1/2/3'))
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, BACKGROUND_QUERY, reply('rgb:ff/ff/ff'), reply('rgb:1/2/3')])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does nothing when disabled, even with valid replies', () => {
+    const { background, writes } = controller(false)
+    background.start()
+    background.consumeInput(reply())
+    background.setColor('#FFFFFF')
+    background.restore()
+    expect(writes).toEqual([])
+  })
+
+  it('rejects theme command injection and fails safely when the write port throws', () => {
+    const writes: string[] = []
+    const background = new TerminalBackground({ write: data => {
+      writes.push(data)
+      if (data === desired) throw new Error('broken write')
+    } }, true)
+    background.setColor(`${ESC}]11;red${ST}`)
+    background.start()
+    expect(writes).toEqual([])
+    background.setColor('#282C34')
+    background.start()
+    expect(() => background.consumeInput(reply())).not.toThrow()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply()])
+    background.setColor('#FFFFFF')
+    background.restore()
+    expect(writes).toHaveLength(3)
+  })
+})
+
+/** Same StdinBuffer → TerminalSession → TUI boundary as the interactive Surface. */
+class VirtualTerminal implements Terminal, ManagedTerminal {
+  columns = 80
+  rows = 24
+  kittyProtocolActive = false
+  writes: string[] = []
+  readonly stdin = new StdinBuffer({ timeout: 10 })
+  start(onInput: (data: string) => void): void {
+    this.stdin.on('data', onInput)
+    this.stdin.on('paste', content => { onInput(paste(content)) })
+  }
+  stop(): void { this.stdin.destroy() }
+  drainInput(): Promise<void> { return Promise.resolve() }
+  restoreProtocolsSync(): void { this.stdin.clear() }
+  restoreRawModeSync(): void {}
+  write(data: string): void { this.writes.push(data) }
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+function inputHarness() {
+  const terminal = new VirtualTerminal()
+  const tui = new TUI(terminal, false)
+  const session = createTerminalSession(terminal, true, () => undefined, truecolor)
+  const keys: string[] = []
+  tui.addInputListener(data => {
+    if (session.consumeInput(data)) return { consume: true }
+    keys.push(data)
+    return undefined
+  })
+  const composer = new Input()
+  const search = new Input()
+  const nestedSearch = new Input()
+  tui.addChild(composer)
+  tui.setFocus(composer)
+  session.setBackgroundColor('#282C34')
+  session.enter()
+  // No query before input listeners/raw mode are ready.
+  expect(terminal.writes).not.toContain(BACKGROUND_QUERY)
+  tui.start()
+  tui.showOverlay(search)
+  tui.showOverlay(nestedSearch)
+  session.startBackgroundSync()
+  return { terminal, session, keys, composer, search, nestedSearch, close: () => { session.restore(); tui.stop() } }
+}
+
+describe('OSC framing and nested input isolation', () => {
+  it.each([ST, '\u0007'])('handles every split, including slow fragments after the OSC opener (%j)', end => {
+    vi.useFakeTimers()
+    const data = reply(ORIGINAL, end)
+    for (let split = 1; split < data.length; split++) {
+      const harness = inputHarness()
+      try {
+        harness.terminal.stdin.process(`a${ESC}${data.slice(0, split)}`)
+        vi.advanceTimersByTime(split === 1 ? 5 : 100)
+        harness.terminal.stdin.process(`${data.slice(split)}b`)
+        expect(harness.keys, `split ${split}`).toEqual(['a', ESC, 'b'])
+        expect(harness.nestedSearch.getValue()).toBe('ab')
+        expect(harness.search.getValue()).toBe('')
+        expect(harness.composer.getValue()).toBe('')
+        expect(harness.terminal.writes).toContain(desired)
+      } finally { harness.close() }
+    }
+  })
+
+  it('discards a delayed reply after timeout without dirtying a nested search or changing color', () => {
+    vi.useFakeTimers()
+    const harness = inputHarness()
+    try {
+      harness.terminal.stdin.process(`${ESC}]11;rgb:0c0c/`)
+      vi.advanceTimersByTime(1000)
+      expect(harness.terminal.stdin.flush()).toEqual([])
+      harness.terminal.stdin.process(`1234/abcd${ST}z`)
+      expect(harness.keys).toEqual(['z'])
+      expect(harness.nestedSearch.getValue()).toBe('z')
+      expect(harness.terminal.writes).not.toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('preserves opaque paste and normal keys while canceling truncated OSC on a fresh escape', () => {
+    const harness = inputHarness()
+    try {
+      const literal = paste(`中文 ${reply()} [<35;20;13M`)
+      harness.terminal.stdin.process(`${ESC}]11;rgb:bad${literal}${ESC}[A`)
+      expect(harness.keys).toEqual([literal, `${ESC}[A`])
+      expect(harness.terminal.writes).not.toContain(desired)
+      harness.terminal.stdin.process(`${ESC}]11;unfinished${ESC}[B`)
+      expect(harness.keys.at(-1)).toBe(`${ESC}[B`)
+      harness.terminal.stdin.process(reply())
+      expect(harness.terminal.writes).toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('bounds oversized OSC, preserves split ST, and does not turn the tail into text', () => {
+    const harness = inputHarness()
+    try {
+      harness.terminal.stdin.process(`${ESC}]11;${'f'.repeat(100_000)}${ESC}`)
+      expect(harness.terminal.stdin.getBuffer().length).toBeLessThanOrEqual(1024)
+      harness.terminal.stdin.process('\\z')
+      expect(harness.keys).toEqual(['z'])
+      expect(harness.terminal.writes).not.toContain(desired)
+    } finally { harness.close() }
+  })
+
+  it('restores background synchronously before fatal cleanup and private-mode teardown', async () => {
+    const harness = inputHarness()
+    harness.terminal.stdin.process(reply())
+    const exit = vi.fn()
+    const handle = createFatalHandler({
+      restore: () => { harness.session.restore() },
+      cleanup: async () => {
+        expect(harness.terminal.writes).toContain(reply())
+        harness.close()
+      },
+      writeError: () => undefined,
+      formatError: () => '',
+      exit,
+    })
+    handle(undefined, 143)
+    const restoredAt = harness.terminal.writes.indexOf(reply())
+    const leaveAt = harness.terminal.writes.findIndex(data => data.includes(`${ESC}[?1049l`))
+    expect(restoredAt).toBeGreaterThan(-1)
+    expect(restoredAt).toBeLessThan(leaveAt)
+    await vi.waitFor(() => { expect(exit).toHaveBeenCalledWith(143) })
+    expect(harness.terminal.writes.filter(data => data === reply())).toHaveLength(1)
+  })
+})

--- a/tests/terminal-background.test.ts
+++ b/tests/terminal-background.test.ts
@@ -19,9 +19,10 @@ const paste = (text: string): string => `${ESC}[200~${text}${ESC}[201~`
 
 function controller(enabled = true) {
   const writes: string[] = []
-  const background = new TerminalBackground({ write: data => { writes.push(data) } }, enabled)
+  const notice = vi.fn()
+  const background = new TerminalBackground({ write: data => { writes.push(data) } }, enabled, notice)
   background.setColor('#282C34')
-  return { background, writes }
+  return { background, writes, notice }
 }
 
 afterEach(() => { vi.useRealTimers() })
@@ -52,6 +53,85 @@ describe('terminal background capability policy', () => {
 })
 
 describe('background ownership', () => {
+  it('defers its single query until input is ready and a synchronizing mode is selected', () => {
+    const { background, writes } = controller()
+    background.setColor('#282C34', 'terminal')
+    background.start()
+    expect(writes).toEqual([])
+    background.setColor('#282C34', 'explicit')
+    background.start()
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.consumeInput(reply())
+    background.setColor('#282C34', 'theme')
+    expect(writes).toEqual([BACKGROUND_QUERY, desired])
+    background.restore()
+  })
+
+  it('restores on terminal mode and reuses the same exact snapshot across all mode switches', () => {
+    const { background, writes } = controller()
+    background.start()
+    background.consumeInput(reply())
+    background.setColor('#282C34', 'explicit')
+    background.setColor('#FFFFFF', 'terminal')
+    background.setColor('#123456', 'terminal')
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply()])
+    background.setColor('#123456', 'theme')
+    background.setColor('#123456', 'explicit')
+    background.restore()
+    expect(writes).toEqual([BACKGROUND_QUERY, desired, reply(), reply('rgb:12/34/56'), reply()])
+  })
+
+  it('captures a pending reply in terminal mode without recoloring or re-querying', () => {
+    const { background, writes } = controller()
+    background.start()
+    background.setColor('#FFFFFF', 'terminal')
+    background.consumeInput(reply())
+    background.consumeInput(reply('rgb:1/2/3'))
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.setColor('#FFFFFF', 'theme')
+    expect(writes).toEqual([BACKGROUND_QUERY, reply('rgb:ff/ff/ff')])
+    background.setColor('#FFFFFF', 'terminal')
+    background.restore()
+    expect(writes.at(-1)).toBe(reply())
+    expect(writes).toHaveLength(3)
+  })
+
+  it('never retries an expired query and reports unavailable theme sync once, even after mode changes', () => {
+    vi.useFakeTimers()
+    const { background, writes, notice } = controller()
+    background.start()
+    background.setColor('#FFFFFF', 'terminal')
+    vi.advanceTimersByTime(BACKGROUND_QUERY_TIMEOUT_MS)
+    expect(notice).not.toHaveBeenCalled()
+    background.consumeInput(reply())
+    background.setColor('#FFFFFF', 'explicit')
+    expect(notice).not.toHaveBeenCalled()
+    for (let i = 0; i < 3; i++) {
+      background.setColor('#FFFFFF', 'theme')
+      background.setColor('#FFFFFF', 'terminal')
+      background.start()
+    }
+    expect(notice).toHaveBeenCalledExactlyOnceWith('timeout')
+    expect(writes).toEqual([BACKGROUND_QUERY])
+    background.restore()
+  })
+
+  it('reports disabled sync only in theme mode and resets notice/probe ownership on resume', () => {
+    const { background, writes, notice } = controller(false)
+    background.setColor('#282C34', 'terminal')
+    background.start()
+    background.setColor('#282C34', 'explicit')
+    expect(notice).not.toHaveBeenCalled()
+    background.setColor('#282C34', 'theme')
+    background.start()
+    expect(notice).toHaveBeenCalledExactlyOnceWith('unsupported')
+    background.restore()
+    background.start()
+    expect(notice).toHaveBeenCalledTimes(2)
+    expect(writes).toEqual([])
+    background.restore()
+  })
+
   it('waits for a valid reply, follows theme changes and restores exact original precision once', () => {
     vi.useFakeTimers()
     const { background, writes } = controller()

--- a/tests/terminal-background.test.ts
+++ b/tests/terminal-background.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/client/terminal-background.ts'
 import { createTerminalSession, type ManagedTerminal } from '../src/client/terminal-session.ts'
 import { createFatalHandler } from '../src/process-guards.ts'
+import { OverlayQueue } from '../src/client/overlays.ts'
 
 const ESC = '\u001B'
 const ST = `${ESC}\\`
@@ -300,10 +301,28 @@ function inputHarness() {
   tui.showOverlay(search)
   tui.showOverlay(nestedSearch)
   session.startBackgroundSync()
-  return { terminal, session, keys, composer, search, nestedSearch, close: () => { session.restore(); tui.stop() } }
+  return { terminal, tui, session, keys, composer, search, nestedSearch, close: () => { session.restore(); tui.stop() } }
 }
 
 describe('OSC framing and nested input isolation', () => {
+  it.each(['theme', 'terminal', 'explicit'] as const)('keeps OSC replies out of an actual API-key overlay in %s mode', async mode => {
+    vi.useFakeTimers()
+    const harness = inputHarness()
+    const overlays = new OverlayQueue(harness.tui)
+    const secret = overlays.secretInput({ title: 'API key' })
+    try {
+      await vi.advanceTimersByTimeAsync(40)
+      harness.session.setBackgroundColor('#282C34', mode)
+      harness.terminal.stdin.process(`sk-fixture${reply()}${reply('invalid')}`)
+      vi.advanceTimersByTime(BACKGROUND_QUERY_TIMEOUT_MS + 1)
+      harness.terminal.stdin.process(`${reply('rgb:1/2/3')}-tail\r`)
+      expect(await secret).toBe('sk-fixture-tail')
+      expect(harness.search.getValue()).toBe('')
+      expect(harness.composer.getValue()).toBe('')
+      expect(harness.keys.join('')).not.toContain(']11;')
+    } finally { overlays.dispose(); harness.close() }
+  })
+
   it.each([ST, '\u0007'])('handles every split, including slow fragments after the OSC opener (%j)', end => {
     vi.useFakeTimers()
     const data = reply(ORIGINAL, end)

--- a/tests/theme-config.test.ts
+++ b/tests/theme-config.test.ts
@@ -86,11 +86,23 @@ describe('theme colors and generated palettes', () => {
 describe('durable custom theme validation', () => {
   it('migrates legacy dark/light values and resolves named themes', () => {
     expect(normalizeAppearance({ theme: 'light' })).toEqual({
-      theme: 'light', codeTheme: 'auto', customThemes: [],
+      theme: 'light', codeTheme: 'auto', backgroundMode: 'theme', customThemes: [],
     })
     const ocean = editableTheme(BUILT_IN_THEMES.dark, 'ocean', 'Ocean')
     const appearance = normalizeAppearance({ theme: 'custom:ocean', customThemes: [ocean] })
     expect(resolveTheme(appearance).name).toBe('Ocean')
+  })
+
+  it.each(['theme', 'terminal', 'explicit'])('accepts the independent %s background mode', backgroundMode => {
+    const appearance = normalizeAppearance({ theme: 'dark', backgroundMode })
+    expect(appearance.backgroundMode).toBe(backgroundMode)
+    expect(resolveAppearanceTheme(appearance)).not.toHaveProperty('backgroundMode')
+  })
+
+  it.each([null, '', 'auto', 0, false, {}])('rejects invalid background mode %j', backgroundMode => {
+    expect(() => normalizeAppearance({ theme: 'dark', backgroundMode })).toThrow('背景模式')
+    setUiLocale('en')
+    expect(() => normalizeAppearance({ theme: 'dark', backgroundMode })).toThrow('background mode')
   })
 
   it('pairs DeepSeek light with light code by default and accepts an explicit dark code theme', () => {

--- a/tests/theme-export.test.ts
+++ b/tests/theme-export.test.ts
@@ -22,7 +22,7 @@ import {
   type TuiSettingsPathOp,
 } from '../src/protocol.ts'
 
-function document(value: TuiAppearanceSettings, revision = 0): TuiSettingsDocument {
+function document(value: Omit<TuiAppearanceSettings, 'backgroundMode'>, revision = 0): TuiSettingsDocument {
   return {
     namespace: TUI_APPEARANCE_SETTINGS_NAMESPACE,
     schema: {},

--- a/tests/theme-export.test.ts
+++ b/tests/theme-export.test.ts
@@ -103,6 +103,7 @@ describe('/theme export', () => {
         refresh: vi.fn(),
         refreshHeader: vi.fn(),
         applyTheme: vi.fn(),
+        applyAppearance: vi.fn(),
         applyLocale: vi.fn(),
         setEditor: vi.fn(),
         copy: vi.fn(),

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -20,6 +20,7 @@ import {
   background,
   color,
   currentTheme,
+  setBackgroundMode,
   setTheme,
   styleTerminalText,
   surfaceRow,
@@ -51,12 +52,14 @@ function enableTruecolor(): void {
 
 afterEach(() => {
   setTheme(BUILT_IN_THEMES.dark)
+  setBackgroundMode('theme')
   vi.unstubAllEnvs()
 })
 
 describe('terminal themes', () => {
   it('switches every semantic layer between DeepSeek dark and light palettes', () => {
     enableTruecolor()
+    setBackgroundMode('explicit')
 
     setTheme(BUILT_IN_THEMES.dark)
     expect(background.canvas('frame')).toContain('\u001B[48;2;9;14;27m')
@@ -145,7 +148,7 @@ describe('appearance settings', () => {
     enableTruecolor()
     setTheme(themeFromAppearance(appearance('light')))
 
-    expect(background.canvas('interface')).toContain('\u001B[48;2;246;248;253m')
+    expect(background.canvas('interface')).toContain('\u001B[49m')
     expect(background.code('const answer = 42')).toContain('\u001B[48;2;255;255;255m')
     expect(background.code('const answer = 42')).toContain('\u001B[38;2;29;36;51m')
   })

--- a/tests/transcript-viewport.test.ts
+++ b/tests/transcript-viewport.test.ts
@@ -6,6 +6,7 @@ import type {
 import { internals, Transcript } from '../src/client/transcript.ts'
 import type { TranscriptImagePayload } from '../src/client/transcript.ts'
 import { terminalMouseDelta } from '../src/client/terminal-session.ts'
+import { background, setBackgroundMode } from '../src/client/theme.ts'
 
 function assistant(key: string, text: string): ChatConversationViewNode {
   return {
@@ -121,6 +122,7 @@ function plain(lines: readonly string[]): string {
 }
 
 afterEach(() => {
+  setBackgroundMode('theme')
   resetRenderCounters()
   internals.fingerprintsComputed = 0
   internals.markdownCreated = 0
@@ -131,6 +133,39 @@ afterEach(() => {
 })
 
 describe('transcript block viewport', () => {
+  it('preserves the historical viewport, selection, hit maps and render budget across background mode changes', () => {
+    vi.stubEnv('NO_COLOR', undefined)
+    vi.stubEnv('COLORTERM', 'truecolor')
+    vi.stubEnv('TERM', 'xterm-256color')
+    const transcript = new Transcript(() => 8)
+    transcript.update(snapshot(Array.from({ length: 100 }, (_, index) =>
+      assistant(`background-${index}`, `line-${index}`))))
+    transcript.render(80)
+    transcript.scrollBy(20)
+    transcript.render(80)
+    const before = transcript.hitViewportEdgeAnchor(4, 80, 'older', 'before')
+    const after = transcript.hitViewportEdgeAnchor(20, 80, 'newer', 'after')
+    expect(before).toBeDefined()
+    expect(after).toBeDefined()
+    transcript.applyPointerSelection(before!, after!, 'character')
+    const selection = transcript.currentSelection()
+    const copied = transcript.copySelectionText()
+    const lines = plain(transcript.render(80))
+    const maps = transcript.viewportMaps()
+    resetRenderCounters()
+    for (const mode of ['terminal', 'explicit', 'theme'] as const) {
+      setBackgroundMode(mode)
+      transcript.invalidate()
+      expect(plain(transcript.render(80).map(background.canvas))).toBe(lines)
+      expect(transcript.currentSelection()).toEqual(selection)
+      expect(transcript.copySelectionText()).toBe(copied)
+      expect(transcript.viewportMaps()).toEqual(maps)
+    }
+    expect(internals.lastFullLinesCopied).toBe(0)
+    expect(internals.blocksVisited).toBeLessThan(40)
+    transcript.dispose()
+  })
+
   it('bounds editor-only render work by the viewport instead of history size', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 8)

--- a/tests/tui-render-stability.test.ts
+++ b/tests/tui-render-stability.test.ts
@@ -696,7 +696,7 @@ describe('SeekTTY Box + BottomAnchoredLayout first-frame bytes (not native pixel
       const painted = tui.render(columns)
       expect(painted.length, label).toBe(rows)
       expect(painted.every(line => visibleWidth(line) === columns), label).toBe(true)
-      if (color) expect(first, label).toMatch(/\u001B\[48;/u)
+      if (color) expect(first, label).toContain('\u001B[49m')
       terminal.reset()
       tui.requestRender(true)
       await nextFrame()


### PR DESCRIPTION
## Dependency and review scope

Depends on #162, which is still open. Please merge #162 first, then review/merge this feature PR. This is a separate branch and does not add functionality to the existing background-sync PR.

Until #162 lands, the comparison against `main` includes its prerequisite commit `662b753`. The feature itself consists of three commits: `8f96856`, `e4273fd`, and `53b0b5f`.

## Summary

Let the main canvas inherit terminal-owned transparency, blur, and background-image effects while retaining SeekTTY's interface theme. This changes the default canvas behavior; `explicit` preserves the previous explicit background fill.

| `seektty-appearance.backgroundMode` | Main canvas | Terminal color ownership |
| --- | --- | --- |
| `theme` (default, including legacy settings) | Terminal default background (`SGR 49`) | Synchronize the theme color through the existing guarded OSC 11 controller |
| `terminal` | Terminal default background (`SGR 49`) | Do not recolor; restore the original captured earlier in the current lifetime |
| `explicit` | Explicit theme background | Preserve the previous color-sync behavior; opacity still depends on the terminal |

- Share one localized three-option editor between `/theme` and `/settings seektty-appearance`.
- Persist through Harness Settings before applying; failed saves and cancellation preserve the current appearance. Theme preview/import/export do not overwrite the background mode.
- Keep the canvas, full-row blank filling, and old-character cleanup. Mode changes force a full repaint without restarting the session or changing viewport geometry, scroll anchors, selection, or mouse hit regions.
- Keep panel, code-block, selection, and hover backgrounds and syntax-highlighting colors unchanged.
- Preserve one deferred asynchronous 500 ms OSC 11 query per active terminal lifetime, exact original-color restoration, deduplicated writes, and safe handling of mode switches during a pending query.
- Consume malformed, duplicate, late, and unsolicited OSC replies before editable fields. Unsupported or disabled synchronization leaves the default canvas in place with one non-blocking notice in `theme` mode.
- Retain `SEEKTTY_TERMINAL_BACKGROUND=off`, multiplexer, low-color, and non-interactive safety restrictions. The environment switch disables recoloring, not the selected canvas mode.

No dependencies, opacity-percentage probes, terminal-specific opacity APIs, or terminal-configuration writes are added. Harness remains the owner of Settings, Profiles, Sessions, plugins, and persistence.

## Validation

Results recorded during implementation for this candidate:

- [x] `pnpm run check`: 113 test files; 962 passed, 1 unrelated conditional skip; typecheck and build passed.
- [x] Package allowlist: 23 entries; no consumer `workspace:` dependency, personal theme, credential, or local Profile included.
- [x] Fresh, unmodified official dsh `0.1.1-rc.2`: isolated candidate install, boot, remove, reinstall, second boot, launcher, and Host module-identity checks passed.
- [x] Existing Windows ConPTY mouse harness: packaged boot, gestures, resize, and exit passed.
- [x] Additional truecolor ConPTY probe: `theme → terminal → explicit → theme`, persisted settings, theme entry, resize, explicit RGB output, and clean exit passed. This exercised unavailable-query fallback, **not** GUI transparency or successful OSC 11 restoration in a real emulator.
- [x] Pre-PR `git diff --check` passed.
- [ ] Windows Terminal real-window visual acceptance: not signed off.
- [ ] macOS and Linux real-terminal visual acceptance: no devices available.
- [ ] Real tmux/screen acceptance: not performed; unit policy coverage only.

Automated, PTY, and real-terminal results are intentionally kept separate. No claim of completed three-platform visual verification is made. See `docs/background-inheritance-acceptance.md` for the dated implementation-stage record and manual checklist, and `docs/terminal-background-compatibility.md` for behavior and fallback details.

## Commit structure and documentation

1. Appearance configuration, terminal-color lifecycle, and unit tests.
2. Inherited main canvas, shared operation entry points, and rendering/integration tests.
3. English README with synchronized Chinese documentation, compatibility notes, and acceptance results.

No version bump or release is included. The local candidate retains version `1.2.4`. Personal themes and the unrelated #161 taskbook remain outside this PR.

## 中文说明

本 PR 基于尚未合并的 #162，请先合并基础 PR；本次功能独立分支、共 3 个提交，不向原 PR 追加功能。

主画布默认使用“主题颜色＋终端效果”，增加 `theme`、`terminal`、`explicit` 三种背景模式，在 `/theme` 和 `/settings seektty-appearance` 中共用中英文编辑器。保存成功立即生效，失败保持原状态，主题预览与导入导出不覆盖背景模式。

保留原画布布局、空白清理及鼠标命中，模式切换完整重绘但不重建会话、不移动选区或滚动锚点；弹窗、代码块、选区和 hover 仍保留独立底色。不读取透明度、不调用专用透明度 API、不修改终端配置、不新增依赖。

复用并完善 OSC 11 查询与精确恢复生命周期，切回 `terminal` 时恢复原色，禁用或不支持改色时安全降级，不让控制序列进入聊天、搜索或 API Key 输入框。

全量检查、打包、官方 dsh 隔离安装／启动／移除／重装及 ConPTY 验证已通过；三端实机视觉验收尚未全部完成，文档明确区分实机、PTY 与单元结果。本 PR 不发布版本，也不包含个人主题和 #161 任务书。
