### PR TITLE
fix(update): detect SeekTTY versions from npm latest

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import crossSpawn from "cross-spawn";
 
 const DSH_DIST_TAGS_URL = "https://registry.npmjs.org/-/package/@deepseek-ai/dsh/dist-tags";
-const SEEKTTY_LATEST_RELEASE_URL = "https://api.github.com/repos/Hilbert-beinghappy/seektty/releases/latest";
+const SEEKTTY_DIST_TAGS_URL = "https://registry.npmjs.org/-/package/seektty/dist-tags";
 const DEFAULT_SCAN_TIMEOUT_MS = 3e3;
 /** Peer-aligned auto-install floor for the rc.6–rc.8 Host line. */
 const AUTO_PERMITTED_DSH_MINIMUM = DSH_COMPATIBILITY.minimum;
@@ -33,23 +33,19 @@ function cleanVersion(value) {
 	return trimmed === "" ? void 0 : trimmed;
 }
 /**
-* Query npm `latest` and the SeekTTY GitHub `releases/latest` tag.
+* Query the npm `latest` dist-tags for dsh and SeekTTY.
 * Each source fails independently and silently; the result never rejects.
 * @param fetchImpl - injectable fetch used by tests.
 * @param timeoutMs - per-request abort timeout.
 */
 async function scanLatestVersions(fetchImpl = fetch, timeoutMs = DEFAULT_SCAN_TIMEOUT_MS) {
-	const [distTags, release] = await Promise.all([fetchJson(fetchImpl, DSH_DIST_TAGS_URL, timeoutMs).catch(() => void 0), fetchJson(fetchImpl, SEEKTTY_LATEST_RELEASE_URL, timeoutMs).catch(() => void 0)]);
-	const tags = distTags;
-	const rel = release;
+	const [dshDistTags, seekttyDistTags] = await Promise.all([fetchJson(fetchImpl, DSH_DIST_TAGS_URL, timeoutMs).catch(() => void 0), fetchJson(fetchImpl, SEEKTTY_DIST_TAGS_URL, timeoutMs).catch(() => void 0)]);
+	const dshTags = dshDistTags;
+	const seekttyTags = seekttyDistTags;
 	return {
-		dshLatest: cleanVersion(tags?.latest),
-		seekttyLatestTag: cleanVersion(rel?.tag_name)
+		dshLatest: cleanVersion(dshTags?.latest),
+		seekttyLatest: cleanVersion(seekttyTags?.latest)
 	};
-}
-/** Strip a single leading `v` so release tags compare as versions. */
-function tagToVersion(tag) {
-	return tag.startsWith("v") ? tag.slice(1) : tag;
 }
 const DSH_CLI_VERSION_LINE = /^(?:dsh\s+)?v?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?)$/u;
 /**
@@ -85,8 +81,8 @@ function isAutoPermittedDshVersion(version) {
 	return vsMin !== void 0 && vsLegacyMax !== void 0 && vsMin >= 0 && vsLegacyMax <= 0;
 }
 function seekttyIsNewer(scan, facts) {
-	if (scan.seekttyLatestTag === void 0) return false;
-	const order = compareDshVersion(tagToVersion(scan.seekttyLatestTag), facts.seekttyVersion);
+	if (scan.seekttyLatest === void 0) return false;
+	const order = compareDshVersion(scan.seekttyLatest, facts.seekttyVersion);
 	return order !== void 0 && order > 0;
 }
 function dshIsInstallable(scan, facts) {
@@ -118,10 +114,9 @@ function exclusiveUpdatePlan(plan) {
 * peer-aligned auto range and newer than the actually installed Host.
 */
 function updatePlan(scan, facts) {
-	const seekttyVersion = scan.seekttyLatestTag === void 0 ? void 0 : tagToVersion(scan.seekttyLatestTag);
-	if (!facts.seekttyPinned && seekttyVersion !== void 0 && seekttyIsNewer(scan, facts)) return exclusiveUpdatePlan({
+	if (!facts.seekttyPinned && scan.seekttyLatest !== void 0 && seekttyIsNewer(scan, facts)) return exclusiveUpdatePlan({
 		dshSpec: void 0,
-		seekttySpec: `seektty@${seekttyVersion}`
+		seekttySpec: `seektty@${scan.seekttyLatest}`
 	});
 	return exclusiveUpdatePlan({
 		dshSpec: dshIsInstallable(scan, facts) ? `@deepseek-ai/dsh@${scan.dshLatest}` : void 0,
@@ -140,7 +135,7 @@ function updateAdvice(scan, facts, english) {
 	if (dshIsOutsideAutoRange(scan)) lines.push(launcherCopy(`dsh ${scan.dshLatest} 超出 SeekTTY 当前许可范围，不会安装。`, `dsh ${scan.dshLatest} is outside SeekTTY's permitted range and will not be installed.`, english));
 	else if (scan.dshLatest !== void 0 && isAutoPermittedDshVersion(scan.dshLatest) && !facts.dshPinned && facts.dshInstalled === void 0) lines.push(launcherCopy("无法读取已安装的 dsh 版本，本轮不会更新 dsh。", "Could not read the installed dsh version; dsh will not be updated this round.", english));
 	else if (installable.dshSpec !== void 0) lines.push(launcherCopy(`dsh 有可安装版本 ${scan.dshLatest}（当前已装 ${facts.dshInstalled}）。`, `An installable dsh ${scan.dshLatest} is available (installed ${facts.dshInstalled}).`, english));
-	if (!facts.seekttyPinned && seekttyIsNewer(scan, facts)) lines.push(launcherCopy(`SeekTTY 有新版本 ${scan.seekttyLatestTag}（当前 ${facts.seekttyVersion}）。`, `A newer SeekTTY ${scan.seekttyLatestTag} is available (running ${facts.seekttyVersion}).`, english));
+	if (!facts.seekttyPinned && seekttyIsNewer(scan, facts)) lines.push(launcherCopy(`SeekTTY 有新版本 ${scan.seekttyLatest}（当前 ${facts.seekttyVersion}）。`, `A newer SeekTTY ${scan.seekttyLatest} is available (running ${facts.seekttyVersion}).`, english));
 	if (installable.dshSpec !== void 0 || installable.seekttySpec !== void 0) lines.push(launcherCopy("运行 deepseek --update 即可更新本轮许可的那一个组件。", "Run deepseek --update to install this round's permitted component.", english));
 	return lines;
 }
@@ -404,8 +399,8 @@ async function runUpdate(args, environment = process.env, execute = run, write =
 	write(launcherCopy("正在检查 dsh 与 SeekTTY 的最新版本…\n", "Checking the latest dsh and SeekTTY versions…\n", english));
 	const facts = installedFacts(environment, profile);
 	const result = await scan();
-	if (result.dshLatest === void 0 && result.seekttyLatestTag === void 0) {
-		write(launcherCopy("无法访问 npm Registry 或 GitHub Releases，请检查网络后重试。\n", "Could not reach the npm Registry or GitHub Releases. Check the network and retry.\n", english));
+	if (result.dshLatest === void 0 && result.seekttyLatest === void 0) {
+		write(launcherCopy("无法访问 npm Registry，请检查网络后重试。\n", "Could not reach the npm Registry. Check the network and retry.\n", english));
 		return 1;
 	}
 	const plan = updatePlan(result, facts);
@@ -419,8 +414,8 @@ async function runUpdate(args, environment = process.env, execute = run, write =
 	});
 }
 /**
-* Default launch policy: fetch official dsh `latest` and the SeekTTY GitHub
-* Release, then apply them. Offline and install failures never block boot.
+* Default launch policy: fetch the npm `latest` dist-tags for official dsh and
+* SeekTTY, then apply them. Offline and install failures never block boot.
 */
 async function maybeAutoUpdate(args, environment = process.env, execute = run, write = (chunk) => {
 	process.stderr.write(chunk);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -73,7 +73,7 @@ export function isUpdateRequest(args: readonly string[]): boolean {
   return args.includes('--update')
 }
 
-/** How the launcher follows official dsh `latest` and SeekTTY GitHub Releases. */
+/** How the launcher follows the npm `latest` dist-tags for official dsh and SeekTTY. */
 export type UpdateMode = 'auto' | 'check' | 'off'
 
 /**
@@ -429,10 +429,10 @@ export async function runUpdate(
   write(launcherCopy('正在检查 dsh 与 SeekTTY 的最新版本…\n', 'Checking the latest dsh and SeekTTY versions…\n', english))
   const facts = installedFacts(environment, profile)
   const result = await scan()
-  if (result.dshLatest === undefined && result.seekttyLatestTag === undefined) {
+  if (result.dshLatest === undefined && result.seekttyLatest === undefined) {
     write(launcherCopy(
-      '无法访问 npm Registry 或 GitHub Releases，请检查网络后重试。\n',
-      'Could not reach the npm Registry or GitHub Releases. Check the network and retry.\n',
+      '无法访问 npm Registry，请检查网络后重试。\n',
+      'Could not reach the npm Registry. Check the network and retry.\n',
       english,
     ))
     return 1
@@ -449,8 +449,8 @@ export async function runUpdate(
 }
 
 /**
- * Default launch policy: fetch official dsh `latest` and the SeekTTY GitHub
- * Release, then apply them. Offline and install failures never block boot.
+ * Default launch policy: fetch the npm `latest` dist-tags for official dsh and
+ * SeekTTY, then apply them. Offline and install failures never block boot.
  */
 export async function maybeAutoUpdate(
   args: readonly string[],

--- a/src/version-scan.ts
+++ b/src/version-scan.ts
@@ -1,7 +1,7 @@
 /**
- * Live version scan against the official dsh npm `latest` dist-tag and the
- * SeekTTY GitHub releases. npm `next` and harness GitHub pre-releases are
- * ignored: those channels are not the stable line this Bundle follows.
+ * Live version scan against the npm `latest` dist-tags for official dsh and
+ * SeekTTY. npm `next` is ignored: that channel is not the stable line this
+ * Bundle follows.
  * Network failures degrade silently. Must not import locale.ts.
  */
 
@@ -13,7 +13,7 @@ import {
 } from './dsh-compat.ts'
 
 export const DSH_DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/@deepseek-ai/dsh/dist-tags'
-export const SEEKTTY_LATEST_RELEASE_URL = 'https://api.github.com/repos/Hilbert-beinghappy/seektty/releases/latest'
+export const SEEKTTY_DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/seektty/dist-tags'
 export const DEFAULT_SCAN_TIMEOUT_MS = 3_000
 
 /** Peer-aligned auto-install floor for the rc.6–rc.8 Host line. */
@@ -27,8 +27,8 @@ export const AUTO_PERMITTED_DSH_EXACT = DSH_COMPATIBILITY.tested
 export interface VersionScan {
   /** npm `latest` dist-tag of `@deepseek-ai/dsh`. */
   readonly dshLatest?: string | undefined
-  /** Tag name of the newest SeekTTY GitHub release, e.g. `v1.1.0`. */
-  readonly seekttyLatestTag?: string | undefined
+  /** npm `latest` dist-tag of `seektty`. */
+  readonly seekttyLatest?: string | undefined
 }
 
 /** Local facts the scan is compared against. */
@@ -78,7 +78,7 @@ function cleanVersion(value: unknown): string | undefined {
 }
 
 /**
- * Query npm `latest` and the SeekTTY GitHub `releases/latest` tag.
+ * Query the npm `latest` dist-tags for dsh and SeekTTY.
  * Each source fails independently and silently; the result never rejects.
  * @param fetchImpl - injectable fetch used by tests.
  * @param timeoutMs - per-request abort timeout.
@@ -87,21 +87,16 @@ export async function scanLatestVersions(
   fetchImpl: FetchLike = fetch as unknown as FetchLike,
   timeoutMs: number = DEFAULT_SCAN_TIMEOUT_MS,
 ): Promise<VersionScan> {
-  const [distTags, release] = await Promise.all([
+  const [dshDistTags, seekttyDistTags] = await Promise.all([
     fetchJson(fetchImpl, DSH_DIST_TAGS_URL, timeoutMs).catch(() => undefined),
-    fetchJson(fetchImpl, SEEKTTY_LATEST_RELEASE_URL, timeoutMs).catch(() => undefined),
+    fetchJson(fetchImpl, SEEKTTY_DIST_TAGS_URL, timeoutMs).catch(() => undefined),
   ])
-  const tags = distTags as { latest?: unknown } | undefined
-  const rel = release as { tag_name?: unknown } | undefined
+  const dshTags = dshDistTags as { latest?: unknown } | undefined
+  const seekttyTags = seekttyDistTags as { latest?: unknown } | undefined
   return {
-    dshLatest: cleanVersion(tags?.latest),
-    seekttyLatestTag: cleanVersion(rel?.tag_name),
+    dshLatest: cleanVersion(dshTags?.latest),
+    seekttyLatest: cleanVersion(seekttyTags?.latest),
   }
-}
-
-/** Strip a single leading `v` so release tags compare as versions. */
-export function tagToVersion(tag: string): string {
-  return tag.startsWith('v') ? tag.slice(1) : tag
 }
 
 const DSH_CLI_VERSION_LINE = /^(?:dsh\s+)?v?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?)$/u
@@ -141,8 +136,8 @@ export function isAutoPermittedDshVersion(version: string): boolean {
 }
 
 function seekttyIsNewer(scan: VersionScan, facts: InstalledFacts): boolean {
-  if (scan.seekttyLatestTag === undefined) return false
-  const order = compareDshVersion(tagToVersion(scan.seekttyLatestTag), facts.seekttyVersion)
+  if (scan.seekttyLatest === undefined) return false
+  const order = compareDshVersion(scan.seekttyLatest, facts.seekttyVersion)
   return order !== undefined && order > 0
 }
 
@@ -174,11 +169,10 @@ export function exclusiveUpdatePlan(plan: UpdatePlan): UpdatePlan {
  * peer-aligned auto range and newer than the actually installed Host.
  */
 export function updatePlan(scan: VersionScan, facts: InstalledFacts): UpdatePlan {
-  const seekttyVersion = scan.seekttyLatestTag === undefined ? undefined : tagToVersion(scan.seekttyLatestTag)
-  if (!facts.seekttyPinned && seekttyVersion !== undefined && seekttyIsNewer(scan, facts)) {
+  if (!facts.seekttyPinned && scan.seekttyLatest !== undefined && seekttyIsNewer(scan, facts)) {
     return exclusiveUpdatePlan({
       dshSpec: undefined,
-      seekttySpec: `seektty@${seekttyVersion}`,
+      seekttySpec: `seektty@${scan.seekttyLatest}`,
     })
   }
   return exclusiveUpdatePlan({
@@ -222,8 +216,8 @@ export function updateAdvice(scan: VersionScan, facts: InstalledFacts, english: 
   }
   if (!facts.seekttyPinned && seekttyIsNewer(scan, facts)) {
     lines.push(launcherCopy(
-      `SeekTTY 有新版本 ${scan.seekttyLatestTag}（当前 ${facts.seekttyVersion}）。`,
-      `A newer SeekTTY ${scan.seekttyLatestTag} is available (running ${facts.seekttyVersion}).`,
+      `SeekTTY 有新版本 ${scan.seekttyLatest}（当前 ${facts.seekttyVersion}）。`,
+      `A newer SeekTTY ${scan.seekttyLatest} is available (running ${facts.seekttyVersion}).`,
       english,
     ))
   }

--- a/tests/version-scan.test.ts
+++ b/tests/version-scan.test.ts
@@ -4,12 +4,11 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   DSH_DIST_TAGS_URL,
-  SEEKTTY_LATEST_RELEASE_URL,
+  SEEKTTY_DIST_TAGS_URL,
   exclusiveUpdatePlan,
   isAutoPermittedDshVersion,
   parseDshCliVersion,
   scanLatestVersions,
-  tagToVersion,
   updateAdvice,
   updatePlan,
   type InstalledFacts,
@@ -75,22 +74,24 @@ function plannedSpecs(plan: UpdatePlan): string[] {
 }
 
 describe('live version scan', () => {
-  it('reads only the npm latest dist-tag and the SeekTTY GitHub release', async () => {
+  it('reads the npm latest dist-tags for dsh and SeekTTY', async () => {
     const scan = await scanLatestVersions(fakeFetch({
       [DSH_DIST_TAGS_URL]: { latest: '0.1.1-rc.2', next: '0.1.2' },
-      [SEEKTTY_LATEST_RELEASE_URL]: { tag_name: 'v1.3.0' },
+      [SEEKTTY_DIST_TAGS_URL]: { latest: '1.3.0', next: '9.9.9' },
     }))
     expect(scan).toEqual({
       dshLatest: '0.1.1-rc.2',
-      seekttyLatestTag: 'v1.3.0',
+      seekttyLatest: '1.3.0',
     })
   })
 
   it('ignores npm next even when that channel is newer', async () => {
     const scan = await scanLatestVersions(fakeFetch({
       [DSH_DIST_TAGS_URL]: { latest: '0.1.0-rc.8', next: '0.1.2' },
+      [SEEKTTY_DIST_TAGS_URL]: { latest: '1.2.1', next: '9.9.9' },
     }))
     expect(scan.dshLatest).toBe('0.1.0-rc.8')
+    expect(scan.seekttyLatest).toBe('1.2.1')
     expect(updatePlan(scan, facts({ dshInstalled: '0.1.0-rc.8' }))).toEqual({
       dshSpec: undefined,
       seekttySpec: undefined,
@@ -98,29 +99,47 @@ describe('live version scan', () => {
     expect(updateAdvice(scan, facts({ dshInstalled: '0.1.0-rc.8' }), true)).toEqual([])
   })
 
-  it('does not query the GitHub harness pre-release feed', async () => {
+  it('queries only the npm dist-tag endpoints', async () => {
     const fetchImpl = vi.fn(fakeFetch({
       [DSH_DIST_TAGS_URL]: { latest: '0.1.1-rc.2', next: '0.1.2' },
-      [SEEKTTY_LATEST_RELEASE_URL]: { tag_name: 'v1.2.1' },
+      [SEEKTTY_DIST_TAGS_URL]: { latest: '1.2.1' },
     }))
     await scanLatestVersions(fetchImpl)
     const urls = fetchImpl.mock.calls.map(call => call[0])
     expect(urls).toHaveLength(2)
-    expect(urls).toEqual(expect.arrayContaining([DSH_DIST_TAGS_URL, SEEKTTY_LATEST_RELEASE_URL]))
-    expect(urls.join('\n')).not.toContain('deepseek-harness')
+    expect(urls).toEqual(expect.arrayContaining([DSH_DIST_TAGS_URL, SEEKTTY_DIST_TAGS_URL]))
+    expect(urls.every(url => url.startsWith('https://registry.npmjs.org/'))).toBe(true)
+    expect(urls.join('\n')).not.toContain('github.com')
   })
 
   it('degrades every source silently instead of rejecting', async () => {
     const scan = await scanLatestVersions(() => Promise.reject(new Error('offline')))
     expect(scan).toEqual({
       dshLatest: undefined,
-      seekttyLatestTag: undefined,
+      seekttyLatest: undefined,
     })
     const partial = await scanLatestVersions(fakeFetch({
       [DSH_DIST_TAGS_URL]: { latest: '0.1.1-rc.2', next: '0.1.2' },
     }))
     expect(partial.dshLatest).toBe('0.1.1-rc.2')
-    expect(partial.seekttyLatestTag).toBeUndefined()
+    expect(partial.seekttyLatest).toBeUndefined()
+
+    const seekttyOnly = await scanLatestVersions(fakeFetch({
+      [SEEKTTY_DIST_TAGS_URL]: { latest: '1.3.0' },
+    }))
+    expect(seekttyOnly.dshLatest).toBeUndefined()
+    expect(seekttyOnly.seekttyLatest).toBe('1.3.0')
+  })
+
+  it('ignores blank and non-string npm latest values', async () => {
+    const scan = await scanLatestVersions(fakeFetch({
+      [DSH_DIST_TAGS_URL]: { latest: 123 },
+      [SEEKTTY_DIST_TAGS_URL]: { latest: '  ' },
+    }))
+    expect(scan).toEqual({
+      dshLatest: undefined,
+      seekttyLatest: undefined,
+    })
   })
 })
 
@@ -193,9 +212,9 @@ describe('update plan gates', () => {
       .toBeUndefined()
   })
 
-  it('plans only SeekTTY when a newer release is available, even if dsh is also eligible', () => {
+  it('plans only SeekTTY when npm latest is newer, even if dsh is also eligible', () => {
     const plan = updatePlan(
-      { dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.3.0' },
+      { dshLatest: '0.1.1-rc.2', seekttyLatest: '1.3.0' },
       facts({ seekttyVersion: '1.2.1', dshInstalled: '0.1.0-rc.8' }),
     )
     expect(plan).toEqual({
@@ -205,8 +224,8 @@ describe('update plan gates', () => {
     expect(plannedSpecs(plan)).toHaveLength(1)
   })
 
-  it('does not form an npm spec from an invalid GitHub release tag', () => {
-    expect(updatePlan({ seekttyLatestTag: 'not-a-version' }, facts())).toEqual({
+  it('does not form an npm spec from an invalid npm dist-tag', () => {
+    expect(updatePlan({ seekttyLatest: 'not-a-version' }, facts())).toEqual({
       dshSpec: undefined,
       seekttySpec: undefined,
     })
@@ -214,10 +233,10 @@ describe('update plan gates', () => {
 
   it('plans at most one spec in every combination', () => {
     const cases = [
-      updatePlan({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.3.0' }, facts()),
+      updatePlan({ dshLatest: '0.1.1-rc.2', seekttyLatest: '1.3.0' }, facts()),
       updatePlan({ dshLatest: '0.1.1-rc.2' }, facts()),
-      updatePlan({ seekttyLatestTag: 'v1.3.0' }, facts()),
-      updatePlan({ dshLatest: '0.1.2', seekttyLatestTag: 'v1.3.0' }, facts()),
+      updatePlan({ seekttyLatest: '1.3.0' }, facts()),
+      updatePlan({ dshLatest: '0.1.2', seekttyLatest: '1.3.0' }, facts()),
       updatePlan({ dshLatest: '0.1.2' }, facts()),
       updatePlan({}, facts()),
     ]
@@ -234,21 +253,19 @@ describe('update plan gates', () => {
   it('keeps DSH_BIN, SEEKTTY_SPEC, and local/link pins from installing that side', () => {
     expect(updatePlan({ dshLatest: '0.1.1-rc.2' }, facts({ dshPinned: true })).dshSpec).toBeUndefined()
     expect(updatePlan(
-      { dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.3.0' },
+      { dshLatest: '0.1.1-rc.2', seekttyLatest: '1.3.0' },
       facts({ seekttyPinned: true }),
     )).toEqual({
       dshSpec: '@deepseek-ai/dsh@0.1.1-rc.2',
       seekttySpec: undefined,
     })
-    expect(tagToVersion('v1.3.0')).toBe('1.3.0')
-    expect(tagToVersion('1.3.0')).toBe('1.3.0')
   })
 
   it('advises installable updates and only prompts for future/gap Hosts', () => {
     expect(updateAdvice({}, facts(), true)).toEqual([])
     expect(updateAdvice({ dshLatest: '0.1.1-rc.2' }, facts({ dshInstalled: '0.1.1-rc.2' }), true))
       .toEqual([])
-    expect(updateAdvice({ seekttyLatestTag: 'v1.3.0' }, facts({ seekttyPinned: true }), true))
+    expect(updateAdvice({ seekttyLatest: '1.3.0' }, facts({ seekttyPinned: true }), true))
       .toEqual([])
     const installable = updateAdvice({ dshLatest: '0.1.1-rc.2' }, facts(), true)
     expect(installable.some(line => line.includes('0.1.1-rc.2'))).toBe(true)
@@ -261,12 +278,12 @@ describe('update plan gates', () => {
     expect(historicGap.some(line => line.includes('0.1.1-rc.1'))).toBe(true)
     expect(historicGap.join('\n')).toMatch(/permitted range|will not be installed/u)
     expect(historicGap.at(-1)).not.toContain('deepseek --update')
-    const future = updateAdvice({ dshLatest: '0.1.2', seekttyLatestTag: 'v1.3.0' }, facts(), true)
+    const future = updateAdvice({ dshLatest: '0.1.2', seekttyLatest: '1.3.0' }, facts(), true)
     expect(future.some(line => line.includes('0.1.2'))).toBe(true)
-    expect(future.some(line => line.includes('v1.3.0'))).toBe(true)
+    expect(future.some(line => line.includes('1.3.0'))).toBe(true)
     expect(future.at(-1)).toContain('deepseek --update')
-    const selfFirst = updateAdvice({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.3.0' }, facts(), true)
-    expect(selfFirst.some(line => line.includes('v1.3.0'))).toBe(true)
+    const selfFirst = updateAdvice({ dshLatest: '0.1.1-rc.2', seekttyLatest: '1.3.0' }, facts(), true)
+    expect(selfFirst.some(line => line.includes('1.3.0'))).toBe(true)
     expect(selfFirst.join('\n')).not.toMatch(/installable dsh|可安装版本/u)
     expect(selfFirst.join('\n')).not.toMatch(/automatically/u)
     const unread = updateAdvice({ dshLatest: '0.1.1-rc.2' }, facts({ dshInstalled: undefined }), true)
@@ -293,7 +310,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8' },
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(status).toBe(0)
     expect(calls).toEqual([
@@ -313,7 +330,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8' },
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '1.2.1' }),
     )
     expect(status).toBe(0)
     expect(calls).toEqual([
@@ -331,7 +348,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8', DSH_BIN: '/opt/dsh/bin/dsh' },
       execute,
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: undefined }),
     )
     expect(status).toBe(0)
     expect(probe).not.toHaveBeenCalled()
@@ -348,7 +365,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8', SEEKTTY_SPEC: 'github:Hilbert-beinghappy/seektty#v1.2.1' },
       execute,
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(status).toBe(0)
     expect(execute).toHaveBeenCalledTimes(1)
@@ -357,7 +374,7 @@ describe('launcher update flow', () => {
     expect(chunks.join('')).not.toMatch(/already the latest/u)
   })
 
-  it('fails clearly when both release channels are unreachable', async () => {
+  it('fails clearly when both npm dist-tag lookups are unreachable', async () => {
     internals.readInstalledDshVersion = () => '0.1.0-rc.8'
     const chunks: string[] = []
     const status = await runUpdate(
@@ -365,7 +382,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8' },
       vi.fn(() => 0),
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: undefined, seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: undefined, seekttyLatest: undefined }),
     )
     expect(status).toBe(1)
     expect(chunks.join('')).toContain('npm Registry')
@@ -377,14 +394,14 @@ describe('launcher update flow', () => {
     await postSessionUpdateNotice(
       { LANG: 'en_US.UTF-8', SEEKTTY_UPDATE: 'check' },
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: undefined }),
     )
     expect(chunks.join('')).toContain('deepseek --update')
     chunks.length = 0
     await postSessionUpdateNotice(
       { LANG: 'en_US.UTF-8' },
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: undefined }),
     )
     expect(chunks).toEqual([])
     chunks.length = 0
@@ -397,7 +414,7 @@ describe('launcher update flow', () => {
     await postSessionUpdateNotice(
       { LANG: 'en_US.UTF-8', SEEKTTY_UPDATE_CHECK: '0' },
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatest: undefined }),
     )
     expect(chunks).toEqual([])
   })
@@ -414,14 +431,14 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8', SEEKTTY_UPDATE: 'check' },
       execute,
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(execute).not.toHaveBeenCalled()
     expect(chunks).toEqual([])
     await postSessionUpdateNotice(
       { LANG: 'en_US.UTF-8', SEEKTTY_UPDATE: 'check' },
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatestTag: undefined }),
+      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatest: undefined }),
     )
     expect(chunks.join('')).toContain('0.1.2')
     expect(chunks.join('')).toMatch(/permitted range|will not be installed/u)
@@ -443,7 +460,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv(),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(calls).toEqual([
       ['dsh', 'plugin', '--profile', 'tui', 'add', PNPM_GVS_CONFIG_ARG, 'seektty@9.9.9'],
@@ -454,7 +471,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(calls).toEqual([
       ['pnpm', 'add', '--global', PNPM_GVS_CONFIG_ARG, '@deepseek-ai/dsh@0.1.1-rc.2'],
@@ -465,7 +482,7 @@ describe('launcher update flow', () => {
       { ...isolatedProfileEnv(), SEEKTTY_SPEC: 'github:Hilbert-beinghappy/seektty#v1.2.1' },
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(calls).toEqual([
       ['pnpm', 'add', '--global', PNPM_GVS_CONFIG_ARG, '@deepseek-ai/dsh@0.1.1-rc.2'],
@@ -476,7 +493,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8', SEEKTTY_UPDATE: '0' },
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )
     expect(calls).toEqual([])
     await maybeAutoUpdate(
@@ -496,7 +513,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv(),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )).resolves.toBeUndefined()
     expect(execute).toHaveBeenCalledTimes(1)
     expect(execute).toHaveBeenCalledWith(
@@ -512,7 +529,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v9.9.9' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '9.9.9' }),
     )).resolves.toBeUndefined()
     expect(execute).toHaveBeenCalledTimes(1)
     expect(execute).toHaveBeenCalledWith('pnpm', ['add', '--global', PNPM_GVS_CONFIG_ARG, '@deepseek-ai/dsh@0.1.1-rc.2'])
@@ -525,7 +542,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatest: '1.2.1' }),
     )
     expect(execute).not.toHaveBeenCalled()
     await maybeAutoUpdate(
@@ -533,7 +550,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.0-rc.9', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.0-rc.9', seekttyLatest: '1.2.1' }),
     )
     expect(execute).not.toHaveBeenCalled()
     await maybeAutoUpdate(
@@ -541,7 +558,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.1', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.1', seekttyLatest: '1.2.1' }),
     )
     expect(execute).not.toHaveBeenCalled()
   })
@@ -571,7 +588,7 @@ describe('launcher update flow', () => {
       { LANG: 'en_US.UTF-8' },
       execute,
       chunk => { chunks.push(chunk) },
-      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.2', seekttyLatest: '1.2.1' }),
     )
     expect(status).toBe(0)
     expect(execute).not.toHaveBeenCalled()
@@ -591,7 +608,7 @@ describe('launcher update flow', () => {
       isolatedProfileEnv({ seektty: 'link:/tmp/seektty' }),
       execute,
       () => {},
-      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatestTag: 'v1.2.1' }),
+      () => Promise.resolve({ dshLatest: '0.1.1-rc.2', seekttyLatest: '1.2.1' }),
     )).resolves.toBeUndefined()
     expect(execute).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary

- detect both dsh and SeekTTY stable versions from npm `latest` dist-tags
- remove the GitHub Release tag conversion from the SeekTTY update path
- preserve independent scan failures, pinned installs, and single-component update priority
- update the committed launcher bundle and regression coverage

## Verification

- `pnpm exec vitest run tests/version-scan.test.ts` (31 passed)
- `pnpm run check` (133 files, 1181 passed, 1 skipped)
- isolated official dsh 0.1.1-rc.2 install, boot, remove, and reinstall cycle
- live scan returned dsh 0.1.1-rc.2 and SeekTTY 1.2.5 from npm

Closes #185