### PR TITLE
fix(overlays): use available width for option descriptions

### DIFF
--- a/docs/issue-163-overlay-description-verification.md
+++ b/docs/issue-163-overlay-description-verification.md
@@ -1,0 +1,51 @@
+# Overlay description width — issue #163
+
+Verified on 2026-08-29 (Asia/Shanghai). Branch: `codex/fix-overlay-description-width`, based on `upstream/main` at `8b41904`. This fix is independent of the pending background PRs #162 and #164.
+
+Issue: [Overlay descriptions truncate despite available space](https://github.com/Hilbert-beinghappy/seektty/issues/163).
+
+## Cause and fix
+
+Both single-select and multi-select overlays truncated descriptions before handing them to pi-tui: `Math.min(60, width - 36)`. Expanding the overlay could not recover the lost suffix. The fixed 32-cell primary column also wasted space for short labels.
+
+- Preserve the complete, translated, terminal-sanitized description in each `SelectItem`, including a single-select row's disabled reason.
+- Use the existing `SelectList` layout options to size the primary column from the widest filtered label, up to its previous 32-cell cap. Alignment stays consistent across scroll windows. Prefix, gap, ANSI/Unicode cell widths and the remaining description budget are calculated by the native renderer, not duplicated in the overlay.
+- Extend the existing pinned `@mariozechner/pi-tui@0.73.1` patch with an optional `descriptionEllipsis`. Overlays request `…` at the final description truncation; other consumers retain their existing default. No new dependency or renderer is introduced.
+- Remove description-width bookkeeping and list reconstruction during resize. The same list retains its query, selection and wheel offset. Multi-select checks, mouse arming, hover, row heights, footer actions and hit testing retain their existing behavior.
+
+Rows remain single-line. Overlong descriptions still show an ellipsis when there is insufficient space; widening the overlay reveals the full source. The existing extremely narrow title-only fallback remains: pi-tui omits descriptions at content widths of 40 cells or less, or when its minimum description budget is unavailable. This fix does not add wrapping or a new detail-view interaction.
+
+Only this package's bundled pi-tui is patched. Official dsh is unmodified, native `dsh plugin` reconciliation is preserved, and the declared Host compatibility range remains `>=0.1.0-rc.6 <=0.1.0-rc.8 || 0.1.1-rc.2` (this acceptance used `0.1.1-rc.2`). No user Profile, terminal settings, personal theme, or #161 taskbook was changed.
+
+## Automated and packaged verification
+
+The initial 16-test regression suite reproduced 12 failures on the old code, including descriptions cut at 60 cells in a 240-cell overlay. The final suite includes 20 description-layout tests and two additional pointer/frame integration cases.
+
+| Layer | Result | Coverage / limits |
+| --- | --- | --- |
+| `pnpm run check` | Passed: 110 test files, 914 passed, 1 unrelated conditional skip | Typecheck, full tests, build and package checks. The conditional Clarify integration test is unrelated. |
+| Description layout regressions | 20 passed | Single/multi-select, widths 40/50/60/79/80/180/240, exact-fit boundaries, long/short titles, disabled reasons, multiline normalization, CJK, emoji, combining characters, ANSI-styled descriptions, built-in and generated custom themes. |
+| Pointer/frame integration | 14 passed, including 2 new cases | Real pi-tui frames with synthetic SGR wheel/click/hover events, resizing, footer activation and no search-input leakage. Not a real GUI terminal. |
+| Official dsh `0.1.1-rc.2` | Passed | Candidate install, full boot to the non-interactive boundary, remove, reinstall, second boot, packed launcher and Host module identity in isolated `DSH_HOME` directories. |
+| Windows ConPTY mouse harness | Passed: 1 cycle, 9,585 captured characters, exit 0 | Packaged interactive boot, mouse/context-menu gestures, resize and exit. This existing smoke test does not visually inspect `/mode` descriptions. |
+| Package and diff | Passed | 23 allowlisted package entries; candidate `lib/index.js` matches the final build; `git diff --check` clean. No consumer `workspace:` dependencies. |
+
+Environment: Windows, Node `26.1.0`, pnpm `11.7.0`, pi-tui `0.73.1`, node-pty `1.1.0`. The local candidate retains version `1.2.4`; this is not a release.
+
+Candidate SHA-256:
+
+```text
+33cfc3a9d74be40a25ec3d53521bdebb30847a3aa8e89b89201181e8423026b9
+```
+
+## Real-terminal acceptance — pending
+
+- Windows Terminal: no new manual visual verification recorded for this fix. ConPTY results above are not equivalent to viewing the terminal window.
+- macOS and Linux: no devices available; untested.
+- Manual checklist: open `/mode` in a wide terminal; verify complete descriptions when they fit; resize narrower/wider; search and scroll to later options; confirm the query, selected arrow, checked rows and scroll window persist; test click, hover, wheel, arrow keys, Enter and the Back button in both selector types.
+
+## 中文结论
+
+根因是单选与多选弹窗在渲染前把描述固定截到最多 60 列，以及短标题仍占满 32 列。现已保留完整描述，让原生列表按实际标题宽度分配空间，在最终渲染边界才添加省略号。resize 不再重建列表，不引入多行布局，也不改鼠标命中系统。极窄窗口沿用原来的仅标题显示方式。
+
+914 项测试通过、1 项无关条件跳过；构建、打包、官方 dsh 隔离安装／启动／移除／重装及 Windows ConPTY 检查通过。新增测试覆盖中英文、emoji、组合字符、自定义主题、ANSI、宽窄窗口、搜索、选中与滚动状态及鼠标事件。三端实机视觉验收仍待人工确认，不把合成帧或 ConPTY 结果记作实机通过。

--- a/lib/index.js
+++ b/lib/index.js
@@ -4441,7 +4441,7 @@ var SelectList = class {
 			const spacing = " ".repeat(Math.max(1, effectivePrimaryColumnWidth - truncatedValueWidth));
 			const remainingWidth = width - (prefixWidth + truncatedValueWidth + spacing.length) - 2;
 			if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
-				const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, "");
+				const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, this.layout.descriptionEllipsis ?? "");
 				if (isSelected) return this.theme.selectedText(`${prefix}${truncatedValue$1}${spacing}${truncatedDesc}`);
 				const descText = this.theme.description(spacing + truncatedDesc);
 				return prefix + truncatedValue$1 + descText;
@@ -35022,13 +35022,18 @@ function dangerConfirmChoices(confirmLabel) {
 		initialChoiceId: dangerConfirmDefault
 	};
 }
-function rowOf(choice, descriptionWidth) {
+const selectListLayout = {
+	minPrimaryColumnWidth: 1,
+	maxPrimaryColumnWidth: 32,
+	descriptionEllipsis: "…"
+};
+function rowOf(choice) {
 	const state = choice.active === true ? "● " : choice.disabledReason === void 0 ? "  " : "× ";
 	const description = choice.disabledReason ?? choice.description;
 	return {
 		value: choice.id,
 		label: escapeTerminalText(`${state}${translateUiText(choice.label)}`),
-		...description === void 0 ? {} : { description: truncateToWidth(escapeTerminalText(translateUiText(description)), descriptionWidth, "…") }
+		...description === void 0 ? {} : { description: escapeTerminalText(translateUiText(description)) }
 	};
 }
 function escapeFrame(lines) {
@@ -35036,9 +35041,6 @@ function escapeFrame(lines) {
 }
 function frameContentWidth(width) {
 	return Math.max(1, width - 4);
-}
-function selectDescriptionWidth(width) {
-	return Math.max(1, Math.min(60, width - 36));
 }
 function modalRule(title, width, top) {
 	const start = top ? "╭" : "╰";
@@ -35148,7 +35150,6 @@ var SearchSelectOverlay = class {
 	input = new Input();
 	list;
 	filtered;
-	descriptionWidth = 36;
 	notice = "";
 	lastHits = [];
 	armedOptionId;
@@ -35186,14 +35187,6 @@ var SearchSelectOverlay = class {
 	}
 	render(width) {
 		const safeWidth = frameContentWidth(width);
-		const descriptionWidth = selectDescriptionWidth(safeWidth);
-		if (descriptionWidth !== this.descriptionWidth) {
-			const selectedId = this.list.getSelectedItem()?.value;
-			const scrollOffset = this.list.getScrollOffset();
-			this.descriptionWidth = descriptionWidth;
-			this.list = this.createList(this.filtered, selectedId);
-			this.list.setScrollOffset(scrollOffset);
-		}
 		const lines = [];
 		if (this.request.detail !== void 0) lines.push(...wrappedDetail(this.request.detail, safeWidth));
 		if (this.request.searchable !== false) {
@@ -35270,8 +35263,8 @@ var SearchSelectOverlay = class {
 		this.hoveredOptionId = void 0;
 	}
 	createList(choices, preferredId) {
-		const rows = choices.map((choice) => rowOf(choice, this.descriptionWidth));
-		const list$1 = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList);
+		const rows = choices.map(rowOf);
+		const list$1 = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList, selectListLayout);
 		const preferredIndex = preferredId === void 0 ? 0 : rows.findIndex((row) => row.value === preferredId);
 		list$1.setSelectedIndex(Math.max(0, preferredIndex));
 		list$1.onSelect = () => {
@@ -35496,7 +35489,6 @@ var MultiSelectOverlay = class {
 	filtered;
 	list;
 	selected = /* @__PURE__ */ new Set();
-	descriptionWidth = 36;
 	notice = "";
 	lastHits = [];
 	armedOptionId;
@@ -35513,14 +35505,6 @@ var MultiSelectOverlay = class {
 	}
 	render(width) {
 		const safeWidth = frameContentWidth(width);
-		const descriptionWidth = selectDescriptionWidth(safeWidth);
-		if (descriptionWidth !== this.descriptionWidth) {
-			const selectedId = this.list.getSelectedItem()?.value;
-			const scrollOffset = this.list.getScrollOffset();
-			this.descriptionWidth = descriptionWidth;
-			this.list = this.createList(selectedId);
-			this.list.setScrollOffset(scrollOffset);
-		}
 		this.input.focused = this.focused;
 		const prefix = this.request.detail === void 0 ? [] : wrappedDetail(this.request.detail, safeWidth);
 		const label = color.muted(ui("搜索 ", "Search "));
@@ -35608,9 +35592,9 @@ var MultiSelectOverlay = class {
 		const rows = this.filtered.map((choice) => ({
 			value: choice.id,
 			label: escapeTerminalText(`${this.selected.has(choice.id) ? "[x]" : "[ ]"} ${translateUiText(choice.label)}`),
-			...choice.description === void 0 ? {} : { description: truncateToWidth(escapeTerminalText(translateUiText(choice.description)), this.descriptionWidth, "…") }
+			...choice.description === void 0 ? {} : { description: escapeTerminalText(translateUiText(choice.description)) }
 		}));
-		const list$1 = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList);
+		const list$1 = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList, selectListLayout);
 		const index = preferredId === void 0 ? 0 : rows.findIndex((row) => row.value === preferredId);
 		list$1.setSelectedIndex(Math.max(0, index));
 		return list$1;

--- a/patches/@mariozechner__pi-tui@0.73.1.patch
+++ b/patches/@mariozechner__pi-tui@0.73.1.patch
@@ -963,9 +963,11 @@ diff --git a/dist/components/select-list.d.ts b/dist/components/select-list.d.ts
 index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787b31fc6c4 100644
 --- a/dist/components/select-list.d.ts
 +++ b/dist/components/select-list.d.ts
-@@ -23,6 +23,15 @@ export interface SelectListLayoutOptions {
+@@ -23,6 +23,17 @@ export interface SelectListLayoutOptions {
      maxPrimaryColumnWidth?: number;
      truncatePrimary?: (context: SelectListTruncatePrimaryContext) => string;
++    /** Opt-in marker at the final description budget; other lists retain their default. */
++    descriptionEllipsis?: string;
  }
 +export interface SelectListRenderSnapshot {
 +    selectedIndex: number;
@@ -979,7 +981,7 @@ index 9db54d907f801e43208a462bca925f2905787b7a..a42964427ae051bafe1348c51ac7c787
  export declare class SelectList implements Component {
      private items;
      private filteredItems;
-@@ -35,7 +44,14 @@ export declare class SelectList implements Component {
+@@ -35,7 +46,14 @@ export declare class SelectList implements Component {
      onSelectionChange?: (item: SelectItem) => void;
      constructor(items: SelectItem[], maxVisible: number, theme: SelectListTheme, layout?: SelectListLayoutOptions);
      setFilter(filter: string): void;
@@ -1099,6 +1101,15 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7c5a32bd21f69bf1dc73f6d704e4e993
              this.notifySelectionChange();
          }
          // Enter
+@@ -99,7 +131,7 @@ export class SelectList {
+             const descriptionStart = prefixWidth + truncatedValueWidth + spacing.length;
+             const remainingWidth = width - descriptionStart - 2; // -2 for safety
+             if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
+-                const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, "");
++                const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, this.layout.descriptionEllipsis ?? "");
+                 if (isSelected) {
+                     return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
+                 }
 diff --git a/dist/keybindings.d.ts b/dist/keybindings.d.ts
 index a6a5a7e8e0eee248adc8b0883b4ce61d7bd26470..cf0293a2f89698f8a0a02aea1dab6fae6bd8784b 100644
 --- a/dist/keybindings.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-tui@0.73.1': f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb
+  '@mariozechner/pi-tui@0.73.1': e44d3ef96bb90482cb00148906628c6cfdbd03edf6ce5f548460a56fc5c1d1bb
 
 importers:
 
@@ -161,7 +161,7 @@ importers:
         version: 3.18.1
       '@mariozechner/pi-tui':
         specifier: 0.73.1
-        version: 0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)
+        version: 0.73.1(patch_hash=e44d3ef96bb90482cb00148906628c6cfdbd03edf6ce5f548460a56fc5c1d1bb)
       '@types/cross-spawn':
         specifier: 6.0.6
         version: 6.0.6
@@ -3227,7 +3227,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mariozechner/pi-tui@0.73.1(patch_hash=f472a23f09e409782394d4bedce056ea5ad453d836a5333226826dc09d6c58fb)':
+  '@mariozechner/pi-tui@0.73.1(patch_hash=e44d3ef96bb90482cb00148906628c6cfdbd03edf6ce5f548460a56fc5c1d1bb)':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2

--- a/src/client/overlays.ts
+++ b/src/client/overlays.ts
@@ -193,7 +193,15 @@ interface NavigationEntry {
   escapeHandler?: (() => void | Promise<void>) | undefined
 }
 
-function rowOf(choice: OverlayChoice, descriptionWidth: number): SelectItem {
+// Let SelectList align against actual labels, retaining the existing primary
+// column cap. Description truncation belongs only to its final row layout.
+const selectListLayout = {
+  minPrimaryColumnWidth: 1,
+  maxPrimaryColumnWidth: 32,
+  descriptionEllipsis: '…',
+} as const
+
+function rowOf(choice: OverlayChoice): SelectItem {
   const state = choice.active === true ? '● ' : choice.disabledReason === undefined ? '  ' : '× '
   const description = choice.disabledReason ?? choice.description
   return {
@@ -201,7 +209,7 @@ function rowOf(choice: OverlayChoice, descriptionWidth: number): SelectItem {
     label: escapeTerminalText(`${state}${translateUiText(choice.label)}`),
     ...description === undefined
       ? {}
-      : { description: truncateToWidth(escapeTerminalText(translateUiText(description)), descriptionWidth, '…') },
+      : { description: escapeTerminalText(translateUiText(description)) },
   }
 }
 
@@ -211,13 +219,6 @@ function escapeFrame(lines: readonly string[]): string[] {
 
 function frameContentWidth(width: number): number {
   return Math.max(1, width - 4)
-}
-
-function selectDescriptionWidth(width: number): number {
-  // pi-tui reserves a 32-cell primary column, a two-cell prefix, and two
-  // safety cells. Pre-truncate to the actual remainder so its final pass
-  // keeps our explicit ellipsis instead of cutting a word silently.
-  return Math.max(1, Math.min(60, width - 36))
 }
 
 function modalRule(title: string | undefined, width: number, top: boolean): string {
@@ -360,7 +361,6 @@ export class SearchSelectOverlay implements Component {
   private readonly input = new Input()
   private list: SelectList
   private filtered: readonly OverlayChoice[]
-  private descriptionWidth = 36
   private notice = ''
   private lastHits: readonly HitRegion[] = []
   private armedOptionId: string | undefined
@@ -398,14 +398,6 @@ export class SearchSelectOverlay implements Component {
 
   render(width: number): string[] {
     const safeWidth = frameContentWidth(width)
-    const descriptionWidth = selectDescriptionWidth(safeWidth)
-    if (descriptionWidth !== this.descriptionWidth) {
-      const selectedId = this.list.getSelectedItem()?.value
-      const scrollOffset = this.list.getScrollOffset()
-      this.descriptionWidth = descriptionWidth
-      this.list = this.createList(this.filtered, selectedId)
-      this.list.setScrollOffset(scrollOffset)
-    }
     const lines: string[] = []
     if (this.request.detail !== undefined) {
       lines.push(...wrappedDetail(this.request.detail, safeWidth))
@@ -489,8 +481,8 @@ export class SearchSelectOverlay implements Component {
   }
 
   private createList(choices: readonly OverlayChoice[], preferredId?: string): SelectList {
-    const rows = choices.map(choice => rowOf(choice, this.descriptionWidth))
-    const list = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList)
+    const rows = choices.map(rowOf)
+    const list = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList, selectListLayout)
     const preferredIndex = preferredId === undefined ? 0 : rows.findIndex(row => row.value === preferredId)
     list.setSelectedIndex(Math.max(0, preferredIndex))
     list.onSelect = () => { this.choose() }
@@ -705,7 +697,6 @@ class MultiSelectOverlay implements Component {
   private filtered: readonly OverlayChoice[]
   private list: SelectList
   private readonly selected = new Set<string>()
-  private descriptionWidth = 36
   private notice = ''
   private lastHits: readonly HitRegion[] = []
   private armedOptionId: string | undefined
@@ -726,14 +717,6 @@ class MultiSelectOverlay implements Component {
 
   render(width: number): string[] {
     const safeWidth = frameContentWidth(width)
-    const descriptionWidth = selectDescriptionWidth(safeWidth)
-    if (descriptionWidth !== this.descriptionWidth) {
-      const selectedId = this.list.getSelectedItem()?.value
-      const scrollOffset = this.list.getScrollOffset()
-      this.descriptionWidth = descriptionWidth
-      this.list = this.createList(selectedId)
-      this.list.setScrollOffset(scrollOffset)
-    }
     this.input.focused = this.focused
     const prefix = this.request.detail === undefined ? [] : wrappedDetail(this.request.detail, safeWidth)
     const label = color.muted(ui('搜索 ', 'Search '))
@@ -828,9 +811,9 @@ class MultiSelectOverlay implements Component {
       label: escapeTerminalText(`${this.selected.has(choice.id) ? '[x]' : '[ ]'} ${translateUiText(choice.label)}`),
       ...(choice.description === undefined
         ? {}
-        : { description: truncateToWidth(escapeTerminalText(translateUiText(choice.description)), this.descriptionWidth, '…') }),
+        : { description: escapeTerminalText(translateUiText(choice.description)) }),
     }))
-    const list = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList)
+    const list = new SelectList(rows, this.request.maxVisible ?? 10, editorTheme.selectList, selectListLayout)
     const index = preferredId === undefined ? 0 : rows.findIndex(row => row.value === preferredId)
     list.setSelectedIndex(Math.max(0, index))
     return list

--- a/tests/overlay-description-layout.test.ts
+++ b/tests/overlay-description-layout.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SelectList, visibleWidth, type Component, type OverlayHandle, type TUI } from '@mariozechner/pi-tui'
+import { setUiLocale } from '../src/client/locale.ts'
+import { OverlayQueue } from '../src/client/overlays.ts'
+import { background, editorTheme, setTheme } from '../src/client/theme.ts'
+import { BUILT_IN_THEMES, generateThemeCandidates, normalizeAppearance, resolveTheme } from '../src/client/theme-config.ts'
+import { stripCopyDecorations } from '../src/client/text-selection.ts'
+
+function harness() {
+  let component!: Component
+  let lines: string[] = []
+  const tui = {
+    terminal: { rows: 40, columns: 240 }, requestRender: vi.fn(),
+    showOverlay: (value: Component) => {
+      component = value
+      return { hide: vi.fn() } as unknown as OverlayHandle
+    },
+  } as unknown as TUI
+  const overlays = new OverlayQueue(tui)
+  const options = () => overlays.hitChildren().filter(hit => hit.role === 'option')
+  return {
+    overlays,
+    key: (data: string) => { component.handleInput?.(data) },
+    render: (width: number) => {
+      lines = component.render(width)
+      for (const line of lines) expect(visibleWidth(line)).toBe(width)
+      return lines.map(stripCopyDecorations).join('\n')
+    },
+    row: (id: string) => {
+      const hit = options().find(hit => hit.action.kind === 'overlay' && hit.action.optionId === id)
+      if (hit === undefined) throw new Error(`missing row ${id}`)
+      expect(hit.rect.height).toBe(1)
+      return stripCopyDecorations(lines[hit.rect.row] ?? '')
+    },
+    ids: () => options().map(hit => hit.action.kind === 'overlay' ? hit.action.optionId : undefined),
+    hits: options,
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('NO_COLOR', undefined)
+  vi.stubEnv('TERM', 'xterm-256color')
+  vi.stubEnv('COLORTERM', 'truecolor')
+  setUiLocale('en')
+})
+afterEach(() => {
+  setUiLocale('zh')
+  setTheme(BUILT_IN_THEMES.dark)
+  vi.unstubAllEnvs()
+})
+
+const descriptions = [
+  'A complete coding agent with file editing, shell commands, workspace search, web search, and configurable tool access.',
+  '功能完整的编码助手，支持文件编辑、Shell、文件与网页检索，并能根据当前工作区设置执行任务；宽窗口应该完整显示这段说明。',
+  '中文 👩🏽‍💻 e\u0301 🙂 '.repeat(8).trim(),
+  '\u001B[38;2;80;180;220m' + 'Styled 中文🙂 '.repeat(8).trim() + '\u001B[0m',
+]
+const customPalette = generateThemeCandidates('ocean', 'Ocean', '#071426 #F4F8FF #6682FF #37C99B').dark
+const customTheme = resolveTheme(normalizeAppearance({ theme: `custom:${customPalette.id}`, customThemes: [customPalette] }))
+
+describe.each(['select', 'multiSelect'] as const)('%s description layout', method => {
+  it.each([BUILT_IN_THEMES.dark, BUILT_IN_THEMES.light, customTheme])('uses wide space for complete multilingual descriptions with theme $id', async theme => {
+    setTheme(theme)
+    const h = harness()
+    const choices = descriptions.map((description, index) => ({ id: String(index), label: `Mode ${index}`, description }))
+    const pending = h.overlays[method]({ title: 'Agent modes', choices })
+    try {
+      for (const width of [240, 60, 180, 50, 240]) {
+        h.render(width)
+        for (const choice of choices) {
+          const row = h.row(choice.id)
+          if (width >= 180) {
+            expect(row).toContain(stripCopyDecorations(choice.description))
+            expect(row).not.toContain('…')
+          } else {
+            expect(row).toContain('…')
+          }
+          expect(row).not.toContain('\uFFFD')
+        }
+        expect(h.ids()).toEqual(choices.map(choice => choice.id))
+      }
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('gives unused short-title column space back to the description', async () => {
+    const h = harness()
+    const description = '12345678'.repeat(8)
+    const pending = h.overlays[method]({ title: 'picker', choices: [{ id: 'go', label: 'Go', description }] })
+    try {
+      h.render(80)
+      expect(h.row('go')).toContain(description)
+      expect(h.row('go')).not.toContain('…')
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('does not add an ellipsis when the final description budget fits exactly', async () => {
+    const h = harness()
+    // At width 80: frame 4, arrow 2, actual label+gap 6/8, and native safety 2.
+    const description = 'x'.repeat(method === 'select' ? 66 : 64)
+    const pending = h.overlays[method]({ title: 'boundary', choices: [{ id: 'go', label: 'Go', description }] })
+    try {
+      h.render(80)
+      expect(h.row('go')).toContain(description)
+      expect(h.row('go')).not.toContain('…')
+      h.render(79)
+      expect(h.row('go')).toContain('…')
+      h.render(80)
+      expect(h.row('go')).toContain(description)
+      h.render(40) // Keep the existing extremely narrow, title-only fallback.
+      expect(h.row('go')).toContain('Go')
+      expect(h.ids()).toEqual(['go'])
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('normalizes multiline descriptions without changing one-row hit geometry', async () => {
+    const h = harness()
+    const pending = h.overlays[method]({ title: 'multiline', choices: [
+      { id: 'one', label: 'One', description: 'first line\nsecond line\n' + 'readable '.repeat(12).trim() },
+    ] })
+    try {
+      h.render(240)
+      expect(h.row('one')).toContain('first line second line ' + 'readable '.repeat(12).trim())
+      expect(h.ids()).toEqual(['one'])
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('keeps long-title columns bounded and descriptions aligned across scroll windows', async () => {
+    const h = harness()
+    const choices = [
+      { id: 'short', label: 'Go', description: 'DESCRIPTION ' + 'a'.repeat(90) },
+      { id: 'long', label: 'Very long title '.repeat(8), description: 'DESCRIPTION ' + 'b'.repeat(90) },
+    ]
+    const pending = h.overlays[method]({ title: 'picker', maxVisible: 1, choices })
+    try {
+      h.render(180)
+      const start = h.row('short').indexOf('DESCRIPTION')
+      expect(h.row('short')).toContain(choices[0]!.description)
+      h.overlays.handleWheel(-1)
+      h.render(180)
+      expect(h.row('long').indexOf('DESCRIPTION')).toBe(start)
+      expect(h.row('long')).toContain(choices[1]!.description)
+      h.render(80)
+      expect(h.row('long')).toContain('…')
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('retains search, selection, checked state, viewport and hit rows across resize', async () => {
+    const h = harness()
+    const choices = Array.from({ length: 16 }, (_, index) => ({
+      id: `item-${index}`, label: `group-${index}`, description: descriptions[index % descriptions.length]!,
+    }))
+    const pending = h.overlays[method]({ title: 'resize', choices, maxVisible: 4 })
+    try {
+      h.key('group')
+      h.render(80)
+      h.overlays.handleWheel(-5)
+      h.render(80)
+      expect(h.overlays.handleOptionClick('item-6')).toBe('focused')
+      if (method === 'multiSelect') h.key(' ')
+      expect(h.overlays.handleHover('item-7')).toBe(true)
+      const expectedIds = choices.slice(5, 9).map(choice => choice.id)
+      const rows = h.hits().map(hit => hit.rect.row)
+      for (const width of [240, 80, 50, 180, 80]) {
+        expect(h.render(width)).toMatch(/Search .*group/u)
+        expect(h.ids()).toEqual(expectedIds)
+        expect(h.hits().map(hit => hit.rect.row)).toEqual(rows)
+        expect(h.row('item-6')).toMatch(/→ .*group-6/u)
+        if (method === 'multiSelect') expect(h.row('item-6')).toContain('[x] group-6')
+        expect(h.overlays.hitChildren().find(hit => hit.action.kind === 'overlay' && hit.action.command === 'footer-confirm'))
+          .toMatchObject({ enabled: true })
+      }
+      // Keyboard reveal only moves the viewport after the selected row reaches its edge.
+      h.key('\u001B[B')
+      h.render(80)
+      expect(h.ids()).toEqual(expectedIds)
+      h.key('\u001B[B')
+      h.key('\u001B[B')
+      h.render(80)
+      expect(h.ids()).toEqual(choices.slice(6, 10).map(choice => choice.id))
+      if (method === 'select') h.key('\r')
+      else expect(h.overlays.handleFooterClick('footer-confirm')).toBe(true)
+      await expect(pending).resolves.toEqual(method === 'select' ? choices[9] : [choices[6]])
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('preserves an off-screen selection while the wheel viewport is resized', async () => {
+    const h = harness()
+    const choices = Array.from({ length: 12 }, (_, index) => ({ id: String(index), label: `row-${index}`, description: descriptions[0]! }))
+    const pending = h.overlays[method]({ title: 'wheel', choices, maxVisible: 3 })
+    try {
+      h.render(80)
+      h.overlays.handleWheel(-6)
+      for (const width of [240, 50, 80]) {
+        expect(h.render(width)).not.toContain('→')
+        expect(h.ids()).toEqual(['6', '7', '8'])
+      }
+      expect(h.overlays.handleFooterClick('footer-back')).toBe(true)
+      await expect(pending).resolves.toBeUndefined()
+    } finally { h.overlays.dispose(); await pending }
+  })
+})
+
+it('does not pre-truncate the disabled reason or make the disabled row clickable', async () => {
+  const h = harness()
+  const pending = h.overlays.select({ title: 'disabled', choices: [
+    { id: 'disabled', label: 'Unavailable', description: 'ignored', disabledReason: descriptions[0]! },
+  ] })
+  try {
+    h.render(240)
+    expect(h.row('disabled')).toContain(descriptions[0])
+    expect(h.overlays.handleOptionClick('disabled')).toBe('none')
+    h.key('\u001B')
+    await expect(pending).resolves.toBeUndefined()
+  } finally { h.overlays.dispose(); await pending }
+})
+
+it('truncates descriptions once at the native row budget, with opt-in ellipsis only', () => {
+  const description = '中文🙂 '.repeat(25)
+  const items = [{ value: 'one', label: 'One', description: background.hover(description) }]
+  const list = new SelectList(items, 3, editorTheme.selectList!, { descriptionEllipsis: '…' })
+  const native = new SelectList(items, 3, editorTheme.selectList!)
+  const row = list.render(80)[0]!
+  expect(stripCopyDecorations(row)).toMatch(/…$/u)
+  expect(visibleWidth(row)).toBeLessThanOrEqual(78)
+  expect(list.getRenderSnapshot()?.visibleRows[0]?.item.description).toBe(items[0]!.description)
+  expect(stripCopyDecorations(native.render(80)[0]!)).not.toContain('…')
+  expect(stripCopyDecorations(list.render(240)[0]!)).toContain(description.trim())
+})

--- a/tests/overlay-pointer-integration.test.ts
+++ b/tests/overlay-pointer-integration.test.ts
@@ -84,7 +84,10 @@ function pointerHarness(hoverFeedback: boolean) {
     }
     const outcome = controller.handle(event)
     const semantic = outcome.semantic
-    if (semantic?.kind === 'hover') {
+    if (semantic?.kind === 'wheel' && semantic.region?.action.kind === 'overlay') {
+      armed = undefined
+      overlays.handleWheel(semantic.lines)
+    } else if (semantic?.kind === 'hover') {
       overlays.handleHover(
         semantic.region?.action.kind === 'overlay' ? semantic.region.action.optionId : undefined,
         semantic.region?.action.kind === 'overlay' ? semantic.region.action.command : undefined,
@@ -158,6 +161,36 @@ afterEach(() => {
 })
 
 describe('overlay pointer / frame integration', () => {
+  it.each(['select', 'multiSelect'] as const)('keeps %s description-row SGR targets through width changes and wheel browsing', async method => {
+    vi.useFakeTimers()
+    const h = pointerHarness(true)
+    const choices = Array.from({ length: 16 }, (_, index) => ({
+      id: `mode-${index}`, label: `Mode ${index}`, description: 'Long description 中文🙂 '.repeat(8),
+    }))
+    const pending = h.overlays[method]({ title: 'modes', maxVisible: 4, choices })
+    try {
+      await h.frame()
+      h.emit(h.region('mode-0'), 65) // Wheel down changes the viewport, not the selection.
+      await h.frame()
+      await h.click('mode-4')
+      if (method === 'multiSelect') h.terminal.input(' ')
+      await h.frame()
+      for (const columns of [240, 70, 180, 100]) {
+        h.terminal.columns = columns
+        await h.repaint()
+        const rect = h.region('mode-4').rect
+        await h.hover('mode-5')
+        expect(h.region('mode-4').rect).toEqual(rect)
+        expect(h.region('mode-4').rect.height).toBe(1)
+        expect(h.region('mode-5').rect.row).toBe(rect.row + 1)
+      }
+      await h.click('footer-confirm')
+      await expect(pending).resolves.toEqual(method === 'select' ? choices[4] : [choices[4]])
+      // Mouse reports must not become search text at any width.
+      expect(h.keyInputs).toEqual(method === 'select' ? [] : [' '])
+    } finally { h.close(); await pending }
+  })
+
   it.each(['dark', 'light'] as const)('single-clicks footer navigation through nested pages with %s hover and no focus cycle', async theme => {
     vi.useFakeTimers()
     vi.stubEnv('NO_COLOR', undefined)


### PR DESCRIPTION
## Summary

Fixes #163.

Overlay descriptions were truncated to at most 60 cells before rendering, even when a wide modal had room for the complete text. Both single-select and multi-select overlays were affected.

- Preserve translated, terminal-sanitized descriptions until the native `SelectList` render boundary.
- Size the title column from the actual filtered labels, retaining the previous 32-cell maximum; let the native layout calculate the remaining description space.
- Add an opt-in description ellipsis to the existing pinned pi-tui patch. Other list consumers retain their previous behavior.
- Remove list reconstruction on resize, retaining search, selected/checked items, scroll offsets and existing one-row mouse hit geometry.
- Keep the existing extremely narrow title-only fallback; no multiline renderer, new dependency, Host modification or version bump.

This PR is based on `main` and is independent of the pending background PRs #162 and #164.

## Validation

- [x] Regression-first: the initial tests reproduced 12 failures on the old implementation.
- [x] `pnpm run check`: 110 files, 914 tests passed, 1 unrelated conditional skip; typecheck/build/pack-check passed.
- [x] 20 description-layout tests covering wide/narrow/exact-fit widths, resize, Unicode, ANSI, built-in/custom themes, single/multi-select, disabled reasons, search and viewport state.
- [x] 14 pointer/frame integration tests, including two new SGR wheel/click/hover/resize cases.
- [x] Unmodified official dsh `0.1.1-rc.2`: isolated install, boot, remove, reinstall, packed launcher and Host identity checks passed.
- [x] Windows ConPTY mouse smoke: one cycle, exit 0.
- [x] Candidate bundle matches the rebuilt `lib/index.js`; package allowlist and diff checks passed.
- [ ] Real Windows/macOS/Linux visual acceptance remains unverified; synthetic frames and ConPTY are recorded separately.

See `docs/issue-163-overlay-description-verification.md` for the acceptance record and manual checklist. Personal themes, the #161 taskbook and everyday Profiles are excluded.

## 中文说明

修复单选、多选弹窗在窗口足够宽时仍将描述固定截到 60 列的问题。保留完整描述，按实际标题宽度分配空间，只在最终渲染阶段按需省略。resize 不再重建列表，搜索、选中、勾选和滚动位置保持不变，不改鼠标命中系统。

914 项测试通过、1 项无关跳过，构建、打包、官方 dsh 隔离插拔及 ConPTY 检查通过；实机视觉验证尚未完成。本 PR 独立于背景功能，不发布版本。
