### PR TITLE
fix(tui): 局部刷新 Welcome，避免流式更新清空历史缓存 (#196)

### DIFF
--- a/docs/issue-196-welcome-invalidation.md
+++ b/docs/issue-196-welcome-invalidation.md
@@ -1,0 +1,53 @@
+# Issue #196：Welcome 局部失效验收
+
+## 范围与基准
+
+- 基准：`01653309943c24ec50cd695547a87ca5aab1988d`（包含 PR #195）。
+- 分支：`codex/fix-welcome-invalidation-196`。
+- 只修 Welcome facts 的等值通知和局部缓存失效；不改变 full/native 渲染、折叠、主题/语法刷新、Harness Session 或订阅生命周期。
+- native 的“已提交历史 + 活动尾部”重构独立讨论于 #197，不作为本修复的前置条件。
+
+## 修复与正式回归
+
+`WelcomeController.setRuntimeFacts()` 按全部字段值比较，等值对象不增加 generation 或通知。异步 Logo/fastfetch 的通知仍保留。
+
+`Transcript.refreshWelcomePresentation()` 按 welcome row 所有权清除 block 的宽度缓存及 component 的行缓存，更新派生布局索引并请求重绘。兼容空 Session 和无 Session 引导页，不依赖 `__empty__` 一个块名；欢迎页隐藏时不动历史、选择、滚动锚点或复制映射。
+
+Surface 的 Welcome 回调只调用该局部入口，不再调用全局 `refreshPresentation()` 或 `tui.invalidate()`。真正的主题/语法失效路径保持原样。
+
+正式测试：
+
+- `tests/welcome-refresh.test.ts`：15 项；覆盖九个 facts 字段、等值/销毁后通知、full/native、无 Session/空 Session、多个宽度、变高/变矮、200 次流式更新、Logo/fastfetch 迟到及切换到非空 Session。
+- 固定样本为 4 个已完成历史节点（共 140,000 字符）和 1 个活动节点，200 次追加、每 40 次排版检查。初始化 5 个 Markdown；后续仅创建 200 个活动组件，历史组件身份不变。旧诊断中的同等通知链是 1200 个新组件。所有 200 个 chunk 标记顺序正确且各出现一次，最终 settled 标记不遗漏。
+- `tests/surface-welcome.test.ts`：2 项；实际 `startTuiSurface()`、异步 Header Promise 和 full/native 接线，20 次更新不触发全局失效，历史组件不重建，草稿与最终正文保留，客户端/订阅/停止只执行一次。Harness 使用测试替身，语法初始化暂挂以隔离 Welcome 回调。
+- Vitest 复用打包时的兼容别名以加载真实 Surface；忽略 `.artifacts` 下保留的旧诊断，避免把“断言旧错误”的实验当成正式回归。
+
+## 2026-09-04 本地验证结果
+
+| 环境/项目 | 结果 |
+| --- | --- |
+| Windows Node 26.1.0，pnpm 11.7.0 | 类型检查通过；142 个测试文件，1345 项通过、1 项跳过 |
+| Debian WSL Node 24.20.0，pnpm 11.7.0 | 独立 Linux 依赖；类型检查通过；142 个测试文件，1345 项通过、1 项跳过 |
+| 构建与包检查 | `pnpm run build`、`pnpm run pack:check` 通过；25 个打包条目，无 `workspace:` 依赖 |
+| Windows 官方 dsh 0.1.1-rc.2 | 隔离 `DSH_HOME` 安装、启动、移除、重装及模块身份检查通过 |
+| WSL 官方 dsh 0.1.1-rc.2 | 同一包的上述生命周期检查通过 |
+| 包内交互检查 | Windows ConPTY、Debian PTY、独立 tmux 均通过手动启用、持久化重启及恢复完整模式/主题命令检查 |
+
+额外本地探针将实际 Surface 的 native 输出交给 `@xterm/headless` 6.0.0：检查了普通缓冲区内 417 行 screen/scrollback，历史哨兵保留，4 个历史标记各一次，最终正文与未发送草稿存在。该探针使用合成 Harness 和模拟 Terminal，不是 PTY 流式端到端测试；探针及输出保留在本地 `.artifacts`，不加入普通测试或发布包。
+
+WSL 初次验证的隔离副本缺少 patches/CI/发布文档及 Git 索引，且混入 Windows PATH 后缺失命令返回 EACCES；补齐测试文件、建立隔离索引并使用纯 Linux PATH 后重跑全套通过。PTY 初次把 shell shim 当作 Node 入口，改用 shim 指向的官方 `lib/bin.js` 后通过；未更改官方安装。Vite 的两处 vendored source-map 缺失警告仍存在，但不是测试失败。
+
+## 候选包
+
+- 文件：`seektty-1.2.5-issue196-20260904T0815.tgz`（独立构建标识，非 npm 发布版本）。
+- SHA-256：`59e14465c18c50e8db090a749db240c568dfdc1af5d4e6cb61d7334ae9e141bd`。
+- Windows/WSL 使用同一文件并核对哈希；无凭据、Session、Profile 或本地诊断数据。
+- 不更新正式安装、Profile 或用户会话；仅提交候选 PR 供复核。
+
+## 复跑与限制
+
+普通回归：`pnpm run typecheck`、`pnpm exec vitest run`、`pnpm run build`、`pnpm run pack:check`。
+
+包生命周期：设置 `DSH_BIN` 为官方 CLI、`SEEKTTY_SPEC` 为本地 tgz，运行 `pnpm run test:stock`。交互检查另设 `DSH_ENTRY` 为官方 `lib/bin.js`，运行 `node scripts/foreground-pty-acceptance.mjs`；Linux tmux 另设 `SEEKTTY_TEST_TMUX=1`。这些脚本只使用隔离、无密钥的 Profile。
+
+本轮没有调用付费模型，没有复现或重新测量 Issue 原报告的 macOS 输入延迟。未完成 UU iPad、macOS 真机和真实长会话延迟验收；不能据此宣称所有卡顿已解决。native 全历史遍历和活动长文本重排成本仍属于 #197 后续讨论。

--- a/lib/index.js
+++ b/lib/index.js
@@ -30047,6 +30047,33 @@ var Transcript = class {
 		return true;
 	}
 	/**
+	* Invalidate only the visible welcome page, including no-Session guidance.
+	* A late welcome resource must not rebuild or disturb an active conversation.
+	* @returns whether a welcome frame needs repainting.
+	*/
+	refreshWelcomePresentation() {
+		if (!this.emptyState || this.welcome === void 0) return false;
+		let changed = false;
+		for (const block$1 of this.blocks) {
+			if (!block$1.rows.some((row) => row.welcome === true)) continue;
+			block$1.linesByWidth.clear();
+			for (const [index, component] of block$1.components.entries()) if (block$1.rows[index]?.welcome === true) this.lineCache.delete(component);
+			changed = true;
+		}
+		if (!changed) return false;
+		this.blockGeneration += 1;
+		this.heightIndex.clear();
+		this.syncHeightIndexCounters();
+		this.searchIndex = void 0;
+		this.lastFullLines = [];
+		this.ownerCopy.clear();
+		this.lineControls.clear();
+		this.lastViewportMaps = [];
+		this.lastPointerControls = [];
+		this.requestRender();
+		return true;
+	}
+	/**
 	* Rebuild colorized rows after a live theme or lazy grammar change.
 	* The current viewport and durable turn cursor remain unchanged.
 	*/
@@ -42376,6 +42403,7 @@ var WelcomeController = class {
 		return this.generation;
 	}
 	setRuntimeFacts(facts) {
+		if (this.disposed || Object.keys(this.facts).every((key) => this.facts[key] === facts[key])) return;
 		this.facts = facts;
 		this.generation += 1;
 		this.requestRender();
@@ -46113,9 +46141,7 @@ async function startTuiSurface(options$1) {
 		});
 		const welcome = new WelcomeController(initialWelcome, welcomeFacts(), (request, signal) => options$1.management.welcome.collectFastfetch(request, signal), (request, signal) => options$1.management.welcome.collectFastfetchLogo(request, signal), () => {
 			if (stopping !== void 0 || transcript === void 0) return;
-			transcript.refreshPresentation();
-			tui.invalidate();
-			requestSurfaceRender();
+			transcript.refreshWelcomePresentation();
 		}, (message) => {
 			reportWelcomeNotice(message);
 		});

--- a/src/client/surface.ts
+++ b/src/client/surface.ts
@@ -352,9 +352,9 @@ export async function startTuiSurface(options: TuiStartOptions): Promise<TuiSurf
       (request, signal) => options.management.welcome.collectFastfetchLogo(request, signal),
       () => {
         if (stopping !== undefined || transcript === undefined) return
-        transcript.refreshPresentation()
-        tui.invalidate()
-        requestSurfaceRender()
+        // Welcome facts/resources are local presentation, not a theme change.
+        // Transcript owns both welcome caches and ignores hidden-page updates.
+        transcript.refreshWelcomePresentation()
       },
       message => { reportWelcomeNotice(message) },
     )

--- a/src/client/transcript.ts
+++ b/src/client/transcript.ts
@@ -2169,6 +2169,40 @@ export class Transcript implements Component, Focusable {
   }
 
   /**
+   * Invalidate only the visible welcome page, including no-Session guidance.
+   * A late welcome resource must not rebuild or disturb an active conversation.
+   * @returns whether a welcome frame needs repainting.
+   */
+  refreshWelcomePresentation(): boolean {
+    if (!this.emptyState || this.welcome === undefined) return false
+    let changed = false
+    for (const block of this.blocks) {
+      if (!block.rows.some(row => row.welcome === true)) continue
+      // Either cache can otherwise serve stale rows after facts/Logo/fastfetch
+      // changes. Match row ownership, not __empty__/__replacement__ block keys.
+      block.linesByWidth.clear()
+      for (const [index, component] of block.components.entries()) {
+        if (block.rows[index]?.welcome === true) this.lineCache.delete(component)
+      }
+      changed = true
+    }
+    if (!changed) return false
+    this.blockGeneration += 1
+    this.heightIndex.clear()
+    this.syncHeightIndexCounters()
+    this.searchIndex = undefined
+    this.lastFullLines = []
+    this.ownerCopy.clear()
+    this.lineControls.clear()
+    this.lastViewportMaps = []
+    this.lastPointerControls = []
+    // Keep the selection, scroll offset and anchor. The next render measures
+    // the new welcome rows and clamps the empty-page viewport as before.
+    this.requestRender()
+    return true
+  }
+
+  /**
    * Rebuild colorized rows after a live theme or lazy grammar change.
    * The current viewport and durable turn cursor remain unchanged.
    */

--- a/src/client/welcome.ts
+++ b/src/client/welcome.ts
@@ -171,6 +171,10 @@ export class WelcomeController {
   fingerprint(): number { return this.generation }
 
   setRuntimeFacts(facts: WelcomeRuntimeFacts): void {
+    // Header facts are refreshed for streaming snapshots even when the welcome
+    // page is hidden. Compare values, not the newly allocated facts object.
+    if (this.disposed || (Object.keys(this.facts) as (keyof WelcomeRuntimeFacts)[])
+      .every(key => this.facts[key] === facts[key])) return
     this.facts = facts
     this.generation += 1
     this.requestRender()

--- a/tests/helpers/welcome-fixture.ts
+++ b/tests/helpers/welcome-fixture.ts
@@ -1,0 +1,39 @@
+import type { ChatConversationViewNode, ConversationSnapshot, SessionId } from '@deepseek-ai/dsh-client-runtime/node-client'
+import type { WelcomeRuntimeFacts } from '../../src/client/welcome.ts'
+import { defaultWelcomeSettings } from '../../src/client/welcome-settings.ts'
+
+export const welcomeFacts: WelcomeRuntimeFacts = {
+  seekttyVersion: 'fixture', profile: 'tui', workspace: 'synthetic',
+  model: 'MODEL_BEFORE', reasoning: 'high', mode: 'standard',
+  permission: 'workspace-write', theme: 'dark', platform: 'test',
+}
+
+export function welcomeSettings() {
+  const defaults = defaultWelcomeSettings()
+  return { ...defaults, infoMode: 'custom' as const,
+    logo: { ...defaults.logo, source: 'none' as const },
+    customRows: [{ kind: 'fact' as const, fact: 'model' as const }],
+  }
+}
+
+export function welcomeAssistant(key: string, text: string, status: 'running' | 'settled', turn = 1): ChatConversationViewNode {
+  return { key, id: key, kind: 'assistant-step', target: 'chat', anchorSeq: turn,
+    location: { kind: 'session' }, visibility: 'visible',
+    data: { status, turn, step: 1, time: 1, blocks: [{ kind: 'text', text }] },
+  }
+}
+
+export function welcomeSnapshot(nodes: readonly ChatConversationViewNode[], id = 'welcome-fixture'): ConversationSnapshot {
+  const byKey = new Map(nodes.map(node => [node.key, node]))
+  const legacy: ConversationSnapshot['chat']['legacy'] = {
+    nodes: [], turnTimings: new Map(), turnEnds: new Map(), partial: null, runningCalls: [],
+  }
+  return {
+    sessionId: id as SessionId, views: { get: () => undefined },
+    chat: { order: nodes.map(node => node.key), nodes: { get: key => byKey.get(key), values: () => nodes },
+      locations: { getTurn: () => [], getStep: () => [] }, timeline: { turnOrder: [], turns: new Map() }, legacy },
+    ...legacy, pending: [], queue: [], running: nodes.some(node => (node.data as { status?: string }).status === 'running'),
+    subagent: null, composerPhase: 'active', removed: false, openState: 'open', openError: null,
+    hasMore: false, loadingOlder: false, promptError: null, blank: nodes.length === 0, lastAgentError: null,
+  }
+}

--- a/tests/surface-welcome.test.ts
+++ b/tests/surface-welcome.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@mariozechner/pi-tui'
+import type { ConversationSnapshot, SessionFace } from '@deepseek-ai/dsh-client-runtime/node-client'
+import type { TuiActiveSession, TuiHeaderFacts, HarnessTuiCapabilities } from '../src/client/capabilities.ts'
+import type { TuiStartOptions, TuiSurfaceHandle } from '../src/client/index.ts'
+import type { TuiClient } from '../src/client/client-runtime.ts'
+import type { TuiManagementBridge, TuiSettingsDocument } from '../src/protocol.ts'
+import { internals as surface, startTuiSurface } from '../src/client/surface.ts'
+import { internals, Transcript } from '../src/client/transcript.ts'
+import { SyntaxHighlighter } from '../src/client/syntax-highlighter.ts'
+import * as provider from '../src/client/provider-onboarding.ts'
+import { welcomeAssistant, welcomeSnapshot, welcomeSettings } from './helpers/welcome-fixture.ts'
+
+vi.mock('../src/client/client-runtime.ts', () => ({ startTuiClient: vi.fn() }))
+
+class SurfaceTerminal implements Terminal {
+  columns = 100
+  rows = 32
+  kittyProtocolActive = false
+  writes: string[] = []
+  start(): void {}
+  stop(): void {}
+  drainInput(): Promise<void> { return Promise.resolve() }
+  write(data: string): void { this.writes.push(data) }
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+const handles: TuiSurfaceHandle[] = []
+afterEach(async () => {
+  for (const handle of handles.splice(0)) await handle.stop()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('actual Surface Header → Welcome wiring (#196)', () => {
+  it.each(['full', 'native'] as const)('%s preserves historical components through asynchronous header changes', async (mouseMode) => {
+    vi.stubEnv('TERM', 'xterm-256color')
+    vi.stubEnv('COLORTERM', 'truecolor')
+    vi.spyOn(provider, 'inspectProviderReadiness').mockResolvedValue({ kind: 'ready' })
+    // Isolate welcome invalidation from genuine lazy syntax invalidation. Syntax
+    // behavior remains covered by the existing syntax/theme regression suites.
+    vi.spyOn(SyntaxHighlighter, 'create').mockImplementation(() => new Promise(() => {}))
+    const terminal = new SurfaceTerminal()
+    vi.spyOn(surface, 'createTerminal').mockReturnValue(terminal)
+    vi.spyOn(surface, 'isInteractive').mockReturnValue(true)
+    const documents: TuiSettingsDocument[] = [
+      ['locale', { locale: 'en' }],
+      ['seektty-appearance', { theme: 'dark', colorMode: 'rgb', backgroundFill: 'theme', terminalBackgroundSync: 'off' }],
+      ['seektty-behavior', { mouseMode, desktopNotifications: false }],
+      ['seektty-welcome', welcomeSettings()],
+    ].map(([namespace, value]) => ({ namespace: namespace as string, value, schema: {}, revision: 1, applies: 'live', secrets: [] }))
+    const management = {
+      settings: { describe: vi.fn(async () => documents) },
+      welcome: { collectFastfetch: vi.fn(async () => ({ status: 'cancelled', rows: [] })), collectFastfetchLogo: vi.fn(async () => ({ status: 'cancelled' })) },
+    } as unknown as TuiManagementBridge
+    let snapshot: ConversationSnapshot = welcomeSnapshot([])
+    const session = {
+      getSnapshot: () => snapshot,
+      projections: { faceOf: () => ({ getSnapshot: () => undefined }) },
+      loadOlder: vi.fn(async () => {}),
+    } as unknown as SessionFace
+    const active = {
+      sessionId: snapshot.sessionId, session, workspacePath: 'synthetic',
+      summary: { id: snapshot.sessionId, displayTitle: 'fixture', agentPreset: 'standard' },
+    } as TuiActiveSession
+    let listener!: (current: TuiActiveSession | undefined, value: ConversationSnapshot | undefined) => void
+    const unsubscribe = vi.fn()
+    let model = 'MODEL_BEFORE'
+    const header: TuiHeaderFacts = { hostVersion: 'fixture', nodeVersion: 'fixture', platform: 'win32', architecture: 'x64',
+      profile: 'tui', workspace: 'synthetic', session: 'fixture', mode: 'standard', model, permission: 'workspace-write', running: false }
+    const headerFacts = vi.fn(async () => ({ ...header, model }))
+    const capabilities = {
+      active: () => active,
+      subscribeActive: vi.fn((callback: typeof listener) => { listener = callback; return unsubscribe }),
+      headerFacts, draftAttachments: () => [], jobs: () => [],
+      managementBridge: () => management,
+      subagentPresentation: () => ({
+        continuation: () => ({ support: 'unsupported', reason: 'navigation-unavailable' }),
+        publicStatusEvidence: () => ({ support: 'unsupported', reason: 'session-status-unavailable' }),
+        listDirectChildren: async () => ({ support: 'unsupported', reason: 'catalog-unavailable' }),
+      }),
+    } as unknown as HarnessTuiCapabilities
+    const dispose = vi.fn(async () => {})
+    const start = vi.spyOn(surface, 'startClient').mockResolvedValue({ capabilities, session,
+      ctx: { fiber: { dispose } }, sessionId: snapshot.sessionId, workspacePath: 'synthetic',
+    } as unknown as TuiClient)
+    const handle = await startTuiSurface({ api: {}, rpc: {}, cwd: 'synthetic', management, draft: 'UNSENT_DRAFT' } as TuiStartOptions)
+    handles.push(handle)
+    await vi.waitFor(() => expect(terminal.writes.join('')).toContain('MODEL_BEFORE'))
+    const unit = 'cached historical content.\n'
+    const history = Array.from({ length: 4 }, (_, i) => welcomeAssistant(`history-${i}`, unit.repeat(100), 'settled', i + 1))
+    snapshot = welcomeSnapshot([...history, welcomeAssistant('live', 'LIVE_START', 'running', 5)])
+    listener(active, snapshot)
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const before = internals.markdownCreated
+    const globalRefresh = vi.spyOn(Transcript.prototype, 'refreshPresentation')
+    for (let i = 0; i < 20; i++) {
+      if (i === 10) model = 'MODEL_CHANGED_WHILE_HIDDEN'
+      snapshot = welcomeSnapshot([...history, welcomeAssistant('live', `LIVE_START ${'stream '.repeat(i + 1)}`, 'running', 5)])
+      listener(active, snapshot)
+      // Allow every header Promise to run, rather than suppressing them with one
+      // synchronous notification burst and mistaking that for a fixed callback.
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+    expect(internals.markdownCreated - before).toBe(20)
+    expect(globalRefresh).not.toHaveBeenCalled()
+    expect(headerFacts.mock.calls.length).toBeGreaterThanOrEqual(20)
+    expect(start).toHaveBeenCalledOnce()
+    expect(capabilities.subscribeActive).toHaveBeenCalledOnce()
+    expect(dispose).not.toHaveBeenCalled()
+    snapshot = welcomeSnapshot([...history, welcomeAssistant('live', 'LIVE_START FINAL_SURFACE_END', 'settled', 5)])
+    listener(active, snapshot)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(terminal.writes.join('')).toContain('UNSENT_DRAFT')
+    expect(terminal.writes.join('')).toContain('FINAL_SURFACE_END')
+    await handle.stop()
+    handles.splice(handles.indexOf(handle), 1)
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/welcome-refresh.test.ts
+++ b/tests/welcome-refresh.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { stripVTControlCharacters } from 'node:util'
+import type { TuiWelcomeFastfetchLogoResult, TuiWelcomeFastfetchResult } from '../src/protocol.ts'
+import { Transcript, internals } from '../src/client/transcript.ts'
+import { WelcomeController } from '../src/client/welcome.ts'
+import { setBackgroundMode, setRendering } from '../src/client/theme.ts'
+import { welcomeAssistant, welcomeFacts, welcomeSettings, welcomeSnapshot } from './helpers/welcome-fixture.ts'
+
+const plain = (lines: readonly string[]) => stripVTControlCharacters(lines.join('\n'))
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => { resolve = done })
+  return { promise, resolve }
+}
+function fixture(native: boolean, resource?: 'fastfetch' | 'logo') {
+  const factsResult = deferred<TuiWelcomeFastfetchResult>()
+  const logoResult = deferred<TuiWelcomeFastfetchLogoResult>()
+  let transcript!: Transcript
+  const requestRender = vi.fn()
+  const settings = welcomeSettings()
+  const welcome = new WelcomeController({ ...settings,
+    infoMode: resource === 'fastfetch' ? 'mixed' : 'custom',
+    logo: { ...settings.logo, source: resource === 'logo' ? 'fastfetch' : 'none' },
+  }, welcomeFacts, () => factsResult.promise, () => logoResult.promise,
+  () => { transcript.refreshWelcomePresentation() }, vi.fn())
+  transcript = new Transcript(() => 32, requestRender, vi.fn(), welcome)
+  transcript.setNativeMode(native)
+  return { transcript, welcome, requestRender, factsResult, logoResult,
+    dispose() { transcript.dispose(); welcome.dispose() },
+  }
+}
+afterEach(() => { setBackgroundMode('theme'); vi.restoreAllMocks(); vi.unstubAllEnvs() })
+
+describe('welcome-local invalidation (#196)', () => {
+  it('does not notify for equal facts, but notices every changed field', () => {
+    const notify = vi.fn()
+    const controller = new WelcomeController(welcomeSettings(), welcomeFacts,
+      async () => ({ status: 'cancelled', rows: [] }), async () => ({ status: 'cancelled' }), notify, vi.fn())
+    try {
+      controller.setRuntimeFacts({ ...welcomeFacts })
+      expect(controller.fingerprint()).toBe(0)
+      expect(notify).not.toHaveBeenCalled()
+      let facts = { ...welcomeFacts }
+      for (const key of Object.keys(facts) as (keyof typeof facts)[]) {
+        facts = { ...facts, [key]: facts[key] + '_CHANGED' }
+        controller.setRuntimeFacts(facts)
+        controller.setRuntimeFacts({ ...facts })
+      }
+      expect(notify).toHaveBeenCalledTimes(9)
+      expect(controller.fingerprint()).toBe(9)
+      controller.dispose()
+      controller.setRuntimeFacts(welcomeFacts)
+      expect(notify).toHaveBeenCalledTimes(9)
+    } finally { controller.dispose() }
+  })
+
+  for (const native of [false, true]) {
+    const mode = native ? 'native' : 'full'
+    for (const withSession of [false, true]) {
+      it(`${mode}: refreshes both caches for ${withSession ? 'empty Session' : 'no Session'} without a snapshot update`, () => {
+        const f = fixture(native)
+        try {
+          if (withSession) f.transcript.update(welcomeSnapshot([]))
+          else f.transcript.empty()
+          expect(plain(f.transcript.render(100))).toContain('MODEL_BEFORE')
+          // Prime a second width; all welcome width entries must be invalidated.
+          f.transcript.render(80)
+          const update = vi.spyOn(f.transcript, 'update')
+          const globalRefresh = vi.spyOn(f.transcript, 'refreshPresentation')
+          const presentation = f.transcript.snapshotPresentation()
+          f.requestRender.mockClear()
+          f.welcome.setRuntimeFacts({ ...welcomeFacts, model: 'MODEL_AFTER\n'.repeat(8) })
+          expect(f.transcript.snapshotPresentation()).toEqual(presentation)
+          for (const width of [100, 80, 40]) {
+            const rendered = plain(f.transcript.render(width))
+            expect(rendered).toContain('MODEL_AFTER')
+            expect(rendered).not.toContain('MODEL_BEFORE')
+          }
+          f.welcome.setRuntimeFacts({ ...welcomeFacts, model: 'SHORT_MODEL' })
+          expect(plain(f.transcript.render(100))).toContain('SHORT_MODEL')
+          expect(update).not.toHaveBeenCalled()
+          expect(globalRefresh).not.toHaveBeenCalled()
+          expect(f.requestRender).toHaveBeenCalledTimes(2)
+        } finally { f.dispose() }
+      })
+    }
+
+    it(`${mode}: 200 streamed updates do not rebuild settled history`, () => {
+      setRendering({ colorMode: 'rgb', backgroundFill: 'theme', terminalBackgroundSync: 'off' })
+      const f = fixture(native)
+      try {
+        const unit = '中文缓存测试 synthetic history with fixed content.\n'
+        const text = unit.repeat(Math.ceil(35000 / unit.length)).slice(0, 35000)
+        const history = Array.from({ length: 4 }, (_, index) => welcomeAssistant(`history-${index}`, text, 'settled', index + 1))
+        let current = 'LIVE_BEGIN\n\n'
+        const before = internals.markdownCreated
+        f.transcript.update(welcomeSnapshot([...history, welcomeAssistant('live', current, 'running', 5)]))
+        f.transcript.render(100)
+        expect(internals.markdownCreated - before).toBe(5)
+        const historyIdentities = [...f.transcript['nodeCache'].values()].slice(0, 4)
+        const initialized = internals.markdownCreated
+        const globalRefresh = vi.spyOn(f.transcript, 'refreshPresentation')
+        for (let i = 0; i < 200; i++) {
+          current += `CHUNK${String(i).padStart(3, '0')}END\n\n`
+          f.transcript.update(welcomeSnapshot([...history, welcomeAssistant('live', current, 'running', 5)]))
+          f.welcome.setRuntimeFacts({ ...welcomeFacts })
+          if ((i + 1) % 40 === 0) f.transcript.render(100)
+        }
+        expect(internals.markdownCreated - initialized).toBe(200)
+        expect(globalRefresh).not.toHaveBeenCalled()
+        for (let i = 0; i < 4; i++) expect(f.transcript['nodeCache'].get(`history-${i}`)).toBe(historyIdentities[i])
+        const final = welcomeSnapshot([...history, welcomeAssistant('live', current + 'FINAL_SETTLED_END', 'settled', 5)])
+        f.transcript.update(final)
+        const rendered = f.transcript.render(100)
+        const output = plain(native ? rendered : f.transcript['renderBlock'](4, 96).lines)
+        expect(output.match(/CHUNK\d{3}END/g)).toEqual(Array.from({ length: 200 }, (_, i) => `CHUNK${String(i).padStart(3, '0')}END`))
+        expect(output.match(/FINAL_SETTLED_END/g)).toHaveLength(1)
+        const beforeChange = f.transcript.snapshotPresentation()
+        const beforeCount = internals.markdownCreated
+        f.requestRender.mockClear()
+        f.welcome.setRuntimeFacts({ ...welcomeFacts, model: 'CHANGED_HIDDEN' })
+        expect(f.transcript.snapshotPresentation()).toEqual(beforeChange)
+        expect(internals.markdownCreated).toBe(beforeCount)
+        expect(f.requestRender).not.toHaveBeenCalled()
+      } finally { f.dispose() }
+    })
+
+    for (const resource of ['fastfetch', 'logo'] as const) for (const switchSession of [false, true]) {
+      it(`${mode}: ${resource} completion ${switchSession ? 'after changing Session preserves history' : 'updates visible welcome'}`, async () => {
+        const f = fixture(native, resource)
+        try {
+          f.transcript.update(welcomeSnapshot([]))
+          f.transcript.render(100)
+          f.welcome.activate()
+          f.transcript.render(100)
+          if (switchSession) {
+            f.transcript.update(welcomeSnapshot([welcomeAssistant('next', 'NEW_SESSION_SENTINEL', 'settled')], 'next-session'))
+            f.transcript.render(100)
+          }
+          const before = f.transcript.snapshotPresentation()
+          const count = internals.markdownCreated
+          f.requestRender.mockClear()
+          if (resource === 'logo') f.logoResult.resolve({ status: 'ok', ansi: 'LOGO_READY' })
+          else f.factsResult.resolve({ status: 'ok', rows: [{ kind: 'field', label: 'OS', value: 'FASTFETCH_READY' }] })
+          await Promise.resolve()
+          await Promise.resolve()
+          const output = plain(f.transcript.render(100))
+          expect(internals.markdownCreated).toBe(count)
+          if (switchSession) {
+            expect(output).toContain('NEW_SESSION_SENTINEL')
+            expect(output).not.toContain('READY')
+            expect(f.requestRender).not.toHaveBeenCalled()
+            expect(f.transcript.snapshotPresentation()).toEqual(before)
+          } else {
+            expect(output).toContain(resource === 'logo' ? 'LOGO_READY' : 'FASTFETCH_READY')
+            expect(f.requestRender).toHaveBeenCalled()
+          }
+        } finally { f.dispose() }
+      })
+    }
+  }
+})

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 
 const local = (path: string): string => resolve(import.meta.dirname, path)
 
-const aliases = {
+export const aliases = {
   '@deepseek-ai/dsh-api-gateway/node-client': local('vendor/api-gateway/client/index.js'),
   '@deepseek-ai/dsh-api-gateway/client': local('vendor/api-gateway/client/index.js'),
   '@deepseek-ai/dsh-api-remotes/node-client': local('vendor/api-remotes/client/index.js'),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,15 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import { resolve } from 'node:path'
+import { aliases } from './tsdown.config.ts'
 
 export default defineConfig({
   resolve: {
     alias: {
+      ...aliases,
       '@deepseek-ai/dsh-tui-protocol': resolve(import.meta.dirname, 'src/protocol.ts'),
     },
   },
   test: {
-    exclude: [...configDefaults.exclude, '**/._*'],
+    exclude: [...configDefaults.exclude, '**/._*', '**/.artifacts/**'],
   },
 })


### PR DESCRIPTION
## 范围

Refs #196；#197 的 native 历史/活动尾部重构单独讨论，不包含在本 PR。

按 #196 的讨论提交最小候选补丁，请 @Hilbert-beinghappy 复核。基准为 `01653309943c24ec50cd695547a87ca5aab1988d`，保留 PR #195 最终正文完整性行为。不自动合并、部署或发布。

## 修改

- Welcome facts 按九个字段值比较，重复等值对象不通知。
- Transcript 新增 Welcome 专属失效入口：只清可见欢迎页的 block/component 两层缓存及派生布局索引，处理空 Session 和无 Session；隐藏欢迎页的迟到回调不碰历史。
- Surface 的 Welcome 回调不再全局清空 Transcript 或调用 `tui.invalidate()`。真正的主题/语法刷新路径不改。
- 17 项正式回归覆盖 full/native、异步事实/Logo/fastfetch、两种空页面、迟到回调切会话、200 次更新最终完整性，以及实际 Surface Header Promise 接线与生命周期。
- Vitest 复用生产打包别名；提交同步生成的 `lib/index.js`。

## 验证

- Windows Node 26.1.0、Debian WSL Node 24.20.0，pnpm 11.7.0：两端各 1345 项通过、1 项跳过；类型检查通过。
- 构建与 pack-check 通过：25 个允许的包条目，无 `workspace:` 依赖。
- 固定 4 个已完成历史节点（140,000 字符）+ 1 个活动节点、200 次更新：后续只新建 200 个活动 Markdown，历史组件身份保持；旧诊断相同通知链为 1200 个。200 个 chunk 顺序与次数、最终 settled 正文均检查。
- 实际 Surface + 合成 Harness 的 full/native 测试：Header Promise 每次执行，20 次更新不全局失效，客户端与订阅各一次，最终正文及草稿保留。
- 补充本地 native Surface → xterm/headless 6.0.0 探针检查了 417 行 screen/scrollback：历史哨兵、四个无重复历史标记、最终正文和草稿均保留。这是模拟 Terminal，不是 PTY 流式端到端测试。
- **未修改的官方 dsh 0.1.1-rc.2**：Windows/WSL 隔离 `DSH_HOME` 均通过安装、启动、移除、重装和模块身份检查。
- 同一候选包通过 Windows ConPTY、Debian PTY、独立 tmux 的键盘菜单、full/native 切换、持久化重启和恢复命令检查。

完整命令、初跑环境问题与限制见 `docs/issue-196-welcome-invalidation.md`。

本地候选：`seektty-1.2.5-issue196-20260904T0815.tgz`，SHA-256 `59e14465c18c50e8db090a749db240c568dfdc1af5d4e6cb61d7334ae9e141bd`。未上传本地数据或修改正式安装；可从本分支构建自己的包。

## 尚未证明的部分

没有调用真实付费模型，未重现 macOS 原报告的 27.561s 输入延迟；本轮没有 UU iPad/macOS 真机验收。组件创建数减少不等于所有流式成本消失：节点指纹、长活动文本及 native 全历史绘制路径仍留待 #197。请对候选做源码复核；macOS 真实场景是否补测由复核方再确认，不代为承诺结果。
