### PR TITLE
release: enable npm publication for SeekTTY 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,30 +47,30 @@ Install SeekTTY on the tested official DeepSeek Harness `0.1.1-rc.2`:
 ```sh
 pnpm add --global --config.enable-global-virtual-store=false @deepseek-ai/dsh@0.1.1-rc.2
 
-dsh plugin --profile tui add --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+dsh plugin --profile tui add --config.enable-global-virtual-store=false seektty@1.2.5
 
 dsh --profile tui
 ```
 
 These commands install the prebuilt Bundle through native `dsh plugin` reconciliation. The per-command pnpm option avoids the pnpm 11 Global Virtual Store layout that the Cordis loader in the currently tested dsh releases cannot reliably load. SeekTTY never changes global pnpm configuration. Clarify and Auxiliary Runtime are optional, not default dependencies; their historical joint acceptance is listed under [Compatibility](#compatibility-and-verification).
 
-Versioned download URLs become available only after that release is published. Before publication, use the local-tarball instructions in the [1.2.5 owner review and release checklist](docs/release-v1.2.5-verification.md). This pull request is a release candidate only; merging it does not publish a tag, GitHub Release, or npm package.
+The exact `seektty@1.2.5` npm package and the GitHub Release tarball are built from the same reviewed package inputs. The [1.2.5 owner review and release checklist](docs/release-v1.2.5-verification.md) records the publication and verification procedure.
 
 ### Bare `deepseek` launcher
 
-After installing `dsh`, install the same SeekTTY release globally and pin Profile reconciliation to that tarball:
+After installing `dsh`, install the same SeekTTY release globally and pin Profile reconciliation to its exact npm version:
 
 ```sh
-pnpm add --global --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+pnpm add --global --config.enable-global-virtual-store=false seektty@1.2.5
+export SEEKTTY_SPEC=seektty@1.2.5
 deepseek
 ```
 
-PowerShell uses the same package URL:
+PowerShell uses the same exact npm spec:
 
 ```powershell
-pnpm add --global --config.enable-global-virtual-store=false 'https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz'
-$env:SEEKTTY_SPEC='https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz'
+pnpm add --global --config.enable-global-virtual-store=false 'seektty@1.2.5'
+$env:SEEKTTY_SPEC='seektty@1.2.5'
 deepseek
 ```
 
@@ -100,7 +100,7 @@ SeekTTY `1.2.5` brings a Fastfetch-style welcome page, terminal-integrated backg
 - Wide overlays use available space for full option descriptions while preserving search, selection, scroll position, and pointer geometry across resize. Hover styling and transparent surfaces are consistent across nested controls.
 - Launcher provisioning, compatible updates, and TUI plugin mutations disable pnpm 11 Global Virtual Store per command. Known `store/v11/links` loader failures receive precise, credential-redacted recovery without changing global pnpm configuration or bypassing native Profile reconciliation.
 
-See the bilingual [release notes](docs/release-v1.2.5.md) for changes and the [owner review checklist](docs/release-v1.2.5-verification.md) for verification limits. Version 1.2.4 remains the latest published release until the Owner explicitly approves and performs publication.
+See the bilingual [release notes](docs/release-v1.2.5.md) for changes and the [owner review checklist](docs/release-v1.2.5-verification.md) for verification limits and npm Registry publication evidence.
 
 ## Interface
 
@@ -350,8 +350,8 @@ Replace the former `deepseek-tui` global package once:
 
 ```sh
 pnpm remove --global --config.enable-global-virtual-store=false deepseek-tui
-pnpm add --global --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+pnpm add --global --config.enable-global-virtual-store=false seektty@1.2.5
+export SEEKTTY_SPEC=seektty@1.2.5
 deepseek
 ```
 
@@ -359,13 +359,14 @@ Custom Profiles migrate independently on first launch. Native dsh-only installat
 
 ```sh
 dsh plugin --profile tui remove --config.enable-global-virtual-store=false deepseek-tui
-dsh plugin --profile tui add --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+dsh plugin --profile tui add --config.enable-global-virtual-store=false seektty@1.2.5
 ```
 
-Removing SeekTTY changes only the target Profile, never the dsh installation:
+To remove both the Profile Bundle and the optional global launcher while leaving the dsh installation untouched:
 
 ```sh
 dsh plugin --profile tui remove --config.enable-global-virtual-store=false seektty
+pnpm remove --global --config.enable-global-virtual-store=false seektty
 ```
 
 ## Compatibility and verification

--- a/README.zh.md
+++ b/README.zh.md
@@ -47,30 +47,30 @@
 ```sh
 pnpm add --global --config.enable-global-virtual-store=false @deepseek-ai/dsh@0.1.1-rc.2
 
-dsh plugin --profile tui add --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+dsh plugin --profile tui add --config.enable-global-virtual-store=false seektty@1.2.5
 
 dsh --profile tui
 ```
 
 这些命令通过原生 `dsh plugin` 协调机制安装预构建 Bundle。逐命令 pnpm 参数会避开 pnpm 11 Global Virtual Store 布局；当前已测 dsh 版本的 Cordis Loader 还不能可靠加载该布局。SeekTTY 绝不会修改全局 pnpm 配置。Clarify 与 Auxiliary Runtime 均为可选插件，不是默认依赖；历史联合验收组合见[兼容性](#兼容与验证)。
 
-带版本号的下载地址仅在对应版本正式发布后可用。发布前请按 [1.2.5 Owner 审核与发布清单](docs/release-v1.2.5-verification.md)中的本地 tarball 方式测试。本 PR 仅为 Release 候选；合并不会自动创建 tag、GitHub Release 或 npm 包。
+`seektty@1.2.5` npm 包与 GitHub Release tarball 使用同一份已审核包输入构建。[1.2.5 Owner 审核与发布清单](docs/release-v1.2.5-verification.md)记录发布和验证流程。
 
 ### 裸 `deepseek` 启动器
 
-安装 `dsh` 后，可全局安装同一个 SeekTTY Release，并把 Profile 协调固定到该 tarball：
+安装 `dsh` 后，可全局安装同一个 SeekTTY Release，并把 Profile 协调固定到精确 npm 版本：
 
 ```sh
-pnpm add --global --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+pnpm add --global --config.enable-global-virtual-store=false seektty@1.2.5
+export SEEKTTY_SPEC=seektty@1.2.5
 deepseek
 ```
 
-PowerShell 使用相同的包地址：
+PowerShell 使用相同的精确 npm spec：
 
 ```powershell
-pnpm add --global --config.enable-global-virtual-store=false 'https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz'
-$env:SEEKTTY_SPEC='https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz'
+pnpm add --global --config.enable-global-virtual-store=false 'seektty@1.2.5'
+$env:SEEKTTY_SPEC='seektty@1.2.5'
 deepseek
 ```
 
@@ -100,7 +100,7 @@ SeekTTY `1.2.5` 为官方 Harness `0.1.1-rc.2` 带来 Fastfetch 风格欢迎页�
 - 宽弹窗会使用可用空间显示完整选项描述，resize 时保留搜索、选中、滚动与鼠标命中；多层控件的 hover 和透明表面语义保持一致。
 - 启动器协调、兼容更新和 TUI 插件变更逐命令关闭 pnpm 11 Global Virtual Store。已知 `store/v11/links` Loader 故障会得到精确且脱敏的恢复提示，不修改全局 pnpm 配置，也不绕过原生 Profile 协调。
 
-完整变更见双语[发布说明](docs/release-v1.2.5.md)，验证边界见 [Owner 审核清单](docs/release-v1.2.5-verification.md)。在 Owner 明确批准并执行发布前，1.2.4 仍是最新正式版本。
+完整变更见双语[发布说明](docs/release-v1.2.5.md)，验证边界与 npm Registry 发布证据见 [Owner 审核清单](docs/release-v1.2.5-verification.md)。
 
 ## 界面预览
 
@@ -350,8 +350,8 @@ TUI `/plugin` 与原生 `dsh plugin` 会协调同一份 Profile 依赖、Bundle 
 
 ```sh
 pnpm remove --global --config.enable-global-virtual-store=false deepseek-tui
-pnpm add --global --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
-export SEEKTTY_SPEC=https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+pnpm add --global --config.enable-global-virtual-store=false seektty@1.2.5
+export SEEKTTY_SPEC=seektty@1.2.5
 deepseek
 ```
 
@@ -359,13 +359,14 @@ deepseek
 
 ```sh
 dsh plugin --profile tui remove --config.enable-global-virtual-store=false deepseek-tui
-dsh plugin --profile tui add --config.enable-global-virtual-store=false https://github.com/Hilbert-beinghappy/seektty/releases/download/v1.2.5/seektty-1.2.5.tgz
+dsh plugin --profile tui add --config.enable-global-virtual-store=false seektty@1.2.5
 ```
 
-移除 SeekTTY 只影响目标 Profile，不会修改 dsh 本体：
+如需同时移除 Profile Bundle 和可选的全局启动器，可执行以下命令；dsh 本体不受影响：
 
 ```sh
 dsh plugin --profile tui remove --config.enable-global-virtual-store=false seektty
+pnpm remove --global --config.enable-global-virtual-store=false seektty
 ```
 
 ## 兼容与验证

--- a/docs/release-v1.2.5-verification.md
+++ b/docs/release-v1.2.5-verification.md
@@ -3,7 +3,7 @@
 This is the review record for the `1.2.5` release candidate. It is not evidence that `v1.2.5` has been tagged or published.
 
 - Previous published release: `v1.2.4`.
-- Candidate branch: `codex/release-1.2.5`. Its cumulative scope is every merged change after `v1.2.4` (PRs #162, #164, #165, #169, #170, #172, #177, #178, and #180), the completed local Fastfetch-welcome series, the pnpm 11 layout adapter, and release-document updates.
+- Candidate branch: `codex/npm-publish-1.2.5`, based on merged PR #182. Its cumulative scope is every merged change after `v1.2.4`, the pnpm 11 layout adapter, and the npm publication contract.
 - Candidate artifact: `seektty-1.2.5.tgz`, built with pnpm `11.7.0`.
 - Tested Host: unmodified official `@deepseek-ai/dsh@0.1.1-rc.2`.
 - Release notes: [English and Chinese in one document](release-v1.2.5.md).
@@ -36,16 +36,16 @@ The final values below must describe the exact package inputs proposed for Owner
 
 | Gate | Result |
 | --- | --- |
-| `pnpm run check` | Pass — 123 test files; 1084 passed / 1 conditional skip; typecheck, build, and pack check passed |
+| `pnpm run check` | Pass — 123 test files; 1086 passed / 1 conditional skip; typecheck, build, and pack check passed |
 | Tracked `lib/` and launcher `--version` | Pass — generated bundle rebuilt; launcher reports `seektty 1.2.5` and tested dsh `0.1.1-rc.2` |
 | Package allowlist | Pass — 25 packaged entries, including the sanitized built-in welcome Logo; no Profile, Session, `.env`, cache, or personal theme paths included |
 | Welcome/Fastfetch automated coverage | Pass — defaults, three information modes, safe/trusted sources, process limits, cache generations, ANSI sanitization, responsive layouts, draft rollback, navigation, and direct top/bottom row movement |
 | Structural TUI performance | Pass — 12 isolated runs at 1k / 10k / 50k / 100k transcript lines, 80 columns × 24 rows |
 | Windows GVS=false isolated lifecycle | Pass — official dsh install plus add, boot, remove, re-add, second boot, launcher isolation, and Host identity checks |
 | Windows GVS=true compatibility branch | Pass as a diagnostic gate — real paths entered `store/v11/links`; the exact current dsh/Cordis failure and recovery advice were classified. This is not a claim of GVS=true support |
-| GitHub CI, Windows/macOS/Linux × Node 22/24 | Pending PR checks; Owner must review |
+| GitHub CI, Windows/macOS/Linux × Node 22/24 | Pass — all six pnpm 11 layout jobs plus the main check and Windows launcher job succeeded on PR #182 |
 
-Candidate SHA-256 (`seektty-1.2.5.tgz`): `7ce2ec82c449bc5b58e0fb3dcca0ba973f80f196f0661610a3ff77163f1e877f`.
+Record the final candidate SHA-256 in the draft GitHub Release and external `SHA256SUMS` after building from the approved merge commit. It is intentionally not embedded here because this document is part of the tarball being hashed.
 
 Local evidence was collected on Windows `10.0.22631`, x64, Node.js `v26.1.0`, pnpm `11.7.0`, against the unmodified official dsh `0.1.1-rc.2`. The package targets Node `^22.19.0 || >=24`; the PR matrix separately covers Node 22 and 24.
 
@@ -109,17 +109,18 @@ pnpm test:pnpm11-layout true /path/to/candidate-directory
 - [ ] Confirm the failure message contains no credential and does not misclassify unrelated loader failures.
 - [ ] Decide whether pending macOS/Linux real-terminal checks block publication or should remain explicitly untested.
 - [ ] Explicitly authorize tag and GitHub Release creation in a separate action. Merging this PR alone is not publication authorization.
-- [ ] Keep `private: true` unless npm identity, access, Trusted Publishing, provenance, and rollback are separately reviewed and approved.
+- [ ] Confirm npm identity, verified email, 2FA, public access, rollback, and the exact `seektty@1.2.5` package before the final interactive publish.
 
 ## Publication procedure — Owner only, after approval
 
 1. Confirm the merge commit has green required checks and no package-input changes after the reviewed artifact was produced.
 2. Rebuild `seektty-1.2.5.tgz`, verify its allowlist and checksum, and store `SHA256SUMS` outside the checkout.
-3. Create `v1.2.5` at the exact approved commit and prepare a **draft** GitHub Release using [the bilingual notes](release-v1.2.5.md).
-4. Attach the tarball and `SHA256SUMS`; verify version, tag, filename, and checksum before publishing the draft.
-5. After publication, download the assets again, compare SHA-256, and repeat isolated installation from the downloaded package.
+3. Confirm `npm whoami`, the public package name, version, `latest` dist-tag, packed file list, and checksum.
+4. Create `v1.2.5` at the exact approved commit and prepare a **draft** GitHub Release using [the bilingual notes](release-v1.2.5.md). Attach the same tarball and checksum file.
+5. After a final Owner confirmation, publish that exact tarball interactively with 2FA: `npm publish /absolute/path/seektty-1.2.5.tgz --access public --tag latest --registry=https://registry.npmjs.org/`.
+6. Verify Registry metadata and the isolated official-dsh lifecycle from `seektty@1.2.5`, then publish the prepared GitHub Release and compare its downloaded asset SHA-256.
 
-This candidate intentionally has no automated publishing workflow and no npm Registry publication step.
+This first npm release intentionally has no automated publishing workflow. Configure npm Trusted Publishing only after the package exists; do not add a long-lived write token.
 
 ## Rollback
 
@@ -137,4 +138,4 @@ Do not delete `DSH_HOME`, Settings, Sessions, or plugin manifests. If the global
 
 Owner 需要审核欢迎页与 Fastfetch 信任边界、主题／透明背景、代码高亮、对话与选择器交互、pnpm 适配范围、六组 CI 矩阵、精确候选包、打包白名单和 SHA-256，并在隔离 `DSH_HOME` 下启动验证。GVS=true 当前若命中已知上游 Loader 错误，只能说明诊断正确，不能宣称已经支持该布局。macOS/Linux CI 与真实桌面终端人工验收继续分开记录。
 
-合并这个 PR 不等于授权发布。只有 Owner 后续明确批准，才创建 `v1.2.5` 和 GitHub Release。包继续保留 `private: true`；npm 身份、权限、Trusted Publishing、provenance 与回滚没有单独审核前，不进行 npm 发布。
+合并准备 PR 不等于执行发布。包已配置为公开 npm 包，启动器与自更新改用精确 npm 版本 spec；Owner 仍需审核精确 tarball、文件清单、SHA-256、CI、npm 身份与回滚方案，并在 `npm publish` 前作最后一次明确确认。首次发布后再配置 Trusted Publishing，不保存长期写 Token。

--- a/docs/release-v1.2.5.md
+++ b/docs/release-v1.2.5.md
@@ -65,7 +65,7 @@ SeekTTY 1.2.5 replaces the old empty-session screen with a configurable Fastfetc
 
 ### Owner publication boundary
 
-The package remains `private: true`. This pull request prepares versioned source, generated bundles, bilingual documentation, and verification evidence only. The Owner must review the exact artifact and CI matrix before separately deciding whether to create `v1.2.5` and a GitHub Release. There is no npm Registry publication step in this candidate.
+The package is configured for public publication at `https://registry.npmjs.org/`, and launcher provisioning and self-update use exact npm version specs. This document is not evidence that `seektty@1.2.5` has been published. The Owner must review the exact tarball, checksum, packed file list, and CI matrix, then explicitly confirm the first interactive npm publication.
 
 ## 中文
 
@@ -130,4 +130,4 @@ SeekTTY 1.2.5 使用可配置的 Fastfetch 风格欢迎页替换旧空会话界�
 
 ### Owner 发布边界
 
-包继续保留 `private: true`。本 PR 只准备版本化源码、生成 bundle、双语文档和验证证据。Owner 必须审核精确候选包与 CI 矩阵，再单独决定是否创建 `v1.2.5` 与 GitHub Release。本候选不包含 npm Registry 发布步骤。
+包已配置为公开发布到 `https://registry.npmjs.org/`，启动器首次协调和自更新均使用精确 npm 版本 spec。本文件不代表 `seektty@1.2.5` 已经发布。Owner 必须审核精确 tarball、SHA-256、打包文件清单和 CI 矩阵，再明确确认首次交互式 npm 发布。

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { a as PACKAGE_NAME, c as defaultPluginSpec, d as isVersionRequest, f as launcherCopy, i as HOST_DESCRIBE_VERSION_PLACEHOLDER, m as versionMessage, n as measureStartupSync, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as compareDshVersion } from "./startup-trace-CP4shtZL.js";
+import { a as PACKAGE_NAME, c as defaultPluginSpec, d as isVersionRequest, f as launcherCopy, i as HOST_DESCRIBE_VERSION_PLACEHOLDER, m as versionMessage, n as measureStartupSync, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, s as compareDshVersion } from "./startup-trace-DU93JLgh.js";
 import { c as pnpmGvsRecoveryAdvice, i as dshPluginCommand, l as withPnpmGvsCompatibility, o as isPnpmGlobalVirtualStorePath, r as dshPluginArgs, s as pnpmCommand } from "./pnpm-compat-CJOPs__B.js";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
@@ -118,9 +118,10 @@ function exclusiveUpdatePlan(plan) {
 * peer-aligned auto range and newer than the actually installed Host.
 */
 function updatePlan(scan, facts) {
-	if (!facts.seekttyPinned && seekttyIsNewer(scan, facts)) return exclusiveUpdatePlan({
+	const seekttyVersion = scan.seekttyLatestTag === void 0 ? void 0 : tagToVersion(scan.seekttyLatestTag);
+	if (!facts.seekttyPinned && seekttyVersion !== void 0 && seekttyIsNewer(scan, facts)) return exclusiveUpdatePlan({
 		dshSpec: void 0,
-		seekttySpec: `github:Hilbert-beinghappy/seektty#${scan.seekttyLatestTag}`
+		seekttySpec: `seektty@${seekttyVersion}`
 	});
 	return exclusiveUpdatePlan({
 		dshSpec: dshIsInstallable(scan, facts) ? `@deepseek-ai/dsh@${scan.dshLatest}` : void 0,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import { a as saveLanguage, c as ui, i as localeSettings, l as uiLocale, o as setUiLocale, r as localeFromSettings, s as translateUiText, t as languageSelection } from "./locale-DfNiG1ip.js";
-import { c as defaultPluginSpec, l as dshCompatibilityError, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, t as measureStartup, u as dshCompatibilityNotice } from "./startup-trace-CP4shtZL.js";
+import { c as defaultPluginSpec, l as dshCompatibilityError, o as PACKAGE_VERSION, p as launcherPrefersEnglish, r as DSH_COMPATIBILITY, t as measureStartup, u as dshCompatibilityNotice } from "./startup-trace-DU93JLgh.js";
 import { s as pnpmCommand } from "./pnpm-compat-CJOPs__B.js";
 import { n as assertCredentialFreeUrl, r as redactMarketplaceUrl, t as PluginMarketplace } from "./plugin-marketplace-DT40_tRk.js";
 import { a as installerSecrets, o as redactInstallerText, t as TUI_STARTUP_SERVICE } from "./startup-BjSO60YP.js";

--- a/lib/startup-trace-DU93JLgh.js
+++ b/lib/startup-trace-DU93JLgh.js
@@ -86,11 +86,11 @@ function dshCompatibilityNotice(hostVersion, compatibility, english) {
 	if (newest !== void 0 && newest > 0) return english ? `dsh ${hostVersion} is newer than the tested ${compatibility.tested}. SeekTTY continues; report issues if anything misbehaves.` : `dsh ${hostVersion} 新于已测试的 ${compatibility.tested}。SeekTTY 将继续运行；如有异常请反馈。`;
 }
 /**
-* Default GitHub plugin spec pinned to this package version.
+* Default npm plugin spec pinned to this package version.
 * @param version - package.json version without a leading v.
 */
 function defaultPluginSpec(version) {
-	return `github:Hilbert-beinghappy/seektty#v${version}`;
+	return `seektty@${version}`;
 }
 /**
 * Launcher `--version` text. Must not import locale.ts.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "seektty",
   "version": "1.2.5",
-  "private": true,
   "description": "SeekTTY, a pluggable DeepSeek-colored terminal surface for DeepSeek Harness",
   "keywords": [
     "deepseek",
@@ -19,6 +18,10 @@
   },
   "homepage": "https://github.com/Hilbert-beinghappy/seektty#readme",
   "bugs": "https://github.com/Hilbert-beinghappy/seektty/issues",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "packageManager": "pnpm@11.7.0",
   "engines": {
     "node": "^22.19.0 || >=24"

--- a/src/dsh-compat.ts
+++ b/src/dsh-compat.ts
@@ -133,11 +133,11 @@ export function dshCompatibilityNotice(
 }
 
 /**
- * Default GitHub plugin spec pinned to this package version.
+ * Default npm plugin spec pinned to this package version.
  * @param version - package.json version without a leading v.
  */
 export function defaultPluginSpec(version: string): string {
-  return `github:Hilbert-beinghappy/seektty#v${version}`
+  return `seektty@${version}`
 }
 
 /**

--- a/src/version-scan.ts
+++ b/src/version-scan.ts
@@ -49,7 +49,7 @@ export interface InstalledFacts {
 export interface UpdatePlan {
   /** Global install spec for dsh, e.g. `@deepseek-ai/dsh@0.1.0-rc.7`. */
   readonly dshSpec?: string | undefined
-  /** Plugin spec for the newest SeekTTY release, e.g. `github:...#v1.2.1`. */
+  /** Exact npm spec for the newest SeekTTY release, e.g. `seektty@1.2.1`. */
   readonly seekttySpec?: string | undefined
 }
 
@@ -174,10 +174,11 @@ export function exclusiveUpdatePlan(plan: UpdatePlan): UpdatePlan {
  * peer-aligned auto range and newer than the actually installed Host.
  */
 export function updatePlan(scan: VersionScan, facts: InstalledFacts): UpdatePlan {
-  if (!facts.seekttyPinned && seekttyIsNewer(scan, facts)) {
+  const seekttyVersion = scan.seekttyLatestTag === undefined ? undefined : tagToVersion(scan.seekttyLatestTag)
+  if (!facts.seekttyPinned && seekttyVersion !== undefined && seekttyIsNewer(scan, facts)) {
     return exclusiveUpdatePlan({
       dshSpec: undefined,
-      seekttySpec: `github:Hilbert-beinghappy/seektty#${scan.seekttyLatestTag}`,
+      seekttySpec: `seektty@${seekttyVersion}`,
     })
   }
   return exclusiveUpdatePlan({

--- a/tests/dsh-compat.test.ts
+++ b/tests/dsh-compat.test.ts
@@ -10,8 +10,8 @@ import {
 } from '../src/dsh-compat.ts'
 
 describe('dsh version and compatibility', () => {
-  it('pins the default plugin spec to the package tag and prints --version without spawning', () => {
-    expect(defaultPluginSpec('1.0.0')).toBe('github:Hilbert-beinghappy/seektty#v1.0.0')
+  it('pins the default plugin spec to the exact npm version and prints --version without spawning', () => {
+    expect(defaultPluginSpec('1.0.0')).toBe('seektty@1.0.0')
     expect(isVersionRequest(['--cwd', '.', '--version'])).toBe(true)
     expect(isVersionRequest(['-V'])).toBe(true)
     expect(isVersionRequest(['--cwd', '.'])).toBe(false)

--- a/tests/package-contract.test.ts
+++ b/tests/package-contract.test.ts
@@ -26,6 +26,14 @@ describe('out-of-tree Bundle contract', () => {
     expect(DSH_COMPATIBILITY).toEqual((manifest.dsh as { compatibility: unknown }).compatibility)
   })
 
+  it('is configured for a public npm Registry publication', () => {
+    expect(manifest.private).not.toBe(true)
+    expect(manifest.publishConfig).toEqual({
+      access: 'public',
+      registry: 'https://registry.npmjs.org/',
+    })
+  })
+
   it('ships only for the supported terminal platforms', () => {
     expect(manifest.os).toEqual(['darwin', 'linux', 'win32'])
   })
@@ -194,19 +202,19 @@ describe('out-of-tree Bundle contract', () => {
     expect(workflow).toContain('pnpm test:pnpm11-layout true .artifacts')
   })
 
-  it('keeps both READMEs on the release version and explains pre-publication testing', () => {
+  it('keeps both READMEs on the release version and exact npm install spec', () => {
     for (const name of ['README.md', 'README.zh.md']) {
       const text = readFileSync(resolve(root, name), 'utf8')
       expect(text).toContain(`Version-${PACKAGE_VERSION}`)
       expect(text).toContain('DeepSeek%20Harness-0.1.1--rc.2')
       expect(text).toContain('https://github.com/Hilbert-beinghappy/seektty/releases')
-      expect(text).toContain(`/releases/download/v${PACKAGE_VERSION}/seektty-${PACKAGE_VERSION}.tgz`)
+      expect(text).toContain(`seektty@${PACKAGE_VERSION}`)
       expect(text).not.toContain('/releases/download/v1.2.0/')
       expect(text).toContain('pnpm add --global --config.enable-global-virtual-store=false @deepseek-ai/dsh@0.1.1-rc.2')
       expect(text).toContain('store/v11/links')
       expect(text).toContain(`docs/release-v${PACKAGE_VERSION}.md`)
       expect(text).toContain(`docs/release-v${PACKAGE_VERSION}-verification.md`)
-      expect(text).toMatch(/Before publication|发布前/u)
+      expect(text).toContain('npm Registry')
       expect(text).toMatch(/optional, not default dependencies|可选插件，不是默认依赖/u)
       expect(text).toMatch(/Vision-Exp/)
       expect(text).toMatch(/self-first|SeekTTY 自更新优先|每轮只安装一个/u)

--- a/tests/version-scan.test.ts
+++ b/tests/version-scan.test.ts
@@ -200,9 +200,16 @@ describe('update plan gates', () => {
     )
     expect(plan).toEqual({
       dshSpec: undefined,
-      seekttySpec: 'github:Hilbert-beinghappy/seektty#v1.3.0',
+      seekttySpec: 'seektty@1.3.0',
     })
     expect(plannedSpecs(plan)).toHaveLength(1)
+  })
+
+  it('does not form an npm spec from an invalid GitHub release tag', () => {
+    expect(updatePlan({ seekttyLatestTag: 'not-a-version' }, facts())).toEqual({
+      dshSpec: undefined,
+      seekttySpec: undefined,
+    })
   })
 
   it('plans at most one spec in every combination', () => {
@@ -217,10 +224,10 @@ describe('update plan gates', () => {
     for (const plan of cases) expect(plannedSpecs(plan).length).toBeLessThanOrEqual(1)
     expect(exclusiveUpdatePlan({
       dshSpec: '@deepseek-ai/dsh@0.1.1-rc.2',
-      seekttySpec: 'github:Hilbert-beinghappy/seektty#v1.3.0',
+      seekttySpec: 'seektty@1.3.0',
     })).toEqual({
       dshSpec: undefined,
-      seekttySpec: 'github:Hilbert-beinghappy/seektty#v1.3.0',
+      seekttySpec: 'seektty@1.3.0',
     })
   })
 
@@ -290,7 +297,7 @@ describe('launcher update flow', () => {
     )
     expect(status).toBe(0)
     expect(calls).toEqual([
-      ['dsh', 'plugin', '--profile', 'team', 'add', PNPM_GVS_CONFIG_ARG, 'github:Hilbert-beinghappy/seektty#v9.9.9'],
+      ['dsh', 'plugin', '--profile', 'team', 'add', PNPM_GVS_CONFIG_ARG, 'seektty@9.9.9'],
     ])
   })
 
@@ -439,7 +446,7 @@ describe('launcher update flow', () => {
       () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
     )
     expect(calls).toEqual([
-      ['dsh', 'plugin', '--profile', 'tui', 'add', PNPM_GVS_CONFIG_ARG, 'github:Hilbert-beinghappy/seektty#v9.9.9'],
+      ['dsh', 'plugin', '--profile', 'tui', 'add', PNPM_GVS_CONFIG_ARG, 'seektty@9.9.9'],
     ])
     calls.length = 0
     await maybeAutoUpdate(
@@ -494,7 +501,7 @@ describe('launcher update flow', () => {
     expect(execute).toHaveBeenCalledTimes(1)
     expect(execute).toHaveBeenCalledWith(
       'dsh',
-      ['plugin', '--profile', 'tui', 'add', PNPM_GVS_CONFIG_ARG, 'github:Hilbert-beinghappy/seektty#v9.9.9'],
+      ['plugin', '--profile', 'tui', 'add', PNPM_GVS_CONFIG_ARG, 'seektty@9.9.9'],
     )
   })
 


### PR DESCRIPTION
Prepares the first public npm publication of seektty 1.2.5. Removes the private package block, adds explicit public Registry configuration, switches launcher provisioning and self-update to exact npm specs, updates bilingual install and removal guidance, rebuilds generated output, and adds release-contract coverage. Verified under Node 24 with the full project check, npm publish dry-run, a 25-entry package audit, reproducible SHA-256, the isolated official dsh lifecycle with GVS disabled, and the known GVS=true diagnostic gate. The actual npm publish remains a separate Owner-confirmed action.