### PR TITLE
fix(tui): adapt canvas contrast and refresh theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ The main canvas now defaults to **theme colors + terminal effects**, instead of 
 
 Panels, code blocks, selections and hover keep their independent backgrounds and highlighting. Their transparency can differ from the canvas; even `explicit` is not guaranteed opaque. Background mode belongs to Harness `seektty-appearance` settings, not theme files: theme switching, previews, import and export do not overwrite it.
 
+Canvas text adapts to a known background that differs from the theme. If the background is unknown (including unavailable synchronization), it uses the terminal's default foreground instead of guessing black or white; semantic text colors are reduced, while bold, underline and independent code/panel colors remain. This also updates existing messages without moving the viewport or clearing selection. The open theme menu refreshes its current marker and code-theme description after saving or returning from a child menu.
+
 Color synchronization requires a supported truecolor terminal and a valid reply to one 500 ms asynchronous query. Unsupported or timed-out queries, `NO_COLOR`, limited colors, and tmux/screen do not recolor the terminal. In `theme` mode, an unavailable sync leaves the default background in place with one non-blocking notice, not an automatic RGB fallback. `SEEKTTY_TERMINAL_BACKGROUND=off` disables recoloring only; it does not change the selected mode. Exit restores the captured color. SeekTTY does not read/set opacity, edit terminal configuration, or alter window decorations. See [compatibility](docs/terminal-background-compatibility.md) and [acceptance results](docs/background-inheritance-acceptance.md).
 
 Use `/language` or a direct command to switch the terminal copy live:

--- a/README.zh.md
+++ b/README.zh.md
@@ -284,6 +284,8 @@ SeekTTY 默认使用 DeepSeek 暗色主题。`/theme` 会打开主题中心，�
 
 弹窗、代码块、选区和 hover 保留独立底色与高亮，透明效果可能与主画布不同；`explicit` 也不保证一定不透明。背景模式属于 Harness 的 `seektty-appearance` 设置，不属于主题文件，切换、预览、导入或导出主题均不会覆盖它。
 
+主画布文字会适配已知且与主题不同的背景；背景未知或同步不可用时，使用终端默认前景色，不猜黑白。这时文字的语义配色会减少，但粗体、下划线以及代码块、弹窗的独立配色保留。已有消息也会同步更新，不移动视口或清除选区。打开的主题菜单在保存或从子菜单返回后，会刷新“当前”标记和代码主题说明。
+
 改色需要支持的真彩色终端，并在一次 500 ms 异步查询内收到有效回复。不支持、查询超时、`NO_COLOR`、低色彩及 tmux/screen 均不改色。`theme` 模式同步不可用时保留终端默认背景，给一次非阻塞提示，不自动回退成 RGB 铺底。`SEEKTTY_TERMINAL_BACKGROUND=off` 只禁止改色，不改变所选模式。退出时恢复捕获的原色。SeekTTY 不读取／设置透明度，不修改终端配置或窗口装饰。详见[兼容性说明](docs/terminal-background-compatibility.md)与[验收记录](docs/background-inheritance-acceptance.md)。
 
 使用 `/language` 或直接命令实时切换终端文案：

--- a/docs/terminal-background-compatibility.md
+++ b/docs/terminal-background-compatibility.md
@@ -22,7 +22,7 @@ No dependencies, alpha-percentage probes, terminal-specific opacity APIs, or ter
 - The query is asynchronous and expires after 500 ms. Only a valid `rgb:r/g/b` reply with 1–4 hex digits per channel authorizes a color change. Preserve original channel precision.
 - Switching between synchronizing modes with the same color does not repeat a write. Repaints and mode switches never repeat the query.
 - Entering `terminal` restores the captured original immediately if this run changed it, but retains the snapshot for later switches. If a reply arrives while `terminal` is selected, capture it without recoloring. A later synchronizing mode uses the latest requested theme.
-- Missing, expired, or disabled synchronization in `theme` mode leaves the default canvas background in place with one non-blocking notice per active lifetime. Do not silently switch to explicit RGB. If foreground contrast is poor against an unrelated terminal background, select a matching interface theme or opt into `explicit`.
+- Missing, expired, or disabled synchronization in `theme` mode leaves the default canvas background in place with one non-blocking notice per active lifetime. Do not silently switch to explicit RGB.
 - Restore the captured color synchronously before normal/fatal teardown. Do not use OSC 111: it resets the profile color, which may differ from a color previously chosen by the shell. Write failures are handled best-effort, without breaking cleanup.
 - POSIX suspend restores the background and protocols. Resume starts a new active lifetime, installs input first, then re-queries if needed. Ctrl+Z remains input undo. Uncatchable termination (`SIGKILL`, forced process termination, or terminal crash) cannot guarantee restoration.
 
@@ -34,6 +34,14 @@ Color synchronization still requires an interactive managed terminal and the exi
 
 Direct SSH uses the same bounded query; network latency may cause safe fallback. Multiplexers are excluded because cached replies or outer-window mutations could affect other panes. No passthrough is forced. A successful protocol test cannot prove compositor effects or pixel-perfect padding in every emulator.
 
+## Canvas readability
+
+The saved theme is unchanged. If the captured or applied background differs from its canvas color, RGB foregrounds on the default background are adjusted with the existing contrast calculation to at least 4.5:1. If the background is unknown, canvas foregrounds use `SGR 39`, the terminal's configured foreground. This includes semantic colors embedded in cached Markdown; adapting only the outer text color would be insufficient. No extra query is issued just to discover a terminal-mode background.
+
+Adaptation runs at the canvas rendering boundary, so mode changes or background replies do not recreate transcript nodes, disturb selection, or move scroll anchors. Explicit background islands retain their original colors (panels, code, hover, selection), as does `explicit` canvas mode. A matching synchronized theme background keeps the theme palette. Color calculations are cached with a bounded size.
+
+Default foregrounds rely on a readable terminal palette; opacity and images can still affect the actual pixel contrast. The 4.5:1 calculation applies to known opaque RGB colors, not arbitrary wallpaper or compositor output. Unknown/indexed terminal palettes are not guessed, and `NO_COLOR` retains uncolored output. Native macOS/Windows GUI visual acceptance must still be recorded separately from synthetic and PTY checks.
+
 ## Verification
 
 See [dated acceptance results and manual checklist](background-inheritance-acceptance.md). Unit/synthetic frame tests, real PTY/ConPTY tests, official packaged lifecycle checks, and real GUI-terminal acceptance are recorded separately. Missing devices remain **untested**.
@@ -41,7 +49,7 @@ See [dated acceptance results and manual checklist](background-inheritance-accep
 Focused checks:
 
 ```sh
-pnpm exec vitest run tests/appearance-background.test.ts tests/actions-background.test.ts tests/background-inheritance.test.ts tests/terminal-background.test.ts tests/theme-config.test.ts tests/actions-theme.test.ts tests/transcript-viewport.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
+pnpm exec vitest run tests/appearance-background.test.ts tests/actions-background.test.ts tests/background-inheritance.test.ts tests/terminal-background.test.ts tests/theme.test.ts tests/theme-config.test.ts tests/actions-theme.test.ts tests/transcript-viewport.test.ts tests/terminal-input-framing.test.ts tests/terminal-session.test.ts tests/process-guards.test.ts
 pnpm run check
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23148,6 +23148,7 @@ function mix(left, right, amount) {
 		b: first.b + (second.b - first.b) * ratio
 	});
 }
+/** Derive a readable foreground without mutating the saved palette. */
 function ensureContrast(color$1, background$1, minimum) {
 	const normalized = normalizeThemeColor(color$1);
 	if (themeContrast(normalized, background$1) >= minimum) return normalized;
@@ -23174,15 +23175,15 @@ function ensureContrast(color$1, background$1, minimum) {
 * Derive a transient interaction style from any interface theme, without changing its saved colors.
 * Oklab keeps the hover between panel and selection; text legibility is no worse than the panel.
 */
-function resolveHoverStyle(colors) {
-	const background$1 = ensureContrast(mix(colors.surface, colors.selection, .5), colors.text, Math.min(4.5, themeContrast(colors.text, colors.surface)));
+function resolveHoverStyle(colors$1) {
+	const background$1 = ensureContrast(mix(colors$1.surface, colors$1.selection, .5), colors$1.text, Math.min(4.5, themeContrast(colors$1.text, colors$1.surface)));
 	const hover = oklabOf(background$1);
 	return {
 		background: background$1,
 		underline: [
-			colors.canvas,
-			colors.surface,
-			colors.selection
+			colors$1.canvas,
+			colors$1.surface,
+			colors$1.selection
 		].some((color$1) => {
 			const other$1 = oklabOf(color$1);
 			return Math.hypot(hover.lightness - other$1.lightness, hover.a - other$1.a, hover.b - other$1.b) < .025;
@@ -23193,15 +23194,15 @@ function hueDistance(left, right) {
 	const distance = Math.abs(left - right) % 360;
 	return Math.min(distance, 360 - distance);
 }
-function statusColor(colors, targetHue, fallback, background$1) {
-	const candidate = colors.map((color$1) => ({
+function statusColor(colors$1, targetHue, fallback, background$1) {
+	const candidate = colors$1.map((color$1) => ({
 		color: color$1,
 		value: oklchOf(color$1)
 	})).filter((entry) => entry.value.chroma >= .035).sort((left, right) => hueDistance(left.value.hue, targetHue) - hueDistance(right.value.hue, targetHue))[0];
 	return ensureContrast(candidate !== void 0 && hueDistance(candidate.value.hue, targetHue) <= 75 ? candidate.color : fallback, background$1, 3);
 }
-function accentColors(colors, background$1, foreground) {
-	const selected = colors.filter((color$1) => color$1 !== background$1 && color$1 !== foreground).map((color$1) => ({
+function accentColors(colors$1, background$1, foreground) {
+	const selected = colors$1.filter((color$1) => color$1 !== background$1 && color$1 !== foreground).map((color$1) => ({
 		color: color$1,
 		value: oklchOf(color$1),
 		contrast: themeContrast(color$1, background$1)
@@ -23237,11 +23238,11 @@ function generatedSyntax(background$1, foreground, muted, accents) {
 		regexp: value(4)
 	};
 }
-function candidateTheme(id, name$1, colors, tone) {
-	const ordered = [...colors].sort((left, right) => luminance(left) - luminance(right));
+function candidateTheme(id, name$1, colors$1, tone) {
+	const ordered = [...colors$1].sort((left, right) => luminance(left) - luminance(right));
 	const canvas = tone === "dark" ? ordered[0] ?? "#000000" : ordered.at(-1) ?? "#FFFFFF";
 	const text$1 = ensureContrast(ordered.filter((color$1) => color$1 !== canvas).sort((left, right) => themeContrast(right, canvas) - themeContrast(left, canvas))[0] ?? (tone === "dark" ? "#FFFFFF" : "#000000"), canvas, 4.5);
-	const accents = accentColors(colors, canvas, text$1);
+	const accents = accentColors(colors$1, canvas, text$1);
 	const brand = accents[0] ?? text$1;
 	const brandHue = oklchOf(brand).hue;
 	const accent = accents.find((color$1) => hueDistance(oklchOf(color$1).hue, brandHue) >= 35) ?? accents[1] ?? brand;
@@ -23249,10 +23250,10 @@ function candidateTheme(id, name$1, colors, tone) {
 	const selection = mix(canvas, brand, tone === "dark" ? .28 : .18);
 	const muted = ensureContrast(mix(text$1, canvas, .42), canvas, 3);
 	const border = ensureContrast(mix(text$1, canvas, .68), canvas, 1.5);
-	const success = statusColor(colors, 150, "#2FBF8F", canvas);
-	const warning = statusColor(colors, 75, "#D99B3D", canvas);
-	const danger = statusColor(colors, 20, "#E66476", canvas);
-	const syntaxAccents = accentColors(colors, surface, text$1);
+	const success = statusColor(colors$1, 150, "#2FBF8F", canvas);
+	const warning = statusColor(colors$1, 75, "#D99B3D", canvas);
+	const danger = statusColor(colors$1, 20, "#E66476", canvas);
+	const syntaxAccents = accentColors(colors$1, surface, text$1);
 	const theme = {
 		id,
 		name: name$1,
@@ -23274,7 +23275,7 @@ function candidateTheme(id, name$1, colors, tone) {
 		syntax: generatedSyntax(surface, text$1, muted, syntaxAccents),
 		tokenColors: []
 	};
-	const paletteContrast = colors.reduce((sum, color$1) => sum + themeContrast(color$1, canvas), 0) / colors.length;
+	const paletteContrast = colors$1.reduce((sum, color$1) => sum + themeContrast(color$1, canvas), 0) / colors$1.length;
 	return {
 		theme,
 		score: themeContrast(text$1, canvas) * 2 + themeContrast(brand, canvas) + paletteContrast
@@ -23287,11 +23288,11 @@ function candidateTheme(id, name$1, colors, tone) {
 */
 function parseThemePalette(input) {
 	const matches$1 = input.match(/#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)/giu) ?? [];
-	const colors = [...new Set(matches$1.map(normalizeThemeColor))];
+	const colors$1 = [...new Set(matches$1.map(normalizeThemeColor))];
 	const residue = matches$1.reduce((value, match) => value.replace(match, " "), input).replace(/[\s,;|]+/gu, "");
 	if (residue !== "") throw new Error(ui(`无法识别的配色内容 ${JSON.stringify(residue.slice(0, 40))}`, `Unrecognized palette text ${JSON.stringify(residue.slice(0, 40))}`));
-	if (colors.length < 3 || colors.length > 16) throw new Error(ui("配色需要 3–16 个不重复的 HEX/RGB 颜色", "A palette requires 3–16 unique HEX/RGB colors"));
-	return colors;
+	if (colors$1.length < 3 || colors$1.length > 16) throw new Error(ui("配色需要 3–16 个不重复的 HEX/RGB 颜色", "A palette requires 3–16 unique HEX/RGB colors"));
+	return colors$1;
 }
 /**
 * Generate both contrast directions from an unlabelled color palette.
@@ -23301,9 +23302,9 @@ function parseThemePalette(input) {
 * @returns dark/light candidates and the higher-scoring recommendation.
 */
 function generateThemeCandidates(id, name$1, input) {
-	const colors = parseThemePalette(input);
-	const dark = candidateTheme(id, name$1, colors, "dark");
-	const light = candidateTheme(id, name$1, colors, "light");
+	const colors$1 = parseThemePalette(input);
+	const dark = candidateTheme(id, name$1, colors$1, "dark");
+	const light = candidateTheme(id, name$1, colors$1, "light");
 	return {
 		dark: dark.theme,
 		light: light.theme,
@@ -23527,6 +23528,77 @@ function editableTheme(theme, id, name$1) {
 			...rule.fontStyle === void 0 ? {} : { fontStyle: [...rule.fontStyle] }
 		}))
 	};
+}
+
+const DEFAULT_FG = "\x1B[39m";
+const SGR = /\u001B\[([0-9;:]*)m/gu;
+let cachedBackground;
+const colors = /* @__PURE__ */ new Map();
+function readableForeground(rgb$1, background$1) {
+	if (rgb$1 === void 0 || background$1 === void 0) return DEFAULT_FG;
+	if (background$1 !== cachedBackground) {
+		colors.clear();
+		cachedBackground = background$1;
+	}
+	const cached = colors.get(rgb$1);
+	if (cached !== void 0) return cached;
+	const hex = ensureContrast(rgb$1, background$1, 4.5);
+	const sequence = `\u001B[38;2;${[
+		1,
+		3,
+		5
+	].map((index) => Number.parseInt(hex.slice(index, index + 2), 16)).join(";")}m`;
+	if (colors.size >= 256) colors.clear();
+	colors.set(rgb$1, sequence);
+	return sequence;
+}
+/**
+* Adapt already-styled canvas rows, including cached Markdown foregrounds.
+* Track explicit background islands so code, panels and selections retain their
+* original foregrounds. Only SGR is interpreted; all text and geometry survive.
+*/
+function readableCanvas(text$1, background$1) {
+	let explicitBackground = false;
+	let foreground = DEFAULT_FG;
+	let rgb$1;
+	return text$1.replace(SGR, (sequence, parameters) => {
+		const fields = parameters === "" ? ["0"] : parameters.split(";");
+		let changed = false;
+		for (let index = 0; index < fields.length; index += 1) {
+			const field = fields[index] ?? "0";
+			const parts = field.split(":");
+			const code = Number(parts[0]);
+			if (code === 0) {
+				foreground = DEFAULT_FG;
+				rgb$1 = void 0;
+				explicitBackground = false;
+				changed = true;
+			} else if (code === 38 || code === 48 || code === 58) {
+				const colon = parts.length > 1;
+				const mode = Number(colon ? parts[1] : fields[index + 1]);
+				const count = mode === 2 ? 3 : mode === 5 ? 1 : 0;
+				const values = colon ? parts.slice(-count) : fields.slice(index + 2, index + 2 + count);
+				const colorFields = colon ? field : fields.slice(index, index + 2 + count).join(";");
+				if (!colon) index += 1 + count;
+				if (code === 38) {
+					foreground = `\u001B[${colorFields}m`;
+					rgb$1 = mode === 2 && values.length === 3 && values.every((value) => /^\d+$/u.test(value) && Number(value) <= 255) ? `#${values.map((value) => Number(value).toString(16).padStart(2, "0")).join("")}` : void 0;
+					changed = true;
+				} else if (code === 48) {
+					explicitBackground = true;
+					changed = true;
+				}
+			} else if (code === 39 || code >= 30 && code <= 37 || code >= 90 && code <= 97) {
+				foreground = `\u001B[${field}m`;
+				rgb$1 = void 0;
+				changed = true;
+			} else if (code === 49 || code >= 40 && code <= 47 || code >= 100 && code <= 107) {
+				explicitBackground = code !== 49;
+				changed = true;
+			}
+		}
+		return changed ? sequence + (explicitBackground ? foreground : readableForeground(rgb$1, background$1)) : sequence;
+	});
 }
 
 const RESET = "\x1B[0m";
@@ -23834,6 +23906,11 @@ function setTheme(theme) {
 function setBackgroundMode(mode) {
 	backgroundMode = mode;
 }
+let terminalCanvasBackground;
+/** Actual background reported by the managed terminal, never persisted as a theme. */
+function setTerminalCanvasBackground(color$1) {
+	terminalCanvasBackground = color$1;
+}
 /**
 * Connect the asynchronously prepared syntax highlighter to Markdown rendering.
 * @param highlighter - synchronous cached renderer, or undefined during teardown.
@@ -23869,7 +23946,11 @@ const color = {
 };
 /** Background layers shared by the full frame, panels, and selected rows. */
 const background = {
-	canvas: (text$1) => layer(backgroundMode === "explicit" ? palette.canvas : void 0, text$1),
+	canvas: (text$1) => {
+		const row = layer(backgroundMode === "explicit" ? palette.canvas : void 0, text$1);
+		if (terminalColorLevel() === 0 || backgroundMode === "explicit" || terminalCanvasBackground?.toLowerCase() === selectedTheme.colors.canvas.toLowerCase()) return row;
+		return readableCanvas(row, terminalColorLevel() === 3 ? terminalCanvasBackground : void 0);
+	},
 	surface: (text$1) => layer(palette.surface, text$1),
 	hover: hoverLayer,
 	selection: (text$1) => layer(palette.selection, text$1),
@@ -29226,7 +29307,7 @@ function sourcePath(input) {
 	return resolve(trimmed);
 }
 function mergeTheme(base, current, path$1) {
-	const colors = optionalRecord(current.colors, `${path$1}.colors`);
+	const colors$1 = optionalRecord(current.colors, `${path$1}.colors`);
 	const semanticTokenColors = optionalRecord(current.semanticTokenColors, `${path$1}.semanticTokenColors`);
 	const rawTokenColors = current.tokenColors ?? [];
 	if (!Array.isArray(rawTokenColors)) throw new Error(ui(`${path$1}.tokenColors 必须是数组`, `${path$1}.tokenColors must be an array`));
@@ -29237,7 +29318,7 @@ function mergeTheme(base, current, path$1) {
 		...type === void 0 ? {} : { type },
 		colors: {
 			...base.colors,
-			...colors
+			...colors$1
 		},
 		tokenColors: [...base.tokenColors, ...rawTokenColors],
 		semanticTokenColors: {
@@ -29298,9 +29379,9 @@ function safeColor(value, background$1, fallback) {
 		return fallback;
 	}
 }
-function firstColor(colors, keys, background$1, fallback) {
+function firstColor(colors$1, keys, background$1, fallback) {
 	for (const key of keys) {
-		const value = colors[key];
+		const value = colors$1[key];
 		if (typeof value !== "string") continue;
 		try {
 			return normalizeThemeColorOn(value, background$1);
@@ -29442,14 +29523,14 @@ function syntaxColors(value, background$1, foreground, rules, fallback) {
 		...Object.fromEntries(entries)
 	};
 }
-function uiColors(colors, background$1, foreground, tone) {
+function uiColors(colors$1, background$1, foreground, tone) {
 	const fallback = BUILT_IN_THEMES[tone].colors;
-	const surface = firstColor(colors, [
+	const surface = firstColor(colors$1, [
 		"sideBar.background",
 		"editorWidget.background",
 		"panel.background"
 	], background$1, background$1);
-	const brand = firstColor(colors, [
+	const brand = firstColor(colors$1, [
 		"textLink.foreground",
 		"activityBarBadge.background",
 		"button.background"
@@ -29458,22 +29539,22 @@ function uiColors(colors, background$1, foreground, tone) {
 		canvas: background$1,
 		surface,
 		text: foreground,
-		muted: firstColor(colors, ["descriptionForeground", "editorLineNumber.foreground"], background$1, fallback.muted),
-		border: firstColor(colors, [
+		muted: firstColor(colors$1, ["descriptionForeground", "editorLineNumber.foreground"], background$1, fallback.muted),
+		border: firstColor(colors$1, [
 			"focusBorder",
 			"panel.border",
 			"editorGroup.border"
 		], background$1, fallback.border),
 		brand,
-		accent: firstColor(colors, ["textLink.activeForeground", "terminal.ansiBlue"], background$1, brand),
-		selection: firstColor(colors, ["editor.selectionBackground", "list.activeSelectionBackground"], background$1, fallback.selection),
-		success: firstColor(colors, [
+		accent: firstColor(colors$1, ["textLink.activeForeground", "terminal.ansiBlue"], background$1, brand),
+		selection: firstColor(colors$1, ["editor.selectionBackground", "list.activeSelectionBackground"], background$1, fallback.selection),
+		success: firstColor(colors$1, [
 			"testing.iconPassed",
 			"gitDecoration.addedResourceForeground",
 			"terminal.ansiGreen"
 		], background$1, fallback.success),
-		warning: firstColor(colors, ["editorWarning.foreground", "terminal.ansiYellow"], background$1, fallback.warning),
-		danger: firstColor(colors, ["editorError.foreground", "terminal.ansiRed"], background$1, fallback.danger)
+		warning: firstColor(colors$1, ["editorWarning.foreground", "terminal.ansiYellow"], background$1, fallback.warning),
+		danger: firstColor(colors$1, ["editorError.foreground", "terminal.ansiRed"], background$1, fallback.danger)
 	};
 }
 /**
@@ -31184,55 +31265,61 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 	}
 	async themeCenter() {
 		const bridge = this.capabilities.managementBridge().settings;
-		const appearance = appearanceFromSettings(appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE)));
-		const activeCodeTheme = resolveCodeTheme(appearance);
-		const choices = [
-			{
-				id: "dark",
-				label: ui("DeepSeek 暗色", "DeepSeek dark"),
-				description: ui("内置 · 深灰蓝画布", "Built in · deep blue-gray canvas")
-			},
-			{
-				id: "light",
-				label: ui("DeepSeek 亮色", "DeepSeek light"),
-				description: ui("内置 · 柔和冷白画布", "Built in · soft cool-white canvas")
-			},
-			...appearance.customThemes.map((theme) => ({
-				id: customThemeId(theme),
-				label: theme.name,
-				description: `${theme.tone === "dark" ? ui("暗色", "Dark") : ui("亮色", "Light")} · ${theme.source === "palette" ? ui("颜色组生成", "Generate from palette") : theme.source === "vscode" ? ui("VS Code 导入", "VS Code import") : ui("手动配色", "Manual colors")}`
-			}))
-		];
-		choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme));
-		choices.push({
-			id: "__background__",
-			label: ui("背景模式", "Background mode"),
-			description: ui("选择主画布背景；独立于主题文件", "Choose the canvas background independently of theme files")
-		}, {
-			id: "__code__",
-			label: ui("代码块主题", "Code-block theme"),
-			description: ui(`${appearance.codeTheme === "auto" ? "自动匹配" : "独立指定"} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === "auto" ? "Automatic" : "Explicit"} · current ${activeCodeTheme.name}`)
-		}, {
-			id: "__edit__",
-			label: ui("自定义颜色与代码高亮", "Custom colors and syntax highlighting"),
-			description: ui("修改背景、文字和语法颜色", "Edit backgrounds, text, and syntax colors")
-		}, {
-			id: "__palette__",
-			label: ui("用颜色组合自动配置", "Generate automatically from a color palette"),
-			description: ui("输入 3–16 个 HEX/RGB 颜色代码", "Enter 3–16 HEX/RGB colors")
-		}, {
-			id: "__import__",
-			label: ui("导入 VS Code 主题", "Import VS Code theme"),
-			description: ui("本地 JSON/JSONC · 支持相对 include", "Local JSON/JSONC · relative includes supported")
-		}, {
-			id: "__export__",
-			label: ui("导出主题 JSON", "Export theme JSON"),
-			description: ui("写出可分享的 SeekTTY 主题文件", "Write a shareable SeekTTY theme file")
-		}, {
-			id: "__delete__",
-			label: ui("删除主题", "Delete theme"),
-			description: ui("管理命名自定义主题", "Manage named custom themes")
-		});
+		const readChoices = async () => {
+			const appearance = appearanceFromSettings(appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE, { bypassCache: true })));
+			const activeCodeTheme = resolveCodeTheme(appearance);
+			const choices = [
+				{
+					id: "dark",
+					label: ui("DeepSeek 暗色", "DeepSeek dark"),
+					description: ui("内置 · 深灰蓝画布", "Built in · deep blue-gray canvas")
+				},
+				{
+					id: "light",
+					label: ui("DeepSeek 亮色", "DeepSeek light"),
+					description: ui("内置 · 柔和冷白画布", "Built in · soft cool-white canvas")
+				},
+				...appearance.customThemes.map((theme) => ({
+					id: customThemeId(theme),
+					label: theme.name,
+					description: `${theme.tone === "dark" ? ui("暗色", "Dark") : ui("亮色", "Light")} · ${theme.source === "palette" ? ui("颜色组生成", "Generate from palette") : theme.source === "vscode" ? ui("VS Code 导入", "VS Code import") : ui("手动配色", "Manual colors")}`
+				}))
+			];
+			choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme));
+			choices.push({
+				id: "__background__",
+				label: ui("背景模式", "Background mode"),
+				description: ui("选择主画布背景；独立于主题文件", "Choose the canvas background independently of theme files")
+			}, {
+				id: "__code__",
+				label: ui("代码块主题", "Code-block theme"),
+				description: ui(`${appearance.codeTheme === "auto" ? "自动匹配" : "独立指定"} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === "auto" ? "Automatic" : "Explicit"} · current ${activeCodeTheme.name}`)
+			}, {
+				id: "__edit__",
+				label: ui("自定义颜色与代码高亮", "Custom colors and syntax highlighting"),
+				description: ui("修改背景、文字和语法颜色", "Edit backgrounds, text, and syntax colors")
+			}, {
+				id: "__palette__",
+				label: ui("用颜色组合自动配置", "Generate automatically from a color palette"),
+				description: ui("输入 3–16 个 HEX/RGB 颜色代码", "Enter 3–16 HEX/RGB colors")
+			}, {
+				id: "__import__",
+				label: ui("导入 VS Code 主题", "Import VS Code theme"),
+				description: ui("本地 JSON/JSONC · 支持相对 include", "Local JSON/JSONC · relative includes supported")
+			}, {
+				id: "__export__",
+				label: ui("导出主题 JSON", "Export theme JSON"),
+				description: ui("写出可分享的 SeekTTY 主题文件", "Write a shareable SeekTTY theme file")
+			}, {
+				id: "__delete__",
+				label: ui("删除主题", "Delete theme"),
+				description: ui("管理命名自定义主题", "Manage named custom themes")
+			});
+			return choices.map((choice) => ({
+				...choice,
+				label: `${currentMark(choice.id === appearance.theme)}${choice.label}`
+			}));
+		};
 		const options$1 = {
 			width: 68,
 			maxHeight: "90%",
@@ -31243,20 +31330,26 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 			await navigation.selectPage({
 				title: ui("主题", "Theme"),
 				detail: ui("手动配色、颜色组合自动生成，或导入 VS Code JSON/JSONC", "Edit colors, generate from a palette, or import VS Code JSON/JSONC"),
-				choices: choices.map((choice) => ({
-					...choice,
-					label: `${currentMark(choice.id === appearance.theme)}${choice.label}`
-				})),
+				choices: await readChoices(),
 				options: options$1
 			}, async (selected) => {
-				if (selected.id === "__code__") await this.themeCode("", navigation);
-				else if (selected.id === "__background__") await this.editBackgroundMode(navigation);
-				else if (selected.id === "__palette__") await this.themePalette("", navigation);
-				else if (selected.id === "__import__") await this.themeImport("", navigation);
-				else if (selected.id === "__export__") await this.themeExport("", navigation);
-				else if (selected.id === "__edit__") await this.themeEdit("", navigation);
-				else if (selected.id === "__delete__") await this.themeDelete("", navigation);
-				else await this.activateTheme(selected.id);
+				let notice;
+				try {
+					if (selected.id === "__code__") await this.themeCode("", navigation);
+					else if (selected.id === "__background__") await this.editBackgroundMode(navigation);
+					else if (selected.id === "__palette__") await this.themePalette("", navigation);
+					else if (selected.id === "__import__") await this.themeImport("", navigation);
+					else if (selected.id === "__export__") await this.themeExport("", navigation);
+					else if (selected.id === "__edit__") await this.themeEdit("", navigation);
+					else if (selected.id === "__delete__") await this.themeDelete("", navigation);
+					else await this.activateTheme(selected.id);
+				} catch (error) {
+					notice = capabilityError(error);
+					this.host.notice(notice, "error");
+				}
+				if (navigation.signal.aborted) return;
+				const refreshed = await readChoices();
+				if (!navigation.signal.aborted) navigation.updateChoices(refreshed, notice);
 			});
 		}, options$1);
 	}
@@ -37155,10 +37248,12 @@ var TerminalBackground = class {
 	applied;
 	changed = false;
 	timer;
-	constructor(terminal, enabled, onUnavailable = () => void 0) {
+	reportedColor;
+	constructor(terminal, enabled, onUnavailable = () => void 0, onColorChanged = () => void 0) {
 		this.terminal = terminal;
 		this.enabled = enabled;
 		this.onUnavailable = onUnavailable;
+		this.onColorChanged = onColorChanged;
 	}
 	/** Set color and policy atomically, without writing an intermediate theme. */
 	setColor(color$1, mode = this.mode) {
@@ -37167,6 +37262,7 @@ var TerminalBackground = class {
 		this.mode = mode;
 		if (mode === "terminal") this.restoreOriginal();
 		else this.sync();
+		this.reportColor();
 	}
 	start() {
 		this.active = true;
@@ -37209,6 +37305,7 @@ var TerminalBackground = class {
 			this.timer = void 0;
 			this.original = reply[1].toLowerCase();
 			this.sync();
+			this.reportColor();
 		}
 		return true;
 	}
@@ -37223,6 +37320,7 @@ var TerminalBackground = class {
 		this.original = void 0;
 		this.applied = void 0;
 		this.changed = false;
+		this.reportColor();
 	}
 	/** Switching to terminal-only restores color without losing the lifetime snapshot. */
 	restoreOriginal() {
@@ -37246,6 +37344,16 @@ var TerminalBackground = class {
 			this.restoreOriginal();
 			this.notifyUnavailable();
 		}
+		this.reportColor();
+	}
+	reportColor() {
+		const actual = this.unavailable === "write-failed" ? void 0 : this.changed ? this.applied : this.original;
+		const color$1 = actual === void 0 ? void 0 : `#${actual.slice(4).split("/").map((channel) => Math.round(Number.parseInt(channel, 16) * 255 / (16 ** channel.length - 1)).toString(16).padStart(2, "0")).join("")}`;
+		if (color$1 === this.reportedColor) return;
+		this.reportedColor = color$1;
+		try {
+			this.onColorChanged(color$1);
+		} catch {}
 	}
 	notifyUnavailable() {
 		if (!this.active || this.mode !== "theme" || this.unavailable === void 0 || this.notified) return;
@@ -37415,8 +37523,8 @@ function supportsManagedTerminal(interactive, term) {
 * Existing pi-tui paste, keyboard, raw-mode, and listener state stays with pi-tui.
 * Live mouse toggles write only mouse/focus private modes and never 1049h/1049l.
 */
-function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env, onBackgroundUnavailable) {
-	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable);
+function createTerminalSession(terminal, enabled, beforeRestore = () => void 0, env = process.env, onBackgroundUnavailable, onBackgroundColorChanged) {
+	const background$1 = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable, onBackgroundColorChanged);
 	let active = false;
 	let mouseMode = "full";
 	let hoverFeedback = true;
@@ -38943,10 +39051,15 @@ async function startTuiSurface(options$1) {
 	};
 	let stopTuiRenderingSync = () => void 0;
 	let reportBackgroundUnavailable = () => void 0;
+	let repaintBackground = () => void 0;
+	setTerminalCanvasBackground(void 0);
 	const terminalSession = createTerminalSession(terminal, true, () => {
 		stopTuiRenderingSync();
 	}, process.env, () => {
 		reportBackgroundUnavailable();
+	}, (color$1) => {
+		setTerminalCanvasBackground(color$1);
+		repaintBackground();
 	});
 	const [settingsDocuments, client, initialProviderReadiness] = await (async () => {
 		try {
@@ -38993,6 +39106,11 @@ async function startTuiSurface(options$1) {
 		};
 		const capabilities = client.capabilities;
 		let stopping;
+		repaintBackground = () => {
+			if (stopping !== void 0) return;
+			tui.invalidate();
+			tui.requestRender(true);
+		};
 		let active;
 		const profile = options$1.profile ?? "tui";
 		const contextBar = new ContextBar(profile, options$1.cwd);

--- a/scripts/mouse-pty-harness.mjs
+++ b/scripts/mouse-pty-harness.mjs
@@ -204,6 +204,20 @@ async function oneCycle(index, home, env) {
     await log.waitFor(/键位速查|Keyboard shortcuts/u, 10_000)
     session.write('\u001B')
     await delay(100)
+    // Keep the theme menu open across two saves; its current marker must follow
+    // authoritative Settings without reopening or making a Provider request.
+    session.write('/theme')
+    await delay(100)
+    session.write('\r')
+    await log.waitFor(/当前 · DeepSeek 暗色|Current · DeepSeek dark/u, 10_000)
+    for (const marker of [/当前 · DeepSeek 亮色|Current · DeepSeek light/u, /当前 · DeepSeek 暗色|Current · DeepSeek dark/u]) {
+      const since = log.text().length
+      session.write('\u001B[B')
+      session.write('\r')
+      await log.waitFor(marker, 10_000, since)
+    }
+    session.write('\u001B')
+    await delay(100)
     // Exercise the packaged transient popup, outside-left dismissal and outside-right replacement.
     // These gestures do not select a menu action or make a Provider request.
     for (const [col, row] of [[10, 6], [65, 18]]) {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1270,55 +1270,67 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 
   private async themeCenter(): Promise<void> {
     const bridge = this.capabilities.managementBridge().settings
-    const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE))
-    const appearance = appearanceFromSettings(document)
-    const activeCodeTheme = resolveCodeTheme(appearance)
-    const choices: OverlayChoice[] = [
-      { id: 'dark', label: ui('DeepSeek 暗色', "DeepSeek dark"), description: ui('内置 · 深灰蓝画布', "Built in · deep blue-gray canvas") },
-      { id: 'light', label: ui('DeepSeek 亮色', "DeepSeek light"), description: ui('内置 · 柔和冷白画布', "Built in · soft cool-white canvas") },
-      ...appearance.customThemes.map(theme => ({
-        id: customThemeId(theme),
-        label: theme.name,
-        description: `${theme.tone === 'dark' ? ui('暗色', "Dark") : ui('亮色', "Light")} · ${theme.source === 'palette' ? ui('颜色组生成', "Generate from palette") : theme.source === 'vscode' ? ui('VS Code 导入', "VS Code import") : ui('手动配色', "Manual colors")}`,
-      })),
-    ]
-    choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme))
-    choices.push(
-      {
-        id: '__background__',
-        label: ui('背景模式', 'Background mode'),
-        description: ui('选择主画布背景；独立于主题文件', 'Choose the canvas background independently of theme files'),
-      },
-      {
-        id: '__code__',
-        label: ui('代码块主题', "Code-block theme"),
-        description: ui(`${appearance.codeTheme === 'auto' ? '自动匹配' : '独立指定'} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === 'auto' ? 'Automatic' : 'Explicit'} · current ${activeCodeTheme.name}`),
-      },
-      { id: '__edit__', label: ui('自定义颜色与代码高亮', "Custom colors and syntax highlighting"), description: ui('修改背景、文字和语法颜色', "Edit backgrounds, text, and syntax colors") },
-      { id: '__palette__', label: ui('用颜色组合自动配置', "Generate automatically from a color palette"), description: ui('输入 3–16 个 HEX/RGB 颜色代码', "Enter 3–16 HEX/RGB colors") },
-      { id: '__import__', label: ui('导入 VS Code 主题', "Import VS Code theme"), description: ui('本地 JSON/JSONC · 支持相对 include', "Local JSON/JSONC · relative includes supported") },
-      { id: '__export__', label: ui('导出主题 JSON', "Export theme JSON"), description: ui('写出可分享的 SeekTTY 主题文件', "Write a shareable SeekTTY theme file") },
-      { id: '__delete__', label: ui('删除主题', "Delete theme"), description: ui('管理命名自定义主题', "Manage named custom themes") },
-    )
+    const readChoices = async (): Promise<OverlayChoice[]> => {
+      const document = appearanceSettings(await bridge.describe(TUI_APPEARANCE_SETTINGS_NAMESPACE, { bypassCache: true }))
+      const appearance = appearanceFromSettings(document)
+      const activeCodeTheme = resolveCodeTheme(appearance)
+      const choices: OverlayChoice[] = [
+        { id: 'dark', label: ui('DeepSeek 暗色', "DeepSeek dark"), description: ui('内置 · 深灰蓝画布', "Built in · deep blue-gray canvas") },
+        { id: 'light', label: ui('DeepSeek 亮色', "DeepSeek light"), description: ui('内置 · 柔和冷白画布', "Built in · soft cool-white canvas") },
+        ...appearance.customThemes.map(theme => ({
+          id: customThemeId(theme),
+          label: theme.name,
+          description: `${theme.tone === 'dark' ? ui('暗色', "Dark") : ui('亮色', "Light")} · ${theme.source === 'palette' ? ui('颜色组生成', "Generate from palette") : theme.source === 'vscode' ? ui('VS Code 导入', "VS Code import") : ui('手动配色', "Manual colors")}`,
+        })),
+      ]
+      choices.sort((left, right) => Number(right.id === appearance.theme) - Number(left.id === appearance.theme))
+      choices.push(
+        {
+          id: '__background__',
+          label: ui('背景模式', 'Background mode'),
+          description: ui('选择主画布背景；独立于主题文件', 'Choose the canvas background independently of theme files'),
+        },
+        {
+          id: '__code__',
+          label: ui('代码块主题', "Code-block theme"),
+          description: ui(`${appearance.codeTheme === 'auto' ? '自动匹配' : '独立指定'} · 当前 ${activeCodeTheme.name}`, `${appearance.codeTheme === 'auto' ? 'Automatic' : 'Explicit'} · current ${activeCodeTheme.name}`),
+        },
+        { id: '__edit__', label: ui('自定义颜色与代码高亮', "Custom colors and syntax highlighting"), description: ui('修改背景、文字和语法颜色', "Edit backgrounds, text, and syntax colors") },
+        { id: '__palette__', label: ui('用颜色组合自动配置', "Generate automatically from a color palette"), description: ui('输入 3–16 个 HEX/RGB 颜色代码', "Enter 3–16 HEX/RGB colors") },
+        { id: '__import__', label: ui('导入 VS Code 主题', "Import VS Code theme"), description: ui('本地 JSON/JSONC · 支持相对 include', "Local JSON/JSONC · relative includes supported") },
+        { id: '__export__', label: ui('导出主题 JSON', "Export theme JSON"), description: ui('写出可分享的 SeekTTY 主题文件', "Write a shareable SeekTTY theme file") },
+        { id: '__delete__', label: ui('删除主题', "Delete theme"), description: ui('管理命名自定义主题', "Manage named custom themes") },
+      )
+      return choices.map(choice => ({
+        ...choice,
+        label: `${currentMark(choice.id === appearance.theme)}${choice.label}`,
+      }))
+    }
     const options = { width: 68, maxHeight: '90%', anchor: 'center', margin: 1 } as const
     await this.overlayFlow(this.host.overlays, async (navigation) => {
       await navigation.selectPage({
         title: ui('主题', "Theme"),
         detail: ui('手动配色、颜色组合自动生成，或导入 VS Code JSON/JSONC', "Edit colors, generate from a palette, or import VS Code JSON/JSONC"),
-        choices: choices.map(choice => ({
-          ...choice,
-          label: `${currentMark(choice.id === appearance.theme)}${choice.label}`,
-        })),
+        choices: await readChoices(),
         options,
       }, async (selected) => {
-        if (selected.id === '__code__') await this.themeCode('', navigation)
-        else if (selected.id === '__background__') await this.editBackgroundMode(navigation)
-        else if (selected.id === '__palette__') await this.themePalette('', navigation)
-        else if (selected.id === '__import__') await this.themeImport('', navigation)
-        else if (selected.id === '__export__') await this.themeExport('', navigation)
-        else if (selected.id === '__edit__') await this.themeEdit('', navigation)
-        else if (selected.id === '__delete__') await this.themeDelete('', navigation)
-        else await this.activateTheme(selected.id as TuiThemeId)
+        let notice: string | undefined
+        try {
+          if (selected.id === '__code__') await this.themeCode('', navigation)
+          else if (selected.id === '__background__') await this.editBackgroundMode(navigation)
+          else if (selected.id === '__palette__') await this.themePalette('', navigation)
+          else if (selected.id === '__import__') await this.themeImport('', navigation)
+          else if (selected.id === '__export__') await this.themeExport('', navigation)
+          else if (selected.id === '__edit__') await this.themeEdit('', navigation)
+          else if (selected.id === '__delete__') await this.themeDelete('', navigation)
+          else await this.activateTheme(selected.id as TuiThemeId)
+        } catch (error) {
+          notice = capabilityError(error)
+          this.host.notice(notice, 'error')
+        }
+        if (navigation.signal.aborted) return
+        const refreshed = await readChoices()
+        if (!navigation.signal.aborted) navigation.updateChoices(refreshed, notice)
       })
     }, options)
   }

--- a/src/client/canvas-foreground.ts
+++ b/src/client/canvas-foreground.ts
@@ -1,0 +1,61 @@
+import { ensureContrast } from './theme-config.ts'
+
+const DEFAULT_FG = '\u001B[39m'
+const SGR = /\u001B\[([0-9;:]*)m/gu
+let cachedBackground: string | undefined
+const colors = new Map<string, string>()
+
+function readableForeground(rgb: string | undefined, background: string | undefined): string {
+  // Unknown terminal palettes (including indexed colors) must not be guessed.
+  if (rgb === undefined || background === undefined) return DEFAULT_FG
+  if (background !== cachedBackground) { colors.clear(); cachedBackground = background }
+  const cached = colors.get(rgb)
+  if (cached !== undefined) return cached
+  const hex = ensureContrast(rgb, background, 4.5)
+  const channels = [1, 3, 5].map(index => Number.parseInt(hex.slice(index, index + 2), 16))
+  const sequence = `\u001B[38;2;${channels.join(';')}m`
+  if (colors.size >= 256) colors.clear()
+  colors.set(rgb, sequence)
+  return sequence
+}
+
+/**
+ * Adapt already-styled canvas rows, including cached Markdown foregrounds.
+ * Track explicit background islands so code, panels and selections retain their
+ * original foregrounds. Only SGR is interpreted; all text and geometry survive.
+ */
+export function readableCanvas(text: string, background?: string): string {
+  let explicitBackground = false
+  let foreground = DEFAULT_FG
+  let rgb: string | undefined
+  return text.replace(SGR, (sequence: string, parameters: string) => {
+    const fields = parameters === '' ? ['0'] : parameters.split(';')
+    let changed = false
+    for (let index = 0; index < fields.length; index += 1) {
+      const field = fields[index] ?? '0'
+      const parts = field.split(':')
+      const code = Number(parts[0])
+      if (code === 0) {
+        foreground = DEFAULT_FG; rgb = undefined; explicitBackground = false; changed = true
+      } else if (code === 38 || code === 48 || code === 58) {
+        const colon = parts.length > 1
+        const mode = Number(colon ? parts[1] : fields[index + 1])
+        const count = mode === 2 ? 3 : mode === 5 ? 1 : 0
+        const values = colon ? parts.slice(-count) : fields.slice(index + 2, index + 2 + count)
+        const colorFields = colon ? field : fields.slice(index, index + 2 + count).join(';')
+        if (!colon) index += 1 + count
+        if (code === 38) {
+          foreground = `\u001B[${colorFields}m`
+          rgb = mode === 2 && values.length === 3 && values.every(value => /^\d+$/u.test(value) && Number(value) <= 255)
+            ? `#${values.map(value => Number(value).toString(16).padStart(2, '0')).join('')}` : undefined
+          changed = true
+        } else if (code === 48) { explicitBackground = true; changed = true }
+      } else if (code === 39 || (code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+        foreground = `\u001B[${field}m`; rgb = undefined; changed = true
+      } else if (code === 49 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+        explicitBackground = code !== 49; changed = true
+      }
+    }
+    return changed ? sequence + (explicitBackground ? foreground : readableForeground(rgb, background)) : sequence
+  })
+}

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -66,7 +66,7 @@ import {
   type ProviderOnboardingResult,
 } from './provider-onboarding.ts'
 import { adoptSyntaxHighlighter, SyntaxHighlighter } from './syntax-highlighter.ts'
-import { background, color, escapeTerminalText, setBackgroundMode, setCodeHighlighter, setTheme } from './theme.ts'
+import { background, color, escapeTerminalText, setBackgroundMode, setCodeHighlighter, setTerminalCanvasBackground, setTheme } from './theme.ts'
 import { Transcript } from './transcript.ts'
 import { canReadClipboardText, readClipboardText, writeClipboard } from './clipboard.ts'
 import { graphemeRangeAt, type SelectionAnchor } from './text-selection.ts'
@@ -195,8 +195,11 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
   }
   let stopTuiRenderingSync = (): void => undefined
   let reportBackgroundUnavailable = (): void => undefined
+  let repaintBackground = (): void => undefined
+  setTerminalCanvasBackground(undefined)
   const terminalSession = createTerminalSession(terminal, true, () => { stopTuiRenderingSync() }, process.env,
-    () => { reportBackgroundUnavailable() })
+    () => { reportBackgroundUnavailable() },
+    color => { setTerminalCanvasBackground(color); repaintBackground() })
   const startup = await (async () => {
     try {
       return await measureStartup('settings+client', () => Promise.all([
@@ -244,6 +247,13 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
     }
     const capabilities = client.capabilities
     let stopping: Promise<void> | undefined
+    repaintBackground = () => {
+      if (stopping !== undefined) return
+      // Adapt cached foregrounds at the canvas boundary; no transcript rebuild,
+      // selection reset, or scroll-anchor movement is needed for this repaint.
+      tui.invalidate()
+      tui.requestRender(true)
+    }
     let active: TuiActiveSession | undefined
     const profile = options.profile ?? 'tui'
     const contextBar = new ContextBar(profile, options.cwd)

--- a/src/client/terminal-background.ts
+++ b/src/client/terminal-background.ts
@@ -28,11 +28,13 @@ export class TerminalBackground {
   private applied: string | undefined
   private changed = false
   private timer: ReturnType<typeof setTimeout> | undefined
+  private reportedColor: string | undefined
 
   constructor(
     private readonly terminal: { write(data: string): void },
     private readonly enabled: boolean,
     private readonly onUnavailable: (reason: BackgroundSyncUnavailable) => void = () => undefined,
+    private readonly onColorChanged: (color: string | undefined) => void = () => undefined,
   ) {}
 
   /** Set color and policy atomically, without writing an intermediate theme. */
@@ -43,6 +45,7 @@ export class TerminalBackground {
     this.mode = mode
     if (mode === 'terminal') this.restoreOriginal()
     else this.sync()
+    this.reportColor()
   }
 
   start(): void {
@@ -91,6 +94,7 @@ export class TerminalBackground {
       this.timer = undefined
       this.original = reply[1].toLowerCase()
       this.sync()
+      this.reportColor()
     }
     return true
   }
@@ -106,6 +110,7 @@ export class TerminalBackground {
     this.original = undefined
     this.applied = undefined
     this.changed = false
+    this.reportColor()
   }
 
   /** Switching to terminal-only restores color without losing the lifetime snapshot. */
@@ -132,6 +137,19 @@ export class TerminalBackground {
       this.restoreOriginal()
       this.notifyUnavailable()
     }
+    this.reportColor()
+  }
+
+  private reportColor(): void {
+    const actual = this.unavailable === 'write-failed' ? undefined : this.changed ? this.applied : this.original
+    // OSC channels may contain 1–4 hex digits. Scale, rather than truncate,
+    // and retain the untouched original string for restoration above.
+    const color = actual === undefined ? undefined : `#${actual.slice(4).split('/').map(channel =>
+      Math.round(Number.parseInt(channel, 16) * 255 / (16 ** channel.length - 1)).toString(16).padStart(2, '0'),
+    ).join('')}`
+    if (color === this.reportedColor) return
+    this.reportedColor = color
+    try { this.onColorChanged(color) } catch { /* presentation cannot disrupt terminal cleanup */ }
   }
 
   private notifyUnavailable(): void {

--- a/src/client/terminal-session.ts
+++ b/src/client/terminal-session.ts
@@ -66,8 +66,9 @@ export function createTerminalSession(
   beforeRestore: () => void = () => undefined,
   env: Readonly<NodeJS.ProcessEnv> = process.env,
   onBackgroundUnavailable?: (reason: BackgroundSyncUnavailable) => void,
+  onBackgroundColorChanged?: (color: string | undefined) => void,
 ): TerminalSession {
-  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable)
+  const background = new TerminalBackground(terminal, enabled && supportsTerminalBackground(env), onBackgroundUnavailable, onBackgroundColorChanged)
   let active = false
   let mouseMode: MouseReportingMode = 'full'
   let hoverFeedback = true

--- a/src/client/theme-config.ts
+++ b/src/client/theme-config.ts
@@ -330,7 +330,8 @@ function mix(left: string, right: string, amount: number): string {
   })
 }
 
-function ensureContrast(color: string, background: string, minimum: number): string {
+/** Derive a readable foreground without mutating the saved palette. */
+export function ensureContrast(color: string, background: string, minimum: number): string {
   const normalized = normalizeThemeColor(color)
   if (themeContrast(normalized, background) >= minimum) return normalized
   const targets = ['#000000', '#FFFFFF'] as const

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -8,6 +8,7 @@ import {
 import { BUILT_IN_THEMES, resolveHoverStyle, type ResolvedTuiTheme } from './theme-config.ts'
 import { DEFAULT_TUI_BACKGROUND_MODE, type TuiBackgroundMode } from '@deepseek-ai/dsh-tui-protocol'
 import { ui } from './locale.ts'
+import { readableCanvas } from './canvas-foreground.ts'
 
 const RESET = '\u001B[0m'
 const ESC = 0x1B
@@ -341,6 +342,11 @@ export function currentTheme(): ResolvedTuiTheme { return selectedTheme }
 /** Independent of theme previews/imports; only the main canvas inherits terminal effects. */
 export function setBackgroundMode(mode: TuiBackgroundMode): void { backgroundMode = mode }
 
+let terminalCanvasBackground: string | undefined
+
+/** Actual background reported by the managed terminal, never persisted as a theme. */
+export function setTerminalCanvasBackground(color?: string): void { terminalCanvasBackground = color }
+
 /**
  * Connect the asynchronously prepared syntax highlighter to Markdown rendering.
  * @param highlighter - synchronous cached renderer, or undefined during teardown.
@@ -381,7 +387,12 @@ export const color = {
 
 /** Background layers shared by the full frame, panels, and selected rows. */
 export const background = {
-  canvas: (text: string): string => layer(backgroundMode === 'explicit' ? palette.canvas : undefined, text),
+  canvas: (text: string): string => {
+    const row = layer(backgroundMode === 'explicit' ? palette.canvas : undefined, text)
+    if (terminalColorLevel() === 0 || backgroundMode === 'explicit'
+      || terminalCanvasBackground?.toLowerCase() === selectedTheme.colors.canvas.toLowerCase()) return row
+    return readableCanvas(row, terminalColorLevel() === 3 ? terminalCanvasBackground : undefined)
+  },
   surface: (text: string): string => layer(palette.surface, text),
   hover: hoverLayer,
   selection: (text: string): string => layer(palette.selection, text),

--- a/tests/actions-theme.test.ts
+++ b/tests/actions-theme.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { HarnessTuiCapabilities } from '../src/client/capabilities.ts'
 import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
-import type { OverlayNavigation, OverlayQueue } from '../src/client/overlays.ts'
+import { OverlayQueue, type OverlayNavigation } from '../src/client/overlays.ts'
+import { setUiLocale } from '../src/client/locale.ts'
 import type { Transcript } from '../src/client/transcript.ts'
 import { BUILT_IN_THEMES, editableTheme } from '../src/client/theme-config.ts'
 import {
@@ -88,6 +90,118 @@ function actionHarness(
   }
   return { actions: new TuiActions(capabilities, host), host }
 }
+
+afterEach(() => { setUiLocale('zh') })
+
+function menuHarness(state: ReturnType<typeof settingsState>) {
+  let mounted: Component | undefined
+  const overlays = new OverlayQueue({
+    showOverlay: (component: Component) => { mounted = component; return { hide: vi.fn() } as unknown as OverlayHandle },
+    requestRender: vi.fn(),
+  } as unknown as TUI)
+  return {
+    ...actionHarness(state.settings, overlays), overlays,
+    text: () => mounted?.render(110).join('\n').replace(/\u001B\[[0-9;:]*m/gu, '') ?? '',
+    key: (data: string) => mounted?.handleInput?.(data),
+  }
+}
+
+describe('live theme menu', () => {
+  it.each(['zh', 'en'] as const)('refreshes current marks and preserves the query and selection (%s)', async locale => {
+    setUiLocale(locale)
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
+    const h = menuHarness(state)
+    const pending = h.actions.execute('theme', '')
+    const current = locale === 'zh' ? '当前 · DeepSeek ' : 'Current · DeepSeek '
+    const dark = locale === 'zh' ? '暗色' : 'dark'
+    const light = locale === 'zh' ? '亮色' : 'light'
+    try {
+      await vi.waitFor(() => expect(h.text()).toContain(current + dark))
+      h.key('\u001B[B'); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain(current + light))
+      expect(h.text()).not.toContain(current + dark)
+      expect(h.text()).toMatch(new RegExp(`→\\s+${current}${light}`, 'u'))
+      h.key('\r') // Stable selection remains light, now current; no new write.
+      await vi.waitFor(() => expect(h.host.notice).toHaveBeenLastCalledWith(expect.any(String), 'info'))
+      expect(state.mutate).toHaveBeenCalledTimes(1)
+      h.key(dark); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain(current + dark))
+      expect(h.text()).toMatch(new RegExp(`(?:搜索|Search)\\s*>\\s*${dark}`, 'u'))
+      expect(state.current().value).toMatchObject({ theme: 'dark', codeTheme: 'auto' })
+      expect(state.settings.describe).toHaveBeenCalledWith(TUI_APPEARANCE_SETTINGS_NAMESPACE, { bypassCache: true })
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('refreshes the parent description after returning from the code theme child', async () => {
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
+    const h = menuHarness(state)
+    const pending = h.actions.execute('theme', '')
+    try {
+      await vi.waitFor(() => expect(h.text()).toContain('代码块主题'))
+      h.key('代码块主题'); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain('DeepSeek 亮色代码'))
+      h.key('DeepSeek 亮色代码'); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain('独立指定 · 当前 DeepSeek 亮色'))
+      expect(state.current().value).toMatchObject({ theme: 'dark', codeTheme: 'light' })
+      expect(state.mutate).toHaveBeenCalledTimes(1)
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('keeps the authoritative marker and an inline error after a failed save, then permits retry', async () => {
+    const custom = editableTheme(BUILT_IN_THEMES.dark, 'ocean', 'Ocean')
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [custom] })
+    state.mutate.mockRejectedValueOnce(new Error('save rejected'))
+    const h = menuHarness(state)
+    const pending = h.actions.execute('theme', '')
+    try {
+      await vi.waitFor(() => expect(h.text()).toContain('Ocean'))
+      h.key('\u001B[B'); h.key('\u001B[B'); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain('save rejected'))
+      expect(h.text()).toContain('当前 · DeepSeek 暗色')
+      expect(h.text()).not.toContain('当前 · Ocean')
+      expect(h.host.applyAppearance).not.toHaveBeenCalled()
+      h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain('当前 · Ocean'))
+      expect(h.text()).not.toContain('save rejected')
+      expect(state.current().value).toMatchObject({ theme: 'custom:ocean' })
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('leaves theme state unchanged when a child is cancelled', async () => {
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
+    const h = menuHarness(state)
+    const pending = h.actions.execute('theme', '')
+    try {
+      await vi.waitFor(() => expect(h.text()).toContain('代码块主题'))
+      h.key('代码块主题'); h.key('\r')
+      await vi.waitFor(() => expect(h.text()).toContain('DeepSeek 亮色代码'))
+      h.key('\u001B')
+      await vi.waitFor(() => expect(h.text()).toContain('自动匹配 · 当前 DeepSeek 暗色'))
+      expect(state.mutate).not.toHaveBeenCalled()
+      expect(h.host.applyAppearance).not.toHaveBeenCalled()
+    } finally { h.overlays.dispose(); await pending }
+  })
+
+  it('ignores a late refresh after the menu is closed', async () => {
+    const state = settingsState({ theme: 'dark', codeTheme: 'auto', customThemes: [] })
+    const h = menuHarness(state)
+    const describe = vi.mocked(state.settings.describe)
+    let release: ((value: readonly TuiSettingsDocument[]) => void) | undefined
+    const pending = h.actions.execute('theme', '')
+    try {
+      await vi.waitFor(() => expect(h.text()).toContain('当前 · DeepSeek 暗色'))
+      // Selecting the current theme reads once, then the menu refresh awaits.
+      describe.mockResolvedValueOnce([state.current()]).mockImplementationOnce(() => new Promise(resolve => { release = resolve }))
+      h.key('\r')
+      await vi.waitFor(() => expect(release).toBeDefined())
+      h.overlays.dispose()
+      release!([state.current()])
+      await pending
+      expect(state.mutate).not.toHaveBeenCalled()
+      expect(h.host.notice).not.toHaveBeenCalledWith(expect.any(String), 'error')
+    } finally { h.overlays.dispose(); release?.([state.current()]); await pending }
+  })
+})
 
 describe('/theme commands', () => {
   it('switches a built-in theme through Harness Settings and applies the resolved theme live', async () => {

--- a/tests/background-inheritance.test.ts
+++ b/tests/background-inheritance.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Box, TUI, visibleWidth, type Terminal } from '@mariozechner/pi-tui'
 import { BottomAnchoredLayout } from '../src/client/chrome.ts'
-import { background, color, setBackgroundMode, setTheme } from '../src/client/theme.ts'
+import { background, color, setBackgroundMode, setTerminalCanvasBackground, setTheme } from '../src/client/theme.ts'
 import { BUILT_IN_THEMES } from '../src/client/theme-config.ts'
 import { tuiFrameApi } from '../src/client/pi-tui-adapters.ts'
 import type { TuiBackgroundMode } from '../src/protocol.ts'
@@ -21,6 +21,7 @@ afterEach(() => {
   vi.useRealTimers()
   vi.unstubAllEnvs()
   setBackgroundMode('theme')
+  setTerminalCanvasBackground(undefined)
   setTheme(BUILT_IN_THEMES.dark)
 })
 
@@ -110,6 +111,12 @@ describe('canvas / layout / overlay frame integration (synthetic terminal)', () 
         expect(await redraw(mode)).toEqual(original)
         expect(tuiFrameApi(tui).getLastFrameGeometry?.()).toEqual(geometry)
       }
+      const beforeReply = tui.render(terminal.columns)
+      setTerminalCanvasBackground('#ffffff')
+      expect(await redraw('terminal')).toEqual(original)
+      expect(tui.render(terminal.columns)).not.toEqual(beforeReply)
+      expect(tuiFrameApi(tui).getLastFrameGeometry?.()).toEqual(geometry)
+      setTerminalCanvasBackground(undefined)
       const overlay = tui.showOverlay({ render: () => [background.surface('overlay')], invalidate: () => undefined }, { width: 20 })
       await frame()
       overlay.hide()

--- a/tests/terminal-background.test.ts
+++ b/tests/terminal-background.test.ts
@@ -54,6 +54,51 @@ describe('terminal background capability policy', () => {
 })
 
 describe('background ownership', () => {
+  it('reports applied, restored and unknown colors without another query or precision loss', () => {
+    const writes: string[] = []
+    const changed = vi.fn()
+    const background = new TerminalBackground({ write: data => { writes.push(data) } }, true, undefined, changed)
+    background.setColor('#282c34')
+    background.start()
+    expect(changed).not.toHaveBeenCalled()
+    background.consumeInput(reply('rgb:f/8000/00'))
+    expect(changed).toHaveBeenLastCalledWith('#282c34')
+    background.setColor('#282c34', 'terminal')
+    expect(changed).toHaveBeenLastCalledWith('#ff8000')
+    expect(writes.at(-1)).toBe(reply('rgb:f/8000/00'))
+    background.restore()
+    expect(changed).toHaveBeenLastCalledWith(undefined)
+    expect(writes.filter(value => value === BACKGROUND_QUERY)).toHaveLength(1)
+  })
+
+  it.each(['disabled', 'timeout', 'write-failed'] as const)('does not report a guessed background after %s', reason => {
+    vi.useFakeTimers()
+    const changed = vi.fn()
+    const background = new TerminalBackground({ write: () => {
+      if (reason === 'write-failed') throw new Error('write failed')
+    } }, reason !== 'disabled', undefined, changed)
+    background.setColor('#282c34')
+    background.start()
+    vi.advanceTimersByTime(BACKGROUND_QUERY_TIMEOUT_MS)
+    background.consumeInput(reply())
+    expect(changed).not.toHaveBeenCalled()
+    background.restore()
+  })
+
+  it('invalidates a known background when a later write or restoration fails', () => {
+    let fail = false
+    const changed = vi.fn()
+    const background = new TerminalBackground({ write: () => { if (fail) throw new Error('write failed') } }, true, undefined, changed)
+    background.setColor('#282c34')
+    background.start()
+    background.consumeInput(reply())
+    expect(changed).toHaveBeenLastCalledWith('#282c34')
+    fail = true
+    background.setColor('#ffffff')
+    expect(changed).toHaveBeenLastCalledWith(undefined)
+    background.restore()
+  })
+
   it('defers its single query until input is ready and a synchronizing mode is selected', () => {
     const { background, writes } = controller()
     background.setColor('#282C34', 'terminal')

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -21,12 +21,13 @@ import {
   color,
   currentTheme,
   setBackgroundMode,
+  setTerminalCanvasBackground,
   setTheme,
   styleTerminalText,
   surfaceRow,
   terminalColorLevel,
 } from '../src/client/theme.ts'
-import { BUILT_IN_THEMES, editableTheme } from '../src/client/theme-config.ts'
+import { BUILT_IN_THEMES, editableTheme, themeContrast } from '../src/client/theme-config.ts'
 
 function appearance(
   theme: TuiThemeId,
@@ -53,10 +54,76 @@ function enableTruecolor(): void {
 afterEach(() => {
   setTheme(BUILT_IN_THEMES.dark)
   setBackgroundMode('theme')
+  setTerminalCanvasBackground(undefined)
   vi.unstubAllEnvs()
 })
 
 describe('terminal themes', () => {
+  // Evaluate the effective foreground at text, not just the presence of an
+  // earlier escape that a nested Markdown token could override.
+  function foregroundAt(row: string, text: string): string | undefined {
+    const prefix = row.slice(0, row.indexOf(text))
+    const match = [...prefix.matchAll(/\u001B\[(39|38;2;(\d+);(\d+);(\d+))m/gu)].at(-1)
+    if (match?.[1] === '39') return undefined
+    if (match === undefined) throw new Error('missing foreground')
+    return `#${match.slice(2).map(value => Number(value).toString(16).padStart(2, '0')).join('')}`
+  }
+
+  it.each([['dark', '#ffffff'], ['light', '#000000']] as const)(
+    'adapts cached %s text to a known mismatched terminal background %s', (theme, terminalBackground) => {
+      enableTruecolor()
+      setTheme(BUILT_IN_THEMES[theme])
+      setBackgroundMode('terminal')
+      const cached = `body ${color.muted('muted')} ${color.brand('heading')} ${color.danger('error')} ${color.accent('link')}`
+      setTerminalCanvasBackground(terminalBackground)
+      const row = background.canvas(cached)
+      for (const word of ['body', 'muted', 'heading', 'error', 'link']) {
+        const actual = foregroundAt(row, word)
+        expect(actual).toBeDefined()
+        expect(themeContrast(actual!, terminalBackground)).toBeGreaterThanOrEqual(4.5)
+      }
+      expect(visibleWidth(row)).toBe(visibleWidth(cached))
+      expect(currentTheme()).toBe(BUILT_IN_THEMES[theme])
+      // Repaint the same cached row when the background becomes unknown.
+      setTerminalCanvasBackground(undefined)
+      for (const word of ['body', 'muted', 'heading', 'error', 'link']) {
+        expect(foregroundAt(background.canvas(cached), word)).toBeUndefined()
+      }
+    },
+  )
+
+  it.each(['theme', 'terminal'] as const)('uses terminal foregrounds for unknown %s backgrounds, preserving explicit islands', mode => {
+    enableTruecolor()
+    setBackgroundMode(mode)
+    const islands = [background.code('code'), background.surface('panel'), background.hover('hover'), background.selection('selection')]
+    const row = background.canvas(`body ${color.muted('muted')} \u001B[1mbold\u001B[0m ${islands.join(' ')} tail`)
+    for (const word of ['body', 'muted', 'bold', 'tail']) expect(foregroundAt(row, word)).toBeUndefined()
+    for (const [index, word] of ['code', 'panel', 'hover', 'selection'].entries()) {
+      expect(foregroundAt(row, word)).toBe(foregroundAt(islands[index]!, word))
+    }
+    expect(row).toContain('\u001B[1mbold')
+    expect(row.replace(/\u001B\[[0-9;:]*m/gu, '')).toBe('body muted bold code panel hover selection tail')
+  })
+
+  it('keeps saved theme colors for explicit fill and confirmed matching theme backgrounds', () => {
+    enableTruecolor()
+    setBackgroundMode('explicit')
+    const row = background.canvas(`body ${color.muted('muted')}`)
+    expect(foregroundAt(row, 'body')?.toLowerCase()).toBe(BUILT_IN_THEMES.dark.colors.text.toLowerCase())
+    setBackgroundMode('theme')
+    setTerminalCanvasBackground(BUILT_IN_THEMES.dark.colors.canvas)
+    expect(foregroundAt(background.canvas('body'), 'body')).toBe(foregroundAt(row, 'body'))
+  })
+
+  it('handles combined, indexed and colon SGR foregrounds without changing text or geometry', () => {
+    enableTruecolor()
+    setBackgroundMode('terminal')
+    const row = background.canvas('\u001B[1;38;5;255mindexed\u001B[38:2::255:255:255mcolon\u001B[48;2;0;0;0mcode\u001B[49mtail')
+    for (const word of ['indexed', 'colon', 'tail']) expect(foregroundAt(row, word)).toBeUndefined()
+    expect(row).toContain('\u001B[38:2::255:255:255mcode')
+    expect(visibleWidth(row)).toBe('indexedcoloncodetail'.length)
+  })
+
   it('switches every semantic layer between DeepSeek dark and light palettes', () => {
     enableTruecolor()
     setBackgroundMode('explicit')

--- a/tests/transcript-viewport.test.ts
+++ b/tests/transcript-viewport.test.ts
@@ -6,7 +6,7 @@ import type {
 import { internals, Transcript } from '../src/client/transcript.ts'
 import type { TranscriptImagePayload } from '../src/client/transcript.ts'
 import { terminalMouseDelta } from '../src/client/terminal-session.ts'
-import { background, setBackgroundMode } from '../src/client/theme.ts'
+import { background, setBackgroundMode, setTerminalCanvasBackground } from '../src/client/theme.ts'
 
 function assistant(key: string, text: string): ChatConversationViewNode {
   return {
@@ -123,6 +123,7 @@ function plain(lines: readonly string[]): string {
 
 afterEach(() => {
   setBackgroundMode('theme')
+  setTerminalCanvasBackground(undefined)
   resetRenderCounters()
   internals.fingerprintsComputed = 0
   internals.markdownCreated = 0
@@ -153,8 +154,9 @@ describe('transcript block viewport', () => {
     const lines = plain(transcript.render(80))
     const maps = transcript.viewportMaps()
     resetRenderCounters()
-    for (const mode of ['terminal', 'explicit', 'theme'] as const) {
+    for (const [mode, color] of [['terminal', '#ffffff'], ['explicit', undefined], ['theme', undefined], ['terminal', '#000000']] as const) {
       setBackgroundMode(mode)
+      setTerminalCanvasBackground(color)
       transcript.invalidate()
       expect(plain(transcript.render(80).map(background.canvas))).toBe(lines)
       expect(transcript.currentSelection()).toEqual(selection)


### PR DESCRIPTION
## 问题与修复

Closes #167
Closes #168

### 终端背景下的文字可读性

- 在主画布渲染边界适配前景色，覆盖已缓存的 Markdown、正文和辅助文字，而不只调整最外层颜色。
- 受控背景同步得到的 RGB 背景与主题不匹配时，复用已有颜色计算将画布 RGB 文字对比度调整到至少 4.5:1。
- 背景未知、查询超时、禁用或不支持同步时，使用终端默认前景色 `SGR 39`，不猜黑白、不增加额外查询。
- 保留代码块、弹窗、选区和 hover 的独立背景及前景色；显式主题底色和匹配的主题背景保留原配色。
- 背景状态变化触发重绘，不重建会话节点、不清除选区、不改变滚动锚点或命中几何。颜色计算使用有界缓存。

### 主题菜单即时刷新

- 保存主题或从子菜单返回后，重新读取 Host Settings 并更新当前标记、代码主题说明及自定义主题列表。
- 复用 `updateChoices` 保留搜索词、选中项与列表位置。
- 保存失败保留权威状态及菜单内错误，允许重试；忽略菜单关闭后的异步刷新。

不改写保存的主题定义或终端配置，不改变 `NO_COLOR`、禁用开关和 tmux/screen 安全边界。

## 验证

- `pnpm run check`：1001 项通过，1 项可选 Clarify 安装测试因未提供外部安装包跳过；类型检查、构建与打包检查通过。
- `pnpm test:stock`：隔离 `DSH_HOME`、未修改的官方 dsh `0.1.1-rc.2` 下安装、启动、卸载和重装通过。
- `pnpm test:mouse-pty`：同一主题菜单中暗色 → 亮色 → 暗色的当前标记更新、鼠标交互及正常退出通过。
- 浅底/深底、未知背景、嵌套 ANSI 配色、独立代码/选区背景、历史视口与选择保留、子菜单返回、失败重试和晚到刷新均有回归测试。
- 与 #166 的合并版本：1019 项通过、1 项上述可选测试跳过，合并包生命周期和 PTY 验证通过；用户已完成该本地合并版本的手工测试并确认可以提交 PR。

## 边界、合并与回滚

终端默认前景色依赖用户的终端配色；4.5:1 计算针对已知不透明 RGB，不保证背景图、透明叠加等任意像素背景的对比度。未知背景下会减少正文语义颜色，保留粗体、下划线与独立区域配色。PTY 不等同于所有 GUI 终端验收。

直接面向 `main`，不依赖 #166；已做两个修复分支的合并预检。构建产物同步提交，无设置、Profile 或 Session 迁移。回滚本 PR 即恢复原渲染和菜单逻辑。
