### PR TITLE
feat(queue): prioritize queued messages after interrupt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22519,6 +22519,25 @@ var HarnessTuiCapabilities = class {
 		if (!result.ok) throw new Error(ui(`队列操作失败：${result.error.message}`, `Queue operation failed: ${result.error.message}`));
 	}
 	/**
+	* Stop one running turn while preserving its inbox, then promote one queued
+	* message through the Host's native steering operation. The captured Session
+	* face is kept across both acknowledgements so a UI selection change cannot
+	* redirect the second operation to another Session.
+	* @param sessionId - Session selected when the queue row was opened.
+	* @param itemId - authoritative queued message identity.
+	*/
+	async interruptAndSteer(sessionId, itemId) {
+		const active = this.requireActive();
+		if (active.sessionId !== sessionId) throw new Error(ui("会话已切换，未打断原任务", "The active session changed; the original turn was not interrupted"));
+		const snapshot = active.session.getSnapshot();
+		const queued = snapshot.queue.some((row) => row.id === itemId && row.placement === "queued");
+		if (!snapshot.running || !queued) throw new Error(ui("任务或队列状态已变化，请重新打开队列", "The turn or queue changed; reopen the queue and try again"));
+		const cancelled = await active.session.cancel();
+		if (!cancelled.ok) throw new Error(ui(`打断任务失败：${cancelled.error.message}`, `Failed to interrupt the turn: ${cancelled.error.message}`));
+		const promoted = await active.session.updateQueue(itemId, { kind: "steer" });
+		if (!promoted.ok) throw new Error(ui(`任务已请求停止，但消息提前处理状态未确认：${promoted.error.message}；请查看队列`, `The turn was asked to stop, but message promotion is unconfirmed: ${promoted.error.message}; inspect the queue`));
+	}
+	/**
 	* Answer a Runtime-owned approval wait with the Host protocol's correlated value.
 	* @param wait - correlated Runtime approval interaction.
 	* @param outcome - Host-supported one-shot allow or rejection.
@@ -31830,7 +31849,9 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		};
 	}
 	async queueChoice(nav, id) {
-		const rows = this.capabilities.active()?.session.getSnapshot().queue ?? [];
+		const active = this.capabilities.active();
+		const snapshot = active?.session.getSnapshot();
+		const rows = snapshot?.queue ?? [];
 		const queued = rows.filter((row$1) => row$1.placement === "queued");
 		if (id === "__all_steer__") {
 			for (const row$1 of queued) await this.capabilities.updateQueue(row$1.id, { kind: "steer" });
@@ -31848,6 +31869,12 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 		const action = await nav.select({
 			title: ui("队列操作", "Queue action"),
 			choices: [
+				{
+					id: "interrupt",
+					label: ui("停止当前任务并优先处理", "Stop current turn and prioritize"),
+					description: ui("保留其他排队消息，停止后优先处理这一条", "Keep the rest of the queue and prioritize this message after stopping"),
+					...snapshot?.running === true ? {} : { disabledReason: ui("当前没有正在运行的任务", "No turn is currently running") }
+				},
 				{
 					id: "steer",
 					label: ui("转为引导", "Convert to steering"),
@@ -31867,6 +31894,12 @@ The directory, user files, and all session logs are kept; sessions become ungrou
 			searchable: false
 		});
 		if (action === void 0) return;
+		if (action.id === "interrupt" && active !== void 0) {
+			if (!await nav.confirm(ui("停止当前任务并优先处理这条消息？", "Stop the current turn and prioritize this message?"), ui("当前生成会停止；其他排队消息将按原顺序保留。", "The current generation will stop; other queued messages keep their order."), ui("停止并优先处理", "Stop and prioritize"))) return;
+			await this.capabilities.interruptAndSteer(active.sessionId, row.id);
+			this.host.notice(ui("已请求停止当前任务；所选消息将优先处理", "Stop requested; the selected message will be handled first"), "success");
+			return;
+		}
 		if (action.id === "steer") await this.capabilities.updateQueue(row.id, { kind: "steer" });
 		else if (action.id === "remove") await this.capabilities.updateQueue(row.id, { kind: "remove" });
 		else if (action.id === "edit" && row.text !== null) {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1898,7 +1898,9 @@ The directory, user files, and all session logs are kept; sessions become ungrou
   }
 
   private async queueChoice(nav: OverlayNavigation, id: string): Promise<void> {
-    const rows = this.capabilities.active()?.session.getSnapshot().queue ?? []
+    const active = this.capabilities.active()
+    const snapshot = active?.session.getSnapshot()
+    const rows = snapshot?.queue ?? []
     const queued = rows.filter(row => row.placement === 'queued')
     if (id === '__all_steer__') {
       for (const row of queued) await this.capabilities.updateQueue(row.id, { kind: 'steer' })
@@ -1921,6 +1923,12 @@ The directory, user files, and all session logs are kept; sessions become ungrou
     const action = await nav.select({
       title: ui('队列操作', "Queue action"),
       choices: [
+        {
+          id: 'interrupt',
+          label: ui('停止当前任务并优先处理', "Stop current turn and prioritize"),
+          description: ui('保留其他排队消息，停止后优先处理这一条', "Keep the rest of the queue and prioritize this message after stopping"),
+          ...(snapshot?.running === true ? {} : { disabledReason: ui('当前没有正在运行的任务', "No turn is currently running") }),
+        },
         { id: 'steer', label: ui('转为引导', "Convert to steering"), description: ui('并入当前轮次', "Merge into current turn") },
         { id: 'edit', label: ui('编辑', "Edit"), ...(row.text === null ? { disabledReason: ui('含非文本内容，无法文本编辑', "Contains non-text content and cannot be edited as text") } : {}) },
         { id: 'remove', label: ui('删除', "Delete"), description: ui('从待处理队列移除', "Remove from the pending queue") },
@@ -1928,6 +1936,17 @@ The directory, user files, and all session logs are kept; sessions become ungrou
       searchable: false,
     })
     if (action === undefined) return
+    if (action.id === 'interrupt' && active !== undefined) {
+      const confirmed = await nav.confirm(
+        ui('停止当前任务并优先处理这条消息？', "Stop the current turn and prioritize this message?"),
+        ui('当前生成会停止；其他排队消息将按原顺序保留。', "The current generation will stop; other queued messages keep their order."),
+        ui('停止并优先处理', "Stop and prioritize"),
+      )
+      if (!confirmed) return
+      await this.capabilities.interruptAndSteer(active.sessionId, row.id)
+      this.host.notice(ui('已请求停止当前任务；所选消息将优先处理', "Stop requested; the selected message will be handled first"), 'success')
+      return
+    }
     if (action.id === 'steer') await this.capabilities.updateQueue(row.id, { kind: 'steer' })
     else if (action.id === 'remove') await this.capabilities.updateQueue(row.id, { kind: 'remove' })
     else if (action.id === 'edit' && row.text !== null) {

--- a/src/client/capabilities.ts
+++ b/src/client/capabilities.ts
@@ -1650,6 +1650,41 @@ export class HarnessTuiCapabilities {
   }
 
   /**
+   * Stop one running turn while preserving its inbox, then promote one queued
+   * message through the Host's native steering operation. The captured Session
+   * face is kept across both acknowledgements so a UI selection change cannot
+   * redirect the second operation to another Session.
+   * @param sessionId - Session selected when the queue row was opened.
+   * @param itemId - authoritative queued message identity.
+   */
+  async interruptAndSteer(
+    sessionId: SessionId,
+    itemId: ConversationSnapshot['queue'][number]['id'],
+  ): Promise<void> {
+    const active = this.requireActive()
+    if (active.sessionId !== sessionId) {
+      throw new Error(ui('会话已切换，未打断原任务', 'The active session changed; the original turn was not interrupted'))
+    }
+    const snapshot = active.session.getSnapshot()
+    const queued = snapshot.queue.some(row => row.id === itemId && row.placement === 'queued')
+    if (!snapshot.running || !queued) {
+      throw new Error(ui('任务或队列状态已变化，请重新打开队列', 'The turn or queue changed; reopen the queue and try again'))
+    }
+
+    const cancelled = await active.session.cancel()
+    if (!cancelled.ok) {
+      throw new Error(ui(`打断任务失败：${cancelled.error.message}`, `Failed to interrupt the turn: ${cancelled.error.message}`))
+    }
+    const promoted = await active.session.updateQueue(itemId, { kind: 'steer' })
+    if (!promoted.ok) {
+      throw new Error(ui(
+        `任务已请求停止，但消息提前处理状态未确认：${promoted.error.message}；请查看队列`,
+        `The turn was asked to stop, but message promotion is unconfirmed: ${promoted.error.message}; inspect the queue`,
+      ))
+    }
+  }
+
+  /**
    * Answer a Runtime-owned approval wait with the Host protocol's correlated value.
    * @param wait - correlated Runtime approval interaction.
    * @param outcome - Host-supported one-shot allow or rejection.

--- a/tests/queue-order.test.ts
+++ b/tests/queue-order.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import type { Component, OverlayHandle, TUI } from '@mariozechner/pi-tui'
 import { TuiActions, type TuiActionHost } from '../src/client/actions.ts'
-import type { HarnessTuiCapabilities, TuiActiveSession } from '../src/client/capabilities.ts'
+import { HarnessTuiCapabilities, type TuiActiveSession } from '../src/client/capabilities.ts'
 import { OverlayQueue } from '../src/client/overlays.ts'
 import type { Transcript } from '../src/client/transcript.ts'
 import { moveIndex, queueListChoiceOrder } from '../src/client/queue-order.ts'
@@ -92,8 +92,14 @@ describe('queue reorder', () => {
     expect(plain(mounted!.render(80))).toContain('queued hello')
 
     handleInput(mounted!, ENTER)
-    await vi.waitFor(() => { expect(plain(mounted!.render(80))).toContain('编辑') })
+    await vi.waitFor(() => {
+      const menu = plain(mounted!.render(80))
+      expect(menu).toContain('停止当前任务并优先处理')
+      expect(menu).toContain('转为引导')
+      expect(menu).toContain('编辑')
+    })
 
+    handleInput(mounted!, DOWN)
     handleInput(mounted!, DOWN)
     handleInput(mounted!, ENTER)
     await vi.waitFor(() => { expect(plain(mounted!.render(80))).toContain('编辑排队消息') })
@@ -109,5 +115,93 @@ describe('queue reorder', () => {
     await pending
     expect(updateQueue).not.toHaveBeenCalled()
     expect(notice.mock.calls.some(call => String(call[0]).includes('已提交'))).toBe(false)
+  })
+
+  it('cancels before promoting the selected queued message on its captured session', async () => {
+    const calls: string[] = []
+    const session = {
+      getSnapshot: () => ({
+        running: true,
+        queue: [{ id: 'msg-1', placement: 'queued' }],
+      }),
+      cancel: vi.fn(async () => {
+        calls.push('cancel')
+        return { ok: true, value: { accepted: true } }
+      }),
+      updateQueue: vi.fn(async () => {
+        calls.push('steer')
+        return { ok: true, value: { accepted: true } }
+      }),
+    }
+    const capabilities = Object.create(HarnessTuiCapabilities.prototype) as HarnessTuiCapabilities
+    Object.defineProperty(capabilities, 'active', {
+      value: () => ({ sessionId: 'session-1', session }) as unknown as TuiActiveSession,
+    })
+
+    await capabilities.interruptAndSteer('session-1' as never, 'msg-1' as never)
+
+    expect(calls).toEqual(['cancel', 'steer'])
+    expect(session.updateQueue).toHaveBeenCalledWith('msg-1', { kind: 'steer' })
+  })
+
+  it('does not interrupt when the selected queue occurrence is stale', async () => {
+    const session = {
+      getSnapshot: () => ({ running: true, queue: [] }),
+      cancel: vi.fn(),
+      updateQueue: vi.fn(),
+    }
+    const capabilities = Object.create(HarnessTuiCapabilities.prototype) as HarnessTuiCapabilities
+    Object.defineProperty(capabilities, 'active', {
+      value: () => ({ sessionId: 'session-1', session }) as unknown as TuiActiveSession,
+    })
+
+    await expect(capabilities.interruptAndSteer('session-1' as never, 'msg-1' as never))
+      .rejects.toThrow('任务或队列状态已变化')
+    expect(session.cancel).not.toHaveBeenCalled()
+    expect(session.updateQueue).not.toHaveBeenCalled()
+  })
+
+  it('does not promote a message when the interrupt request is rejected', async () => {
+    const session = {
+      getSnapshot: () => ({
+        running: true,
+        queue: [{ id: 'msg-1', placement: 'queued' }],
+      }),
+      cancel: vi.fn(async () => ({
+        ok: false,
+        error: { code: 'cancel-failed', message: 'not cancellable', details: {} },
+      })),
+      updateQueue: vi.fn(),
+    }
+    const capabilities = Object.create(HarnessTuiCapabilities.prototype) as HarnessTuiCapabilities
+    Object.defineProperty(capabilities, 'active', {
+      value: () => ({ sessionId: 'session-1', session }) as unknown as TuiActiveSession,
+    })
+
+    await expect(capabilities.interruptAndSteer('session-1' as never, 'msg-1' as never))
+      .rejects.toThrow('打断任务失败')
+    expect(session.updateQueue).not.toHaveBeenCalled()
+  })
+
+  it('reports an unconfirmed promotion without retrying after cancellation', async () => {
+    const session = {
+      getSnapshot: () => ({
+        running: true,
+        queue: [{ id: 'msg-1', placement: 'queued' }],
+      }),
+      cancel: vi.fn(async () => ({ ok: true, value: { accepted: true } })),
+      updateQueue: vi.fn(async () => ({
+        ok: false,
+        error: { code: 'steer-unavailable', message: 'turn already idle', details: {} },
+      })),
+    }
+    const capabilities = Object.create(HarnessTuiCapabilities.prototype) as HarnessTuiCapabilities
+    Object.defineProperty(capabilities, 'active', {
+      value: () => ({ sessionId: 'session-1', session }) as unknown as TuiActiveSession,
+    })
+
+    await expect(capabilities.interruptAndSteer('session-1' as never, 'msg-1' as never))
+      .rejects.toThrow('消息提前处理状态未确认')
+    expect(session.updateQueue).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

- add a distinct queue action that stops the active turn and prioritizes the selected queued message
- keep the existing steering action for messages that should join the current turn
- pin the operation to the selected Session and revalidate running/queued state before cancellation
- preserve Host-owned queue semantics on cancellation, rejection, races, and uncertain promotion results

## Verification

- pnpm run check
- manual acceptance testing completed by the requester with multiple queued messages

Closes #157
