### PR TITLE
fix(native): preserve restarted assistant streams and initial jobs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2285,6 +2285,13 @@ var NativeTerminalApi = class extends AbstractApiClient {
 		const disposeInteractions = this.interactions.subscribe(pushInteraction);
 		const follows = /* @__PURE__ */ new Set();
 		const queueBaselines = /* @__PURE__ */ new Map();
+		const jobBaselines = /* @__PURE__ */ new Map();
+		const pushJobs = (value) => {
+			const frame = muxFrameSchema.parse(value);
+			if (frame.type !== "session/jobs") throw new Error("Expected a native jobs frame");
+			jobBaselines.set(frame.sessionId, frame);
+			push(frame);
+		};
 		const pushQueue = (value) => {
 			const frame = muxFrameSchema.parse(value);
 			if (frame.type !== "session/queue") throw new Error("Expected a native queue frame");
@@ -2322,6 +2329,8 @@ var NativeTerminalApi = class extends AbstractApiClient {
 					});
 					const pendingQueue = queueBaselines.get(sessionId$1);
 					if (pendingQueue !== void 0) push(pendingQueue);
+					const pendingJobs = jobBaselines.get(sessionId$1);
+					if (pendingJobs !== void 0) push(pendingJobs);
 					this.interactions.replay(sessionId$1, pushInteraction);
 					project(sessionId$1, frame.projections);
 					if (frame.assistantStream !== void 0) push({
@@ -2366,7 +2375,7 @@ var NativeTerminalApi = class extends AbstractApiClient {
 					sessionId: sessionId$1,
 					items
 				});
-				for (const [sessionId$1, jobs] of Object.entries(frame.value.jobs)) push({
+				for (const [sessionId$1, jobs] of Object.entries(frame.value.jobs)) pushJobs({
 					type: "session/jobs",
 					sessionId: sessionId$1,
 					jobs
@@ -2376,7 +2385,7 @@ var NativeTerminalApi = class extends AbstractApiClient {
 				...frame,
 				type: "session/queue"
 			});
-			else if (frame.type === "jobs") push({
+			else if (frame.type === "jobs") pushJobs({
 				...frame,
 				type: "session/jobs"
 			});
@@ -4824,12 +4833,20 @@ var NativeAssistantStream = class {
 	nextIndex = 0;
 	accumulator;
 	settlementSeq;
+	startedAfterSeq = -Infinity;
+	activationGeneration = 0;
+	/** Used to reject history reads started before an Agent activation changed. */
+	get generation() {
+		return this.activationGeneration;
+	}
 	snapshot() {
 		return this.accumulator?.toPartial() ?? null;
 	}
 	baseline(value) {
-		if (value.revision <= this.revision) return;
 		const active = value.activeAttempt;
+		if (active !== void 0 && active.startedAfterSeq < this.startedAfterSeq) return;
+		const restarted = active !== void 0 && active.attemptId !== this.attemptId && active.startedAfterSeq > this.startedAfterSeq && value.revision <= this.revision;
+		if (!restarted && value.revision <= this.revision) return;
 		const previous = this.accumulator;
 		this.accumulator = active === void 0 ? void 0 : new PartialAccumulator(active.turn, active.step);
 		try {
@@ -4843,13 +4860,19 @@ var NativeAssistantStream = class {
 			throw error;
 		}
 		this.revision = value.revision;
+		if (restarted) this.activationGeneration += 1;
+		if (active !== void 0) this.startedAfterSeq = active.startedAfterSeq;
 		this.attemptId = active?.attemptId;
 		this.nextIndex = active?.nextIndex ?? 0;
 		this.settlementSeq = void 0;
 	}
 	accept(frame) {
-		if (frame.revision <= this.revision) return;
 		if (frame.type === "start") {
+			if (frame.startedAfterSeq < this.startedAfterSeq) return;
+			const restarted = frame.revision === 1 && frame.attemptId !== this.attemptId && frame.startedAfterSeq > this.startedAfterSeq;
+			if (!restarted && frame.revision <= this.revision) return;
+			if (restarted && this.revision >= 0) this.activationGeneration += 1;
+			this.startedAfterSeq = frame.startedAfterSeq;
 			this.revision = frame.revision;
 			this.attemptId = frame.attemptId;
 			this.nextIndex = 0;
@@ -4857,6 +4880,7 @@ var NativeAssistantStream = class {
 			this.accumulator = new PartialAccumulator(frame.turn, frame.step);
 			return;
 		}
+		if (frame.revision <= this.revision) return;
 		if (frame.attemptId !== this.attemptId || this.accumulator === void 0) throw new Error("Assistant stream has no matching baseline");
 		if (frame.index !== this.nextIndex) throw new Error("Assistant stream chunk gap requires a new baseline");
 		if (frame.type === "chunk") {
@@ -6627,7 +6651,8 @@ var Session = class {
 		this.openError = null;
 		this.notifier.markDirty();
 		try {
-			let { result } = await this.history({ maxMessages: PAGE_MESSAGES });
+			let response = await this.history({ maxMessages: PAGE_MESSAGES });
+			let { result } = response;
 			if (generation !== this.openGeneration) return;
 			if (!result.ok) {
 				this.openState = "error";
@@ -6635,14 +6660,15 @@ var Session = class {
 				return;
 			}
 			this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-			if (result.value.assistantStream !== void 0) this.nativeAssistant.baseline(result.value.assistantStream);
+			response.applyAssistantBaseline();
 			const tailSeq = this.windowTailSeq();
 			if (this.subscribedLastSeq !== null && tailSeq !== null && this.subscribedLastSeq > tailSeq) {
-				result = (await this.history({ maxMessages: PAGE_MESSAGES })).result;
+				response = await this.history({ maxMessages: PAGE_MESSAGES });
+				result = response.result;
 				if (generation !== this.openGeneration) return;
 				if (result.ok) {
 					this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-					if (result.value.assistantStream !== void 0) this.nativeAssistant.baseline(result.value.assistantStream);
+					response.applyAssistantBaseline();
 				}
 			}
 			this.openState = "open";
@@ -6729,10 +6755,11 @@ var Session = class {
 		this.stitching = true;
 		const generation = this.openGeneration;
 		try {
-			const { result } = await this.history({ maxMessages: PAGE_MESSAGES });
+			const response = await this.history({ maxMessages: PAGE_MESSAGES });
+			const { result } = response;
 			if (result.ok && generation === this.openGeneration && this.openState === "open") {
 				this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-				if (result.value.assistantStream !== void 0) this.nativeAssistant.baseline(result.value.assistantStream);
+				response.applyAssistantBaseline();
 			}
 		} catch (error) {
 			console.error("[web-runtime] gap repair failed:", error);
@@ -6780,14 +6807,23 @@ var Session = class {
 		};
 	}
 	/** Select ordinary or addressed history transport from the stored browser fact. */
-	history(payload) {
-		return this.address === void 0 ? this.api.sessions.history({
+	async history(payload) {
+		const assistant = this.nativeAssistant;
+		const generation = assistant.generation;
+		const response = await (this.address === void 0 ? this.api.sessions.history({
 			sessionId: this.sessionId,
 			...payload
 		}) : this.api.subagents.history({
 			...this.address,
 			...payload
-		});
+		}));
+		return {
+			...response,
+			applyAssistantBaseline: () => {
+				if (assistant !== this.nativeAssistant || generation !== assistant.generation) return;
+				if (response.result.ok && response.result.value.assistantStream !== void 0) assistant.baseline(response.result.value.assistantStream);
+			}
+		};
 	}
 };
 /** Convert one wire history row into the assembler's transport-neutral input. */

--- a/src/client/native-assistant-stream.ts
+++ b/src/client/native-assistant-stream.ts
@@ -17,12 +17,20 @@ export class NativeAssistantStream {
   private nextIndex = 0
   private accumulator: PartialAccumulator | undefined
   private settlementSeq: number | undefined
+  private startedAfterSeq = -Infinity
+  private activationGeneration = 0
+
+  /** Used to reject history reads started before an Agent activation changed. */
+  get generation(): number { return this.activationGeneration }
 
   snapshot(): PartialAssistant | null { return this.accumulator?.toPartial() ?? null }
 
   baseline(value: SessionAssistantStreamBaseline): void {
-    if (value.revision <= this.revision) return
     const active = value.activeAttempt
+    if (active !== undefined && active.startedAfterSeq < this.startedAfterSeq) return
+    const restarted = active !== undefined && active.attemptId !== this.attemptId
+      && active.startedAfterSeq > this.startedAfterSeq && value.revision <= this.revision
+    if (!restarted && value.revision <= this.revision) return
     const previous = this.accumulator
     this.accumulator = active === undefined ? undefined : new PartialAccumulator(active.turn, active.step)
     try {
@@ -38,14 +46,23 @@ export class NativeAssistantStream {
       throw error
     }
     this.revision = value.revision
+    if (restarted) this.activationGeneration += 1
+    if (active !== undefined) this.startedAfterSeq = active.startedAfterSeq
     this.attemptId = active?.attemptId
     this.nextIndex = active?.nextIndex ?? 0
     this.settlementSeq = undefined
   }
 
   accept(frame: SessionAssistantStreamFrame): void {
-    if (frame.revision <= this.revision) return
     if (frame.type === 'start') {
+      // rc.1 recreates continuable child Agents with revision 1. The durable
+      // start position distinguishes that activation from an old replayed start.
+      if (frame.startedAfterSeq < this.startedAfterSeq) return
+      const restarted = frame.revision === 1 && frame.attemptId !== this.attemptId
+        && frame.startedAfterSeq > this.startedAfterSeq
+      if (!restarted && frame.revision <= this.revision) return
+      if (restarted && this.revision >= 0) this.activationGeneration += 1
+      this.startedAfterSeq = frame.startedAfterSeq
       this.revision = frame.revision
       this.attemptId = frame.attemptId
       this.nextIndex = 0
@@ -53,6 +70,7 @@ export class NativeAssistantStream {
       this.accumulator = new PartialAccumulator(frame.turn, frame.step)
       return
     }
+    if (frame.revision <= this.revision) return
     if (frame.attemptId !== this.attemptId || this.accumulator === undefined) {
       throw new Error('Assistant stream has no matching baseline')
     }

--- a/src/host/api-compat.ts
+++ b/src/host/api-compat.ts
@@ -194,6 +194,13 @@ export class NativeTerminalApi extends AbstractApiClient implements TerminalDoma
     const disposeInteractions = this.interactions.subscribe(pushInteraction)
     const follows = new Set<string>()
     const queueBaselines = new Map<string, Extract<MuxFrame, { type: 'session/queue' }>>()
+    const jobBaselines = new Map<string, Extract<MuxFrame, { type: 'session/jobs' }>>()
+    const pushJobs = (value: unknown) => {
+      const frame = muxFrameSchema.parse(value)
+      if (frame.type !== 'session/jobs') throw new Error('Expected a native jobs frame')
+      jobBaselines.set(frame.sessionId, frame)
+      push(frame)
+    }
     const pushQueue = (value: unknown) => {
       const frame = muxFrameSchema.parse(value)
       if (frame.type !== 'session/queue') throw new Error('Expected a native queue frame')
@@ -219,6 +226,8 @@ export class NativeTerminalApi extends AbstractApiClient implements TerminalDoma
             // control baseline after the retained client's subscribed reset.
             const pendingQueue = queueBaselines.get(sessionId)
             if (pendingQueue !== undefined) push(pendingQueue)
+            const pendingJobs = jobBaselines.get(sessionId)
+            if (pendingJobs !== undefined) push(pendingJobs)
             this.interactions.replay(sessionId, pushInteraction)
             project(sessionId, frame.projections)
             if (frame.assistantStream !== undefined) push({ type: 'session/assistant-baseline', sessionId, baseline: frame.assistantStream })
@@ -246,10 +255,10 @@ export class NativeTerminalApi extends AbstractApiClient implements TerminalDoma
       for await (const frame of this.ctx.sessionController.control(lifetime)) {
         if (frame.type === 'baseline') {
           for (const [sessionId, items] of Object.entries(frame.value.queues)) pushQueue({ type: 'session/queue', sessionId, items })
-          for (const [sessionId, jobs] of Object.entries(frame.value.jobs)) push({ type: 'session/jobs', sessionId, jobs })
+          for (const [sessionId, jobs] of Object.entries(frame.value.jobs)) pushJobs({ type: 'session/jobs', sessionId, jobs })
           for (const [sessionId, value] of Object.entries(frame.value.projections)) project(sessionId, value)
         } else if (frame.type === 'queue') pushQueue({ ...frame, type: 'session/queue' })
-        else if (frame.type === 'jobs') push({ ...frame, type: 'session/jobs' })
+        else if (frame.type === 'jobs') pushJobs({ ...frame, type: 'session/jobs' })
         else if (frame.type === 'projection' && frame.seq >= 0) push({ ...frame, type: 'session/projection' })
       }
     })())

--- a/tests/native-activation-jobs.test.ts
+++ b/tests/native-activation-jobs.test.ts
@@ -1,0 +1,61 @@
+import { Context } from '@deepseek-ai/cordis'
+import { SessionId, SessionSeq, SessionStore } from '@deepseek-ai/dsh-session'
+import { LlmAttemptId } from '@deepseek-ai/dsh-llm/brand'
+import { expect, it } from 'vitest'
+import { NativeTerminalApi } from '../src/host/api-compat.ts'
+import { NativeAssistantStream } from '../src/client/native-assistant-stream.ts'
+import { SessionManager } from '../vendor/client-runtime/client/sessions/manager.js'
+
+it.each([[true, 'baseline'], [false, 'baseline'], [true, 'updated'], [false, 'updated'], [true, 'empty'], [false, 'empty']] as const)('preserves the latest jobs with control-first=%s and %s snapshot', async (controlFirst, mode) => {
+  const ctx = new Context()
+  const store = new SessionStore(ctx)
+  const session = store.create(SessionId('review-session'))
+  const gate = Promise.withResolvers<void>()
+  const jobs = [{ id: 'running-build', kind: 'bash', label: 'build', status: 'running', startedAt: 1 }]
+  const latestJobs = mode === 'empty' ? [] : [{ ...jobs[0]!, id: 'new-build' }]
+  const waitForAbort = (signal: AbortSignal) => new Promise<void>(resolve => {
+    if (signal.aborted) resolve()
+    else signal.addEventListener('abort', () => resolve(), { once: true })
+  })
+  ctx.provide('sessionController')
+  ctx.set('sessionController', {
+    async *follow(_request: unknown, signal: AbortSignal) {
+      if (controlFirst) await gate.promise
+      yield { type: 'snapshot', header: session.header, cursor: -1, records: [], hasMore: false, projections: { asOfSeq: -1, values: {} } }
+      if (!controlFirst) gate.resolve()
+      await waitForAbort(signal)
+    },
+    async *control(signal: AbortSignal) {
+      if (!controlFirst) await gate.promise
+      yield { type: 'baseline', value: { queues: {}, jobs: { 'review-session': jobs }, projections: {} } }
+      if (mode !== 'baseline') yield { type: 'jobs', sessionId: 'review-session', jobs: latestJobs }
+      if (controlFirst) gate.resolve()
+      await waitForAbort(signal)
+    },
+  })
+  const api = new NativeTerminalApi(ctx)
+  const manager = new SessionManager(api, ctx.remote, undefined, undefined, undefined)
+  const abort = new AbortController()
+  const stream = api.openMux({}, abort.signal)[Symbol.asyncIterator]()
+  try {
+    for (let i = 0; i < ((controlFirst ? 3 : 2) + (mode === 'baseline' ? 0 : 1)); i++) manager.handleMuxEnvelope((await stream.next()).value!)
+    expect(manager.getListSnapshot().jobsBySession[SessionId('review-session')]).toEqual(mode === 'empty' ? undefined : mode === 'baseline' ? jobs : latestJobs)
+  } finally {
+    abort.abort()
+    await stream.return?.()
+    await ctx.fiber.dispose()
+  }
+})
+
+it('shows a new activation whose official assistant revision starts again at one', () => {
+  const stream = new NativeAssistantStream()
+  const first = LlmAttemptId('first-activation')
+  stream.accept({ type: 'start', attemptId: first, revision: 1, startedAfterSeq: -1, turn: 1, step: 1 })
+  stream.accept({ type: 'chunk', attemptId: first, revision: 2, index: 0, time: 1, chunk: { type: 'text-delta', index: 0, text: 'first' } })
+  stream.accept({ type: 'end', attemptId: first, revision: 3, index: 1, outcome: { kind: 'committed', eventType: 'assistant/message', seq: 9 } })
+  stream.settle(9)
+  const second = LlmAttemptId('second-activation')
+  stream.accept({ type: 'start', attemptId: second, revision: 1, startedAfterSeq: SessionSeq(9), turn: 2, step: 1 })
+  stream.accept({ type: 'chunk', attemptId: second, revision: 2, index: 0, time: 2, chunk: { type: 'text-delta', index: 0, text: 'second' } })
+  expect(stream.snapshot()?.blocks).toEqual([{ kind: 'text', text: 'second' }])
+})

--- a/tests/native-assistant-stream.test.ts
+++ b/tests/native-assistant-stream.test.ts
@@ -1,3 +1,4 @@
+import { SessionSeq } from '@deepseek-ai/dsh-session'
 import { describe, expect, it } from 'vitest'
 import { LlmAttemptId } from '@deepseek-ai/dsh-llm/brand'
 import { AssistantStreamAccumulator } from '@deepseek-ai/dsh-llm/assistant-stream'
@@ -70,4 +71,25 @@ describe('native transient assistant stream', () => {
     stream.accept({ type: 'end', attemptId, revision: 4, index: 2, outcome: { kind: 'abandoned' } })
     expect(stream.snapshot()).toBeNull()
   })
+})
+
+it('rebaselines a restarted activation and ignores retired activation baselines and starts', () => {
+  const stream = start()
+  stream.accept(chunk(20))
+  const next = LlmAttemptId('next')
+  const official = new AssistantStreamAccumulator()
+  official.push({ time: 1, chunk: { type: 'text-delta', index: 0, text: 'new' } })
+  const baseline = { revision: 2, activeAttempt: { attemptId: next, startedAfterSeq: SessionSeq(9), turn: 2, step: 1,
+    nextIndex: 1, stream: z.array(z.json()).parse(official.snapshot()) } }
+  expect(() => stream.baseline({ ...baseline, activeAttempt: { ...baseline.activeAttempt, nextIndex: 3 } })).toThrow()
+  expect(stream.snapshot()?.blocks).toEqual([{ kind: 'text', text: 'hello' }])
+  expect(stream.generation).toBe(0)
+  stream.baseline(baseline)
+  expect(stream.generation).toBe(1)
+  stream.accept({ type: 'start', attemptId, revision: 1, startedAfterSeq: -1, turn: 1, step: 2 })
+  stream.baseline({ revision: 100, activeAttempt: { attemptId, startedAfterSeq: -1, turn: 1, step: 2, nextIndex: 0, stream: [] } })
+  stream.baseline(baseline)
+  stream.accept({ type: 'start', attemptId: next, revision: 1, startedAfterSeq: SessionSeq(9), turn: 2, step: 1 })
+  stream.accept({ ...chunk(3, 1), attemptId: next })
+  expect(stream.snapshot()?.blocks).toEqual([{ kind: 'text', text: 'newhello' }])
 })

--- a/tests/native-history-gap.test.js
+++ b/tests/native-history-gap.test.js
@@ -22,3 +22,20 @@ it('keeps the successful opening window when its gap repull fails', async () => 
   expect(session.getSnapshot()).toMatchObject({ openState: 'open', openError: null })
   expect(session.projections.faceOf('title').getSnapshot()).toBe('Retained history')
 })
+
+it.each([true, false])('keeps the new activation across a late history response (empty: %s)', async empty => {
+  const pending = Promise.withResolvers()
+  const session = new Session('fixture', { sessions: { history: () => pending.promise } }, {})
+  const send = frame => session.handleMuxEnvelope('stream', { type: 'session/assistant-stream', sessionId: 'fixture', frame })
+  send({ type: 'start', attemptId: 'old', revision: 1, startedAfterSeq: -1, turn: 1, step: 1 })
+  send({ type: 'chunk', attemptId: 'old', revision: 2, index: 0, time: 1, chunk: { type: 'text-delta', index: 0, text: 'old' } })
+  const opening = session.open()
+  send({ type: 'start', attemptId: 'new', revision: 1, startedAfterSeq: 9, turn: 2, step: 1 })
+  send({ type: 'chunk', attemptId: 'new', revision: 2, index: 0, time: 1, chunk: { type: 'text-delta', index: 0, text: 'new' } })
+  pending.resolve({ result: { ok: true, value: { events: [], hasMore: false,
+    projections: { asOfSeq: -1, values: {} }, assistantStream: { revision: 10,
+      ...(empty ? {} : { activeAttempt: { attemptId: 'old', startedAfterSeq: -1, turn: 1, step: 1, nextIndex: 0, stream: [] } }) },
+  } } })
+  await opening
+  expect(session.getSnapshot().partial?.blocks).toEqual([{ kind: 'text', text: 'new' }])
+})

--- a/vendor/client-runtime/client/sessions/session.js
+++ b/vendor/client-runtime/client/sessions/session.js
@@ -585,7 +585,8 @@ export class Session {
         this.openError = null;
         this.notifier.markDirty();
         try {
-            let { result } = await this.history({ maxMessages: PAGE_MESSAGES });
+            let response = await this.history({ maxMessages: PAGE_MESSAGES });
+            let { result } = response;
             if (generation !== this.openGeneration)
                 return;
             if (!result.ok) {
@@ -594,16 +595,17 @@ export class Session {
                 return;
             }
             this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-            if (result.value.assistantStream !== undefined) this.nativeAssistant.baseline(result.value.assistantStream);
+            response.applyAssistantBaseline();
             // Gap detection: baseline past the window tail and liveBuffer did not cover it -> pull the tail page once more.
             const tailSeq = this.windowTailSeq();
             if (this.subscribedLastSeq !== null && tailSeq !== null && this.subscribedLastSeq > tailSeq) {
-                result = (await this.history({ maxMessages: PAGE_MESSAGES })).result;
+                response = await this.history({ maxMessages: PAGE_MESSAGES });
+                result = response.result;
                 if (generation !== this.openGeneration)
                     return;
                 if (result.ok) {
                     this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-                    if (result.value.assistantStream !== undefined) this.nativeAssistant.baseline(result.value.assistantStream);
+                    response.applyAssistantBaseline();
                 }
             }
             this.openState = 'open';
@@ -694,11 +696,12 @@ export class Session {
         this.stitching = true;
         const generation = this.openGeneration;
         try {
-            const { result } = await this.history({ maxMessages: PAGE_MESSAGES });
+            const response = await this.history({ maxMessages: PAGE_MESSAGES });
+            const { result } = response;
             // Failure or superseded by a full resync: drop — the resync path rebuilds and clears the buffer itself.
             if (result.ok && generation === this.openGeneration && this.openState === 'open') {
                 this.installWindow(result.value.events, result.value.hasMore, result.value.projections);
-                if (result.value.assistantStream !== undefined) this.nativeAssistant.baseline(result.value.assistantStream);
+                response.applyAssistantBaseline();
             }
         }
         catch (error) {
@@ -749,10 +752,19 @@ export class Session {
         };
     }
     /** Select ordinary or addressed history transport from the stored browser fact. */
-    history(payload) {
-        return this.address === undefined
+    async history(payload) {
+        const assistant = this.nativeAssistant;
+        const generation = assistant.generation;
+        const response = await (this.address === undefined
             ? this.api.sessions.history({ sessionId: this.sessionId, ...payload })
-            : this.api.subagents.history({ ...this.address, ...payload });
+            : this.api.subagents.history({ ...this.address, ...payload }));
+        // Check at consumption, not just response arrival: live frames may run
+        // between these awaits. Durable history remains independently usable.
+        return { ...response, applyAssistantBaseline: () => {
+            if (assistant !== this.nativeAssistant || generation !== assistant.generation) return;
+            if (response.result.ok && response.result.value.assistantStream !== undefined)
+                assistant.baseline(response.result.value.assistantStream);
+        } };
     }
 }
 /** Convert one wire history row into the assembler's transport-neutral input. */


### PR DESCRIPTION
## Problem and behavior

Fixes the two P2 findings from the review of #205: https://github.com/Hilbert-beinghappy/seektty/pull/205#issuecomment-5644748121.

- A continuable child Agent can restart its assistant-stream revision at 1 while its Session stays open. Accept the new activation using the attempt identity and durable start position, retain duplicate/stale-frame protection, and reject history baselines requested before the activation changed. A restarted child's text now streams immediately instead of waiting for durable settlement.
- Native control may publish jobs before follow publishes `session/subscribed`, which clears the retained client's job map. Replay the latest per-session jobs snapshot after subscription, including updates and empty snapshots, so task visibility is independent of arrival order.

Regressions exercise the real NativeTerminalApi/SessionManager path for both arrival orders, jobs updates/clears, restarted streaming, stale starts/baselines, malformed-baseline rollback, and late history responses with or without an active attempt. Generated `lib/index.js` is included.

## Validation

- Windows, Node 26.1.0, pnpm 11.7.0: `pnpm run check` passed (178 test files, 1542 tests passed, 1 existing skip; typecheck/build/pack-check passed, 28 package entries).
- Final packed candidate passed install → boot → remove → reinstall under an isolated DSH_HOME against unmodified official dsh 0.1.5-rc.1; verifier confirmed 231 exact-version dsh packages. Cleared inherited NODE_PATH only in the test subprocess to prevent the machine's global plugin from contaminating isolation. Compatibility scope remains exactly 0.1.5-rc.1.
- One earlier full run hit the existing context-menu Escape timing test; its isolated rerun and the final full run passed without changing that test or menu behavior.
- Stock boot validation covers the loader/non-TTY startup boundary and packed worker contract; this is not a claim of new interactive cross-platform acceptance. No npm publication or normal-profile upgrade was performed.
