### PR TITLE
fix: 修正对话控件命中与工具卡折叠

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27415,7 +27415,7 @@ function toolBlockRows(block$1, preferences, depth, cardKey) {
 	if ("kind" in block$1) {
 		const duration = block$1.callTime === null ? "" : ` · ${toolDurationText(Math.max(0, block$1.time - block$1.callTime))}`;
 		const failed = settledToolFailed(block$1);
-		const details$1 = expanded ? viewDetails(block$1, preferences.diffContextLines) : settledInvocationDetails(block$1, preferences.diffContextLines);
+		const details$1 = expanded ? viewDetails(block$1, preferences.diffContextLines) : [];
 		return [
 			{
 				format: "plain",
@@ -27426,7 +27426,7 @@ function toolBlockRows(block$1, preferences, depth, cardKey) {
 			...block$1.subCalls.flatMap((child) => toolBlockRows(child, preferences, depth + 1))
 		];
 	}
-	const details = runningViewDetails(block$1, preferences.diffContextLines);
+	const details = expanded ? runningViewDetails(block$1, preferences.diffContextLines) : [];
 	return [
 		{
 			format: "plain",
@@ -27537,6 +27537,8 @@ function deliverablesFingerprint(node) {
 	return producedForClosing(location$1.turn.data.get("deliverables"), node.data.seq);
 }
 function nodeFingerprint(node, preferences) {
+	const tool = node.kind === "tool-call" ? toolChatData(node.data)?.root : void 0;
+	const toolKey = tool === void 0 ? node.key : callKey(tool, node.key) ?? node.key;
 	return JSON.stringify({
 		kind: node.kind,
 		data: node.data,
@@ -27545,8 +27547,8 @@ function nodeFingerprint(node, preferences) {
 		reasoning: preferences.reasoning,
 		toolOutputLineLimit: preferences.toolOutputLineLimit,
 		diffContextLines: preferences.diffContextLines,
-		expanded: preferences.expandedTools.has(node.key),
-		collapsed: preferences.collapsedTools.has(node.key),
+		expanded: preferences.expandedTools.has(toolKey),
+		collapsed: preferences.collapsedTools.has(toolKey),
 		reasoningExpanded: preferences.expandedReasoning.has(node.key),
 		reasoningCollapsed: preferences.collapsedReasoning.has(node.key),
 		focusedTool: preferences.focusedTool

--- a/lib/index.js
+++ b/lib/index.js
@@ -28053,8 +28053,8 @@ var Transcript = class {
 	/** Resolve the nearest selectable cell on the visible edge during auto-scroll. */
 	hitViewportEdgeAnchor(col, width, edge, affinity = "before") {
 		const maps = [...this.lastViewportMaps].sort((left, right) => left.row - right.row);
-		const map = edge === "older" ? maps[0] : maps.at(-1);
-		if (map === void 0 || map.cellOffsets.length === 0) return void 0;
+		const map = edge === "older" ? maps.find((candidate) => candidate.cellOffsets.some((offset) => offset !== void 0)) : maps.findLast((candidate) => candidate.cellOffsets.some((offset) => offset !== void 0));
+		if (map === void 0) return void 0;
 		const inset = width >= 12 ? 2 : 0;
 		return anchorAtCell(map, Math.max(0, Math.min(col - inset, map.cellOffsets.length - 1)), affinity);
 	}
@@ -28519,7 +28519,10 @@ var Transcript = class {
 		};
 	}
 	finiteViewportLines(contentWidth, rows) {
-		if (this.blocks.length === 0) return Array.from({ length: rows }, () => "");
+		if (this.blocks.length === 0) return {
+			lines: Array.from({ length: rows }, () => ""),
+			leadingPadding: rows
+		};
 		let startIndex;
 		let startOffset;
 		if (this.viewportAnchor.followLatest) {
@@ -28542,6 +28545,7 @@ var Transcript = class {
 				remaining -= rendered.lines.length - offset;
 			}
 			let visible = parts.flatMap((part) => part.lines);
+			let leadingPadding = 0;
 			const hasOlder$1 = startIndex > 0 || startOffset > 0 || this.hasMore;
 			if (hasOlder$1 && visible.length > 0) {
 				let lineBase = 0;
@@ -28558,7 +28562,8 @@ var Transcript = class {
 					lineBase += part.lines.length;
 				}
 				if (latestTurn !== void 0 && visible.length - latestTurn.visibleOffset <= rows) {
-					visible = [...Array.from({ length: rows - (visible.length - latestTurn.visibleOffset) }, () => ""), ...visible.slice(latestTurn.visibleOffset)];
+					leadingPadding = rows - (visible.length - latestTurn.visibleOffset);
+					visible = [...Array.from({ length: leadingPadding }, () => ""), ...visible.slice(latestTurn.visibleOffset)];
 					startIndex = latestTurn.blockIndex;
 					startOffset = latestTurn.lineOffset;
 				}
@@ -28581,7 +28586,10 @@ var Transcript = class {
 				hasNewer: false
 			};
 			this.scrollOffset = 0;
-			return result;
+			return {
+				lines: result,
+				leadingPadding: leadingPadding + padding$1
+			};
 		}
 		startIndex = this.blocks.findIndex((block$1) => block$1.key === this.viewportAnchor.blockKey);
 		if (startIndex < 0) {
@@ -28626,7 +28634,10 @@ var Transcript = class {
 			hasNewer
 		};
 		const padding = Math.max(0, rows - filled.visible.length);
-		return [...filled.visible, ...Array.from({ length: padding }, () => "")].slice(0, rows);
+		return {
+			lines: [...filled.visible, ...Array.from({ length: padding }, () => "")].slice(0, rows),
+			leadingPadding: 0
+		};
 	}
 	logicalRowLines(row) {
 		if (row.format === "rule") return [];
@@ -28710,7 +28721,7 @@ var Transcript = class {
 		this.lastScrollbar = model;
 		return appendScrollbarColumn(withSearch, paintScrollbar(model, this.hoveredRegionId?.startsWith("transcript:scrollbar:") === true ? this.hoveredRegionId.slice(21) : void 0), width);
 	}
-	captureViewportMaps(lines, contentWidth) {
+	captureViewportMaps(lines, contentWidth, leadingPadding) {
 		const start = this.viewportState?.start;
 		const maps = [];
 		const pointerControls = [];
@@ -28724,11 +28735,8 @@ var Transcript = class {
 		}
 		let blockIndex = this.blocks.findIndex((block$1) => block$1.key === start.blockKey);
 		let lineOffset = start.lineOffset;
-		let started = false;
 		for (let row = 0; row < lines.length; row += 1) {
-			const empty = (lines[row] ?? "").replace(/\u001B\[[0-9;:]*m/gu, "").trim() === "";
-			if (!started && empty) continue;
-			started = true;
+			if (row < leadingPadding) continue;
 			const block$1 = this.blocks[blockIndex];
 			if (block$1 === void 0) break;
 			const copy = this.ownerCopy.get(block$1.key);
@@ -28776,7 +28784,7 @@ var Transcript = class {
 		if (Number.isFinite(totalRows) && !this.emptyState) {
 			const rows$1 = this.search === void 0 ? totalRows : Math.max(1, totalRows - 1);
 			const visible = this.finiteViewportLines(contentWidth, rows$1);
-			const mapped = this.captureViewportMaps(visible, contentWidth);
+			const mapped = this.captureViewportMaps(visible.lines, contentWidth, visible.leadingPadding);
 			const selected = paintSelection(this.search === void 0 ? mapped.lines : this.highlightVisible(mapped.lines, this.search.query), mapped.maps, this.selection, this.blocks.map((block$1) => block$1.key));
 			internals$2.selectionCellsProjected += mapped.maps.reduce((count, map) => count + map.cellOffsets.filter((offset) => offset !== void 0).length, 0);
 			return this.presentLines(selected, width, inset, contentWidth);

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -836,7 +836,9 @@ function toolBlockRows(
   if ('kind' in block) {
     const duration = block.callTime === null ? '' : ` · ${toolDurationText(Math.max(0, block.time - block.callTime))}`
     const failed = settledToolFailed(block)
-    const details = expanded ? viewDetails(block, preferences.diffContextLines) : settledInvocationDetails(block, preferences.diffContextLines)
+    // A collapsed card is the header only. Keeping invocation arguments visible
+    // made a successful second toggle look like it had not collapsed at all.
+    const details = expanded ? viewDetails(block, preferences.diffContextLines) : []
     return [
       {
         format: 'plain',
@@ -847,7 +849,7 @@ function toolBlockRows(
       ...block.subCalls.flatMap(child => toolBlockRows(child, preferences, depth + 1)),
     ]
   }
-  const details = runningViewDetails(block, preferences.diffContextLines)
+  const details = expanded ? runningViewDetails(block, preferences.diffContextLines) : []
   return [
     {
       format: 'plain',
@@ -1003,6 +1005,8 @@ function nodeFingerprint(
   node: ChatConversationViewNode,
   preferences: TranscriptPreferences,
 ): string {
+  const tool = node.kind === 'tool-call' ? toolChatData(node.data)?.root : undefined
+  const toolKey = tool === undefined ? node.key : callKey(tool, node.key) ?? node.key
   return JSON.stringify({
     kind: node.kind,
     data: node.data,
@@ -1011,8 +1015,10 @@ function nodeFingerprint(
     reasoning: preferences.reasoning,
     toolOutputLineLimit: preferences.toolOutputLineLimit,
     diffContextLines: preferences.diffContextLines,
-    expanded: preferences.expandedTools.has(node.key),
-    collapsed: preferences.collapsedTools.has(node.key),
+    // Tool presentation is keyed by the Harness callId. Projection node keys
+    // are independent identities and commonly differ in real Sessions.
+    expanded: preferences.expandedTools.has(toolKey),
+    collapsed: preferences.collapsedTools.has(toolKey),
     reasoningExpanded: preferences.expandedReasoning.has(node.key),
     reasoningCollapsed: preferences.collapsedReasoning.has(node.key),
     focusedTool: preferences.focusedTool,

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -1322,6 +1322,12 @@ interface TranscriptViewportState {
   readonly hasNewer: boolean
 }
 
+interface TranscriptViewportLines {
+  readonly lines: readonly string[]
+  /** Synthetic rows inserted before the first logical transcript line. */
+  readonly leadingPadding: number
+}
+
 interface TranscriptSearchIndex {
   readonly width: number
   readonly generation: number
@@ -1640,8 +1646,10 @@ export class Transcript implements Component, Focusable {
     affinity: SelectionAnchor['affinity'] = 'before',
   ): SelectionAnchor | undefined {
     const maps = [...this.lastViewportMaps].sort((left, right) => left.row - right.row)
-    const map = edge === 'older' ? maps[0] : maps.at(-1)
-    if (map === undefined || map.cellOffsets.length === 0) return undefined
+    const map = edge === 'older'
+      ? maps.find(candidate => candidate.cellOffsets.some(offset => offset !== undefined))
+      : maps.findLast(candidate => candidate.cellOffsets.some(offset => offset !== undefined))
+    if (map === undefined) return undefined
     const inset = width >= 12 ? 2 : 0
     const localCol = Math.max(0, Math.min(col - inset, map.cellOffsets.length - 1))
     return anchorAtCell(map, localCol, affinity)
@@ -2121,8 +2129,10 @@ export class Transcript implements Component, Focusable {
     return { visible, index, offset }
   }
 
-  private finiteViewportLines(contentWidth: number, rows: number): string[] {
-    if (this.blocks.length === 0) return Array.from({ length: rows }, () => '')
+  private finiteViewportLines(contentWidth: number, rows: number): TranscriptViewportLines {
+    if (this.blocks.length === 0) {
+      return { lines: Array.from({ length: rows }, () => ''), leadingPadding: rows }
+    }
     let startIndex: number
     let startOffset: number
     if (this.viewportAnchor.followLatest) {
@@ -2150,6 +2160,7 @@ export class Transcript implements Component, Focusable {
         remaining -= rendered.lines.length - offset
       }
       let visible = parts.flatMap(part => part.lines)
+      let leadingPadding = 0
       const hasOlder = startIndex > 0 || startOffset > 0 || this.hasMore
       if (hasOlder && visible.length > 0) {
         let lineBase = 0
@@ -2166,8 +2177,9 @@ export class Transcript implements Component, Focusable {
           lineBase += part.lines.length
         }
         if (latestTurn !== undefined && visible.length - latestTurn.visibleOffset <= rows) {
+          leadingPadding = rows - (visible.length - latestTurn.visibleOffset)
           visible = [
-            ...Array.from({ length: rows - (visible.length - latestTurn.visibleOffset) }, () => ''),
+            ...Array.from({ length: leadingPadding }, () => ''),
             ...visible.slice(latestTurn.visibleOffset),
           ]
           startIndex = latestTurn.blockIndex
@@ -2181,7 +2193,7 @@ export class Transcript implements Component, Focusable {
       this.viewportAnchor = { ...start, followLatest: true }
       this.viewportState = { contentWidth, rows, start, hasOlder, hasNewer: false }
       this.scrollOffset = 0
-      return result
+      return { lines: result, leadingPadding: leadingPadding + padding }
     }
 
     startIndex = this.blocks.findIndex(block => block.key === this.viewportAnchor.blockKey)
@@ -2212,7 +2224,10 @@ export class Transcript implements Component, Focusable {
     this.viewportAnchor = { ...start, followLatest: false }
     this.viewportState = { contentWidth, rows, start, hasOlder, hasNewer }
     const padding = Math.max(0, rows - filled.visible.length)
-    return [...filled.visible, ...Array.from({ length: padding }, () => '')].slice(0, rows)
+    return {
+      lines: [...filled.visible, ...Array.from({ length: padding }, () => '')].slice(0, rows),
+      leadingPadding: 0,
+    }
   }
 
   private logicalRowLines(row: TranscriptRow): readonly string[] {
@@ -2309,6 +2324,7 @@ export class Transcript implements Component, Focusable {
   private captureViewportMaps(
     lines: readonly string[],
     contentWidth: number,
+    leadingPadding: number,
   ): { readonly lines: readonly string[]; readonly maps: readonly ViewportCellMap[] } {
     const start = this.viewportState?.start
     const maps: ViewportCellMap[] = []
@@ -2320,11 +2336,8 @@ export class Transcript implements Component, Focusable {
     }
     let blockIndex = this.blocks.findIndex(block => block.key === start.blockKey)
     let lineOffset = start.lineOffset
-    let started = false
     for (let row = 0; row < lines.length; row += 1) {
-      const empty = (lines[row] ?? '').replace(/\u001B\[[0-9;:]*m/gu, '').trim() === ''
-      if (!started && empty) continue
-      started = true
+      if (row < leadingPadding) continue
       const block = this.blocks[blockIndex]
       if (block === undefined) break
       const copy = this.ownerCopy.get(block.key)
@@ -2370,7 +2383,7 @@ export class Transcript implements Component, Focusable {
     if (Number.isFinite(totalRows) && !this.emptyState) {
       const rows = this.search === undefined ? totalRows : Math.max(1, totalRows - 1)
       const visible = this.finiteViewportLines(contentWidth, rows)
-      const mapped = this.captureViewportMaps(visible, contentWidth)
+      const mapped = this.captureViewportMaps(visible.lines, contentWidth, visible.leadingPadding)
       const highlighted = this.search === undefined
         ? mapped.lines
         : this.highlightVisible(mapped.lines, this.search.query)

--- a/tests/tool-card-expand.test.ts
+++ b/tests/tool-card-expand.test.ts
@@ -19,9 +19,9 @@ function chatNode(key: string, data: unknown): ChatConversationViewNode {
   }
 }
 
-function tool(key: string, title: string, result: string): ChatConversationViewNode {
+function tool(key: string, title: string, result: string, nodeKey: string = key): ChatConversationViewNode {
   return {
-    ...chatNode(key, {
+    ...chatNode(nodeKey, {
       root: {
         kind: 'tool-result',
         callId: key,
@@ -138,14 +138,17 @@ describe('per-card tool expand', () => {
     const transcript = new Transcript(() => 12)
     transcript.update(snapshot([
       tool('a', 'First tool', 'result-a'),
-      tool('b', 'Second tool', 'result-b'),
+      // Harness projection keys and tool callIds are independent in real Sessions.
+      tool('b', 'Second tool', 'result-b', 'tool-view-b'),
     ]))
     expect(transcript.pointerToggleTool('b')).toEqual({ kind: 'tool', key: 'b' })
     const rendered = stripAnsi(transcript.render(80).join('\n'))
     expect(rendered).toContain('result-b')
     expect(rendered).not.toContain('result-a')
     expect(transcript.pointerToggleTool('b')).toEqual({ kind: 'tool', key: 'b' })
-    expect(stripAnsi(transcript.render(80).join('\n'))).not.toContain('result-b')
+    const collapsed = stripAnsi(transcript.render(80).join('\n'))
+    expect(collapsed).not.toContain('result-b')
+    expect(collapsed).not.toContain('fixture_tool({')
     const origin = { col: 0, row: 0, width: 80, height: 12 }
     const hits = transcript.controlHitRegions(origin)
     expect(hits.some(region => region.id === 'transcript:tool:b'

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -296,10 +296,13 @@ describe('conversation viewport', () => {
         { kind: 'text', text: '结论' },
       ]),
     ]))
-    const collapsed = transcript.render(60).join('\n')
+    const collapsedLines = transcript.render(60)
+    const collapsed = collapsedLines.join('\n')
     expect(collapsed).toContain('思考（已折叠）')
     expect(collapsed).not.toContain('完成后的推理')
     const hits = transcript.controlHitRegions({ col: 0, row: 0, width: 60, height: 12 })
+    const reasoningHit = hits.find(region => region.id === 'transcript:reasoning:a1')
+    expect(reasoningHit?.rect.row).toBe(collapsedLines.findIndex(line => line.includes('思考（已折叠）')))
     expect(hits.some(region => region.id === 'transcript:reasoning:a1'
       && region.activation === 'direct'
       && region.action.kind === 'transcript'
@@ -307,6 +310,28 @@ describe('conversation viewport', () => {
 
     expect(transcript.pointerToggleReasoning('a1')).toBe(true)
     expect(transcript.render(60).join('\n')).toContain('完成后的推理')
+    transcript.dispose()
+  })
+
+  it('keeps a collapsed reasoning hit on its rendered row when the viewport starts with a block gap', () => {
+    vi.stubEnv('NO_COLOR', '1')
+    const transcript = new Transcript(() => 3)
+    transcript.update(snapshot([
+      user('u1', 'earlier question'),
+      assistantStep('a1', 'settled', [
+        { kind: 'reasoning', text: '完成后的推理' },
+        { kind: 'text', text: '结论' },
+      ]),
+    ]))
+
+    const rendered = transcript.render(60)
+    const headerRow = rendered.findIndex(line => line.includes('思考（已折叠）'))
+    expect(headerRow).toBe(1)
+
+    const origin = { col: 0, row: 4, width: 60, height: 3 }
+    const hit = transcript.controlHitRegions(origin)
+      .find(region => region.id === 'transcript:reasoning:a1')
+    expect(hit?.rect.row).toBe(origin.row + headerRow)
     transcript.dispose()
   })
 

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -390,14 +390,22 @@ describe('conversation viewport', () => {
     const dim = transcript.render(80).join('\n')
     expect(dim).toContain('\u001B[38;2;52;65;95m◆')
     expect(dim).toContain('Russia Ukraine war latest news ceasefire 2025')
-    expect(dim).toContain('web_search({')
-    expect(dim).toContain('"query": "Russia Ukraine war latest news ceasefire 2025"')
+    expect(dim).not.toContain('web_search({')
+    expect(dim).not.toContain('"query": "Russia Ukraine war latest news ceasefire 2025"')
     expect(dim).toContain(' · 0s')
     expect(dim).not.toContain('运行中')
 
+    expect(transcript.pointerToggleTool('call-1')).toEqual({ kind: 'tool', key: 'call-1' })
+    const expanded = transcript.render(80).join('\n')
+    expect(expanded).toContain('web_search({')
+    expect(expanded).toContain('"query": "Russia Ukraine war latest news ceasefire 2025"')
+    expect(transcript.pointerToggleTool('call-1')).toEqual({ kind: 'tool', key: 'call-1' })
+    expect(transcript.render(80).join('\n')).not.toContain('web_search({')
+
+    const beforePulse = requestRender.mock.calls.length
     vi.advanceTimersByTime(640)
     expect(transcript.render(80).join('\n')).toContain('\u001B[38;2;145;167;255m◆')
-    expect(requestRender).toHaveBeenCalledTimes(4)
+    expect(requestRender).toHaveBeenCalledTimes(beforePulse + 4)
 
     vi.advanceTimersByTime(5_360)
     expect(transcript.render(80).join('\n')).toContain(' · 6s')
@@ -619,7 +627,7 @@ describe('conversation viewport', () => {
     expect(stripAnsi(rendered.join('\n'))).not.toContain('```')
   })
 
-  it('renders tool headers as action and duration with connected themed invocation code', () => {
+  it('renders expanded tool invocations with the connected themed code surface', () => {
     vi.stubEnv('NO_COLOR', undefined)
     vi.stubEnv('TERM', 'xterm-256color')
     vi.stubEnv('COLORTERM', 'truecolor')
@@ -636,19 +644,20 @@ describe('conversation viewport', () => {
         { card: 'terminal', output: 'RESULT', exitCode: 0 },
       ),
     ]))
+    transcript.pointerToggleTool('terminal-1')
 
     const rendered = transcript.render(70)
     const plain = stripAnsi(rendered.join('\n'))
     const command = rendered.find(row => row.includes('$ printf'))
     expect(plain).toContain('◆ 检查主题支持 · 15ms')
     expect(plain).not.toContain('完成')
-    expect(plain).not.toContain('RESULT')
+    expect(plain).toContain('RESULT')
     expect(command).toContain('⎿')
     expect(command).toContain('\u001B[49m')
     expect(command).not.toContain('\u001B[48;')
   })
 
-  it('shows structured tool parameters as connected JSON code while collapsed', () => {
+  it('shows structured tool parameters only while expanded', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 12)
     transcript.update(snapshot([
@@ -659,11 +668,17 @@ describe('conversation viewport', () => {
       ),
     ]))
 
-    const rendered = transcript.render(60).join('\n')
-    expect(rendered).toContain('◆ Inspect · 15ms')
-    expect(rendered).toContain('⎿  fixture_tool({')
-    expect(rendered).toContain('"path": "src/index.ts"')
-    expect(rendered).not.toContain('done')
+    const collapsed = transcript.render(60).join('\n')
+    expect(collapsed).toContain('◆ Inspect · 15ms')
+    expect(collapsed).not.toContain('fixture_tool({')
+    expect(collapsed).not.toContain('"path": "src/index.ts"')
+    expect(collapsed).not.toContain('done')
+
+    transcript.pointerToggleTool('json-1')
+    const expanded = transcript.render(60).join('\n')
+    expect(expanded).toContain('⎿  fixture_tool({')
+    expect(expanded).toContain('"path": "src/index.ts"')
+    expect(expanded).toContain('done')
   })
 
   it('renders a search as its tool invocation instead of repeating the title', () => {
@@ -683,6 +698,7 @@ describe('conversation viewport', () => {
         { name: 'web_search', argsRaw: '{"query":"Donald Trump latest news today"}' },
       ),
     ]))
+    transcript.pointerToggleTool('search-1')
 
     const rendered = transcript.render(80).join('\n')
     expect(rendered).toContain('◆ Donald Trump latest news today · 15ms')
@@ -747,7 +763,7 @@ describe('conversation viewport', () => {
     expect(rendered).toContain('11 export { answer }')
   })
 
-  it('keeps the actual read invocation connected while tool results are collapsed', () => {
+  it('hides both the read invocation and result while collapsed', () => {
     vi.stubEnv('NO_COLOR', '1')
     const transcript = new Transcript(() => 12)
     transcript.update(snapshot([
@@ -776,9 +792,15 @@ describe('conversation viewport', () => {
 
     const rendered = transcript.render(100).join('\n')
     expect(rendered).toContain('◆ Reading bwq1gladk · 15ms')
-    expect(rendered).toContain('  ⎿  read({')
-    expect(rendered).toContain('"file_path": "/private/tmp/claude-501/tasks/bwq1gladk.output"')
+    expect(rendered).not.toContain('read({')
+    expect(rendered).not.toContain('"file_path": "/private/tmp/claude-501/tasks/bwq1gladk.output"')
     expect(rendered).not.toContain('complete')
+
+    transcript.pointerToggleTool('read-collapsed')
+    const expanded = transcript.render(100).join('\n')
+    expect(expanded).toContain('  ⎿  read({')
+    expect(expanded).toContain('"file_path": "/private/tmp/claude-501/tasks/bwq1gladk.output"')
+    expect(expanded).toContain('complete')
   })
 
   it('highlights tool JSON and diffs while leaving terminal ANSI output untouched', () => {


### PR DESCRIPTION
## 修改内容

- 修正 transcript 首屏存在真实空行或合成顶部留白时，思考折叠控件的屏幕命中行偏移；仅跳过渲染器插入的合成留白，不再误跳过会话本身的空行。
- 工具卡折叠态现在只保留标题，参数与结果只在展开态显示；运行中与已完成工具使用同一套折叠语义。
- 修正真实 Session 中投影节点 key 与工具 `callId` 不同导致的缓存失效错误：第一次点击可展开，第二次点击不再复用展开帧。
- 增加节点 key / `callId` 不同、展开后再次折叠及运行中工具切换的回归覆盖。

## 验证

- `pnpm run check`
- 116 个测试文件通过
- 1035 项测试通过，1 项条件跳过
- 类型检查、构建与打包白名单检查通过

Closes #179