### PR TITLE
feat(transcript): toggle Thinking while streaming

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26642,11 +26642,19 @@ function explicitHardBreakIndexes(row, width) {
 	}
 	return breaks;
 }
-function thinkingRow() {
+function thinkingRow(key, expanded) {
 	return {
 		format: "plain",
-		text: ui("正在思考…", "Thinking…"),
-		pulse: "thinking"
+		text: expanded ? ui("正在思考… ▾", "Thinking… ▾") : ui("正在思考…（已折叠） ▸", "Thinking… (collapsed) ▸"),
+		pulse: "thinking",
+		reasoningKey: key
+	};
+}
+function reasoningHeaderRow(key, expanded) {
+	return {
+		format: "plain",
+		text: color.muted(expanded ? ui("▾ 思考", "▾ Reasoning") : ui("▸ 思考（已折叠）", "▸ Reasoning (collapsed)")),
+		reasoningKey: key
 	};
 }
 var PulsingRow = class {
@@ -26839,7 +26847,7 @@ function assistantBlockText(block$1, preferences) {
 		case "other": return color.muted(ui("模型扩展内容 · /trajectory 查看详情", "Extended model content · use /trajectory for details"));
 	}
 }
-function assistantBlockRows(block$1, preferences, liveReasoning = false) {
+function assistantBlockRows(block$1, preferences, liveReasoning = false, reasoning) {
 	switch (block$1.kind) {
 		case "text": return block$1.text === "" ? [] : [{
 			format: "markdown",
@@ -26847,15 +26855,16 @@ function assistantBlockRows(block$1, preferences, liveReasoning = false) {
 		}];
 		case "reasoning": {
 			if (block$1.text === "") return [];
-			if (!preferences.reasoning && !liveReasoning) return [];
-			if (liveReasoning && !preferences.reasoning) return [{
+			if (reasoning !== void 0 && !reasoning.expanded) return [];
+			if (reasoning === void 0 && !preferences.reasoning && !liveReasoning) return [];
+			if (liveReasoning) return [{
 				format: "plain",
 				text: color.muted(block$1.text)
 			}];
 			const quoted = block$1.text.split("\n").map((line) => `> ${line}`).join("\n");
 			return [{
 				format: "markdown",
-				text: `> **${ui("思考", "Reasoning")}**\n>\n${quoted}`
+				text: reasoning === void 0 ? `> **${ui("思考", "Reasoning")}**\n>\n${quoted}` : quoted
 			}];
 		}
 		case "image": return [imageRow(block$1.attachment)];
@@ -27334,8 +27343,15 @@ function nodeFingerprint(node, preferences) {
 		diffContextLines: preferences.diffContextLines,
 		expanded: preferences.expandedTools.has(node.key),
 		collapsed: preferences.collapsedTools.has(node.key),
+		reasoningExpanded: preferences.expandedReasoning.has(node.key),
+		reasoningCollapsed: preferences.collapsedReasoning.has(node.key),
 		focusedTool: preferences.focusedTool
 	});
+}
+function reasoningExpanded(preferences, key, defaultExpanded) {
+	if (preferences.collapsedReasoning.has(key)) return false;
+	if (preferences.expandedReasoning.has(key)) return true;
+	return preferences.reasoning || defaultExpanded;
 }
 function nonnegativeNumber(value) {
 	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : void 0;
@@ -27397,15 +27413,20 @@ function assistantStepData(data) {
 	const value = data;
 	return (value.status === "running" || value.status === "settled" || value.status === "interrupted") && Array.isArray(value.blocks) ? value : void 0;
 }
-function assistantStepRows(data, preferences) {
+function assistantStepRows(data, preferences, fallbackKey) {
 	const step = assistantStepData(data);
 	if (step === void 0) return [];
-	const hasFoldedReasoning = !preferences.reasoning && step.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "");
+	const hasReasoning = step.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "");
 	const thinking = !step.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "") && step.status === "running";
-	const content = step.blocks.flatMap((block$1) => block$1.kind === "tool-call" ? [] : assistantBlockRows(block$1, preferences, thinking && !preferences.reasoning));
-	if (content.length === 0 && step.status === "settled" && !hasFoldedReasoning) return [];
+	const key = fallbackKey;
+	const expanded = reasoningExpanded(preferences, key, thinking);
+	const content = step.blocks.flatMap((block$1) => block$1.kind === "tool-call" ? [] : assistantBlockRows(block$1, preferences, thinking, {
+		key,
+		expanded
+	}));
+	if (content.length === 0 && step.status === "settled" && !hasReasoning) return [];
 	const rows = [];
-	if (thinking) rows.push(thinkingRow());
+	if (hasReasoning) rows.push(thinking ? thinkingRow(key, expanded) : reasoningHeaderRow(key, expanded));
 	rows.push(...content);
 	if (step.status === "interrupted") rows.push({
 		format: "plain",
@@ -27483,7 +27504,7 @@ function retryRows(data, preferences) {
 	}]);
 }
 function chatNodeRows(node, preferences) {
-	if (node.kind === "assistant-step") return assistantStepRows(node.data, preferences);
+	if (node.kind === "assistant-step") return assistantStepRows(node.data, preferences, node.key);
 	if (node.kind === "tool-call") {
 		if (preferences.tools === "hidden") return [];
 		const data = toolChatData(node.data);
@@ -27589,6 +27610,9 @@ var Transcript = class {
 	toolFocus = false;
 	expandedTools = /* @__PURE__ */ new Set();
 	collapsedTools = /* @__PURE__ */ new Set();
+	expandedReasoning = /* @__PURE__ */ new Set();
+	collapsedReasoning = /* @__PURE__ */ new Set();
+	reasoningStates = /* @__PURE__ */ new Map();
 	nodeCache = /* @__PURE__ */ new Map();
 	lineCache = /* @__PURE__ */ new WeakMap();
 	focused = false;
@@ -27725,13 +27749,13 @@ var Transcript = class {
 				height: 1
 			},
 			zIndex: 11,
-			role: control.kind === "tool" ? "button" : "option",
+			role: control.kind === "example" ? "option" : "button",
 			enabled: true,
-			activation: control.kind === "tool" ? "direct" : "arm",
+			activation: control.kind === "example" ? "arm" : "direct",
 			hover: "highlight",
 			action: {
 				kind: "transcript",
-				command: control.kind === "tool" ? "toggle" : "example",
+				command: control.kind === "tool" ? "toggle" : control.kind === "reasoning" ? "toggle-reasoning" : "example",
 				targetKey: control.id
 			}
 		}));
@@ -27774,6 +27798,20 @@ var Transcript = class {
 			kind: "tool",
 			key
 		};
+	}
+	/** Toggle one visible reasoning region without mutating the Session log. */
+	pointerToggleReasoning(key) {
+		if (!this.reasoningStates.has(key) || this.snapshot === void 0) return false;
+		if (this.reasoningStates.get(key) === true) {
+			this.expandedReasoning.delete(key);
+			this.collapsedReasoning.add(key);
+		} else {
+			this.collapsedReasoning.delete(key);
+			this.expandedReasoning.add(key);
+		}
+		this.update(this.snapshot, this.imageLoader);
+		this.requestRender();
+		return true;
 	}
 	/** Track/end-cap click. A thumb press without movement does not jump. */
 	handleScrollbarClick(region, point, origin) {
@@ -27894,6 +27932,7 @@ var Transcript = class {
 		this.lineControls.clear();
 		this.lastViewportMaps = [];
 		this.lastPointerControls = [];
+		this.reasoningStates.clear();
 		this.selection = void 0;
 		this.syncHeightIndexCounters();
 		this.replace([{
@@ -27920,6 +27959,9 @@ var Transcript = class {
 			this.sessionId = sessionId;
 			this.expandedTools.clear();
 			this.collapsedTools.clear();
+			this.expandedReasoning.clear();
+			this.collapsedReasoning.clear();
+			this.reasoningStates.clear();
 			this.toolCursor = 0;
 			this.nodeCache.clear();
 			this.viewportAnchor = {
@@ -27951,12 +27993,22 @@ var Transcript = class {
 			diffContextLines: this.diffContextLines,
 			expandedTools: this.expandedTools,
 			collapsedTools: this.collapsedTools,
+			expandedReasoning: this.expandedReasoning,
+			collapsedReasoning: this.collapsedReasoning,
 			...this.toolFocus ? { focusedTool: this.toolKeys()[this.toolCursor] } : {}
 		};
 		const visibleNodes = snapshot.chat.order.flatMap((key) => {
 			const node = snapshot.chat.nodes.get(key);
 			return node === void 0 || node.visibility !== "visible" ? [] : [node];
 		});
+		this.reasoningStates.clear();
+		for (const node of visibleNodes) {
+			const step = assistantStepData(node.data);
+			if (step?.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "") !== true) continue;
+			const key = node.key;
+			const thinking = step.status === "running" && !step.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "");
+			this.reasoningStates.set(key, reasoningExpanded(preferences, key, thinking));
+		}
 		const blocks = [];
 		const keep = /* @__PURE__ */ new Set();
 		let hasVisibleRows = false;
@@ -27992,16 +28044,25 @@ var Transcript = class {
 		}
 		if (snapshot.partial !== null && !visibleNodes.some((node) => node.kind === "assistant-step")) {
 			const partial = snapshot.partial;
+			const key = "__partial__";
+			const thinking = !partial.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "");
+			const hasReasoning = partial.blocks.some((block$1) => block$1.kind === "reasoning" && block$1.text !== "");
+			const expanded = reasoningExpanded(preferences, key, thinking);
+			if (hasReasoning) this.reasoningStates.set(key, expanded);
 			take("__partial__", JSON.stringify({
 				partial,
 				tools: preferences.tools,
 				reasoning: preferences.reasoning,
+				reasoningExpanded: preferences.expandedReasoning.has(key),
+				reasoningCollapsed: preferences.collapsedReasoning.has(key),
 				toolOutputLineLimit: preferences.toolOutputLineLimit,
 				diffContextLines: preferences.diffContextLines
 			}), () => {
-				const thinking = !partial.blocks.some((block$1) => block$1.kind === "text" && block$1.text !== "");
-				const partialRows = partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences, thinking && !preferences.reasoning));
-				return grouped([...thinking ? [thinkingRow()] : [], ...partialRows]);
+				const partialRows = partial.blocks.flatMap((block$1) => assistantBlockRows(block$1, preferences, thinking, {
+					key,
+					expanded
+				}));
+				return grouped([...hasReasoning ? [thinking ? thinkingRow(key, expanded) : reasoningHeaderRow(key, expanded)] : [], ...partialRows]);
 			});
 		}
 		if (preferences.tools !== "hidden" && !visibleNodes.some((node) => node.kind === "tool-call")) for (const call of snapshot.runningCalls) take(`__running__:${call.callId}`, JSON.stringify({
@@ -28181,6 +28242,9 @@ var Transcript = class {
 			const control = row?.toolKey !== void 0 ? {
 				kind: "tool",
 				id: row.toolKey
+			} : row?.reasoningKey !== void 0 ? {
+				kind: "reasoning",
+				id: row.reasoningKey
 			} : row?.exampleId !== void 0 ? {
 				kind: "example",
 				id: row.exampleId
@@ -28881,7 +28945,9 @@ var Transcript = class {
 			toolOutputLineLimit: this.toolOutputLineLimit,
 			diffContextLines: this.diffContextLines,
 			expandedTools: this.expandedTools,
-			collapsedTools: this.collapsedTools
+			collapsedTools: this.collapsedTools,
+			expandedReasoning: this.expandedReasoning,
+			collapsedReasoning: this.collapsedReasoning
 		}, key)) {
 			this.expandedTools.delete(key);
 			if (this.toolVisibility === "expanded") this.collapsedTools.add(key);
@@ -40047,6 +40113,10 @@ async function startTuiSurface(options$1) {
 			}
 			if (region?.action.kind === "transcript" && region.action.command === "toggle" && region.action.targetKey !== void 0) {
 				transcript.pointerToggleTool(region.action.targetKey);
+				return;
+			}
+			if (region?.action.kind === "transcript" && region.action.command === "toggle-reasoning" && region.action.targetKey !== void 0) {
+				transcript.pointerToggleReasoning(region.action.targetKey);
 				return;
 			}
 			if (region?.action.kind === "transcript" && region.action.command === "example" && region.action.targetKey !== void 0) {

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -1439,6 +1439,10 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
         transcript.pointerToggleTool(region.action.targetKey)
         return
       }
+      if (region?.action.kind === 'transcript' && region.action.command === 'toggle-reasoning' && region.action.targetKey !== undefined) {
+        transcript.pointerToggleReasoning(region.action.targetKey)
+        return
+      }
       if (region?.action.kind === 'transcript' && region.action.command === 'example' && region.action.targetKey !== undefined) {
         const id = region.action.targetKey
         transcript.focusExample(id)

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -112,6 +112,8 @@ interface TranscriptPreferences {
   readonly diffContextLines: number
   readonly expandedTools: ReadonlySet<string>
   readonly collapsedTools: ReadonlySet<string>
+  readonly expandedReasoning: ReadonlySet<string>
+  readonly collapsedReasoning: ReadonlySet<string>
   readonly focusedTool?: string
 }
 
@@ -161,6 +163,8 @@ type TranscriptRow = ({
   readonly exampleId?: string
   /** Tool-card identity for per-card expand in focus mode. */
   readonly toolKey?: string
+  /** Reasoning-region identity for pointer-only presentation toggles. */
+  readonly reasoningKey?: string
 }
 
 /** Preserve source newlines that would otherwise be indistinguishable from exact-width wraps. */
@@ -213,8 +217,25 @@ export type TranscriptFocusAction = {
   readonly key: string
 }
 
-function thinkingRow(): TranscriptRow {
-  return { format: 'plain', text: ui('正在思考…', 'Thinking…'), pulse: 'thinking' }
+function thinkingRow(key: string, expanded: boolean): TranscriptRow {
+  return {
+    format: 'plain',
+    text: expanded
+      ? ui('正在思考… ▾', 'Thinking… ▾')
+      : ui('正在思考…（已折叠） ▸', 'Thinking… (collapsed) ▸'),
+    pulse: 'thinking',
+    reasoningKey: key,
+  }
+}
+
+function reasoningHeaderRow(key: string, expanded: boolean): TranscriptRow {
+  return {
+    format: 'plain',
+    text: color.muted(expanded
+      ? ui('▾ 思考', '▾ Reasoning')
+      : ui('▸ 思考（已折叠）', '▸ Reasoning (collapsed)')),
+    reasoningKey: key,
+  }
 }
 
 class PulsingRow implements Component {
@@ -463,13 +484,15 @@ function assistantBlockRows(
   block: AssistantBlock,
   preferences: TranscriptPreferences,
   liveReasoning = false,
+  reasoning?: { readonly key: string; readonly expanded: boolean },
 ): TranscriptRow[] {
   switch (block.kind) {
     case 'text': return block.text === '' ? [] : [{ format: 'markdown', text: block.text }]
     case 'reasoning': {
       if (block.text === '') return []
-      if (!preferences.reasoning && !liveReasoning) return []
-      if (liveReasoning && !preferences.reasoning) {
+      if (reasoning !== undefined && !reasoning.expanded) return []
+      if (reasoning === undefined && !preferences.reasoning && !liveReasoning) return []
+      if (liveReasoning) {
         // Plain text keeps a stable wrapped prefix while tokens append, so
         // earlier reasoning lines already in scrollback do not look changed.
         return [{ format: 'plain', text: color.muted(block.text) }]
@@ -477,7 +500,7 @@ function assistantBlockRows(
       const quoted = block.text.split('\n').map(line => `> ${line}`).join('\n')
       return [{
         format: 'markdown',
-        text: `> **${ui('思考', 'Reasoning')}**\n>\n${quoted}`,
+        text: reasoning === undefined ? `> **${ui('思考', 'Reasoning')}**\n>\n${quoted}` : quoted,
       }]
     }
     case 'image': return [imageRow(block.attachment)]
@@ -989,8 +1012,20 @@ function nodeFingerprint(
     diffContextLines: preferences.diffContextLines,
     expanded: preferences.expandedTools.has(node.key),
     collapsed: preferences.collapsedTools.has(node.key),
+    reasoningExpanded: preferences.expandedReasoning.has(node.key),
+    reasoningCollapsed: preferences.collapsedReasoning.has(node.key),
     focusedTool: preferences.focusedTool,
   })
+}
+
+function reasoningExpanded(
+  preferences: TranscriptPreferences,
+  key: string,
+  defaultExpanded: boolean,
+): boolean {
+  if (preferences.collapsedReasoning.has(key)) return false
+  if (preferences.expandedReasoning.has(key)) return true
+  return preferences.reasoning || defaultExpanded
 }
 
 function nonnegativeNumber(value: unknown): number | undefined {
@@ -1094,19 +1129,20 @@ function assistantStepData(data: unknown): AssistantChatData | undefined {
     : undefined
 }
 
-function assistantStepRows(data: unknown, preferences: TranscriptPreferences): TranscriptRow[] {
+function assistantStepRows(data: unknown, preferences: TranscriptPreferences, fallbackKey: string): TranscriptRow[] {
   const step = assistantStepData(data)
   if (step === undefined) return []
-  const hasFoldedReasoning = !preferences.reasoning
-    && step.blocks.some(block => block.kind === 'reasoning' && block.text !== '')
+  const hasReasoning = step.blocks.some(block => block.kind === 'reasoning' && block.text !== '')
   const hasAnswer = step.blocks.some(block => block.kind === 'text' && block.text !== '')
   const thinking = !hasAnswer && step.status === 'running'
+  const key = fallbackKey
+  const expanded = reasoningExpanded(preferences, key, thinking)
   const content = step.blocks.flatMap(block => block.kind === 'tool-call'
     ? []
-    : assistantBlockRows(block, preferences, thinking && !preferences.reasoning))
-  if (content.length === 0 && step.status === 'settled' && !hasFoldedReasoning) return []
+    : assistantBlockRows(block, preferences, thinking, { key, expanded }))
+  if (content.length === 0 && step.status === 'settled' && !hasReasoning) return []
   const rows: TranscriptRow[] = []
-  if (thinking) rows.push(thinkingRow())
+  if (hasReasoning) rows.push(thinking ? thinkingRow(key, expanded) : reasoningHeaderRow(key, expanded))
   rows.push(...content)
   if (step.status === 'interrupted') rows.push({ format: 'plain', text: color.warning(ui('已停止', 'Stopped')) })
   return grouped(rows)
@@ -1184,7 +1220,7 @@ function retryRows(data: unknown, preferences: TranscriptPreferences): Transcrip
 }
 
 function chatNodeRows(node: ChatConversationViewNode, preferences: TranscriptPreferences): TranscriptRow[] {
-  if (node.kind === 'assistant-step') return assistantStepRows(node.data, preferences)
+  if (node.kind === 'assistant-step') return assistantStepRows(node.data, preferences, node.key)
   if (node.kind === 'tool-call') {
     if (preferences.tools === 'hidden') return []
     const data = toolChatData(node.data)
@@ -1240,7 +1276,7 @@ interface TranscriptBlockLines {
 }
 
 interface TranscriptPointerControl {
-  readonly kind: 'tool' | 'example'
+  readonly kind: 'tool' | 'reasoning' | 'example'
   readonly id: string
 }
 
@@ -1331,6 +1367,9 @@ export class Transcript implements Component, Focusable {
   private toolFocus = false
   private readonly expandedTools = new Set<string>()
   private readonly collapsedTools = new Set<string>()
+  private readonly expandedReasoning = new Set<string>()
+  private readonly collapsedReasoning = new Set<string>()
+  private readonly reasoningStates = new Map<string, boolean>()
   private readonly nodeCache = new Map<string, TranscriptBlock>()
   private readonly lineCache = new WeakMap<Component, { width: number; lines: readonly string[] }>()
   focused = false
@@ -1348,7 +1387,7 @@ export class Transcript implements Component, Focusable {
   private readonly lineControls = new Map<string, readonly (TranscriptPointerControl | undefined)[]>()
   private lastPointerControls: readonly {
     readonly row: number
-    readonly kind: 'tool' | 'example'
+    readonly kind: 'tool' | 'reasoning' | 'example'
     readonly id: string
   }[] = []
   private hoveredRegionId: string | undefined
@@ -1477,13 +1516,15 @@ export class Transcript implements Component, Focusable {
       id: `transcript:${control.kind}:${control.id}`,
       rect: { col: origin.col + inset, row: origin.row + control.row, width, height: 1 },
       zIndex: 11,
-      role: control.kind === 'tool' ? 'button' : 'option',
+      role: control.kind === 'example' ? 'option' : 'button',
       enabled: true,
-      activation: control.kind === 'tool' ? 'direct' : 'arm',
+      activation: control.kind === 'example' ? 'arm' : 'direct',
       hover: 'highlight',
       action: {
         kind: 'transcript',
-        command: control.kind === 'tool' ? 'toggle' : 'example',
+        command: control.kind === 'tool'
+          ? 'toggle'
+          : control.kind === 'reasoning' ? 'toggle-reasoning' : 'example',
         targetKey: control.id,
       },
     }))
@@ -1527,6 +1568,21 @@ export class Transcript implements Component, Focusable {
     this.update(this.snapshot, this.imageLoader)
     this.requestRender()
     return { kind: 'tool', key }
+  }
+
+  /** Toggle one visible reasoning region without mutating the Session log. */
+  pointerToggleReasoning(key: string): boolean {
+    if (!this.reasoningStates.has(key) || this.snapshot === undefined) return false
+    if (this.reasoningStates.get(key) === true) {
+      this.expandedReasoning.delete(key)
+      this.collapsedReasoning.add(key)
+    } else {
+      this.collapsedReasoning.delete(key)
+      this.expandedReasoning.add(key)
+    }
+    this.update(this.snapshot, this.imageLoader)
+    this.requestRender()
+    return true
   }
 
   /** Track/end-cap click. A thumb press without movement does not jump. */
@@ -1668,6 +1724,7 @@ export class Transcript implements Component, Focusable {
     this.lineControls.clear()
     this.lastViewportMaps = []
     this.lastPointerControls = []
+    this.reasoningStates.clear()
     this.selection = undefined
     this.syncHeightIndexCounters()
     this.replace([{ format: 'plain', text: color.muted(this.emptyCopy()) }])
@@ -1695,6 +1752,9 @@ export class Transcript implements Component, Focusable {
       this.sessionId = sessionId
       this.expandedTools.clear()
       this.collapsedTools.clear()
+      this.expandedReasoning.clear()
+      this.collapsedReasoning.clear()
+      this.reasoningStates.clear()
       this.toolCursor = 0
       this.nodeCache.clear()
       this.viewportAnchor = { blockKey: '', lineOffset: 0, followLatest: true }
@@ -1722,12 +1782,23 @@ export class Transcript implements Component, Focusable {
       diffContextLines: this.diffContextLines,
       expandedTools: this.expandedTools,
       collapsedTools: this.collapsedTools,
+      expandedReasoning: this.expandedReasoning,
+      collapsedReasoning: this.collapsedReasoning,
       ...(this.toolFocus ? { focusedTool: this.toolKeys()[this.toolCursor] } : {}),
     }
     const visibleNodes = snapshot.chat.order.flatMap((key) => {
       const node = snapshot.chat.nodes.get(key)
       return node === undefined || node.visibility !== 'visible' ? [] : [node]
     })
+    this.reasoningStates.clear()
+    for (const node of visibleNodes) {
+      const step = assistantStepData(node.data)
+      if (step?.blocks.some(block => block.kind === 'reasoning' && block.text !== '') !== true) continue
+      const key = node.key
+      const thinking = step.status === 'running'
+        && !step.blocks.some(block => block.kind === 'text' && block.text !== '')
+      this.reasoningStates.set(key, reasoningExpanded(preferences, key, thinking))
+    }
     const blocks: TranscriptBlock[] = []
     const keep = new Set<string>()
     let hasVisibleRows = false
@@ -1764,18 +1835,24 @@ export class Transcript implements Component, Focusable {
     }
     if (snapshot.partial !== null && !visibleNodes.some(node => node.kind === 'assistant-step')) {
       const partial = snapshot.partial
+      const key = '__partial__'
+      const thinking = !partial.blocks.some(block => block.kind === 'text' && block.text !== '')
+      const hasReasoning = partial.blocks.some(block => block.kind === 'reasoning' && block.text !== '')
+      const expanded = reasoningExpanded(preferences, key, thinking)
+      if (hasReasoning) this.reasoningStates.set(key, expanded)
       take('__partial__', JSON.stringify({
         partial,
         tools: preferences.tools,
         reasoning: preferences.reasoning,
+        reasoningExpanded: preferences.expandedReasoning.has(key),
+        reasoningCollapsed: preferences.collapsedReasoning.has(key),
         toolOutputLineLimit: preferences.toolOutputLineLimit,
         diffContextLines: preferences.diffContextLines,
       }), () => {
-        const thinking = !partial.blocks.some(block => block.kind === 'text' && block.text !== '')
         const partialRows = partial.blocks.flatMap(block =>
-          assistantBlockRows(block, preferences, thinking && !preferences.reasoning))
+          assistantBlockRows(block, preferences, thinking, { key, expanded }))
         return grouped([
-          ...(thinking ? [thinkingRow()] : []),
+          ...(hasReasoning ? [thinking ? thinkingRow(key, expanded) : reasoningHeaderRow(key, expanded)] : []),
           ...partialRows,
         ])
       })
@@ -1960,6 +2037,8 @@ export class Transcript implements Component, Focusable {
       const start = lines.length
       const control: TranscriptPointerControl | undefined = row?.toolKey !== undefined
         ? { kind: 'tool', id: row.toolKey }
+        : row?.reasoningKey !== undefined
+          ? { kind: 'reasoning', id: row.reasoningKey }
         : row?.exampleId !== undefined
           ? { kind: 'example', id: row.exampleId }
           : undefined
@@ -2232,7 +2311,7 @@ export class Transcript implements Component, Focusable {
   ): { readonly lines: readonly string[]; readonly maps: readonly ViewportCellMap[] } {
     const start = this.viewportState?.start
     const maps: ViewportCellMap[] = []
-    const pointerControls: { readonly row: number; readonly kind: 'tool' | 'example'; readonly id: string }[] = []
+    const pointerControls: { readonly row: number; readonly kind: 'tool' | 'reasoning' | 'example'; readonly id: string }[] = []
     if (start === undefined) {
       this.lastViewportMaps = maps
       this.lastPointerControls = pointerControls
@@ -2715,6 +2794,8 @@ export class Transcript implements Component, Focusable {
       diffContextLines: this.diffContextLines,
       expandedTools: this.expandedTools,
       collapsedTools: this.collapsedTools,
+      expandedReasoning: this.expandedReasoning,
+      collapsedReasoning: this.collapsedReasoning,
     }, key)
     if (expanded) {
       this.expandedTools.delete(key)

--- a/tests/mouse-clicks.test.ts
+++ b/tests/mouse-clicks.test.ts
@@ -10,6 +10,7 @@ describe('click matrix ownership', () => {
     const transcript = readFileSync(resolve(root, 'src/client/transcript.ts'), 'utf8')
     const overlays = readFileSync(resolve(root, 'src/client/overlays.ts'), 'utf8')
     expect(surface).toContain('transcript.pointerToggleTool')
+    expect(surface).toContain('transcript.pointerToggleReasoning')
     expect(surface).toContain('transcript.focusExample')
     expect(surface).toContain('transcript.activateFocused')
     expect(surface).toContain("actions.execute('model'")
@@ -21,6 +22,8 @@ describe('click matrix ownership', () => {
     expect(surface).toContain('activateAutocompleteSelection')
     expect(surface).not.toContain('setAutocompleteSelectedIndex')
     expect(transcript).toContain('toggleToolCard(key)')
+    expect(transcript).toContain("command: control.kind === 'tool'")
+    expect(transcript).toContain("'toggle-reasoning'")
     expect(overlays).toContain("mouseExecute: 'focus-only'")
   })
 

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -266,6 +266,50 @@ describe('conversation viewport', () => {
     transcript.dispose()
   })
 
+  it('keeps a manually folded live reasoning region folded while tokens continue', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 12)
+    transcript.update(snapshot([
+      assistantStep('a1', 'running', [{ kind: 'reasoning', text: '第一段推理' }]),
+    ]))
+    transcript.render(60)
+    const key = 'a1'
+    expect(transcript.pointerToggleReasoning(key)).toBe(true)
+    expect(transcript.render(60).join('\n')).not.toContain('第一段推理')
+    expect(transcript.render(60).join('\n')).toContain('已折叠')
+
+    transcript.update(snapshot([
+      assistantStep('a1', 'running', [{ kind: 'reasoning', text: '第一段推理\n新收到的推理' }]),
+    ]))
+    expect(transcript.render(60).join('\n')).not.toContain('新收到的推理')
+    expect(transcript.pointerToggleReasoning(key)).toBe(true)
+    expect(transcript.render(60).join('\n')).toContain('新收到的推理')
+    transcript.dispose()
+  })
+
+  it('shows a clickable collapsed reasoning header after completion', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 12)
+    transcript.update(snapshot([
+      assistantStep('a1', 'settled', [
+        { kind: 'reasoning', text: '完成后的推理' },
+        { kind: 'text', text: '结论' },
+      ]),
+    ]))
+    const collapsed = transcript.render(60).join('\n')
+    expect(collapsed).toContain('思考（已折叠）')
+    expect(collapsed).not.toContain('完成后的推理')
+    const hits = transcript.controlHitRegions({ col: 0, row: 0, width: 60, height: 12 })
+    expect(hits.some(region => region.id === 'transcript:reasoning:a1'
+      && region.activation === 'direct'
+      && region.action.kind === 'transcript'
+      && region.action.command === 'toggle-reasoning')).toBe(true)
+
+    expect(transcript.pointerToggleReasoning('a1')).toBe(true)
+    expect(transcript.render(60).join('\n')).toContain('完成后的推理')
+    transcript.dispose()
+  })
+
   it('keeps a running tool duration live when color animation is disabled', () => {
     vi.useFakeTimers()
     vi.setSystemTime(20_000)


### PR DESCRIPTION
## Summary

- add a clickable Thinking status/header for live and completed assistant steps
- keep per-block expanded and collapsed presentation state without mutating Session data
- prevent streaming chunks from reopening a manually folded block
- route reasoning header clicks through the transcript hit map while preserving viewport and tool behavior

## Verification

- pnpm run check
- manual acceptance testing completed by the requester during streaming, completion, resize, and scrolling

Closes #158
